### PR TITLE
GHA Regression Testing

### DIFF
--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -113,29 +113,47 @@ jobs:
         id: regression_results
         run: |
           cd test-models/regression/test_models
-          # Process failed.csv: Check if it contains only the header.
+      
+          # Process failed.csv
           if [ -f failed.csv ]; then
-            HEADER="file,code,signal"
-            CONTENT=$(cat failed.csv | tr -d '\r\n')
-            if [ "$CONTENT" = "$HEADER" ]; then
-              FAILED="No failures :white_check_mark:"
+            LINE_COUNT=$(wc -l < failed.csv)
+            if [ "$LINE_COUNT" -eq 1 ]; then
+              FAILED_OUTPUT="No failures :white_check_mark:"
             else
-              FAILED=$(cat failed.csv)
+              HEADER_LINE=$(head -n 1 failed.csv)
+              DATA_LINES=$(tail -n +2 failed.csv)
+              TABLE_HEADER=$(echo "$HEADER_LINE" | awk -F, '{printf "| %s", $1; for(i=2;i<=NF;i++) printf " | %s", $i; print " |"}')
+              HEADER_SEPARATOR=$(echo "$HEADER_LINE" | awk -F, '{printf "|"; for(i=1;i<=NF;i++) printf " --- |"; print ""}')
+              TABLE_DATA=$(echo "$DATA_LINES" | awk -F, '{printf "| %s", $1; for(i=2;i<=NF;i++) printf " | %s", $i; print " |"}')
+              FAILED_OUTPUT="$TABLE_HEADER"$'\n'"$HEADER_SEPARATOR"$'\n'"$TABLE_DATA"
             fi
           else
-            FAILED="No failed.csv found."
+            FAILED_OUTPUT="No failed.csv found."
           fi
-          # Process errors.csv.
+      
+          # Process errors.csv
           if [ -f errors.csv ]; then
-            ERRORS=$(cat errors.csv)
+            LINE_COUNT=$(wc -l < errors.csv)
+            if [ "$LINE_COUNT" -eq 1 ]; then
+              ERRORS_OUTPUT="No errors found."
+            else
+              HEADER_LINE=$(head -n 1 errors.csv)
+              DATA_LINES=$(tail -n +2 errors.csv)
+              TABLE_HEADER=$(echo "$HEADER_LINE" | awk -F, '{printf "| %s", $1; for(i=2;i<=NF;i++) printf " | %s", $i; print " |"}')
+              HEADER_SEPARATOR=$(echo "$HEADER_LINE" | awk -F, '{printf "|"; for(i=1;i<=NF;i++) printf " --- |"; print ""}')
+              TABLE_DATA=$(echo "$DATA_LINES" | awk -F, '{printf "| %s", $1; for(i=2;i<=NF;i++) printf " | %s", $i; print " |"}')
+              ERRORS_OUTPUT="$TABLE_HEADER"$'\n'"$HEADER_SEPARATOR"$'\n'"$TABLE_DATA"
+            fi
           else
-            ERRORS="No errors.csv found."
+            ERRORS_OUTPUT="No errors.csv found."
           fi
-          echo "failed<<EOF" >> $GITHUB_OUTPUT
-          echo "$FAILED" >> $GITHUB_OUTPUT
+      
+          echo "failed_output<<EOF" >> $GITHUB_OUTPUT
+          echo "$FAILED_OUTPUT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          echo "errors<<EOF" >> $GITHUB_OUTPUT
-          echo "$ERRORS" >> $GITHUB_OUTPUT
+      
+          echo "errors_output<<EOF" >> $GITHUB_OUTPUT
+          echo "$ERRORS_OUTPUT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
       
       - name: Comment on Pull Request with Regression Results
@@ -146,12 +164,10 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             ## IFC Regression Results
-            **Failed.csv:**  
-            ```
-            ${{ steps.regression_results.outputs.failed }}
-            ```
-            **Errors.csv:**  
-            ```
-            ${{ steps.regression_results.outputs.errors }}
-            ```
+      
+            **Failed.csv:**
+            ${{ steps.regression_results.outputs.failed_output }}
+      
+            **Errors.csv:**
+            ${{ steps.regression_results.outputs.errors_output }}
     

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Gather Regression Results
         id: regression_results
         run: |
