### PR TITLE
Add performance benchmarking to IFC regression batch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,11 +182,16 @@ jobs:
         run: |
           git clone --depth 1 --branch ${{ env.TEST_MODELS_TAG }} https://github.com/bldrs-ai/test-models.git test-models
 
+      # Perf CSV lands OUTSIDE the diffed test_models folder so machine-specific
+      # timings don't show up as "changes" against test-models's checked-in
+      # baselines. The aggregate is uploaded as a workflow artifact below and
+      # summarised in the PR comment.
       - name: Run IFC Regression Batch Script
         run: |
           node --experimental-specifier-resolution=node ./compiled/src/ifc/ifc_regression_batch_main.js \
             -e "sp-.*\.ifc" \
             -t ${{ env.TEST_MODELS_TAG }} \
+            --perf "${GITHUB_WORKSPACE}/perf.csv" \
             test-models \
             test-models/regression/test_models \
             --parallel --mem-utilization 90
@@ -250,6 +255,39 @@ jobs:
           echo "$ERRORS_OUTPUT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+          # Summarise the top-10 slowest models from the perf CSV. The full
+          # CSV is uploaded as an artifact for finer inspection.
+          PERF_CSV="${GITHUB_WORKSPACE}/perf.csv"
+          if [ -f "$PERF_CSV" ]; then
+            PERF_OUTPUT=$(python - "$PERF_CSV" <<'EOF'
+          import csv, sys
+          with open(sys.argv[1], newline='') as f:
+              rows = list(csv.DictReader(f))
+          if not rows:
+              print("perf.csv is empty.")
+          else:
+              top_n = 10
+              def total(r):
+                  try: return int(r.get('totalTimeMs','0') or 0)
+                  except ValueError: return 0
+              rows.sort(key=total, reverse=True)
+              header = ['file','status','parseTimeMs','geometryTimeMs','totalTimeMs','rssMb','heapUsedMb']
+              print("| " + " | ".join(header) + " |")
+              print("|" + " --- |" * len(header))
+              for r in rows[:top_n]:
+                  print("| " + " | ".join(r.get(h,'') for h in header) + " |")
+              print("")
+              print(f"_Showing top {min(top_n,len(rows))} of {len(rows)} models by totalTimeMs. Full CSV in the run artifacts._")
+          EOF
+          )
+          else
+            PERF_OUTPUT="perf.csv not produced."
+          fi
+
+          echo "perf_output<<EOF" >> $GITHUB_OUTPUT
+          echo "$PERF_OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Create NPM Package
         id: npm_pack
         run: |
@@ -262,6 +300,13 @@ jobs:
         with:
           name: ${{ steps.npm_pack.outputs.package_tgz }}
           path: ${{ steps.npm_pack.outputs.package_tgz }}
