### PR TITLE
Fixed issue with no geometry coming through due to empty geometry segments

### DIFF
--- a/src/core/geometry_aggregator.ts
+++ b/src/core/geometry_aggregator.ts
@@ -130,19 +130,34 @@ export default class GeometryAggregator {
 
     for (const [material, geometries] of materialGeometry) {
 
+      let materialIndex: number | undefined = void 0
+
+      if (material !== void 0) {
+
+        materialIndex = materialVector.size()
+
+        const nativeMaterial = conwaywasm.nativeMaterial(material)
+
+        materialVector.push_back(nativeMaterial)
+      }
+
       for ( const geometry of geometries ) {
 
-        if (material !== void 0) {
+        if (materialIndex !== void 0) {
 
-          geometry.materialIndex = materialVector.size()
+          geometry.materialIndex = materialIndex
           geometry.hasDefaultMaterial = false
 
-          const nativeMaterial = conwaywasm.nativeMaterial(material)
+        } else {
 
-          materialVector.push_back(nativeMaterial)
+          geometry.hasDefaultMaterial = true
         }
 
         const geometryCurrentSize = geometry.currentSize
+
+        if ( geometryCurrentSize === 0 ) {
+          continue
+        }
 
         if (
           currentChunkByteSize !== 0 &&
@@ -167,7 +182,7 @@ export default class GeometryAggregator {
     return {
       geometry: outputGeometry,
       materials: materialVector,
-      chunks: chunks,
+      chunks: chunks.filter( ( where ) => where.count !== 0 ),
     }
   }
 }

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -1313,7 +1313,8 @@ export class IfcGeometryExtraction {
           try {
             transparency = style.Transparency ?? transparency
           } catch (e) {
-            // TODO(conor) - This is hiding a version difference with IFC 2x3 (better skew handling)
+            // TODO(conor) - This is hiding a version difference with IFC 2x3 (better skew
+            // handling)
           }
 
           const surfaceColor = extractColorRGBPremultiplied(style.SurfaceColour, 1 - transparency)
@@ -1322,9 +1323,7 @@ export class IfcGeometryExtraction {
             extractColorOrFactor(style.DiffuseColour, surfaceColor) : surfaceColor
 
           newMaterial.legacyColor = surfaceColor
-
           newMaterial.roughness = extractSpecularHighlight(style.SpecularHighlight)
-
           newMaterial.specular = style.SpecularColour !== null ?
             extractColorOrFactor(style.SpecularColour, surfaceColor) : void 0
 
@@ -1399,14 +1398,17 @@ export class IfcGeometryExtraction {
 
           let transparency = 0
 
+          // TODO(conor) - this will go away with more general schema skew handling
           try {
             transparency = style.Transparency ?? transparency
           } catch (e) {
-            // This is hiding a version difference with IFC 2x3
+            // TODO(conor) - This is hiding a version difference with IFC 2x3 (better skew
+            // handling)
           }
 
           newMaterial.baseColor =
             extractColorRGBPremultiplied(style.SurfaceColour, 1 - transparency)
+
         }
 
       }
@@ -1455,7 +1457,6 @@ export class IfcGeometryExtraction {
         this.extractSurfaceStyle(style)
       }
     }
-
 
     if (surfaceStyleID === void 0) {
       return


### PR DESCRIPTION
Previously in https://github.com/bldrs-ai/test-models-private/issues/4 we fixed a materials issue due to IFC2X3, this particular fixes fixes the next issue we found with no geometry. However, materials are still seemingly not applied.