-          cd test-models/regression
+          cd test-models/regression/test-models
           if [ -f failed.csv ]; then
             FAILED=$(cat failed.csv)
           else

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -20,6 +20,7 @@ jobs:
       # 2. Install dependencies and build your project
       - name: Install Dependencies and Build
         run: |
+          yarn setup
           yarn install
           yarn build-node-MT
           yarn build-incremental

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -53,12 +53,6 @@ jobs:
           path: bin/linux/genie
           key: genie-${{ runner.os }}
 
-      - name: Generate Makefiles with GENie
-        run: |
-          cd dependencies/conway-geom
-          chmod +x ../../bin/linux/genie
-          ../../bin/linux/genie gmake
-
       # --- EMSDK Setup ---
       - name: Enable Emscripten System Library Cache
         id: emscripten-cache

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -129,7 +129,8 @@ jobs:
               print(header_line)
               print(separator_line)
               for row in reader[1:]:
-                  print("| " + " | ".join(row) + " |")
+                sanitized_row = [field.replace("\n", " ").replace("\r", " ") for field in row]
+                print("| " + " | ".join(sanitized_row) + " |")
           EOF
           )
           else
@@ -151,7 +152,8 @@ jobs:
               print(header_line)
               print(separator_line)
               for row in reader[1:]:
-                  print("| " + " | ".join(row) + " |")
+                sanitized_row = [field.replace("\n", " ").replace("\r", " ") for field in row]
+                print("| " + " | ".join(sanitized_row) + " |")
           EOF
           )
           else

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -55,8 +55,9 @@ jobs:
 
       - name: Generate Makefiles with GENie
         run: |
-          chmod +x bin/linux/genie
-          bin/linux/genie gmake
+          cd dependencies/conway-geom
+          chmod +x ../../bin/linux/genie
+          ../../bin/linux/genie gmake
 
       # --- EMSDK Setup ---
       - name: Enable Emscripten System Library Cache
@@ -90,8 +91,7 @@ jobs:
         run: |
           yarn setup
           yarn install
-          yarn build-conway_geom-web-MT:darwin
-          yarn build-incremental
+          yarn build-GHA-MT
 
       # --- Test Models Checkout & Regression ---
       - name: Restore Test Models Cache

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -6,10 +6,12 @@ on:
 
 env:
   TEST_MODELS_TAG: '0.13.802'
+  EMSDK_VERSION: '3.1.72'
+  EMSDK_CACHE_FOLDER: 'cache/emsdk'
 
 jobs:
   run-ifc-regression:
-    # Use your GitHub managed large runner from the RegressionTesting group.
+    # This job uses your GitHub-managed large runner from the RegressionTesting group.
     runs-on: RegressionTesting
 
     steps:
@@ -17,7 +19,73 @@ jobs:
       - name: Checkout Conway Repo
         uses: actions/checkout@v3
 
-      # 2. Install dependencies and build your project
+      # --- GENie Setup ---
+      - name: Restore Cached GENie Build Artifact
+        id: cache-genie-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: bin/linux/genie
+          key: genie-${{ runner.os }}
+
+      - name: Checkout GENie Repository
+        if: steps.cache-genie-restore.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: bkaradzic/GENie
+          path: GENie
+
+      - name: Build GENie
+        if: steps.cache-genie-restore.outputs.cache-hit != 'true'
+        run: |
+          cd GENie
+          make
+
+      - name: Copy GENie Binary
+        if: steps.cache-genie-restore.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p bin/linux
+          cp GENie/bin/linux/genie bin/linux/genie
+
+      - name: Cache GENie Build Artifact
+        if: steps.cache-genie-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: bin/linux/genie
+          key: genie-${{ runner.os }}
+
+      - name: Generate Makefiles with GENie
+        run: |
+          chmod +x bin/linux/genie
+          bin/linux/genie gmake
+
+      # --- EMSDK Setup ---
+      - name: Enable Emscripten System Library Cache
+        id: emscripten-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.EMSDK_CACHE_FOLDER }}
+          key: ${{ env.EMSDK_VERSION }}-${{ runner.os }}
+
+      - name: Install Emscripten
+        id: emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: ${{ env.EMSDK_VERSION }}
+          actions-cache-folder: ${{ env.EMSDK_CACHE_FOLDER }}
+
+      - name: Add emsdk to env
+        run: |
+          echo 'which em++:'
+          which em++
+          em++ -v
+          EMSDK=$(which em++ | sed 's|upstream/emscripten/em++||')
+          EMSCRIPTEN=$(which em++ | sed 's|/em++||')
+          echo "emsdk: $EMSDK"
+          echo "emscripten bin dir: $EMSCRIPTEN"
+          echo "EMSDK=$EMSDK" >> $GITHUB_ENV
+          echo "EMSCRIPTEN=$EMSCRIPTEN" >> $GITHUB_ENV
+
+      # --- Build Conway Project ---
       - name: Install Dependencies and Build
         run: |
           yarn setup