+
+      - name: Upload perf.csv artifact
+        if: ${{ hashFiles('perf.csv') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-${{ github.run_id }}
+          path: perf.csv
 
       - name: Comment on Pull Request with Regression Results and NPM Package Artifact
         if: ${{ github.event_name == 'pull_request' }}
@@ -277,6 +322,9 @@ jobs:
 
             **Errors.csv:**
             ${{ steps.regression_results.outputs.errors_output }}
+
+            **Performance (top 10 by totalTimeMs):**
+            ${{ steps.regression_results.outputs.perf_output }}
 
             **NPM Package Artifact:**
             The package **${{ steps.npm_pack.outputs.package_tgz }}** was generated.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Every PR is gated on two checks defined in `.github/workflows/build.yml`:
 | Job | What it does |
 |---|---|
 | `build` | `yarn install`, WASM + TS compile (WASM cached on the `conway-geom` submodule SHA), `yarn test`, `yarn lint`. |
-| `run-ifc-regression` | `needs: build`. Reuses the same WASM cache. Runs the regression batch against the pinned `test-models` tag, posts a per-PR comment with `failed.csv` / `errors.csv` summaries, and uploads the candidate npm tarball as a workflow artifact. |
+| `run-ifc-regression` | `needs: build`. Reuses the same WASM cache. Runs the regression batch against the pinned `test-models` tag, posts a per-PR comment with `failed.csv` / `errors.csv` / perf summaries, and uploads the candidate npm tarball + `perf.csv` as workflow artifacts. |
 
 A merge to `main` re-runs those two jobs and then chains into `auto-publish` (see [Releases](#releases) below).
 
@@ -186,9 +186,11 @@ A merge to `main` re-runs those two jobs and then chains into `auto-publish` (se
 
 The same batch the regression CI job runs can be invoked locally — see [regression/README.md](regression/README.md) for digest / verbose / batch modes and the catalog of model fixtures. The CI pinned tag is `TEST_MODELS_TAG` near the top of `build.yml`.
 
-## Performance benchmarks (local only today)
+## Performance benchmarks
 
-Perf isn't wired into CI yet. The current flow is a local `scripts/performance_test.sh` against a checkout of [headless-three](https://github.com/bldrs-ai/headless-three) cross-linked via `yarn link` against the working tree; see [scripts/README.md](scripts/README.md). Wiring perf into CI is tracked in #314 — see [Roadmap](#roadmap).
+**Tier 1 — Conway-only perf in CI (live).** Every regression run emits a `perf.csv` of `parseTimeMs / geometryTimeMs / totalTimeMs / rssMb / heapUsedMb / heapTotalMb` per model. The top-10 slowest are posted in the PR comment; the full CSV is uploaded as a workflow artifact. This piggybacks on the existing regression batch so cost is ~0 extra runner minutes.
+
+**Tier 2 — full headless-three perf (planned, #314).** A `perf-three` job on `push: main` that runs `scripts/benchmark.cjs` against a clone of [headless-three](https://github.com/bldrs-ai/headless-three), installing the candidate Conway tarball as H3's `@bldrs-ai/conway` dep. Captures PNG renders + per-model timings via H3's rendering server, including a parallel job for `test-models-private`. Tracked in #314.
 
 
 # Releases
@@ -278,27 +280,23 @@ follow-ups to deepen its coverage. Big items first.
 
 ### #314 — Performance benchmarks in CI
 
-Today perf only runs locally before a major release, against a
-[headless-three](https://github.com/bldrs-ai/headless-three) checkout
-cross-linked via `yarn link`. That makes perf regressions easy to miss
-and impossible to gate merges on.
+**Tier 1 — Conway-only perf (done):** the regression batch now emits a
+per-model `perf.csv` (parse/geometry/total time + RSS/heap MB),
+piggybacking on the existing run so there's no extra runner cost. Top-10
+slowest models appear in each PR comment; the full CSV uploads as an
+artifact. See "Performance benchmarks" above.
 
-Wiring perf into CI as a third job (`needs: build`, parallel to
-`run-ifc-regression`) is the biggest open improvement. The blocker is
-deciding how to host the H3 dependency in the runner — three
-candidates:
-
-- **Vendor H3 as a submodule** of conway. Tight coupling but simplest
-  build chain.
-- **Pre-built H3 container image** that the perf job pulls. Looser
-  coupling, slower runner startup, more infra.
-- **A Conway-only perf harness** that bypasses H3 entirely — measure
-  parse + geometry timings directly off the CLI. Less faithful to the
-  Share end-to-end picture but the easiest to land.
-
-Once perf runs in CI, the comment posted on each PR should include a
-delta vs. main so regressions show up alongside the regression-batch
-results.
+**Tier 2 — full headless-three perf (next):** an end-to-end render-and-time
+job that runs `scripts/benchmark.cjs` against a clone of
+[headless-three](https://github.com/bldrs-ai/headless-three). To avoid the
+local `yarn link` toolchain, the job installs the candidate Conway tarball
+(produced by `run-ifc-regression`) as H3's `@bldrs-ai/conway` dep and pins
+`H3_TAG` in `build.yml`. Gated to `push: main` to keep PR runtime down
+while still exercising every release. A sibling job runs against
+`test-models-private` using `secrets.TEST_MODELS_PRIVATE_TOKEN`, never on
+PR events (so forks can't leak the secret), and uploads results as
+org-scoped artifacts. Delta vs. the previous release lands in the
+auto-publish summary.
 
 ### #315 — Bump pinned `TEST_MODELS_TAG`
 

--- a/regression/README.md
+++ b/regression/README.md
@@ -41,6 +41,7 @@ Here are the options:
  2. Dry run mode (_--dryrun_ or _-d_)
  3. Set the changes file output path (_--changes_ or _-c_ &lt;file path without csv extension&gt;)
  4. Exclusion regex filter that filters out files from being processed (_--exclude_ or _-e_ &lt;regex&gt;).
+ 5. Aggregate performance CSV output (_--perf_ &lt;output path&gt;). Each model emits a one-row `parseTimeMs / geometryTimeMs / totalTimeMs / rssMb / heapUsedMb / heapTotalMb` row; the batch sorts by file name and writes them all to this path. Disabled when unset. The output path should live outside the regression folder so machine-specific timings don't get picked up by the git-diff step.
 
 Assuming you have the test models repository checked out in the cloned in the same parent folder as the conway repository, here would be an example of how to run regression on an the repo, putting the regression baselines in the correct place, as well as creating a custom change file, for a release. This assumes there is a tag (conway-0.1.596) in this case for the release, and that there is a new release for history that will be 0.2.597.
 

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -190,6 +190,64 @@ async function runDiff(
   }
 }
 
+/**
+ * Aggregate all per-file `*.perf.csv` rows in perfDir into a single CSV at
+ * outputCsvPath, sorted by file name. Files are written by individual child
+ * regression runs (one row + one header per file); we keep the header from
+ * the first file we read and concatenate the data rows from the rest. The
+ * input directory is removed afterwards.
+ *
+ * @param perfDir Directory the children wrote their per-file perf CSVs to.
+ * @param outputCsvPath Aggregate perf CSV destination.
+ */
+async function aggregatePerfCsvs(
+    perfDir: string,
+    outputCsvPath: string,
+): Promise<void> {
+
+  const entries = await fsPromises.readdir( perfDir, { withFileTypes: true } )
+  const perfFiles = entries
+      .filter( ( d ) => d.isFile() && d.name.endsWith( '.perf.csv' ) )
+      .map( ( d ) => path.join( perfDir, d.name ) )
+
+  if ( perfFiles.length === 0 ) {
+    console.warn( `No per-file perf CSVs found in ${perfDir}; skipping aggregate.` )
+    return
+  }
+
+  type PerfRow = { file: string; line: string }
+  const rows: PerfRow[] = []
+  let header: string | undefined
+
+  for ( const perfFile of perfFiles ) {
+
+    const contents = await fsPromises.readFile( perfFile, 'utf8' )
+    const lines = contents.split( /\r?\n/ ).filter( ( l ) => l.length > 0 )
+
+    if ( lines.length < 2 ) {
+      continue
+    }
+
+    if ( header === undefined ) {
+      header = lines[ 0 ]
+    }
+
+    // Each per-file CSV has exactly one data row (lines[1]); the first column
+    // is the file name which we use for stable sorting.
+    const dataLine = lines[ 1 ]
+    const firstComma = dataLine.indexOf( ',' )
+    const fileKey = firstComma >= 0 ? dataLine.slice( 0, firstComma ) : dataLine
+    rows.push( { file: fileKey, line: dataLine } )
+  }
+
+  rows.sort( ( a, b ) => a.file.localeCompare( b.file ) )
+
+  const body = rows.map( ( r ) => r.line ).join( '\n' )
+  await fsPromises.writeFile( outputCsvPath, `${header}\n${body}\n` )
+
+  console.log( `Wrote aggregate perf CSV: ${outputCsvPath} (${rows.length} rows)` )
+}
+
 let totalTime = 0 // To keep track of the running total time
 
 /**
@@ -198,14 +256,16 @@ let totalTime = 0 // To keep track of the running total time
  * @param filePath
  * @param outputPath
  * @param maxTimeout
+ * @param perfPath Optional path the child should write a one-row perf CSV to.
  */
 async function runForFile(filePath: string,
-    outputPath: string, maxTimeout:number): Promise<RunResults> {
+    outputPath: string, maxTimeout:number, perfPath?: string): Promise<RunResults> {
   const MAX_TIMEOUT_MS = maxTimeout
   const startTime = Date.now() // Start time
 
-   
-  const safeExecCommand = `node --experimental-specifier-resolution=node ./compiled/src/ifc/ifc_regression_main.js -d "${filePath}" "${outputPath}"`
+  const perfFlag = perfPath ? ` --perf "${perfPath}"` : ''
+
+  const safeExecCommand = `node --experimental-specifier-resolution=node ./compiled/src/ifc/ifc_regression_main.js -d${perfFlag} "${filePath}" "${outputPath}"`
 
   console.log(`Current File: ${filePath}`)
 
@@ -322,6 +382,7 @@ function getSystemMemoryUsagePercent(): number {
  * @param failedLines
  * @param memUtilization
  * @param maxTimeout
+ * @param perfDir If set, the child writes its perf CSV here as <basename>.perf.csv.
  */
 async function processIFCFilesInParallel(
     ifcFiles: string[],
@@ -331,6 +392,7 @@ async function processIFCFilesInParallel(
     failedLines: string[],
     memUtilization: number,
     maxTimeout:number,
+    perfDir?: string,
 ): Promise<void> {
   const concurrencyLimit = os.cpus().length
   console.log(`Concurrency: ${concurrencyLimit} threads - Max Timeout: ${maxTimeout} ms`)
@@ -352,10 +414,14 @@ async function processIFCFilesInParallel(
       console.log(
           `Starting task for "${path.basename(ifcPath)}". Active tasks: ${activeTasks}`,
       )
+      const perfChildPath = perfDir ?
+        path.join(perfDir, `${path.basename(ifcPath, '.ifc')}.perf.csv`) :
+        undefined
       const fileResults = await runForFile(
           ifcPath,
           path.join(outputPath, path.basename(ifcPath, '.ifc')),
           maxTimeout,
+          perfChildPath,
       )
 
       activeTasks--
@@ -402,6 +468,7 @@ async function processIFCFilesInParallel(
  * @param fileLines
  * @param failedLines
  * @param maxTimeout
+ * @param perfDir If set, the child writes its perf CSV here as <basename>.perf.csv.
  */
 async function recursiveWalk(
     parentPath: string,
@@ -411,6 +478,7 @@ async function recursiveWalk(
     fileLines: string[],
     failedLines: string[],
     maxTimeout: number,
+    perfDir?: string,
 ) {
   const items = await fsPromises.readdir(parentPath, { withFileTypes: true })
   items.sort((a, b) => (a.name > b.name ? 1 : -1))
@@ -424,12 +492,16 @@ async function recursiveWalk(
 
     if (item.isDirectory()) {
       await recursiveWalk(resolved, excludeRegex, outputPath,
-          errorLines, fileLines, failedLines, maxTimeout)
+          errorLines, fileLines, failedLines, maxTimeout, perfDir)
     } else if (path.extname(resolved).toLowerCase() === '.ifc') {
+      const perfChildPath = perfDir ?
+        path.join(perfDir, `${path.basename(resolved, '.ifc')}.perf.csv`) :
+        undefined
       const fileResults = await runForFile(
           resolved,
           path.join(outputPath, path.basename(resolved, '.ifc')),
           maxTimeout,
+          perfChildPath,
       )
 
       if (fileResults.type === 'Run') {
@@ -520,6 +592,16 @@ const args = yargs(process.argv.slice(SKIP_PARAMS))
             default: 150000,
           })
 
+          yargs2.option('perf', {
+
+            describe:
+              'Output path for aggregate perf CSV. Each child writes a one-row ' +
+              '<basename>.perf.csv to a temp dir; on completion they are merged ' +
+              'into this file, sorted by file name. Disabled when unset.',
+            type: 'string',
+            default: '',
+          })
+
           yargs2.positional('model_folder', {
             describe: 'Folder containing IFC files, recursively walked',
             type: 'string',
@@ -542,12 +624,25 @@ const args = yargs(process.argv.slice(SKIP_PARAMS))
           const doParallel = (argv['parallel'] as boolean) ?? false // <--- read the parallel flag
           const memUtilization = (argv['mem-utilization'] as number)
           const maxTimeout = (argv['timeout'] as number)
+          const perfOutputPath = ((argv['perf'] as string) ?? '').trim()
 
           if (changes.length === 0) {
             changes = path.join(outputPath, 'changes')
           }
 
           await fsPromises.mkdir(outputPath, { recursive: true })
+
+          // When perf is requested, children write their one-row CSVs into a
+          // throwaway temp dir; we aggregate and clean up afterwards. Keeping
+          // them out of outputPath avoids the runDiff step picking up
+          // machine-specific timings as "changes" against the test-models
+          // checked-in baselines.
+          let perfTmpDir: string | undefined
+          if (perfOutputPath.length > 0) {
+            perfTmpDir = await fsPromises.mkdtemp(
+                path.join(os.tmpdir(), 'conway-perf-'),
+            )
+          }
 
           const mainPath = path.join(outputPath, 'main.csv')
           const errorPath = path.join(outputPath, 'errors.csv')
@@ -573,17 +668,32 @@ const args = yargs(process.argv.slice(SKIP_PARAMS))
                 failedLines,
                 memUtilization,
                 maxTimeout,
+                perfTmpDir,
             )
           } else {
             console.log('Processing in serial mode...')
-             
-            await recursiveWalk(ifcFolder, excludeRegex, outputPath, errorLines, fileLines, failedLines, maxTimeout)
+
+            await recursiveWalk(ifcFolder, excludeRegex, outputPath,
+                errorLines, fileLines, failedLines, maxTimeout, perfTmpDir)
           }
 
           // Write out results
           await fsPromises.writeFile(mainPath, `file,hash,errors\n${  fileLines.join('')}`)
           await fsPromises.writeFile(errorPath, `${errorCSVHeader}\n${  errorLines.join('')}`)
           await fsPromises.writeFile(failedPath, `file,code,signal\n${  failedLines.join('')}`)
+
+          // Aggregate per-child perf rows (if requested) before runDiff so the
+          // run completes deterministically even when the git diff step is
+          // skipped or fails.
+          if (perfTmpDir) {
+            try {
+              await aggregatePerfCsvs(perfTmpDir, perfOutputPath)
+            } catch (e) {
+              console.error('Failed to aggregate perf CSVs:', e)
+            } finally {
+              await fsPromises.rm(perfTmpDir, { recursive: true, force: true })
+            }
+          }
 
           // If user wants a git diff
           await runDiff(ifcFolder, outputPath, target, changes, dryRun)

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -242,6 +242,17 @@ async function aggregatePerfCsvs(
 
   rows.sort( ( a, b ) => a.file.localeCompare( b.file ) )
 
+  // Defensive: if every child wrote a malformed CSV (lines.length < 2 for all),
+  // header stays undefined and rows stays empty. Bail rather than write the
+  // literal "undefined" as a CSV header.
+  if ( rows.length === 0 || header === undefined ) {
+    console.warn(
+        `No usable perf rows in ${perfDir} (${perfFiles.length} file(s) checked); ` +
+        `skipping aggregate write.`,
+    )
+    return
+  }
+
   const body = rows.map( ( r ) => r.line ).join( '\n' )
   await fsPromises.writeFile( outputCsvPath, `${header}\n${body}\n` )
 

--- a/src/ifc/ifc_regression_main.ts
+++ b/src/ifc/ifc_regression_main.ts
@@ -60,6 +60,12 @@ const PERF_MB_PRECISION = 2
  * taken at call time; for the OK path this is right after geometry extraction
  * — close to peak. No-op when perfPath is empty.
  *
+ * Memory semantics: `rssMb` includes the conway-geom WASM heap (mmap'd into
+ * the process) and is the load-bearing memory metric for geometry work.
+ * `heapUsedMb` / `heapTotalMb` are V8-only — useful for tracking JS-side
+ * allocation pressure but they exclude WASM-side buffers. Expect a large
+ * gap between rss and heap on geometry-heavy models.
+ *
  * @param perfPath Path to write the CSV to. Empty string disables.
  * @param ifcFile Source IFC file path (basename used as the row key).
  * @param status OK or FAIL.

--- a/src/ifc/ifc_regression_main.ts
+++ b/src/ifc/ifc_regression_main.ts
@@ -47,6 +47,60 @@ function csvSafeString( from: string ): string {
   return from
 }
 
+// Bytes per megabyte for memory-stat formatting in the perf CSV.
+// eslint-disable-next-line no-magic-numbers
+const BYTES_PER_MB = 1024 * 1024
+
+// Fixed-point precision for perf MB values.
+// eslint-disable-next-line no-magic-numbers
+const PERF_MB_PRECISION = 2
+
+/**
+ * Write a single-row per-file perf CSV at the given path. Memory snapshot is
+ * taken at call time; for the OK path this is right after geometry extraction
+ * — close to peak. No-op when perfPath is empty.
+ *
+ * @param perfPath Path to write the CSV to. Empty string disables.
+ * @param ifcFile Source IFC file path (basename used as the row key).
+ * @param status OK or FAIL.
+ * @param parseTimeMs Parse stage duration in ms.
+ * @param geometryTimeMs Geometry extraction duration in ms.
+ * @param totalTimeMs Sum of parse + geometry in ms.
+ */
+async function writePerfCsvIfRequested(
+    perfPath: string,
+    ifcFile: string,
+    status: 'OK' | 'FAIL',
+    parseTimeMs: number,
+    geometryTimeMs: number,
+    totalTimeMs: number,
+): Promise<void> {
+
+  if ( perfPath.length === 0 ) {
+    return
+  }
+
+  const mem = process.memoryUsage()
+  const rssMb = ( mem.rss / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
+  const heapUsedMb = ( mem.heapUsed / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
+  const heapTotalMb = ( mem.heapTotal / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
+
+  const fileName = csvSafeString( path.basename( ifcFile ) )
+
+  const header =
+    'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,rssMb,heapUsedMb,heapTotalMb\n'
+  const row =
+    `${fileName},${status},${parseTimeMs},${geometryTimeMs},${totalTimeMs},` +
+    `${rssMb},${heapUsedMb},${heapTotalMb}\n`
+
+  try {
+    await fsPromises.writeFile( perfPath, header + row )
+  } catch ( e ) {
+    // Perf is best-effort; never fail the regression run because of a perf write.
+    console.error( `Failed to write perf CSV at ${perfPath}:`, e )
+  }
+}
+
 /**
  * Display errors and dump errors errors to stderr
  *
@@ -123,6 +177,14 @@ function doWork() {
             alias: 'v',
             default: false,
           })
+          yargs2.option('perf', {
+
+            describe:
+              'Write a single-row perf CSV (parse/geometry/total time + memory) at this path',
+            type: 'string',
+            alias: 'p',
+            default: '',
+          })
 
           yargs2.positional('filename', { describe: 'IFC File Paths', type: 'string' })
           yargs2.positional('output', { describe: 'Output path', type: 'string' })
@@ -138,6 +200,7 @@ function doWork() {
           const strict = (argv['strict'] as boolean | undefined) ?? false
           const digest = (argv['digest'] as boolean | undefined) ?? false
           const verbose = (argv['verbose'] as boolean | undefined) ?? false
+          const perfPath = (argv['perf'] as string | undefined) ?? ''
 
           try {
             indexIfcBuffer = fs.readFileSync(ifcFile)
@@ -157,6 +220,8 @@ function doWork() {
 
           const parser = IfcStepParser.Instance
           const bufferInput = new ParsingBuffer(indexIfcBuffer)
+
+          const parseStartMs = Date.now()
 
           const result0 = parser.parseHeader(bufferInput)[ 1 ]
 
@@ -218,13 +283,26 @@ function doWork() {
             default:
           }
 
+          const parseEndMs = Date.now()
+          const parseTimeMs = parseEndMs - parseStartMs
+
           if (model === void 0) {
+            await writePerfCsvIfRequested(
+                perfPath, ifcFile, 'FAIL', parseTimeMs, 0, parseTimeMs)
             return
           }
 
           model.nullOnErrors = !strict
 
+          const geomStartMs = Date.now()
           const result = await geometryExtraction(model)
+          const geomEndMs = Date.now()
+          const geometryTimeMs = geomEndMs - geomStartMs
+          const totalTimeMs = geomEndMs - parseStartMs
+
+          const perfStatus = result === void 0 ? 'FAIL' : 'OK'
+          await writePerfCsvIfRequested(
+              perfPath, ifcFile, perfStatus, parseTimeMs, geometryTimeMs, totalTimeMs)
 
           if ( result === void 0 ) {
             Logger.error( 'Couldn\'t extract geometry')


### PR DESCRIPTION
## Summary
This PR adds performance benchmarking capabilities to the IFC regression batch pipeline. Each child regression run now captures parse time, geometry extraction time, memory usage, and other metrics in a per-file CSV. These are aggregated into a single output file and summarized in PR comments.

## Key Changes

**Core Performance Tracking:**
- Added `writePerfCsvIfRequested()` in `ifc_regression_main.ts` to capture per-file metrics (parse/geometry/total time in ms, RSS/heap memory in MB) after processing each IFC file
- Added `--perf` CLI flag to `ifc_regression_main.ts` to specify where individual perf CSVs should be written
- Instrumented the parse and geometry extraction stages with timing measurements

**Batch Aggregation:**
- Added `aggregatePerfCsvs()` function in `ifc_regression_batch_main.ts` to merge per-file perf CSVs from child processes into a single sorted output file
- Added `--perf` CLI flag to `ifc_regression_batch_main.js` to specify the aggregate perf CSV output path
- Modified `runForFile()`, `processIFCFilesInParallel()`, and `recursiveWalk()` to pass perf paths to child processes
- Uses a temporary directory for per-child CSVs (kept outside the diffed test-models folder to avoid false "changes" in git diff)

**CI Integration:**
- Updated `.github/workflows/build.yml` to:
  - Pass `--perf` flag to the regression batch
  - Parse the perf CSV and extract top-10 slowest models
  - Display performance summary in PR comments as a markdown table
  - Upload full `perf.csv` as a workflow artifact
- Updated documentation in `README.md` to describe the new Tier 1 Conway-only perf benchmarking

## Implementation Details

- Perf CSV writing is best-effort; failures don't fail the regression run
- Per-file CSVs are sorted by filename for deterministic output
- Memory snapshots are taken after geometry extraction (close to peak usage)
- The aggregate CSV includes file name, status (OK/FAIL), timing metrics, and memory stats
- Top-10 slowest models are extracted via Python script in the CI workflow for PR visibility

https://claude.ai/code/session_01PbGRPPVnyQoEqandpSTZh1