### PR TITLE
ci(web): make session bootstrap install resilient to proxy socket resets

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -37,25 +37,47 @@ mkdir -p "$STAMP_DIR"
 stamped() { [ -f "$STAMP_DIR/$1.done" ]; }
 stamp()   { touch "$STAMP_DIR/$1.done"; }
 
-# 1. node_modules. Network: the agent proxy can abort large tarball fetches
-# under parallel load (observed on @swc/core platform binaries), so cap
-# concurrency and retry — yarn caches each fetched tarball, so a retry resumes
-# where the previous attempt aborted rather than restarting. Lockfile drift is
-# NOT a network problem: detect the frozen-lockfile mismatch and fail fast with
-# a clear message instead of burning five retries on a deterministic error.
+# 1. node_modules. Network: yarn v1's keep-alive HTTP agent reuses pooled
+# sockets, and the agent proxy / egress re-terminates TLS and drops those
+# sockets. yarn surfaces a dropped socket as a FATAL "Error: aborted" (stack at
+# TLSSocket.socketCloseListener) and aborts the whole run rather than retrying
+# the one request — so a single reset kills the install. This bites hardest on
+# larger tarballs (e.g. `three`, ~7MB): plain `curl` of the same URL succeeds in
+# <1s (fresh connection), but yarn aborts it even at --network-concurrency 1.
+# This is a well-known yarn-classic-behind-a-proxy failure class
+# (yarnpkg/yarn#4890, #5259; yarnpkg/berry#2257).
+#
+# Mitigations applied here, in order:
+#   a. --network-concurrency 1 + a long --network-timeout: fewer pooled sockets
+#      to be reset, and slow transfers aren't timed out. yarn caches each
+#      fetched tarball, so the retry loop resumes rather than restarting.
+#   b. npm fallback: npm retries connection resets per-request
+#      (--fetch-retries) and reliably completes where yarn's agent cannot, and
+#      registry.npmjs.org is on the proxy's noProxy bypass list so npm fetches
+#      it directly. This DRIFTS the tree from yarn.lock (npm's flat hoist
+#      differs, and the repo has a ts-jest/babel-jest peer conflict yarn
+#      tolerates — hence --legacy-peer-deps), so it is a last resort to keep TS
+#      dev (lint/typecheck/build) working when yarn cannot install at all, not a
+#      yarn.lock-faithful install.
+#
+# Lockfile drift is NOT a network problem: detect the frozen-lockfile mismatch
+# and fail fast with a clear message instead of burning retries on a
+# deterministic error.
 if [ ! -d node_modules ] || ! stamped node_modules; then
   install_ok=false
   install_log="$(mktemp)"
   for attempt in 1 2 3 4 5; do
     log "yarn install (attempt ${attempt})"
     # pipefail (set above) makes this test reflect yarn's exit, not tee's.
-    if yarn install --frozen-lockfile --network-concurrency 4 2>&1 | tee "$install_log"; then
+    if yarn install --frozen-lockfile --network-concurrency 1 \
+        --network-timeout 600000 2>&1 | tee "$install_log"; then
       install_ok=true
       break
     fi
     if grep -qi 'frozen-lockfile\|lockfile needs to be updated' "$install_log"; then
       log "yarn.lock is out of sync with package.json — frozen install cannot proceed; fix the lockfile. Not retrying."
-      break
+      rm -f "$install_log"
+      exit 1
     fi
     if [ "${attempt}" -lt 5 ]; then
       log "yarn install attempt ${attempt} failed (likely network); backing off"
@@ -63,8 +85,20 @@ if [ ! -d node_modules ] || ! stamped node_modules; then
     fi
   done
   rm -f "$install_log"
+
   if [ "${install_ok}" != true ]; then
-    log "yarn install did not complete"
+    log "yarn install exhausted retries; falling back to npm (connection-reset-resilient)"
+    if npm install --legacy-peer-deps --no-audit --no-fund \
+        --fetch-retries=10 --fetch-retry-maxtimeout=60000 \
+        --registry=https://registry.npmjs.org/; then
+      install_ok=true
+      # npm writes a package-lock.json; this repo is yarn-managed, so drop it.
+      rm -f package-lock.json
+    fi
+  fi
+
+  if [ "${install_ok}" != true ]; then
+    log "neither yarn nor npm could complete the install"
     exit 1
   fi
   stamp node_modules


### PR DESCRIPTION
## Why

The SessionStart hook added in #340 keeps failing to install `node_modules` in the Claude-Code-on-web sandbox. Symptom (seen across multiple sessions):

```
info There appears to be trouble with your network connection. Retrying...
error Error: aborted
    at TLSSocket.socketCloseListener (node:_http_client:535:19)
```

### Root cause
yarn v1's keep-alive HTTP agent reuses pooled sockets. The agent proxy / egress re-terminates TLS and drops those sockets, and **yarn treats a dropped socket as fatal** — it aborts the whole run instead of retrying the one request. So a single reset kills the install. It bites hardest on larger tarballs: `three` (~7MB) aborts every attempt **even at `--network-concurrency 1`**, while a plain `curl` of the exact same URL completes in <1s on a fresh connection. This is the well-known yarn-classic-behind-a-proxy failure class ([yarnpkg/yarn#4890](https://github.com/yarnpkg/yarn/issues/4890), [#5259](https://github.com/yarnpkg/yarn/issues/5259), [yarnpkg/berry#2257](https://github.com/yarnpkg/berry/issues/2257)).

Verified this session: both registries are reachable via `curl` (npmjs direct `200` in 0.25s, yarnpkg via proxy `200` in 0.7s) — it is purely yarn's socket handling, not an egress/DNS/policy block. The hook's `--network-concurrency 4` was not low enough; lowering to 1 reduced the abort storms but did not eliminate them on the large tarball.

## What

- **`--network-concurrency 4` → `1`** and add **`--network-timeout 600000`** — fewer pooled sockets to be reset, and slow transfers aren't timed out. yarn caches each fetched tarball, so the existing retry loop resumes rather than restarts.
- **npm fallback** after yarn exhausts its 5 retries. npm retries connection resets per-request (`--fetch-retries`) and reliably completes where yarn's agent cannot; `registry.npmjs.org` is on the proxy's `noProxy` bypass list so npm fetches it directly. This **drifts the tree from `yarn.lock`** (npm's flat hoist differs; the repo's `ts-jest`/`babel-jest` peer conflict that yarn tolerates needs `--legacy-peer-deps`), so it is a **documented last resort** to keep TS dev (lint/typecheck/build) working when yarn cannot install at all — not a `yarn.lock`-faithful install. The stray `package-lock.json` npm writes is removed.
- A **frozen-lockfile mismatch now exits 1 immediately** instead of falling through to the npm fallback, which would silently mask real lockfile drift.

## Verification

In this session: yarn aborted on `three` even at concurrency 1; the npm fallback installed 969 packages in ~23s and produced a working toolchain (`tsc` 4.9.3 + eslint + jest), letting `yarn build-incremental` / `yarn lint` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RW4QuUrYbLcMRmhNbwkg3z)_