### PR TITLE
Support multi-repo session roots in web build environment

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,16 +2,20 @@
 # SessionStart hook (Claude Code on the web).
 #
 # The heavy bootstrap (install + submodules + build) lives in the shared,
-# idempotent scripts/web-setup.sh. The intended place to run it is the cloud
-# *environment setup script* (configured in the web UI as
-# `bash scripts/web-setup.sh || true` — the `|| true` keeps a transient
-# cold-install failure from failing session *creation*), whose filesystem result
-# is snapshotted — so a session
-# starts with node_modules already present and this hook is a near-instant no-op.
+# idempotent scripts/web-setup.sh, exposed as `yarn setup`. The intended place to
+# run it is the cloud *environment setup script* — a multi-repo dispatcher that
+# runs `yarn setup` per checkout (see scripts/web-setup.sh header for the exact
+# field) — whose filesystem result is snapshotted, so a session starts with
+# node_modules already present and this hook is a near-instant no-op.
 #
 # This hook is the fallback: it runs the same shared script for a cold cache (or
 # if the environment setup script was never configured). web-setup.sh is
 # stamp-gated, so when node_modules is already there it returns immediately.
+#
+# CAVEAT: this hook only loads when the session root IS this repo. Under a
+# multi-repo parent root (this repo is a subdir) Claude reads .claude/ from the
+# parent, so the hook never fires — the cloud dispatcher is then the only
+# bootstrap path. Keep that field correct.
 #
 # Reliability + faithfulness rationale (yarn Berry, resume loop, NO npm
 # fallback) lives in scripts/web-setup.sh and design/new/web-build-environment.md.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
-Dependencies are bootstrapped by `scripts/web-setup.sh` (run from the cloud
-environment setup script and/or the SessionStart hook). If `node_modules` is
+Dependencies are bootstrapped by `scripts/web-setup.sh`, exposed as `yarn setup`
+(run from the cloud environment setup script — a multi-repo dispatcher that runs
+`yarn setup` per checkout, see `design/new/web-build-environment.md` — and/or the
+SessionStart hook). If `node_modules` is
 already present, it has run — don't redo it. If `node_modules` is **absent**, the
 bootstrap failed; re-run `bash scripts/web-setup.sh` and, if it still fails,
 report it (see the install-failure rule below) — do not improvise an install.

--- a/design/new/web-build-environment.md
+++ b/design/new/web-build-environment.md
@@ -104,13 +104,42 @@ the snapshot already has up-to-date `node_modules` (and still covers local dev +
 a cold cache). The EMSDK/WASM toolchain is already correctly on-demand
 (`.claude/hooks/wasm-setup.sh`), off the every-session path.
 
