### PR TITLE
fix(compat): stop AP214 web-ifc proxy collapsing instanced placements to origin (#308)

### DIFF
--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -685,19 +685,6 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
           nativePt = geometry.geometry.getPoint(0)
         }
 
-        // extract center
-        const geomCenter: glmatrix.vec3 = glmatrix.vec3.create()
-        const center = geometry.geometry.normalize()
-
-
-        geomCenter[0] = center.x
-        geomCenter[1] = center.y
-        geomCenter[2] = center.z
-
-        // Create a translation matrix from geom.min
-        const translationMatrixGeomMin: glmatrix.mat4 = glmatrix.mat4.create()
-        glmatrix.mat4.fromTranslation(translationMatrixGeomMin, geomCenter)
-
         // create PlacedGeometry
         const expressID = model.getElementByLocalID(geometry.localID)?.expressID as number
 
@@ -775,13 +762,19 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
         // Scale the matrix
         glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
 
-        // Perform the matrix multiplications
+        // Compose the world transform from the engine's scene transform
+        // (newMatrix = nativeTransform). Geometry vertices stay in their
+        // source-unit local space; nativeTransform maps them to metre world
+        // space — the same bare composition the native consumer
+        // geometry_aggregator uses. The per-leaf geometry.normalize() recenter
+        // was removed: AP214 instances/mapped-items share one geometry buffer,
+        // so normalize() mutated it once and later instances lost their offset
+        // and collapsed toward the origin (issue #308 "port cluster"). The
+        // global coordinationMatrix still carries Y-up + COORDINATE_TO_ORIGIN.
         if (newMatrix !== void 0) {
           glmatrix.mat4.multiply(newTransform, coordinationMatrix, newMatrix)
-          glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
         } else {
-          glmatrix.mat4.multiply(newTransform, coordinationMatrix, newTransform)
-          glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
+          glmatrix.mat4.copy(newTransform, coordinationMatrix)
         }
         const newTransformArr = Array.from(newTransform)
         geometryMaterialTransformMap.set(expressID,
@@ -920,19 +913,6 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
           nativePt = geometry.geometry.getPoint(0)
         }
 
-        // extract center
-        const geomCenter: glmatrix.vec3 = glmatrix.vec3.create()
-        const center = geometry.geometry.normalize()
-
-
-        geomCenter[0] = center.x
-        geomCenter[1] = center.y
-        geomCenter[2] = center.z
-
-        // Create a translation matrix from geom.min
-        const translationMatrixGeomMin: glmatrix.mat4 = glmatrix.mat4.create()
-        glmatrix.mat4.fromTranslation(translationMatrixGeomMin, geomCenter)
-
         // create PlacedGeometry
         const expressID = model.getElementByLocalID(geometry.localID)?.expressID as number
 
@@ -1010,13 +990,19 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
         // Scale the matrix
         glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
 
-        // Perform the matrix multiplications
+        // Compose the world transform from the engine's scene transform
+        // (newMatrix = nativeTransform). Geometry vertices stay in their
+        // source-unit local space; nativeTransform maps them to metre world
+        // space — the same bare composition the native consumer
+        // geometry_aggregator uses. The per-leaf geometry.normalize() recenter
+        // was removed: AP214 instances/mapped-items share one geometry buffer,
+        // so normalize() mutated it once and later instances lost their offset
+        // and collapsed toward the origin (issue #308 "port cluster"). The
+        // global coordinationMatrix still carries Y-up + COORDINATE_TO_ORIGIN.
         if (newMatrix !== void 0) {
           glmatrix.mat4.multiply(newTransform, coordinationMatrix, newMatrix)
-          glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
         } else {
-          glmatrix.mat4.multiply(newTransform, coordinationMatrix, newTransform)
-          glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
+          glmatrix.mat4.copy(newTransform, coordinationMatrix)
         }
         const newTransformArr = Array.from(newTransform)
         geometryMaterialTransformMap.set(expressID,


### PR DESCRIPTION
## Symptom

AP214/STEP models loaded into Share **through the web-ifc compat proxy** render with sub-components clustered at the origin — the "port cluster" from #308 — even though the native engine fix (#309 / #312) is present and correct in `1.331.1060`. The native path (`geometry_aggregator`) and the IFC path render fine.

## Root cause

The vendored proxy (`src/compat/web-ifc/ifc_api_proxy_ap214.ts`, carried over from the old `conway-web-ifc-adapter`) reimplements its own transform composition and never benefited from the #308 engine fix. Specifically it recentered each leaf via `geometry.geometry.normalize()` — which **mutates the geometry buffer in place** — and restored the offset with a per-leaf `translationMatrixGeomMin`.

AP214 instances / mapped-items (e.g. the repeated HDMI/USB/RJ45 ports) **share one geometry buffer**. So `normalize()` ran once on the shared buffer; every later instance saw an already-centered buffer (`center ≈ 0`), got an identity `translationMatrixGeomMin`, and **lost its placement offset** — collapsing toward the parent origin.

`linearScalingFactor` was *not* involved: it is a no-op `= 1` for AP214 (the engine bakes unit→metre into the scene transform's basis **and** translation per #312), so the proxy's `scaleMatrix` was dead code.

## Fix

Emit the bare engine scene transform — `flatTransformation = coordinationMatrix × nativeTransform` — leaving vertices in their source-unit local space, exactly as the proven-correct native consumer `geometry_aggregator` does (`vertex × absoluteNativeTransform`, `src/core/geometry_aggregator.ts:102-104`). Removed the per-leaf `normalize()` + `translationMatrixGeomMin` in both `streamAllMeshes` and `loadAllGeometry`.

- The global `coordinationMatrix` (Y-up `NormalizeMat` + `COORDINATE_TO_ORIGIN`) is **unchanged**, so framing/orientation are preserved — only the buggy per-leaf recenter is removed.
- **IFC proxy intentionally untouched** — it renders correctly; its `linearScalingFactor ≠ 1` path is the correct single unit conversion, and its geometry/transforms are both in source units.

## Validation

- CI here covers **compile + native regression** — this is a proxy-only change, so the IFC regression / Tier-A goldens / native AP214 tests are unaffected.
- **Behavioural validation is the Share deploy preview** (the Arty board): after this merges + publishes, Share's pin is bumped and the preview should show the ports/components correctly positioned instead of clustered. Diagnosis was reached statically (sandbox can't run the WASM build), so the preview is the real gate before the release smoke.

Analysis cross-referenced the AP214 vs IFC geometry/transform/unit pipelines end-to-end; key refs: engine `ap214_geometry_extraction.ts` (`uniformScaleAffine` #312, factor=1 vertices), `ap214_scene_builder.ts` (walk yields metre `absoluteNativeTransform`), native `geometry_aggregator.ts:102-104`, proxy `ifc_api_proxy_ap214.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0158fwELRzUztTkjh4UMLSxb)_