### PR TITLE
Switch auto-publish to npm Trusted Publishing (OIDC); publish-before-tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,28 +284,25 @@ jobs:
             (look for the artifact named **${{ steps.npm_pack.outputs.package_tgz }}**).
 
   # ---------------------------------------------------------------------------
-  # Continuous release: on every successful push to main, tag the commit with
-  # the next version and publish to npm. Version is `major.minor` (from
-  # package.json) joined with `git rev-list HEAD --count + 1` for patch. So
-  # every green merge ships a unique patch to @latest; manual major/minor
-  # bumps happen via a PR that edits package.json's version field.
+  # Continuous release: on every successful push to main, publish to npm and
+  # tag the commit. Version is <major>.<PR>.<commit>:
+  #   major  - first segment of package.json's version (manual bump)
+  #   PR     - PR number parsed from the merge commit message (#N)
+  #   commit - 'git rev-list HEAD --count' at the merge commit
+  # So every green merge ships a uniquely-traceable patch to @latest.
+  #
+  # Auth: npm Trusted Publishing via GitHub OIDC. The trusted publisher must
+  # be configured on npmjs.com (Package → Settings → Trusted Publisher) and
+  # bound to repo+workflow. No NPM_TOKEN secret needed.
   # ---------------------------------------------------------------------------
   auto-publish:
     needs: [build, run-ifc-regression]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04-8vcpu-32gb-300gbssd
     permissions:
-      contents: write
+      contents: write    # tag push
+      id-token: write    # OIDC token for npm Trusted Publishing
     steps:
-      - name: Verify NPM_TOKEN is configured
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "${NPM_TOKEN}" ]; then
-            echo "::error::NPM_TOKEN repo secret is not set. Add it under Settings → Secrets and variables → Actions, then re-run this job."
-            exit 1
-          fi
-
       - name: Checkout (full history for rev-list)
         uses: actions/checkout@v4
         with:
@@ -318,6 +315,11 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
+
+      # Trusted Publishing requires npm >= 11.5.1. Node 20 ships with npm 10.x,
+      # so upgrade the global npm binary before the publish step.
+      - name: Upgrade npm to a version that supports OIDC
+        run: npm install -g npm@latest
 
       - name: Compute next version
         id: ver
@@ -376,16 +378,21 @@ jobs:
       - name: Bundle examples
         run: yarn bundle-examples
 
+      # Publish BEFORE tagging. If publish fails, no stranded tag.
+      # npm CLI 11.5.1+ picks up the OIDC token from GHA automatically.
+      - name: Publish to npm
+        run: npm publish --access public
+
+      # Idempotent tag: skip if already on origin (e.g. on a re-run).
       - name: Create and push tag
         env:
           NEW_VERSION: ${{ steps.ver.outputs.version }}
         run: |
+          if git ls-remote --tags origin "$NEW_VERSION" | grep -q "refs/tags/$NEW_VERSION$"; then
+            echo "Tag $NEW_VERSION already exists on origin; skipping."
+            exit 0
+          fi
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git tag -a "$NEW_VERSION" -m "Auto-release $NEW_VERSION"
           git push origin "$NEW_VERSION"
-
-      - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public

--- a/README.md
+++ b/README.md
@@ -195,12 +195,13 @@ The auto-publish job lives in `.github/workflows/build.yml` and runs as
 `needs: [build, run-ifc-regression]` on `push: branches: [main]`. It
 parses the PR number from the merge commit message, stamps the
 computed version into `package.json` + `src/version/version.ts` in
-CI's working tree (not committed back), rebuilds, tags the merge
-commit, and runs `npm publish`.
+CI's working tree (not committed back), rebuilds, publishes to npm,
+and then tags the merge commit.
 
-**Requires:** an `NPM_TOKEN` repo secret (automation token from npmjs).
-Without it the auto-publish job fails on its first step with a clear
-error.
+**Auth:** npm Trusted Publishing via GitHub OIDC. A Trusted Publisher
+configured at npmjs.com on `@bldrs-ai/conway` is bound to this repo +
+`build.yml`. No long-lived `NPM_TOKEN` secret is used; the workflow
+gets a short-lived publish token per run via OIDC.
 
 ### Normal flow: ship a change
 


### PR DESCRIPTION
## Summary

Replaces the `NPM_TOKEN`-based auth with **npm Trusted Publishing** (OIDC) and fixes the publish-before-tag ordering so a publish failure can't strand a tag like `1.321.1025` did yesterday.

**Pre-merge requirement:** the Trusted Publisher on `@bldrs-ai/conway` at npmjs.com must already be configured (per offline message: ✅ done) and bound to:
- Repository: `bldrs-ai/conway`
- Workflow filename: `build.yml`

## Why Trusted Publishing

| | NPM_TOKEN | Trusted Publishing |
|---|---|---|
| Auth | Long-lived secret | Short-lived OIDC token per run |
| Rotation | Manual, easy to forget | None — minted per publish |
| 2FA interaction | Only Automation tokens bypass; we hit this | Bypassed by design |
| Compromise blast radius | Token leak ⇒ unlimited publishes | Limited to one workflow run |

Yesterday's `EOTP` failure was caused by the token being type "Publish" (requires OTP) instead of "Automation". Trusted Publishing removes that whole class of mistake.

## Workflow changes

### Removed
- `Verify NPM_TOKEN is configured` step
- `NODE_AUTH_TOKEN` env on the publish step
- `secrets.NPM_TOKEN` references

### Added
- `permissions: id-token: write` on the `auto-publish` job (for OIDC)
- `npm install -g npm@latest` step — Node 20's bundled npm 10.x doesn't support OIDC; Trusted Publishing needs npm >= 11.5.1

### Reordered + hardened (fixes the stranded-tag bug)
- `Publish to npm` now runs **before** `Create and push tag`. A publish failure no longer leaves an orphan tag.
- Tag step is idempotent: if the tag is already on origin (e.g. on a "Re-run failed jobs"), it logs and exits 0 instead of failing with "tag already exists".

## Recovery for `1.321.1025`

The tag exists on git but the version was never published to npm. After this PR merges, the next auto-publish runs with the fixed workflow and ships a fresh version (something like `1.<this_PR_num>.<rev_count>`). The stranded `1.321.1025` tag can be left as a no-op marker, or you can delete it:

```
git push origin :refs/tags/1.321.1025
```

I'm leaving that as your call — deleting tags is shared-state destructive so I'd rather you confirm.

## Test plan

- [ ] CI green on this PR (build + regression succeed; auto-publish skipped as designed)
- [ ] On merge, the main-push run does:
  1. `build` ✅
  2. `run-ifc-regression` ✅
  3. `auto-publish`:
     - `npm install -g npm@latest` succeeds
     - `npm publish` succeeds **without an NPM_TOKEN** (OIDC kicks in)
     - Tag is pushed AFTER successful publish
- [ ] `npm view @bldrs-ai/conway dist-tags.latest` shows the new `1.<PR>.<commit>` version
- [ ] If publish were to fail for some unforeseen reason, no orphan tag is left behind

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vfq9tqhzt69N3D4821uPCq)_