### PR TITLE
ci(auto-publish): keep `latest` on newest code across out-of-order PR merges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1093,7 +1093,29 @@ jobs:
       # Publish BEFORE tagging. If publish fails, no stranded tag.
       # npm CLI 11.5.1+ picks up the OIDC token from GHA automatically.
       - name: Publish to npm
-        run: npm publish --access public
+        env:
+          NEW_VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          # The version scheme is <major>.<PR#>.<commit-count>. The PR-number
+          # segment is non-monotonic: when PRs merge out of order, a later main
+          # commit can carry a *lower* PR number than the package currently
+          # tagged `latest` (e.g. #345 merging right after #346). npm then
+          # refuses to *implicitly* move `latest` onto the lower SemVer and
+          # aborts the publish ("Cannot implicitly apply the latest tag ...").
+          # The commit-count segment is strictly monotonic on main, so this
+          # build genuinely supersedes `latest` even when its middle segment is
+          # lower — pass `--tag latest` explicitly to override npm's guard and
+          # keep `latest` pointing at the newest code. The in-order case (new
+          # version is the higher SemVer) still takes the plain implicit path.
+          CURRENT_LATEST=$(npm view @bldrs-ai/conway@latest version 2>/dev/null || echo '0.0.0')
+          HIGHEST=$(printf '%s\n%s\n' "$CURRENT_LATEST" "$NEW_VERSION" | sort -V | tail -1)
+          if [ "$NEW_VERSION" != "$CURRENT_LATEST" ] && [ "$HIGHEST" = "$NEW_VERSION" ]; then
+            npm publish --access public
+          else
+            echo "::warning::Computed version ${NEW_VERSION} is not greater than current latest ${CURRENT_LATEST} (out-of-order PR merge); publishing with explicit --tag latest."
+            npm publish --access public --tag latest
+          fi
 
       # Idempotent tag: skip if already on origin (e.g. on a re-run).
       - name: Create and push tag


### PR DESCRIPTION
## Problem

The STEP-metadata work merged to `main` (#345, `48c89d3`) built cleanly as `1.345.1105` but **failed to publish to npm**:

```
npm error Cannot implicitly apply the "latest" tag because previously published
version 1.346.1102 is higher than the new version 1.345.1105.
You must specify a tag using --tag.
```

The auto-release version is `<major>.<PR#>.<commit-count>`. The PR-number segment is **non-monotonic**: docs-only **#346** merged just before code PR **#345**, so `latest` advanced to `1.346.1102` and the later `1.345.1105` build — which actually carries the new web-ifc compat surface Share renders — was rejected by npm's implicit-`latest`-demotion guard.

Net effect: `latest` currently points at `1.346.1102` (the **old** flat compat surface), and the build with the real STEP metadata never reached npm.

## Fix

The commit-count segment **is** strictly monotonic on `main`, so an out-of-order build genuinely supersedes `latest` even when its PR-number segment is lower. The publish step now:

- compares the computed version against the current `latest` (SemVer, `sort -V`);
- in-order (higher) → plain `npm publish --access public` (implicit `latest`, unchanged);
- out-of-order (not higher) → `npm publish --access public --tag latest`, explicitly overriding npm's guard and keeping `latest` on the newest code, with a CI warning.

## Effect of merging

This PR's own merge (PR# > 346) re-triggers `auto-publish` with a version `> 1.346.1102`, so it publishes via the normal path **and** ships the STEP-metadata compat surface to npm — unblocking the matching Share upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfHL21ghUKsAq4xBCNFLdi)_