### PR TITLE
tsc: set preserveConstEnums to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "bldrs.ai datamodel",
   "author": "bldrs.ai",
   "license": "AGPL-3.0",
-  "version": "0.22.940",
+  "version": "0.22.952",
   "repository": "https://github.com/bldrs-ai/conway",
   "files": [
     "./compiled/**/*"

--- a/src/version/version.ts
+++ b/src/version/version.ts
@@ -1,4 +1,4 @@
-const versionString: string = 'Conway Web-Ifc Shim v0.22.940'
+const versionString: string = 'Conway Web-Ifc Shim v0.22.952'
 
 
 export {versionString}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,7 +63,7 @@
     // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 


### PR DESCRIPTION
I was getting a build problem using esbuild in the bolt-template repo.. the .js output of tsc didn't contain the enum def needed to resolve a type in the viewer.  Enabling this flag in tsconfig looks to fix it and all tests pass, so think this is good to put in no matter.

I'll also push a latest npm and test in other other repo once this is in