### PR TITLE
build(version): normalize on-main version to 1.0.0 placeholder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -998,7 +998,10 @@ jobs:
   # ---------------------------------------------------------------------------
   # Continuous release: on every successful push to main, publish to npm and
   # tag the commit. Version is <major>.<PR>.<commit>:
-  #   major  - first segment of package.json's version (manual bump)
+  #   major  - first segment of package.json's version (manual bump). The
+  #            minor/patch in package.json/version.ts are an unstamped 1.0.0
+  #            placeholder on main and are ignored here - both are recomputed
+  #            below, so only edit the major segment to roll a major version.
   #   PR     - PR number parsed from the merge commit message (#N)
   #   commit - 'git rev-list HEAD --count' at the merge commit
   # So every green merge ships a uniquely-traceable patch to @latest.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "bldrs.ai datamodel",
   "author": "bldrs.ai",
   "license": "AGPL-3.0",
-  "version": "1.22.969",
+  "version": "1.0.0",
   "repository": "https://github.com/bldrs-ai/conway",
   "files": [
     "./compiled/**/*"

--- a/src/version/version.ts
+++ b/src/version/version.ts
@@ -1,4 +1,11 @@
-const versionString: string = 'Conway Web-Ifc Shim v1.22.969'
+// Placeholder version for source/dev builds. CI's auto-publish job stamps the
+// real `<major>.<PR>.<commit>` here (and into package.json) at publish time and
+// does NOT commit it back to main — see .github/workflows/build.yml (auto-publish).
+// So on main and in any unstamped local build this intentionally reads 1.0.0;
+// only the first segment (major) is meaningful and is the one CI carries forward.
+// Must stay in `vN.N.N` shape: the CI stamp regex, scripts/updateVersion.mjs, and
+// statistics.ts all match `v\d+\.\d+\.\d+`.
+const versionString: string = 'Conway Web-Ifc Shim v1.0.0'
 
 
 export {versionString}


### PR DESCRIPTION
## Why

The `auto-publish` job in `.github/workflows/build.yml` stamps the real `<major>.<PR>.<commit>` version into `package.json` and `src/version/version.ts` at publish time, but **deliberately does not commit it back to main**. As a result the source tree carried `1.22.969` — a stale-looking number that reads like a real (but wrong) release. In practice CI only ever reads the **major** segment from `package.json`; minor and patch are always recomputed (`PR` = merge PR number, `commit` = `git rev-list HEAD --count`).

This was surfaced while comparing the version Share consumes (`@bldrs-ai/conway@1.334.1066`, the published number) against the in-repo source (`1.22.969`). Nothing was broken — the gap is by design — but the placeholder looked like a forgotten version bump.

## What

- `package.json`: `version` `1.22.969` → `1.0.0`
- `src/version/version.ts`: `versionString` → `Conway Web-Ifc Shim v1.0.0`, with a comment explaining CI stamps the real value and doesn't commit it back, so unstamped/dev builds intentionally report `1.0.0`
- `.github/workflows/build.yml`: expanded the `auto-publish` comment to state that minor/patch are an ignored placeholder and only the major segment is carried forward

An unstamped/dev build now reports a clearly-unreleased `1.0.0` instead of a plausible-but-wrong number.

## Why `1.0.0` and not `1.0.0-dev`

Three consumers require a strict `\d+.\d+.\d+` shape, so a `-dev` suffix would break them:

- CI stamp regex `v[0-9]+\.[0-9]+\.[0-9]+` — `-dev` would survive the stamp as a dangling `v1.<PR>.<commit>-dev`
- `scripts/updateVersion.mjs` (`"(?<major>\d+)\.(?<minor>\d+)\.\d+"`) — `-dev` wouldn't match, silently breaking the local bump
- `statistics.ts` (`v(\d+\.\d+\.\d+)`) — telemetry version parsing

`1.0.0` is the clearest placeholder that survives all three. Verified each regex against the new strings, that `split('.')[0]` still yields major `1`, and that no `1.22.969` remains outside `node_modules`/`compiled`.

## Impact

Published npm versions are unchanged (still `1.<PR>.<commit>` with major `1`). Only the source-tree placeholder changes — it's now honest about being unstamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDX2DtdfiAf8gfTLMSuwpb)_