@@ -25,7 +93,7 @@ jobs:
           yarn build-conway_geom-web-MT:darwin
           yarn build-incremental
 
-      # 3. Restore cached test-models repository (this will be at the workspace root)
+      # --- Test Models Checkout & Regression ---
       - name: Restore Test Models Cache
         id: cache-test-models
         uses: actions/cache@v3
@@ -33,13 +101,11 @@ jobs:
           path: test-models
           key: ${{ runner.os }}-test-models-${{ env.TEST_MODELS_TAG }}
 
-      # 4. Clone test-models if not cached; it will be a top-level directory called "test-models"
       - name: Checkout Test Models Repo if Not Cached
         if: steps.cache-test-models.outputs.cache-hit != 'true'
         run: |
           git clone --depth 1 --branch ${{ env.TEST_MODELS_TAG }} https://github.com/bldrs-ai/test-models.git test-models
 
-      # 5. Run your IFC regression batch script from the conway repository root.
       - name: Run IFC Regression Batch Script
         run: |
           node --experimental-specifier-resolution=node ./compiled/src/ifc/ifc_regression_batch_main.js \
@@ -49,7 +115,6 @@ jobs:
             test-models/regression/test_models \
             --parallel --mem-utilization 90
 
-      # 6. Gather regression results from test-models/regression folder (only failed.csv)
       - name: Gather Regression Results
         id: regression_results
         run: |
@@ -63,7 +128,6 @@ jobs:
           echo "$FAILED" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      # 7. Post a comment on the pull request with the regression results
       - name: Comment on Pull Request with Regression Results
         if: ${{ github.event_name == 'pull_request' }}
         uses: peter-evans/create-or-update-comment@v2

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -1,0 +1,77 @@
+name: IFC Regression Batch
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+env:
+  TEST_MODELS_TAG: '0.13.802'
+
+jobs:
+  run-ifc-regression:
+    # Use your GitHub managed large runner from the RegressionTesting group.
+    runs-on: [RegressionTesting, linux-x64]
+
+    steps:
+      # 1. Checkout the conway repository (your main repo)
+      - name: Checkout Conway Repo
+        uses: actions/checkout@v3
+
+      # 2. Install dependencies and build your project
+      - name: Install Dependencies and Build
+        run: |
+          yarn install
+          yarn build-node-MT
+          yarn build-incremental
+
+      # 3. Restore cached test-models repository (this will be at the workspace root)
+      - name: Restore Test Models Cache
+        id: cache-test-models
+        uses: actions/cache@v3
+        with:
+          path: test-models
+          key: ${{ runner.os }}-test-models-${{ env.TEST_MODELS_TAG }}
+
+      # 4. Clone test-models if not cached; it will be a top-level directory called "test-models"
+      - name: Checkout Test Models Repo if Not Cached
+        if: steps.cache-test-models.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch ${{ env.TEST_MODELS_TAG }} https://github.com/bldrs-ai/test-models.git test-models
+
+      # 5. Run your IFC regression batch script from the conway repository root.
+      - name: Run IFC Regression Batch Script
+        run: |
+          node --experimental-specifier-resolution=node ./compiled/src/ifc/ifc_regression_batch_main.js \
+            -e "sp-.*\.ifc" \
+            -t ${{ env.TEST_MODELS_TAG }} \
+            test-models \
+            test-models/regression/test_models \
+            --parallel --mem-utilization 90
+
+      # 6. Gather regression results from test-models/regression folder (only failed.csv)
+      - name: Gather Regression Results
+        id: regression_results
+        run: |
+          cd test-models/regression
+          if [ -f failed.csv ]; then
+            FAILED=$(cat failed.csv)
+          else
+            FAILED="No failed.csv found."
+          fi
+          echo "failed<<EOF" >> $GITHUB_OUTPUT
+          echo "$FAILED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      # 7. Post a comment on the pull request with the regression results
+      - name: Comment on Pull Request with Regression Results
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## IFC Regression Results
+            **Failed.csv:**  
+            ```
+            ${{ steps.regression_results.outputs.failed }}
+            ```

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Gather Regression Results
         id: regression_results
         run: |
