### PR TITLE
gha: use custom runner

### DIFF
--- a/.github/workflows/ifc-regression.yml
+++ b/.github/workflows/ifc-regression.yml
@@ -11,8 +11,8 @@ env:
 
 jobs:
   run-ifc-regression:
-    # This job uses your GitHub-managed large runner from the RegressionTesting group.
-    runs-on: RegressionTesting
+    # Use our custom runner
+    runs-on: ubuntu-22.04-8vcpu-32gb-300gbssd
 
     steps:
       # 1. Checkout the conway repository (your main repo)


### PR DESCRIPTION
It looks like conway was using the same runner name as Share but that has probably been broken since I reorganized our Share setup for playwright.  This should get conway regression testing running again.