### PR TITLE
Added commandline option for spaces vs not

### DIFF
--- a/src/core/geometry_aggregator.ts
+++ b/src/core/geometry_aggregator.ts
@@ -1,3 +1,4 @@
+import { option } from 'yargs'
 import { ConwayGeometry, GeometryCollection } from '../../dependencies/conway-geom/conway_geometry'
 import { CanonicalMaterial } from './canonical_material'
 import { CanonicalMeshType } from './canonical_mesh'
@@ -18,6 +19,8 @@ export interface GeometryAggregatorOptions {
    * alone.
    */
   maxGeometrySize?: number
+
+  outputSpaces?: boolean
 }
 
 export interface GeometryChunk {
@@ -69,10 +72,10 @@ export default class GeometryAggregator {
 
     const identityTransform = conwaywasm.getIdentityTransform()
 
-    const allSpaces = scene.isAllSpaces()
+    const outputSpaces = scene.isAllSpaces() || (!!this.options.outputSpaces)
 
     // eslint-disable-next-line no-unused-vars
-    for (const [_, nativeTransform, geometry, material] of scene.walk( false, allSpaces )) {
+    for (const [_, nativeTransform, geometry, material] of scene.walk( false, outputSpaces )) {
       if (geometry.type === CanonicalMeshType.BUFFER_GEOMETRY && !geometry.temporary) {
 
         let geometryCollections = materialGeometry.get(material)

--- a/src/ifc/ifc_command_line_main.ts
+++ b/src/ifc/ifc_command_line_main.ts
@@ -79,6 +79,11 @@ function doWork() {
             alias: 's',
             default: false,
           })
+          yargs2.option('spaces', {
+            describe: 'Output Spaces within Rel-Aggregates',
+            type: 'boolean',
+            alias: 'r',
+          })
 
           yargs2.positional('filename', { describe: 'IFC File Paths', type: 'string' })
         }, async (argv) => {
@@ -96,6 +101,7 @@ function doWork() {
 
           const outputProperties = (argv['properties'] as boolean | undefined)
           const strict = (argv['strict'] as boolean | undefined) ?? false
+          const includeSpace = (argv['spaces'] as boolean | undefined)
 
           try {
             indexIfcBuffer = fs.readFileSync(ifcFile)
@@ -178,7 +184,7 @@ function doWork() {
               const maxChunk = (argv['maxchunk'] as number | undefined) ?? DEFAULT_CHUNK
               const maxGeometrySize = maxChunk << MEGABYTE_SHIFT
 
-              serializeGeometry(scene, conwaywasm, fileName, maxGeometrySize)
+              serializeGeometry(scene, conwaywasm, fileName, maxGeometrySize, includeSpace)
             }
 
 
@@ -258,10 +264,11 @@ function serializeGeometry(
     scene: IfcSceneBuilder,
     conwaywasm: ConwayGeometry,
     fileNameNoExtension: string,
-    maxGeometrySize: number ) {
+    maxGeometrySize: number,
+    includeSpaces?: boolean  ) {
   const geometryAggregator =
     new GeometryAggregator(
-        conwaywasm, { maxGeometrySize: maxGeometrySize } )
+        conwaywasm, { maxGeometrySize: maxGeometrySize, outputSpaces: includeSpaces } )
 
   geometryAggregator.append( scene )
 


### PR DESCRIPTION
The rel-aggregates spaces optionality was in the pull request for fixing decimal places (which caused that draft request to auto-merge), this adds the command line option that was missing from that pull request.