### PR TITLE
Fix for long chain CSG operations causing WASM heap out of memory.

### DIFF
--- a/src/ifc/ifc_model_geometry.ts
+++ b/src/ifc/ifc_model_geometry.ts
@@ -1,4 +1,4 @@
-import { CanonicalMesh } from '../core/canonical_mesh'
+import { CanonicalMesh, CanonicalMeshType } from '../core/canonical_mesh'
 import {ModelGeometry} from '../core/model'
 
 
@@ -22,6 +22,26 @@ export class IfcModelGeometry implements ModelGeometry {
    */
   public add( mesh: CanonicalMesh ) {
     this.meshes_.set( mesh.localID, mesh )
+  }
+
+  /**
+   * Drop the mesh for a particular local ID
+   *
+   * @param localID The local ID of the item to delete.
+   */
+  public delete( localID: number ) {
+
+    const value = this.meshes_.get( localID )
+
+    if ( value !== void 0 ) {
+
+      this.meshes_.delete( localID )
+
+      if ( value.type === CanonicalMeshType.BUFFER_GEOMETRY ) {
+
+        value.geometry.delete()
+      }
+    }
   }
 
   /**

--- a/src/ifc/ifc_scene_builder.ts
+++ b/src/ifc/ifc_scene_builder.ts
@@ -88,6 +88,7 @@ export class IfcSceneBuilder implements Scene< StepEntityBase< EntityTypesIfc > 
 
   private scene_: IfcSceneNode[] = []
   private sceneLocalIdMap_ = new Map<number, number>()
+  private geometrySet_ = new Set< number >()
 
   private sceneStack_: IfcSceneTransform[] = []
   private currentParent_?: IfcSceneTransform
@@ -332,6 +333,17 @@ export class IfcSceneBuilder implements Scene< StepEntityBase< EntityTypesIfc > 
   }
 
   /**
+   * Does this scene have a particular piece of geometry?
+   *
+   * @param localID The local ID of the geometry
+   * @return {boolean} True if the scene has this geometry.
+   */
+  public hasGeometry(localID: number): boolean {
+
+    return this.geometrySet_.has( localID )
+  }
+
+  /**
    *
    * @param localID
    * @return {IfcSceneGeometry}
@@ -341,6 +353,8 @@ export class IfcSceneBuilder implements Scene< StepEntityBase< EntityTypesIfc > 
     const nodeIndex = this.scene_.length
 
     let parentIndex: number | undefined
+
+    this.geometrySet_.add( localID )
 
     if (this.currentParent_ !== void 0) {
 


### PR DESCRIPTION
A fix for the issue encountered at https://github.com/bldrs-ai/test-models-private/issues/12 where models with very long chains of CSG operations where a single complex mesh had small subtractions repeated on it over and over would cause an out of memory error on the WASM heap because there was too much geometry being memoized.

We now drop memoizations of boolean result operands when they are not currently geometry in the scene, which means they will not take up memory apart from temporary memory during the actual boolean operation.