### PR TITLE
ci(web): register the SessionStart hook so web sessions can build

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -18,10 +18,25 @@ cd "$REPO"
 
 log() { printf '[session-start] %s\n' "$*"; }
 
-# 1. node_modules
+# 1. node_modules. The agent proxy can abort large tarball fetches under
+# parallel load (observed on @swc/core platform binaries), so cap network
+# concurrency and retry. yarn caches each successfully-fetched tarball, so a
+# retry resumes where the previous attempt aborted rather than restarting.
 if [ ! -d node_modules ] || [ ! -x node_modules/.bin/jest ]; then
-  log "yarn install"
-  yarn install --frozen-lockfile
+  install_ok=false
+  for attempt in 1 2 3 4 5; do
+    log "yarn install (attempt ${attempt})"
+    if yarn install --frozen-lockfile --network-concurrency 4; then
+      install_ok=true
+      break
+    fi
+    log "yarn install attempt ${attempt} failed; backing off"
+    sleep $(( attempt * 5 ))
+  done
+  if [ "${install_ok}" != true ]; then
+    log "yarn install failed after retries"
+    exit 1
+  fi
 else
   log "node_modules present, skipping yarn install"
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,9 +2,14 @@
 # SessionStart hook: bring a fresh Claude Code on the web container to a state
 # where `yarn lint`, `yarn test`, and `yarn build-incremental` all work.
 #
-# Steps are idempotent; expensive work (yarn install, EMSDK install, WASM build)
-# is skipped when its outputs are already present. See PLAYBOOK.md §"Session
-# bootstrap" for the rationale behind each step.
+# Each step is idempotent and gated on a per-step *completion stamp* written
+# only after the step fully succeeds (see `stamped`/`stamp` below). This makes
+# the bootstrap resumable: if a slow cold-start run is killed mid-step (e.g. the
+# synchronous hook hits its timeout, or OOM), no stamp is written, so the next
+# session re-runs that step instead of treating a half-finished artifact as
+# complete. Gating on the artifact alone (`node_modules/.bin/jest` exists) is
+# kill-fragile — a partial install missing typescript/@swc would be skipped
+# forever. See PLAYBOOK.md §"Session bootstrap" for the rationale per step.
 
 set -euo pipefail
 
@@ -18,46 +23,66 @@ cd "$REPO"
 
 log() { printf '[session-start] %s\n' "$*"; }
 
-# 1. node_modules. The agent proxy can abort large tarball fetches under
-# parallel load (observed on @swc/core platform binaries), so cap network
-# concurrency and retry. yarn caches each successfully-fetched tarball, so a
-# retry resumes where the previous attempt aborted rather than restarting.
-if [ ! -d node_modules ] || [ ! -x node_modules/.bin/jest ]; then
+# Per-step completion stamps (gitignored runtime state, not artifacts).
+STAMP_DIR="$REPO/.claude/.bootstrap"
+mkdir -p "$STAMP_DIR"
+stamped() { [ -f "$STAMP_DIR/$1.done" ]; }
+stamp()   { touch "$STAMP_DIR/$1.done"; }
+
+# 1. node_modules. Network: the agent proxy can abort large tarball fetches
+# under parallel load (observed on @swc/core platform binaries), so cap
+# concurrency and retry — yarn caches each fetched tarball, so a retry resumes
+# where the previous attempt aborted rather than restarting. Lockfile drift is
+# NOT a network problem: detect the frozen-lockfile mismatch and fail fast with
+# a clear message instead of burning five retries on a deterministic error.
+if [ ! -d node_modules ] || ! stamped node_modules; then
   install_ok=false
+  install_log="$(mktemp)"
   for attempt in 1 2 3 4 5; do
     log "yarn install (attempt ${attempt})"
