### PR TITLE
switch npm registry from GH to npmjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "license": "AGPL-3.0",
   "version": "0.7.727",
   "repository": "https://github.com/bldrs-ai/conway",
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
-  },
   "files": [
     "./compiled/**/*"
   ],


### PR DESCRIPTION
We found out that GH npm registry requires user authentication even for public packages.  This is too onerous, so switching us over to npmjs.