-**Set the setup-script field to `bash scripts/web-setup.sh || true`, not the bare
-command.** A non-zero setup script makes the *session fail to start* (per the web
-docs), so a transient cold-install failure on the flaky egress would lock you out
-with no way in to fix it. `|| true` lets the session start anyway; the
-SessionStart hook then re-runs the same script and — unlike the setup script — a
-non-zero hook does **not** block the session, so the failure surfaces in-session
-where it is recoverable.
+**Set the setup-script field to the multi-repo dispatcher below, not a bare
+`bash scripts/web-setup.sh`.** Two reasons: (1) the session root may be a *parent
+dir holding several checkouts* (conway, Share, ...), where a repo-relative
+`scripts/web-setup.sh` does not resolve and silently no-ops under the field's
+`|| true`; (2) a non-zero setup script makes the *session fail to start* (per the
+web docs), so a transient cold-install failure on the flaky egress would lock you
+out with no way in to fix it. Each repo exposes its bootstrap as `yarn setup`
+(conway's runs this script); the dispatcher runs `yarn setup` in the CWD if it
+has that target, else in each known subrepo, and always exits 0:
+
+```bash
+has_setup() { [ -f "$1/package.json" ] && node -e 'process.exit(((require(process.argv[1]+"/package.json").scripts)||{}).setup?0:1)' "$(cd "$1" && pwd)" 2>/dev/null; }
+if has_setup .; then yarn setup; else for d in conway Share; do [ -d "$d" ] && has_setup "$d" && ( cd "$d" && yarn setup ); done; fi; true
+```
+
+The trailing `true` is the load-bearing equivalent of the old `|| true`. When the
+root IS conway the SessionStart hook then re-runs the same script and — unlike the
+setup script — a non-zero hook does **not** block the session, so a failure
+surfaces in-session where it is recoverable. Under a multi-repo parent root the
+hook does **not** load (Claude reads `.claude/` from the parent), so the
+dispatcher is the only bootstrap path — keep it correct.
+
+### Multi-repo session root (measured 2026-06)
+
+A web session can be rooted at a parent dir (`/home/user`) with conway, Share,
+conway-geom and test-models checked out side by side, **not** at the conway repo.
+That broke the original single-repo assumptions on two axes at once: the
+setup-script field `bash scripts/web-setup.sh || true` ran from the parent (no
+such path → silent no-op → empty `node_modules`), and the SessionStart hook in
+`conway/.claude/settings.json` never loaded (Claude reads `.claude/` from the
+parent root). The fix is the `yarn setup` convention + dispatcher above. Note the
+in-session egress is as hostile as ever — the Berry fetch still hangs at the
+sustained-install stage in a live session; what makes `yarn setup` complete is
+that the **setup-script phase runs in a healthier network context** and is
+snapshotted, so the dispatcher belongs in the cloud field, not relied on via the
+in-session hook.
 
 ### Snapshot invalidation (and why the install gate hashes the lockfile)
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     }
   },
   "scripts": {
-    "setup": "yarn install && yarn submodule-update && yarn extract-wasm-dependencies",
+    "setup": "bash scripts/web-setup.sh",
     "codex-setup-emsdk": "bash ./scripts/setup-emsdk.sh",
     "clean": "run-script-os",
     "clean:win32": "rd /s /q compiled & rd /s /q \"dependencies/conway-geom/bin/release\" & del /q \"dependencies/conway-geom/Dist/*.map\" && del /q \"dependencies/conway-geom/Dist/*.js\" & yarn \"clean-conway_geom\"",

--- a/scripts/web-setup.sh
+++ b/scripts/web-setup.sh
@@ -6,14 +6,24 @@
 # Used in two places (keep the logic here, not duplicated):
 #   - the Claude Code on the web *environment setup script* (cloud UI), which is
 #     snapshotted/cached so `node_modules` is present right off in every session.
-#     Set that field to:   bash scripts/web-setup.sh || true
-#     The `|| true` is load-bearing: a non-zero setup script makes the SESSION
-#     FAIL TO START, so a transient cold-install failure would lock you out
-#     entirely. With `|| true` the session still starts and the SessionStart hook
-#     re-runs this script — failing loudly but recoverably, in-session — if the
-#     install didn't complete.
+#     This repo exposes the script as `yarn setup` (package.json#scripts.setup).
+#     The session root may be this repo OR a parent dir holding several checkouts
+#     (conway, Share, ...) — in the latter case a bare `scripts/web-setup.sh` does
+#     not resolve and the SessionStart hook below never loads (Claude reads
+#     .claude/ from the parent root, not this subdir). So set the cloud field to a
+#     small multi-repo dispatcher that runs `yarn setup` in the CWD if it has that
+#     target, else in each known subrepo:
+#
+#       has_setup() { [ -f "$1/package.json" ] && node -e 'process.exit(((require(process.argv[1]+"/package.json").scripts)||{}).setup?0:1)' "$(cd "$1" && pwd)" 2>/dev/null; }
+#       if has_setup .; then yarn setup; else for d in conway Share; do [ -d "$d" ] && has_setup "$d" && ( cd "$d" && yarn setup ); done; fi; true
+#
+#     The trailing `true` is load-bearing: a non-zero setup script makes the
+#     SESSION FAIL TO START, so a transient cold-install failure would lock you
+#     out entirely. Exiting 0 lets the session start anyway; when the root IS this
+#     repo the SessionStart hook re-runs this script, surfacing a failure
+#     in-session where it is recoverable.
 #   - the repo SessionStart hook (.claude/hooks/session-start.sh), as a guard for
-#     local dev and for a cold cache.
+#     local dev and a cold cache (only when the session root IS this repo).
 #
 # Why Berry + a resume loop (see design/new/web-build-environment.md):
 # the Claude-Code-on-web egress resets — and sometimes silently hangs —


### PR DESCRIPTION
## Summary

This PR updates the web build environment setup to support session roots that are parent directories containing multiple checkouts (conway, Share, etc.), not just single-repo roots. The changes introduce a multi-repo dispatcher pattern and update documentation and configuration accordingly.

## Key Changes

- **Multi-repo dispatcher in setup-script field**: Replaced bare `bash scripts/web-setup.sh || true` with a dispatcher that intelligently detects whether the session root is the current repo or a parent directory, then runs `yarn setup` in the appropriate location(s). The dispatcher checks for `yarn setup` target availability in `package.json` before executing.

- **`yarn setup` convention**: Changed `package.json#scripts.setup` to invoke `bash scripts/web-setup.sh` directly, establishing a standard entry point that the dispatcher can reliably call across multiple repos.

- **Updated documentation**: 
  - `design/new/web-build-environment.md`: Added detailed explanation of the multi-repo scenario, the dispatcher implementation, and why the setup-script phase runs in a healthier network context than in-session hooks.
  - `scripts/web-setup.sh`: Updated header comments to explain the multi-repo dispatcher pattern and when the SessionStart hook does/doesn't load.
  - `.claude/hooks/session-start.sh`: Added caveat that this hook only loads when the session root IS the repo (not when it's a parent directory).
  - `AGENTS.md`: Updated to reference the `yarn setup` convention and multi-repo dispatcher.

## Implementation Details

The dispatcher uses a helper function `has_setup()` that checks if a directory has a `package.json` with a `setup` script target. It then:
1. Runs `yarn setup` in the CWD if available
2. Otherwise iterates through known subrepos (conway, Share) and runs `yarn setup` in each that has the target
3. Always exits 0 to prevent session startup failure from transient network issues

The trailing `true` ensures the setup-script phase never fails the session, allowing the SessionStart hook (when it loads) to surface failures recoverably in-session.

https://claude.ai/code/session_01JiaruKYiJzttFsTELtU4Wx