-    if yarn install --frozen-lockfile --network-concurrency 4; then
+    # pipefail (set above) makes this test reflect yarn's exit, not tee's.
+    if yarn install --frozen-lockfile --network-concurrency 4 2>&1 | tee "$install_log"; then
       install_ok=true
       break
     fi
-    log "yarn install attempt ${attempt} failed; backing off"
-    sleep $(( attempt * 5 ))
+    if grep -qi 'frozen-lockfile\|lockfile needs to be updated' "$install_log"; then
+      log "yarn.lock is out of sync with package.json — frozen install cannot proceed; fix the lockfile. Not retrying."
+      break
+    fi
+    if [ "${attempt}" -lt 5 ]; then
+      log "yarn install attempt ${attempt} failed (likely network); backing off"
+      sleep $(( attempt * 5 ))
+    fi
   done
+  rm -f "$install_log"
   if [ "${install_ok}" != true ]; then
-    log "yarn install failed after retries"
+    log "yarn install did not complete"
     exit 1
   fi
+  stamp node_modules
 else
-  log "node_modules present, skipping yarn install"
+  log "node_modules present and stamped, skipping yarn install"
 fi
 
 # 2. Submodules (conway-geom + nested)
-if [ ! -f dependencies/conway-geom/genie.lua ]; then
+if [ ! -f dependencies/conway-geom/genie.lua ] || ! stamped submodules; then
   log "git submodule update --init --recursive"
   git submodule update --init --recursive
+  stamp submodules
 else
   log "submodules present, skipping init"
 fi
 
-# 3. Pre-built WASM dependency zip extraction (idempotent)
+# 3. Pre-built WASM dependency zip extraction (idempotent, fast — always run).
 log "yarn extract-wasm-dependencies"
 yarn extract-wasm-dependencies >/dev/null
 
 # 4. EMSDK install at ../emsdk (matches scripts/setup-emsdk.sh + build-codex.sh).
 EMSDK_DIR="$(cd "$REPO/.." && pwd)/emsdk"
-if [ ! -x "$EMSDK_DIR/emsdk_env.sh" ]; then
+if [ ! -x "$EMSDK_DIR/emsdk_env.sh" ] || ! stamped emsdk; then
   log "installing EMSDK 3.1.72 at $EMSDK_DIR (slow on first run, cached afterward)"
   bash "$REPO/scripts/setup-emsdk.sh"
+  stamp emsdk
 else
   log "EMSDK present at $EMSDK_DIR, skipping install"
 fi
@@ -74,12 +99,12 @@ if [ -n "${CLAUDE_ENV_FILE:-}" ] && [ -f "$EMSDK_DIR/emsdk_env.sh" ]; then
 fi
 
 # 5. conway-geom WASM build (MT node target — what tests need).
-# `bundle-examples` rebuilds the bundled CLIs but is also fast and cached.
 WASM_OUT="$REPO/dependencies/conway-geom/Dist/ConwayGeomWasmNodeMT.js"
-if [ ! -f "$WASM_OUT" ]; then
+if [ ! -f "$WASM_OUT" ] || ! stamped wasm; then
   log "building conway-geom WASM (ConwayGeomWasmNodeMT) — first run ~2–4 min"
   chmod +x "$REPO/scripts/build-codex.sh"
   yarn build-codex-MT
+  stamp wasm
 else
   log "WASM artifact present, skipping conway-geom build"
   # Ensure compiled/ exists so tests can run.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 # SessionStart hook: bring a fresh Claude Code on the web container to a state
-# where `yarn lint`, `yarn test`, and `yarn build-incremental` all work.
+# where `yarn lint`, `yarn typecheck`/`yarn build-incremental` work and the
+# TypeScript is editable.
+#
+# Deliberately scoped to the FAST, TS-only path. The EMSDK install and the
+# ~2–4 min conway-geom WASM build — needed only to *run* tests/geometry
+# locally — are NOT done here: the tests-pass invariant is owned by CI, so
+# paying that cost on every session start is wasted time. When you actually
+# need to run tests or geometry in a session, run:
+#
+#     bash .claude/hooks/wasm-setup.sh
 #
 # Each step is idempotent and gated on a per-step *completion stamp* written
