### PR TITLE
CSG recursion depth limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "bldrs.ai datamodel",
   "author": "bldrs.ai",
   "license": "AGPL-3.0",
-  "version": "0.17.899",
+  "version": "0.17.900",
   "repository": "https://github.com/bldrs-ai/conway",
   "files": [
     "./compiled/**/*"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "bldrs.ai datamodel",
   "author": "bldrs.ai",
   "license": "AGPL-3.0",
-  "version": "0.17.886",
+  "version": "0.17.899",
   "repository": "https://github.com/bldrs-ai/conway",
   "files": [
     "./compiled/**/*"

--- a/src/ifc/ifc_command_line_main.ts
+++ b/src/ifc/ifc_command_line_main.ts
@@ -91,7 +91,7 @@ function doWork() {
             alias: 'n',
           })
           yargs2.option('limitcsg', {
-            describe: 'Limit the CSG depth.',
+            describe: 'Don\'t limit the CSG recursion depth.',
             type: 'boolean',
             alias: 'l',
           })
@@ -606,7 +606,7 @@ function propertyExtraction(model: IfcStepModel) {
  */
 function geometryExtraction(
   model: IfcStepModel,
-  limitCSGDepth: boolean = false,
+  limitCSGDepth: boolean = true,
   maxCSGDepth: number = 0):
   IfcSceneBuilder | undefined {
 

--- a/src/ifc/ifc_command_line_main.ts
+++ b/src/ifc/ifc_command_line_main.ts
@@ -143,7 +143,7 @@ function doWork() {
           const strict = (argv['strict'] as boolean | undefined) ?? false
           const includeSpace = (argv['spaces'] as boolean | undefined)
           const noOutput = (argv['nooutput'] as boolean | undefined)
-          const limitCSG = (argv['limitcsg'] as boolean | undefined)
+          const limitCSG = !(argv['limitcsg'] as boolean | undefined)
           const maxCSGDepth = (argv['csgdepth'] as number | undefined)
 
           try {
@@ -607,7 +607,7 @@ function propertyExtraction(model: IfcStepModel) {
 function geometryExtraction(
   model: IfcStepModel,
   limitCSGDepth: boolean = true,
-  maxCSGDepth: number = 0):
+  maxCSGDepth: number = 20):
   IfcSceneBuilder | undefined {
 
   const conwayModel =

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -1400,7 +1400,6 @@ export class IfcGeometryExtraction {
 
         if ( this.limitCSGDepth && this.csgDepth >= maximumCsgMemoizationDepth ) {
  
-
           if ( firstMesh === void 0 ) {
 
             return
@@ -1452,6 +1451,7 @@ export class IfcGeometryExtraction {
           
           return
         }
+
         let flatFirstMeshVector: StdVector<GeometryObject>// = this.nativeVectorGeometry()
 
         if (firstMesh !== void 0 && firstMesh.type === CanonicalMeshType.BUFFER_GEOMETRY) {

--- a/src/loaders/conway_model_loader.ts
+++ b/src/loaders/conway_model_loader.ts
@@ -34,7 +34,7 @@ export class ConwayModelLoader {
    */
   public static async loadModelWithScene(
       data: Uint8Array,
-      limitCSGDepth: boolean = false,
+      limitCSGDepth: boolean = true,
       maximumCSGDepth: number = 20,
       modelID: number = 0 ): Promise<[Model, Scene]> {
 

--- a/src/loaders/conway_model_loader.ts
+++ b/src/loaders/conway_model_loader.ts
@@ -27,11 +27,15 @@ export class ConwayModelLoader {
    * Load a model using the format detector
    *
    * @param data The buffer to load from.
+   * @param limitCSGDepth Whether to limit CSG depth during geometry extraction.
+   * @param maximumCSGDepth The maximum CSG depth allowed during geometry extraction.
    * @param modelID The model id to use for statistics (or 0 if none is provided)
    * @return {Promise<[Model, Scene]>} A promise to return the loaded model and scene.
    */
   public static async loadModelWithScene(
       data: Uint8Array,
+      limitCSGDepth: boolean = false,
+      maximumCSGDepth: number = 20,
       modelID: number = 0 ): Promise<[Model, Scene]> {
 
     const allTimeStart = Date.now()
@@ -306,7 +310,11 @@ export class ConwayModelLoader {
             throw Error( 'Unable to parse model' )
           }
 
-          const conwayModel = new IfcGeometryExtraction(conwayWasm, model)
+          const conwayModel = new IfcGeometryExtraction(
+            conwayWasm,
+            model,
+            limitCSGDepth,
+            maximumCSGDepth)
 
           // parse + extract data model + geometry data
           const startTime = Date.now()

--- a/src/rendering/threejs/simple_viewer_scene.ts
+++ b/src/rendering/threejs/simple_viewer_scene.ts
@@ -145,7 +145,7 @@ const defaultOptions: SimpleViewerSceneOptions = {
 
   toneMapExposure: 0.5,
 
-  limitCSGDepth: false,
+  limitCSGDepth: true,
 
   maxCSGDepth: 20,
 }
@@ -185,7 +185,7 @@ export class SimpleViewerScene {
    * Should we limit the CSG depth? Othwerwise we will only limit the depth
    * of memoization.
    */
-  public limitCSGDepth: boolean = false
+  public limitCSGDepth: boolean = true
 
   /**
    * The limit for CSG recursion depth (or memoization depth).

--- a/src/version/version.ts
+++ b/src/version/version.ts
@@ -1,4 +1,4 @@
-const versionString: string = 'Conway Web-Ifc Shim v0.17.899'
+const versionString: string = 'Conway Web-Ifc Shim v0.17.900'
 
 
 export {versionString}

--- a/src/version/version.ts
+++ b/src/version/version.ts
@@ -1,4 +1,4 @@
-const versionString: string = 'Conway Web-Ifc Shim v0.17.886'
+const versionString: string = 'Conway Web-Ifc Shim v0.17.899'
 
 
 export {versionString}


### PR DESCRIPTION
Changes to allow limiting the CSG recursion depth, including for viewers.

Adds hard limiting of CSG recursion depth, including in viewer components and the ifc command line tool, with a configurable maximum depth (default 20).