-          cd test-models/regression/test-models
+          cd test-models/regression/test_models
           if [ -f failed.csv ]; then
             FAILED=$(cat failed.csv)
           else

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -109,19 +109,35 @@ jobs:
             test-models/regression/test_models \
             --parallel --mem-utilization 90
 
-      - name: Gather Regression Results
+        - name: Gather Regression Results
         id: regression_results
         run: |
           cd test-models/regression/test_models
+          # Process failed.csv: Check if it contains only the header.
           if [ -f failed.csv ]; then
-            FAILED=$(cat failed.csv)
+            HEADER="file,code,signal"
+            CONTENT=$(cat failed.csv | tr -d '\r\n')
+            if [ "$CONTENT" = "$HEADER" ]; then
+              FAILED="No failures :white_check_mark:"
+            else
+              FAILED=$(cat failed.csv)
+            fi
           else
             FAILED="No failed.csv found."
+          fi
+          # Process errors.csv.
+          if [ -f errors.csv ]; then
+            ERRORS=$(cat errors.csv)
+          else
+            ERRORS="No errors.csv found."
           fi
           echo "failed<<EOF" >> $GITHUB_OUTPUT
           echo "$FAILED" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-
+          echo "errors<<EOF" >> $GITHUB_OUTPUT
+          echo "$ERRORS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      
       - name: Comment on Pull Request with Regression Results
         if: ${{ github.event_name == 'pull_request' }}
         uses: peter-evans/create-or-update-comment@v2
@@ -134,3 +150,8 @@ jobs:
             ```
             ${{ steps.regression_results.outputs.failed }}
             ```
+            **Errors.csv:**  
+            ```
+            ${{ steps.regression_results.outputs.errors }}
+            ```
+      

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -114,36 +114,46 @@ jobs:
         run: |
           cd test-models/regression/test_models
       
-          # Process failed.csv
+          # Process failed.csv with Python CSV parsing
           if [ -f failed.csv ]; then
-            LINE_COUNT=$(wc -l < failed.csv)
-            if [ "$LINE_COUNT" -eq 1 ]; then
-              FAILED_OUTPUT="No failures :white_check_mark:"
-            else
-              HEADER_LINE=$(head -n 1 failed.csv)
-              DATA_LINES=$(tail -n +2 failed.csv)
-              TABLE_HEADER=$(echo "$HEADER_LINE" | awk -F, '{printf "| %s", $1; for(i=2;i<=NF;i++) printf " | %s", $i; print " |"}')
-              HEADER_SEPARATOR=$(echo "$HEADER_LINE" | awk -F, '{printf "|"; for(i=1;i<=NF;i++) printf " --- |"; print ""}')
-              TABLE_DATA=$(echo "$DATA_LINES" | awk -F, '{printf "| %s", $1; for(i=2;i<=NF;i++) printf " | %s", $i; print " |"}')
-              FAILED_OUTPUT="$TABLE_HEADER"$'\n'"$HEADER_SEPARATOR"$'\n'"$TABLE_DATA"
-            fi
+            FAILED_OUTPUT=$(python - <<'EOF'
+          import csv
+          with open('failed.csv', newline='') as csvfile:
+              reader = list(csv.reader(csvfile))
+          if len(reader) <= 1:
+              print("No failures :white_check_mark:")
+          else:
+              header = reader[0]
+              header_line = "| " + " | ".join(header) + " |"
+              separator_line = "|" + " --- |" * len(header)
+              print(header_line)
+              print(separator_line)
+              for row in reader[1:]:
+                  print("| " + " | ".join(row) + " |")
+          EOF
+          )
           else
             FAILED_OUTPUT="No failed.csv found."
           fi
       