-# only after the step fully succeeds (see `stamped`/`stamp` below). This makes
-# the bootstrap resumable: if a slow cold-start run is killed mid-step (e.g. the
-# synchronous hook hits its timeout, or OOM), no stamp is written, so the next
-# session re-runs that step instead of treating a half-finished artifact as
-# complete. Gating on the artifact alone (`node_modules/.bin/jest` exists) is
-# kill-fragile — a partial install missing typescript/@swc would be skipped
-# forever. See PLAYBOOK.md §"Session bootstrap" for the rationale per step.
+# only after the step fully succeeds (see `stamped`/`stamp`). This makes the
+# bootstrap resumable: if a slow cold-start run is killed mid-step (timeout,
+# OOM), no stamp is written, so the next session re-runs that step instead of
+# treating a half-finished artifact as complete. Gating on the artifact alone
+# (`node_modules/.bin/jest` exists) is kill-fragile — a partial install missing
+# typescript/@swc would be skipped forever. See PLAYBOOK.md §"Session bootstrap".
 
 set -euo pipefail
 
@@ -64,7 +72,9 @@ else
   log "node_modules present and stamped, skipping yarn install"
 fi
 
-# 2. Submodules (conway-geom + nested)
+# 2. Submodules (conway-geom + nested). tsconfig.json compiles
+# `dependencies/conway-geom/*.ts` directly, so typecheck/build need the
+# submodule checked out — but not its WASM build.
 if [ ! -f dependencies/conway-geom/genie.lua ] || ! stamped submodules; then
   log "git submodule update --init --recursive"
   git submodule update --init --recursive
@@ -73,45 +83,14 @@ else
   log "submodules present, skipping init"
 fi
 
-# 3. Pre-built WASM dependency zip extraction (idempotent, fast — always run).
-log "yarn extract-wasm-dependencies"
-yarn extract-wasm-dependencies >/dev/null
-
-# 4. EMSDK install at ../emsdk (matches scripts/setup-emsdk.sh + build-codex.sh).
-EMSDK_DIR="$(cd "$REPO/.." && pwd)/emsdk"
-if [ ! -x "$EMSDK_DIR/emsdk_env.sh" ] || ! stamped emsdk; then
-  log "installing EMSDK 3.1.72 at $EMSDK_DIR (slow on first run, cached afterward)"
-  bash "$REPO/scripts/setup-emsdk.sh"
-  stamp emsdk
+# 3. compiled/ — `tsc --build` over the TS (incl. conway-geom sources). TS-only;
+# no EMSDK/WASM. Gives a ready `yarn lint`/`yarn build-incremental`.
+if [ ! -d compiled ] || ! stamped build; then
+  log "yarn build-incremental"
+  yarn build-incremental
+  stamp build
 else
-  log "EMSDK present at $EMSDK_DIR, skipping install"
+  log "compiled/ present and stamped, skipping build-incremental"
 fi
 
