### PR TITLE
Add updateVersion.mjs package script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "bldrs.ai datamodel",
   "author": "bldrs.ai",
   "license": "AGPL-3.0",
-  "version": "0.1.0",
+  "version": "0.1.347",
   "repository": "https://github.com/bldrs-ai/conway",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
@@ -52,7 +52,8 @@
     "precommit-node": "yarn build-rebuild-node && yarn lint && yarn test",
     "precommit-web": "yarn build-rebuild-web && yarn lint && yarn test",
     "submodule-update": "git submodule update --init --recursive",
-    "test-watch": "jest --watchAll  --notify"
+    "test-watch": "jest --watchAll  --notify",
+    "update-version": "./scripts/updateVersion.mjs"
   },
   "dependencies": {
     "buffer": "^6.0.3",

--- a/scripts/updateVersion.mjs
+++ b/scripts/updateVersion.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import {execSync} from 'node:child_process'
+import fs from 'fs'
+
+
+/**
+ * Rewrites package.json semver "patch" to git's version count + 1.
+ *
+ * Usage: "./scripts/updateVersion.js"
+ *
+ * @see git rev-list HEAD --count
+ * @see https://semver.org/
+ */
+
+const pkgJsonFilename = 'package.json'
+const gitRevCountCmd = 'git rev-list HEAD --count'
+const versionPattern =
+      /^(?<indent>\s*)"version"\s*:\s*"(?<major>\d+)\.(?<minor>\d+)\.\d+"\s*(?<comma>,)?$/m
+
+// Calculate new semver patch as revision count + 1
+const revisionCount = parseInt(execSync(gitRevCountCmd).toString().trim())
+const newPatch = revisionCount + 1
+
+// Read package.json and replace version
+const file = fs.readFileSync(pkgJsonFilename).toString('utf8')
+const updatedFile =
+      file.replace(versionPattern, `$<indent>"version": "$<major>.$<minor>.${newPatch}"$<comma>`)
+
+// Rewrite package.json with new content.
+fs.writeFileSync(pkgJsonFilename, updatedFile)


### PR DESCRIPTION
This is slightly different from Share's, in that it adds 1 to the existing # of revisions, to predict the version of the result of the current commit.

Combined with a husky auto-script on checkin, this should always give a version matching the commit.  Then, this would only be out of sync when husky scripts are skipped with `git ci -n`

Tested locally.  The new script and newline are manual edits you will not usually get from running the script.  The version should always change if different from last commit.
```
diff --git a/package.json b/package.json
index d0d7e3e..c85b7ae 100644
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "bldrs.ai datamodel",
   "author": "bldrs.ai",
   "license": "AGPL-3.0",
-  "version": "0.1.0",
+  "version": "0.1.347",
   "repository": "https://github.com/bldrs-ai/conway",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
@@ -52,7 +52,8 @@
     "precommit-node": "yarn build-rebuild-node && yarn lint && yarn test",
     "precommit-web": "yarn build-rebuild-web && yarn lint && yarn test",
     "submodule-update": "git submodule update --init --recursive",
-    "test-watch": "jest --watchAll  --notify"
+    "test-watch": "jest --watchAll  --notify",
+    "update-version": "./scripts/updateVersion.mjs"
   },
   "dependencies": {
     "buffer": "^6.0.3",
@@ -91,4 +92,4 @@
   },
   "main": "./compiled/src/index.js",
   "types": "./compiled/src/index.d.ts"
-}
\ No newline at end of file
+}
```