-          # Process errors.csv
+          # Process errors.csv with Python CSV parsing
           if [ -f errors.csv ]; then
-            LINE_COUNT=$(wc -l < errors.csv)
-            if [ "$LINE_COUNT" -eq 1 ]; then
-              ERRORS_OUTPUT="No errors found."
-            else
-              HEADER_LINE=$(head -n 1 errors.csv)
-              DATA_LINES=$(tail -n +2 errors.csv)
-              TABLE_HEADER=$(echo "$HEADER_LINE" | awk -F, '{printf "| %s", $1; for(i=2;i<=NF;i++) printf " | %s", $i; print " |"}')
-              HEADER_SEPARATOR=$(echo "$HEADER_LINE" | awk -F, '{printf "|"; for(i=1;i<=NF;i++) printf " --- |"; print ""}')
-              TABLE_DATA=$(echo "$DATA_LINES" | awk -F, '{printf "| %s", $1; for(i=2;i<=NF;i++) printf " | %s", $i; print " |"}')
-              ERRORS_OUTPUT="$TABLE_HEADER"$'\n'"$HEADER_SEPARATOR"$'\n'"$TABLE_DATA"
-            fi
+            ERRORS_OUTPUT=$(python - <<'EOF'
+          import csv
+          with open('errors.csv', newline='') as csvfile:
+              reader = list(csv.reader(csvfile))
+          if len(reader) <= 1:
+              print("No errors found.")
+          else:
+              header = reader[0]
+              header_line = "| " + " | ".join(header) + " |"
+              separator_line = "|" + " --- |" * len(header)
+              print(header_line)
+              print(separator_line)
+              for row in reader[1:]:
+                  print("| " + " | ".join(row) + " |")
+          EOF
+          )
           else
             ERRORS_OUTPUT="No errors.csv found."
           fi
@@ -155,7 +165,7 @@ jobs:
           echo "errors_output<<EOF" >> $GITHUB_OUTPUT
           echo "$ERRORS_OUTPUT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      
+          
       - name: Comment on Pull Request with Regression Results
         if: ${{ github.event_name == 'pull_request' }}
         uses: peter-evans/create-or-update-comment@v2
@@ -170,4 +180,5 @@ jobs:
       
             **Errors.csv:**
             ${{ steps.regression_results.outputs.errors_output }}
+      
     

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -22,7 +22,8 @@ jobs:
         run: |
           yarn setup
           yarn install
-          yarn build-all-release-node-MT
+          yarn build-conway_geom-web-MT:darwin
+          yarn build-incremental
 
       # 3. Restore cached test-models repository (this will be at the workspace root)
       - name: Restore Test Models Cache

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   run-ifc-regression:
     # Use your GitHub managed large runner from the RegressionTesting group.
-    runs-on: [RegressionTesting, linux-x64]
+    runs-on: RegressionTesting
 
     steps:
       # 1. Checkout the conway repository (your main repo)

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -22,8 +22,7 @@ jobs:
         run: |
           yarn setup
           yarn install
-          yarn build-node-MT
-          yarn build-incremental
+          yarn build-all-release-node-MT
 
       # 3. Restore cached test-models repository (this will be at the workspace root)
       - name: Restore Test Models Cache

--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -109,7 +109,7 @@ jobs:
             test-models/regression/test_models \
             --parallel --mem-utilization 90
 
-        - name: Gather Regression Results
+      - name: Gather Regression Results
         id: regression_results
         run: |
           cd test-models/regression/test_models
@@ -154,4 +154,4 @@ jobs:
             ```
             ${{ steps.regression_results.outputs.errors }}
             ```
-      
+    

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "bldrs.ai datamodel",
   "author": "bldrs.ai",
   "license": "AGPL-3.0",