-# Persist emsdk env into the session so emcc is on PATH for subsequent commands.
-if [ -n "${CLAUDE_ENV_FILE:-}" ] && [ -f "$EMSDK_DIR/emsdk_env.sh" ]; then
-  # shellcheck disable=SC1090,SC1091
-  source "$EMSDK_DIR/emsdk_env.sh" >/dev/null 2>&1 || true
-  {
-    echo "export EMSDK=\"$EMSDK\""
-    echo "export EMSDK_NODE=\"${EMSDK_NODE:-}\""
-    echo "export PATH=\"$EMSDK:$EMSDK/upstream/emscripten:\$PATH\""
-  } >> "$CLAUDE_ENV_FILE"
-fi
-
-# 5. conway-geom WASM build (MT node target — what tests need).
-WASM_OUT="$REPO/dependencies/conway-geom/Dist/ConwayGeomWasmNodeMT.js"
-if [ ! -f "$WASM_OUT" ] || ! stamped wasm; then
-  log "building conway-geom WASM (ConwayGeomWasmNodeMT) — first run ~2–4 min"
-  chmod +x "$REPO/scripts/build-codex.sh"
-  yarn build-codex-MT
-  stamp wasm
-else
-  log "WASM artifact present, skipping conway-geom build"
-  # Ensure compiled/ exists so tests can run.
-  if [ ! -d "$REPO/compiled" ]; then
-    log "compiled/ missing — running yarn build-incremental"
-    yarn build-incremental
-  fi
-fi
-
-log "ready"
+log "ready (TS dev). To run tests/geometry: bash .claude/hooks/wasm-setup.sh"

