### PR TITLE
cli: add a `step` bin so AP214/STEP files get the AP214 engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "types": "./compiled/src/index.d.ts",
   "bin": {
     "cli": "./compiled/examples/cli-bundled.cjs",
+    "step": "./compiled/examples/cli-step-bundled.cjs",
     "browser": "./compiled/examples/browser-bundled.js",
     "validator": "./compiled/examples/validator-bundled.js"
   },
@@ -66,9 +67,10 @@
     "build-codex-all": "yarn run build-codex-base ConwayGeomWasmNode ConwayGeomWasmNodeMT ConwayGeomWasmWeb ConwayGeomWasmWebMT && yarn bumpMinor",
     "build-codex-MT": "yarn run build-codex-base ConwayGeomWasmNodeMT",
     "bundle": "yarn esbuild --bundle --format=cjs --platform=node --banner:js='#!/usr/bin/env node'",
-    "bundle-examples": "yarn bundle-browser && yarn bundle-cli && yarn bundle-validator && shx chmod +x ./compiled/examples/*-bundled.cjs && shx rm -rf compiled/Dist && shx cp -r dependencies/conway-geom/Dist compiled/",
+    "bundle-examples": "yarn bundle-browser && yarn bundle-cli && yarn bundle-cli-step && yarn bundle-validator && shx chmod +x ./compiled/examples/*-bundled.cjs && shx rm -rf compiled/Dist && shx cp -r dependencies/conway-geom/Dist compiled/",
     "bundle-browser": "yarn bundle compiled/examples/browser.js --outfile=compiled/examples/browser-bundled.cjs",
     "bundle-cli": "yarn bundle compiled/src/ifc/ifc_command_line_main.js --outfile=compiled/examples/cli-bundled.cjs",
+    "bundle-cli-step": "yarn bundle compiled/src/AP214E3_2010/ap214_command_line_main.js --outfile=compiled/examples/cli-step-bundled.cjs",
     "bundle-validator": "yarn bundle compiled/examples/validator.js --outfile=compiled/examples/validator-bundled.cjs",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "generate-flamegraph": "node ./scripts/generate_flame_graph.cjs",


### PR DESCRIPTION
## Why your `cli` run found no geometry

```
npx --package=@bldrs-ai/conway@latest exec cli Arty_Z7.stp -g
→ error 'No IfcProjects found?'  +  warning 'No Geometry Found'
   Load Status: OK, Version: AUTOMOTIVE_DESIGN, Geometry Time: 1 ms, Geometry Memory: 0 MB
```

Root cause: **the `cli` bin is bundled from `src/ifc/ifc_command_line_main.js` — the IFC-only CLI** (package.json `bundle-cli`). It always parses with `IfcStepParser` and runs `extractIFCGeometryData()`. An AP214 (`AUTOMOTIVE_DESIGN`) file detects its schema from the STEP header, but the **IFC** geometry extractor then looks for an `IfcProject` (`ifc_geometry_extraction.ts:5765` → `'No IfcProjects found?'`) and produces nothing. The actual AP214 engine is never invoked.

Conway already has a **complete, working AP214 CLI** — `src/AP214E3_2010/ap214_command_line_main.ts` (`AP214GeometryExtraction` + its own OBJ/GLTF/GLB serializer, `-g` flag). It just wasn't exposed via a `bin`.

## Fix

Expose it as a **`step`** bin:

```
npx --package=@bldrs-ai/conway exec step <file.stp> -g
```

- New `step` bin → `cli-step-bundled.cjs`, built by a new `bundle-cli-step` script wired into `bundle-examples` (which already runs in the `build` and `auto-publish` jobs, so it ships).
- **Reuses the existing AP214 main unchanged** — correct-by-construction, **zero change to the IFC `cli`**.

## Validation + caveats

- I **can't run the CLI in the dev sandbox** (no build), so CI here covers compile/bundle + native regression; please re-run `step <your Arty file> -g` to confirm geometry comes out.
- **If `step` still reports "No Geometry Found"** on that specific file, that's a *second, separate* bug — AP214 geometry extraction not handling the representation that file uses (it's an Alibre export). That one needs the file to diagnose; happy to take it next if so.
- **Follow-up:** unify `cli` itself to auto-detect format (IFC vs AP214/AP203) and route internally, so a single command handles everything. I scoped this PR to the safe bin-exposure because the IFC and AP214 mains have separate `yargs` schemas + separate serializers, and retrofitting the IFC main is best done with a STEP geometry fixture so it's actually testable (which ties into the unit-test goal we discussed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0158fwELRzUztTkjh4UMLSxb)_