### PR TITLE
Require fixed node version (16.x) for pkg scripts and npm install.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "test-watch": "jest --watchAll  --notify",
     "update-version": "./scripts/updateVersion.mjs"
   },
+  "engines": {
+    "node": ">=16.0.0 <17.0.0"
+  },
   "dependencies": {
     "buffer": "^6.0.3",
     "gl-matrix": "^3.4.3",


### PR DESCRIPTION
Tested by switching node version and trying package script.

See also
https://github.com/bldrs-ai/headless-three/pull/42

We've been testing Conway with 16 so far.  This isn't directly compatible with the bot move to 18 yet.  This is a step towards that.