--- a/.claude/hooks/wasm-setup.sh
+++ b/.claude/hooks/wasm-setup.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# On-demand conway-geom WASM toolchain setup. Run this in a Claude Code on the
+# web session when you actually need to run tests or geometry locally:
+#
+#     bash .claude/hooks/wasm-setup.sh
+#
+# It is intentionally NOT part of session-start.sh: the EMSDK install and the
+# ~2–4 min WASM build are wasted on the common edit/lint/typecheck loop, and the
+# tests-pass invariant is owned by CI. Assumes session-start.sh already ran
+# (node_modules + submodules present). Steps are idempotent and stamped, so
+# re-running is cheap and a killed run resumes rather than re-does completed work.
+
+set -euo pipefail
+
+REPO="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+cd "$REPO"
+
+log() { printf '[wasm-setup] %s\n' "$*"; }
+
+STAMP_DIR="$REPO/.claude/.bootstrap"
+mkdir -p "$STAMP_DIR"
+stamped() { [ -f "$STAMP_DIR/$1.done" ]; }
+stamp()   { touch "$STAMP_DIR/$1.done"; }
+
+if [ ! -f dependencies/conway-geom/genie.lua ]; then
+  log "conway-geom submodule missing — run session-start.sh first (git submodule update)"
+  exit 1
+fi
+
+# 1. Pre-built WASM dependency zip extraction (idempotent build input).
+log "yarn extract-wasm-dependencies"
+yarn extract-wasm-dependencies >/dev/null
+
+# 2. EMSDK install at ../emsdk (matches scripts/setup-emsdk.sh + build-codex.sh).
+EMSDK_DIR="$(cd "$REPO/.." && pwd)/emsdk"
+if [ ! -x "$EMSDK_DIR/emsdk_env.sh" ] || ! stamped emsdk; then
+  log "installing EMSDK 3.1.72 at $EMSDK_DIR (slow on first run, cached afterward)"
+  bash "$REPO/scripts/setup-emsdk.sh"
+  stamp emsdk
+else
+  log "EMSDK present at $EMSDK_DIR, skipping install"
+fi
+
+# Put emcc on PATH for this process, and persist into the session if invoked
+# where CLAUDE_ENV_FILE is available (so later commands see emcc too).
+if [ -f "$EMSDK_DIR/emsdk_env.sh" ]; then
+  # shellcheck disable=SC1090,SC1091
+  source "$EMSDK_DIR/emsdk_env.sh" >/dev/null 2>&1 || true
+  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    {
+      echo "export EMSDK=\"$EMSDK\""
+      echo "export EMSDK_NODE=\"${EMSDK_NODE:-}\""
+      echo "export PATH=\"$EMSDK:$EMSDK/upstream/emscripten:\$PATH\""
+    } >> "$CLAUDE_ENV_FILE"
+  fi
+fi
+
+# 3. conway-geom WASM build (MT node target — what tests load at runtime).
+WASM_OUT="$REPO/dependencies/conway-geom/Dist/ConwayGeomWasmNodeMT.js"
+if [ ! -f "$WASM_OUT" ] || ! stamped wasm; then
+  log "building conway-geom WASM (ConwayGeomWasmNodeMT) — first run ~2–4 min"
+  chmod +x "$REPO/scripts/build-codex.sh"
+  yarn build-codex-MT
+  stamp wasm
+else
+  log "WASM artifact present, skipping conway-geom build"
+fi
+
+log "ready — yarn test / geometry can now run"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh",
+            "timeout": 900
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh",
-            "timeout": 900
+            "timeout": 1800
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ benchmarks/*private
 /external/IFC-gen-internal/
 /external/IFC-gen-internal/*
 .parcel-cache
+
+# SessionStart hook per-step completion stamps (runtime state)
+.claude/.bootstrap/


### PR DESCRIPTION
## Problem

Claude Code on the web cannot build Conway. A fresh container comes up with **`node_modules` empty**, so `yarn lint` / `yarn typecheck` / `yarn build-incremental` all fail.

Root cause: the web bootstrap script `.claude/hooks/session-start.sh` exists and is well-written, but is **never registered** — there's no `.claude/settings.json` wiring it as a `SessionStart` hook, so the harness never runs it.

## Fix

**1. Register the hook** — new `.claude/settings.json` wires `.claude/hooks/session-start.sh` as a `SessionStart` command hook (synchronous, 1800s timeout).

**2. Scope session start to the fast, TS-only path.** The tests-pass invariant is owned by CI, so paying the EMSDK install + ~2–4 min conway-geom WASM build on *every* session start is wasted time. `session-start.sh` now does only:
- `node_modules` (hardened install — see below)
- submodules (`tsconfig` compiles `dependencies/conway-geom/*.ts` directly, so typecheck needs the submodule but **not** its WASM build)
- `build-incremental` (`compiled/`)

That's everything `yarn lint` / `yarn typecheck` / `yarn build-incremental` and editing need.

**3. Lift the heavy WASM toolchain to on-demand** — new `.claude/hooks/wasm-setup.sh` carries the lifted steps (extract WASM build deps, EMSDK install + env, `yarn build-codex-MT`) for when a session actually needs to run tests/geometry locally:
```
bash .claude/hooks/wasm-setup.sh
```

**4. Make the bootstrap kill-resumable.** Each step is gated on a per-step *completion stamp* (in the gitignored `.claude/.bootstrap/`) written only after the step fully succeeds — not on a first artifact like `node_modules/.bin/jest`. A hard kill mid-step (timeout/OOM) leaves no stamp, so the next session re-runs that step instead of skipping a half-finished install forever.

**5. Smarter install retry.** The agent proxy aborts large tarball fetches under parallel load (observed on `@swc/core` binaries), so `yarn install --network-concurrency 4` retries with backoff (yarn's cache makes retries resume). Lockfile drift is deterministic, not network — it's detected and fails fast with a clear message instead of burning all five retries. No backoff after the final attempt.

## Validation

- Valid JSON; `bash -n` clean on both scripts; both executable; `.claude/.bootstrap/` gitignored.
- Retry control flow logic-tested with a mocked `yarn` (file-backed to avoid the pipe-subshell trap): network-retry succeeds on attempt 3, lockfile drift fast-fails after 1 invocation, persistent failure gives up after 5, and `pipefail` propagates yarn's exit through `tee`.
- **Not runnable end-to-end in the authoring session** (the very env this fixes — `node_modules` empty, proxy throughput aborts the large fetches). The real proof is the next web session after merge.

## Note for the first session after merge

Stamps are new, so the first session re-runs each fast-path step once even if a cached container already has the artifacts (one-time, idempotent), then stamps and skips thereafter. Worth confirming in that first session that `build-incremental` typechecks cleanly without the WASM build (expected, since `tsc` compiles the conway-geom TS sources, not the runtime `.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK1dTxHdkMrT7DDHBLdCds