### PR TITLE
Publish to npm from CI on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,131 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  EMSDK_VERSION: '3.1.72'
+  EMSDK_CACHE_FOLDER: 'cache/emsdk'
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04-8vcpu-32gb-300gbssd
+    steps:
+      # Bail early if NPM_TOKEN hasn't been configured. The publish step at
+      # the end depends on it; failing here surfaces the missing secret
+      # before paying the cost of a full build.
+      - name: Verify NPM_TOKEN is configured
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "::error::NPM_TOKEN repo secret is not set. Add it under Settings → Secrets and variables → Actions, then re-push the tag (or 'Re-run failed jobs' on this run)."
+            exit 1
+          fi
+
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Node with npm registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+
+      - name: Compute conway-geom submodule SHA
+        id: subsha
+        run: echo "sha=$(git -C dependencies/conway-geom rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      # Same WASM cache key as the Build workflow. Tag pushes from main
+      # usually hit a fresh cache populated by the PR's Build job, so the
+      # slow emcc/GENie path is normally skipped.
+      - name: Restore WASM build cache
+        id: wasm-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            dependencies/conway-geom/Dist
+            dependencies/conway-geom/bin/release
+            compiled/dependencies/conway-geom/Dist
+          key: wasm-${{ runner.os }}-emsdk${{ env.EMSDK_VERSION }}-${{ steps.subsha.outputs.sha }}
+
+      - name: Restore GENie cache
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        id: genie-cache
+        uses: actions/cache@v4
+        with:
+          path: bin/linux/genie
+          key: genie-${{ runner.os }}
+
+      - name: Build GENie
+        if: steps.wasm-cache.outputs.cache-hit != 'true' && steps.genie-cache.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 https://github.com/bkaradzic/GENie.git GENie
+          (cd GENie && make)
+          mkdir -p bin/linux
+          cp GENie/bin/linux/genie bin/linux/genie
+
+      - name: Cache Emscripten system libraries
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.EMSDK_CACHE_FOLDER }}
+          key: ${{ env.EMSDK_VERSION }}-${{ runner.os }}
+
+      - name: Install Emscripten
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: ${{ env.EMSDK_VERSION }}
+          actions-cache-folder: ${{ env.EMSDK_CACHE_FOLDER }}
+
+      - name: Export EMSDK paths
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        run: |
+          EMSDK=$(which em++ | sed 's|upstream/emscripten/em++||')
+          EMSCRIPTEN=$(which em++ | sed 's|/em++||')
+          echo "EMSDK=$EMSDK" >> "$GITHUB_ENV"
+          echo "EMSCRIPTEN=$EMSCRIPTEN" >> "$GITHUB_ENV"
+
+      - name: Extract WASM build dependencies
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        run: yarn extract-wasm-dependencies
+
+      # build-GHA-base (not build-GHA-all) - we deliberately skip the
+      # 'yarn bumpMinor' step that build-GHA-all does, because the
+      # published version must match the tag.
+      - name: Build WASM
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        run: yarn run build-GHA-base ConwayGeomWasmNode ConwayGeomWasmNodeMT ConwayGeomWasmWeb ConwayGeomWasmWebMT
+
+      # On cache hit, the WASM step above is skipped and build-gha.sh's
+      # final 'yarn build-incremental' never runs. Catch up here so the
+      # TypeScript output exists for bundle-examples and npm publish.
+      - name: TypeScript build
+        if: steps.wasm-cache.outputs.cache-hit == 'true'
+        run: yarn build-incremental
+
+      - name: Bundle examples
+        run: yarn bundle-examples
+
+      - name: Verify package.json version matches tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME}"
+          if [ "${PKG_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "::error::package.json version (${PKG_VERSION}) does not match pushed tag (${TAG_VERSION})."
+            exit 1
+          fi
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/README.md
+++ b/README.md
@@ -190,23 +190,28 @@ grep '"version"' package.json    # should be 1 ahead of the latest tag on GH
 - Run the performance test suite — see [scripts/README.md](scripts/README.md).
 - Run the regression batch — see [regression/README.md](regression/README.md).
 
-### 2. Publish the release candidate
+### 2. Cut the release candidate
 Run this from a release branch (not directly on `main`):
 ```
 yarn create-release-candidate <major|minor>
 ```
 This bumps `package.json` + `src/version/version.ts`, re-runs
 `build-incremental`, **commits the bump on the current branch**, tags
-that commit, pushes both branch and tag, runs `npm publish --access public`
-(you'll be prompted for npm OTP), and regenerates typedoc. The package is
-published with the default `latest` dist-tag; `stable` is added later
-(step 5).
+that commit, pushes both branch and tag, and regenerates typedoc.
 
-> **Heads up:** the script publishes to npm and pushes the tag *before*
-> the PR in step 3 lands. If the PR is rejected, you'll need to
-> `npm deprecate` (or `npm unpublish` within 72h) the published version,
-> and either delete the pushed tag or move it once a corrected commit
-> lands on `main`.
+The tag push triggers `.github/workflows/publish.yml`, which rebuilds
+WASM + TS, bundles, and runs `npm publish --access public` from CI. The
+package is published with the default `latest` dist-tag; `stable` is
+added later (step 5).
+
+> **Requires:** an `NPM_TOKEN` repo secret (automation token from npmjs).
+> Without it the publish workflow fails loudly on tag push, and you can
+> add the token + re-run the failed job to recover.
+
+> **Heads up:** publish happens via CI *before* the PR in step 3 lands.
+> If the PR is rejected, you'll need to `npm deprecate` (or
+> `npm unpublish` within 72h) the published version, and either delete
+> the pushed tag or move it once a corrected commit lands on `main`.
 
 ### 3. Open the version-bump PR
 The bump commit is already on your release branch. Open a PR from it,

--- a/scripts/create-release-candidate.sh
+++ b/scripts/create-release-candidate.sh
@@ -17,10 +17,6 @@ if [ "$BUMP_TYPE" != "major" ] && [ "$BUMP_TYPE" != "minor" ]; then
     exit 1
 fi
 
-# Login to npmjs, uses OTP
-echo "Login to npmjs"
-npm login
-
 # Extract the current version from package.json
 CURRENT_VERSION=$(node -p "require('./package.json').version")
 IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
@@ -63,16 +59,17 @@ git commit -m "Bump version to $NEW_VERSION"
 echo "Creating git tag $NEW_VERSION..."
 git tag "$NEW_VERSION"
 
-# Push the bump commit on the current branch, then the tag
+# Push the bump commit on the current branch, then the tag. The tag push
+# triggers .github/workflows/publish.yml which builds and runs
+# 'npm publish' from CI. Requires the NPM_TOKEN repo secret to be set;
+# until then the publish workflow will fail loudly on the tag push.
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git push origin "$CURRENT_BRANCH"
 git push origin "$NEW_VERSION"
 
-# Publish to GitHub npm registry
-echo "Publishing to GitHub npm registry..."
-npm publish --access public
-
-# Generate type docs
+# Generate type docs (local artifact)
 yarn typedoc
 
-echo "Release candidate created, tagged (no commit), and published successfully!"
+echo "Release candidate $NEW_VERSION tagged and pushed."
+echo "CI will build and publish to npm on tag push:"
+echo "  https://github.com/bldrs-ai/conway/actions/workflows/publish.yml"


### PR DESCRIPTION
## Summary

Closes #313. Moves `npm publish` out of the local release script into a new tag-triggered CI workflow.

**This PR is stacked on #319** (which contains the CI waterfall). The diff will narrow to just the publish-related changes once #319 merges.

## What changed

### New: `.github/workflows/publish.yml`
- Triggers on push of tags matching `[0-9]+.[0-9]+.[0-9]+`
- Fails fast with a clear message if `NPM_TOKEN` repo secret isn't set
- Reuses the same WASM cache key as Build/Regression → the emcc/GENie path is skipped on the typical post-PR-merge tag push
- Uses `build-GHA-base` (not `build-GHA-all`) to avoid the `yarn bumpMinor` side effect — the published version must match the pushed tag
- Sanity-checks `package.json` version equals the tag before publishing
- `npm publish --access public` with `NODE_AUTH_TOKEN` from the secret

### Modified: `scripts/create-release-candidate.sh`
- Drops the interactive `npm login` (no longer needed; CI uses the automation token)
- Drops the local `npm publish` (delegated to CI on tag push)
- Keeps everything else (version bump, commit, tag, push branch+tag, typedoc)

### Modified: `README.md`
- Release "Cut the release candidate" section updated to reflect the new flow
- Notes the `NPM_TOKEN` setup requirement

## Before merge / before next release

Add the `NPM_TOKEN` repo secret:
1. Create an npm automation token (https://www.npmjs.com/settings/`<user>`/tokens — "Automation" type so it bypasses 2FA)
2. `Settings → Secrets and variables → Actions → New repository secret`, name `NPM_TOKEN`, paste token

Without `NPM_TOKEN`, the publish workflow on tag push fails on the very first step with a clear error pointing to the secret name — no half-publish state, you just add the token and re-run the failed job.

## Test plan

- [x] CI green on this PR (build + regression succeed; publish workflow doesn't run on PR events)
- [ ] After merge, the next `yarn create-release-candidate <bump>` exits cleanly without prompting for npm login or running `npm publish` locally
- [ ] On the tag push from that release, `publish.yml` runs and either:
  - Publishes (if `NPM_TOKEN` is set), or
  - Fails on the verification step with the "add NPM_TOKEN" message

## Stacking note

This branch is based on `claude/ci-waterfall` (PR #319). If #319 merges first, this PR's diff cleans up automatically to just the publish-specific changes. If this merges first, the waterfall changes from #319 ride along.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vfq9tqhzt69N3D4821uPCq)_