-  "version": "0.13.802",
+  "version": "0.13.811",
   "repository": "https://github.com/bldrs-ai/conway",
   "files": [
     "./compiled/**/*"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "bldrs.ai datamodel",
   "author": "bldrs.ai",
   "license": "AGPL-3.0",
-  "version": "0.13.811",
+  "version": "0.13.817",
   "repository": "https://github.com/bldrs-ai/conway",
   "files": [
     "./compiled/**/*"
@@ -33,6 +33,7 @@
     "build-node": "yarn clean && yarn update-version && yarn build-all-release-node",
     "build-web-MT": "yarn clean && yarn update-version && yarn build-all-release-web-MT",
     "build-node-MT": "yarn clean && yarn update-version && yarn build-all-release-node-MT",
+    "build-GHA-MT": "cd dependencies/conway-geom/gmake && make config=releaseemscripten ConwayGeomWasmNode && cd .. && mkdir -p Dist && cp ./bin/release/* Dist/ && cp ConwayGeomWasm.d.ts Dist/ && mkdir -p ../../compiled/dependencies/conway-geom/Dist && cp ./bin/release/* ../../compiled/dependencies/conway-geom/Dist && cd ../.../ && yarn build-incremental",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "cli": "node --experimental-wasm-threads --experimental-specifier-resolution=node ./compiled/src/ifc/ifc_command_line_main.js",
     "browser": "node --experimental-wasm-threads --experimental-specifier-resolution=node ./compiled/src/examples/browser.js",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build-node": "yarn clean && yarn update-version && yarn build-all-release-node",
     "build-web-MT": "yarn clean && yarn update-version && yarn build-all-release-web-MT",
     "build-node-MT": "yarn clean && yarn update-version && yarn build-all-release-node-MT",
-    "build-GHA-MT": "cd dependencies/conway-geom/gmake && make config=releaseemscripten ConwayGeomWasmNode && cd .. && mkdir -p Dist && cp ./bin/release/* Dist/ && cp ConwayGeomWasm.d.ts Dist/ && mkdir -p ../../compiled/dependencies/conway-geom/Dist && cp ./bin/release/* ../../compiled/dependencies/conway-geom/Dist && cd ../.../ && yarn build-incremental",
+    "build-GHA-MT": "cd dependencies/conway-geom/gmake && make config=releaseemscripten ConwayGeomWasmNodeMT && cd .. && mkdir -p Dist && cp ./bin/release/* Dist/ && cp ConwayGeomWasm.d.ts Dist/ && mkdir -p ../../compiled/dependencies/conway-geom/Dist && cp ./bin/release/* ../../compiled/dependencies/conway-geom/Dist && cd ../.../ && yarn build-incremental",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "cli": "node --experimental-wasm-threads --experimental-specifier-resolution=node ./compiled/src/ifc/ifc_command_line_main.js",
     "browser": "node --experimental-wasm-threads --experimental-specifier-resolution=node ./compiled/src/examples/browser.js",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build-node": "yarn clean && yarn update-version && yarn build-all-release-node",
     "build-web-MT": "yarn clean && yarn update-version && yarn build-all-release-web-MT",
     "build-node-MT": "yarn clean && yarn update-version && yarn build-all-release-node-MT",
-    "build-GHA-MT": "cd dependencies/conway-geom/gmake && make config=releaseemscripten ConwayGeomWasmNodeMT && cd .. && mkdir -p Dist && cp ./bin/release/* Dist/ && cp ConwayGeomWasm.d.ts Dist/ && mkdir -p ../../compiled/dependencies/conway-geom/Dist && cp ./bin/release/* ../../compiled/dependencies/conway-geom/Dist && cd ../.../ && yarn build-incremental",
+    "build-GHA-MT": "cd dependencies/conway-geom && chmod +x ../../bin/linux/genie && ../../bin/linux/genie gmake && cd gmake && make config=releaseemscripten ConwayGeomWasmNodeMT && cd .. && mkdir -p Dist && cp ./bin/release/* Dist/ && cp ConwayGeomWasm.d.ts Dist/ && mkdir -p ../../compiled/dependencies/conway-geom/Dist && cp ./bin/release/* ../../compiled/dependencies/conway-geom/Dist && cd ../.../ && yarn build-incremental",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "cli": "node --experimental-wasm-threads --experimental-specifier-resolution=node ./compiled/src/ifc/ifc_command_line_main.js",
     "browser": "node --experimental-wasm-threads --experimental-specifier-resolution=node ./compiled/src/examples/browser.js",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build-node": "yarn clean && yarn update-version && yarn build-all-release-node",
     "build-web-MT": "yarn clean && yarn update-version && yarn build-all-release-web-MT",
     "build-node-MT": "yarn clean && yarn update-version && yarn build-all-release-node-MT",
-    "build-GHA-MT": "cd dependencies/conway-geom && chmod +x ../../bin/linux/genie && ../../bin/linux/genie gmake && cd gmake && make config=releaseemscripten ConwayGeomWasmNodeMT && cd .. && mkdir -p Dist && cp ./bin/release/* Dist/ && cp ConwayGeomWasm.d.ts Dist/ && mkdir -p ../../compiled/dependencies/conway-geom/Dist && cp ./bin/release/* ../../compiled/dependencies/conway-geom/Dist && cd ../.../ && yarn build-incremental",
+    "build-GHA-MT": "cd dependencies/conway-geom && chmod +x ../../bin/linux/genie && ../../bin/linux/genie gmake && cd gmake && make config=releaseemscripten ConwayGeomWasmNodeMT && cd .. && mkdir -p Dist && cp ./bin/release/* Dist/ && cp ConwayGeomWasm.d.ts Dist/ && mkdir -p ../../compiled/dependencies/conway-geom/Dist && cp ./bin/release/* ../../compiled/dependencies/conway-geom/Dist && cd ../../ && yarn build-incremental",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "cli": "node --experimental-wasm-threads --experimental-specifier-resolution=node ./compiled/src/ifc/ifc_command_line_main.js",
     "browser": "node --experimental-wasm-threads --experimental-specifier-resolution=node ./compiled/src/examples/browser.js",

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -312,7 +312,7 @@ async function processIFCFilesInParallel(
     maxTimeout:number,
 ): Promise<void> {
   const concurrencyLimit = os.cpus().length
-  console.log(`concurrencyLimit: ${concurrencyLimit}`)
+  console.log(`Concurrency: ${concurrencyLimit} threads - Max Timeout: ${maxTimeout} ms`)
 
   const limit = pLimit(concurrencyLimit)
   const taskTimeout = 2000
@@ -458,14 +458,6 @@ const args = yargs(process.argv.slice(SKIP_PARAMS))
             default: '',
           })
 
-          yargs2.option('timeout', {
-
-            describe: 'IFC per-file loading timeout in ms (default: 150000)',
-            type: 'number',
-            alias: 'm',
-            default: 150000,
-          })
-
           yargs2.option('parallel', {
             describe: 'Process IFC files in parallel (limited by CPU cores)',
             type: 'boolean',
@@ -490,6 +482,14 @@ const args = yargs(process.argv.slice(SKIP_PARAMS))
               }
             }
             return true
+          })
+
+          yargs2.option('timeout', {
+
+            describe: 'IFC per-file loading timeout in ms (default: 150000)',
+            type: 'number',
+            alias: 'timeout',
+            default: 150000,
           })
 
           yargs2.positional('model_folder', {

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -195,8 +195,9 @@ let totalTime = 0 // To keep track of the running total time
 /**
  * Run a regression test digest for a file.
  */
-async function runForFile(filePath: string, outputPath: string): Promise<RunResults> {
-  const MAX_TIMEOUT_MS = 150000 // 2.5 minutes
+async function runForFile(filePath: string,
+    outputPath: string, maxTimeout:number): Promise<RunResults> {
+  const MAX_TIMEOUT_MS = maxTimeout
   const startTime = Date.now() // Start time
 
   // eslint-disable-next-line max-len
@@ -308,6 +309,7 @@ async function processIFCFilesInParallel(
     fileLines: string[],
     failedLines: string[],
     memUtilization: number,
+    maxTimeout:number,
 ): Promise<void> {
   const concurrencyLimit = os.cpus().length
   console.log(`concurrencyLimit: ${concurrencyLimit}`)
@@ -332,7 +334,9 @@ async function processIFCFilesInParallel(
       const fileResults = await runForFile(
           ifcPath,
           path.join(outputPath, path.basename(ifcPath, '.ifc')),
+          maxTimeout,
       )
+
       activeTasks--
       console.log(
           `Completed task for "${path.basename(ifcPath)}". Active tasks: ${activeTasks}`,
@@ -378,6 +382,7 @@ async function recursiveWalk(
     errorLines: string[],
     fileLines: string[],
     failedLines: string[],
+    maxTimeout: number,
 ) {
   const items = await fsPromises.readdir(parentPath, { withFileTypes: true })
   items.sort((a, b) => (a.name > b.name ? 1 : -1))
@@ -390,11 +395,13 @@ async function recursiveWalk(
     }
 
     if (item.isDirectory()) {
-      await recursiveWalk(resolved, excludeRegex, outputPath, errorLines, fileLines, failedLines)
+      await recursiveWalk(resolved, excludeRegex, outputPath,
+          errorLines, fileLines, failedLines, maxTimeout)
     } else if (path.extname(resolved).toLowerCase() === '.ifc') {
       const fileResults = await runForFile(
           resolved,
           path.join(outputPath, path.basename(resolved, '.ifc')),
+          maxTimeout,
       )
 
       if (fileResults.type === 'Run') {
@@ -451,6 +458,14 @@ const args = yargs(process.argv.slice(SKIP_PARAMS))
             default: '',
           })
 
+          yargs2.option('timeout', {
+
+            describe: 'IFC per-file loading timeout in ms (default: 150000)',
+            type: 'number',
+            alias: 'm',
+            default: 150000,
+          })
+
           yargs2.option('parallel', {
             describe: 'Process IFC files in parallel (limited by CPU cores)',
             type: 'boolean',
@@ -498,6 +513,7 @@ const args = yargs(process.argv.slice(SKIP_PARAMS))
           const excludeFilter = (argv['exclude'] as string) ?? ''
           const doParallel = (argv['parallel'] as boolean) ?? false // <--- read the parallel flag
           const memUtilization = (argv['mem-utilization'] as number)
+          const maxTimeout = (argv['timeout'] as number)
 
           if (changes.length === 0) {
             changes = path.join(outputPath, 'changes')
@@ -528,11 +544,12 @@ const args = yargs(process.argv.slice(SKIP_PARAMS))
                 fileLines,
                 failedLines,
                 memUtilization,
+                maxTimeout,
             )
           } else {
             console.log('Processing in serial mode...')
             // eslint-disable-next-line max-len
-            await recursiveWalk(ifcFolder, excludeRegex, outputPath, errorLines, fileLines, failedLines)
+            await recursiveWalk(ifcFolder, excludeRegex, outputPath, errorLines, fileLines, failedLines, maxTimeout)
           }
 
           // Write out results

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -196,7 +196,7 @@ let totalTime = 0 // To keep track of the running total time
  * Run a regression test digest for a file.
  */
 async function runForFile(filePath: string, outputPath: string): Promise<RunResults> {
-  const MAX_TIMEOUT_MS = 180000 // 3 minutes
+  const MAX_TIMEOUT_MS = 150000 // 2.5 minutes
   const startTime = Date.now() // Start time
 
   // eslint-disable-next-line max-len

--- a/src/version/version.ts
+++ b/src/version/version.ts
@@ -1,4 +1,4 @@
-const versionString: string = 'Conway Web-Ifc Shim v0.13.811'
+const versionString: string = 'Conway Web-Ifc Shim v0.13.817'
 
 
 export {versionString}

--- a/src/version/version.ts
+++ b/src/version/version.ts
@@ -1,4 +1,4 @@
-const versionString: string = 'Conway Web-Ifc Shim v0.13.802'
+const versionString: string = 'Conway Web-Ifc Shim v0.13.811'
 
 
 export {versionString}


### PR DESCRIPTION
* add GHA for regressions testing for test-models
* add build command in package.json for GHA linux
* decrease timeout from 3 to 2.5 minutes for regression testing


Note, the regression report reports no failures because the two models that fail in our performance testing for test-models don't actually fail to parse, they just report no geometry which then fails upstream in display (headless-three). 

Failures in performance testing (test-models):
```
Error processing file ../test-models/ifc/misc/bath-csg-solid.ifc
Error processing file ../test-models/ifc/thatopen/ifcfiles/KIT-Simple-Road-Test-Web-IFC4x3_RC2.ifc
```

Another note, you must commit a tagged version of test-models (I made one for 0.13.802), and currently would need to modify the GHA test-models tagged version it checks out. Can discuss what we want to do there. 