### PR TITLE
build(setup): one-command bootstrap incl. prebuilt conway-geom WASM (no EMSDK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ Build just conway, not conway-geom, e.g. for updating just the Conway API or too
 yarn build-incremental
 ```
 
+#### Running tests without building conway-geom (no EMSDK)
+
+The jest suite loads the conway-geom WASM binaries, which are normally produced
+by the EMSDK/GENie native build. If you only touch the TypeScript, you can skip
+that toolchain entirely: `yarn setup` builds the TypeScript (`build-incremental`)
+and then runs `yarn wasm-prebuilt`, which fetches the WASM `Dist/` bundle from
+the last-published `@bldrs-ai/conway` npm package — so a fresh `yarn setup && yarn
+test` works with no EMSDK. Pin a build with `CONWAY_PREBUILT_WASM_VERSION`, or
+refresh with `yarn wasm-prebuilt --force`.
+This is a convenience for TS-only work — if you change the `conway-geom`
+submodule you must do a real `yarn build` to get matching binaries.
+
 For a full, clean rebuild:
 ```
 yarn build-rebuild

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     }
   },
   "scripts": {
-    "setup": "yarn install && yarn submodule-update && yarn extract-wasm-dependencies",
+    "setup": "yarn install && yarn submodule-update && yarn extract-wasm-dependencies && yarn build-incremental && yarn wasm-prebuilt",
     "codex-setup-emsdk": "bash ./scripts/setup-emsdk.sh",
     "clean": "run-script-os",
     "clean:win32": "rd /s /q compiled & rd /s /q \"dependencies/conway-geom/bin/release\" & del /q \"dependencies/conway-geom/Dist/*.map\" && del /q \"dependencies/conway-geom/Dist/*.js\" & yarn \"clean-conway_geom\"",
@@ -79,6 +79,7 @@
     "browser": "node ./compiled/examples/browser-bundled.cjs",
     "validator": "node ./compiled/examples/validator-bundled.cjs",
     "extract-wasm-dependencies": "node ./scripts/extract-wasm-dependencies.cjs",
+    "wasm-prebuilt": "node ./scripts/fetch-prebuilt-wasm.cjs",
     "build-all-profile-node": "yarn build-profile-conway_geom-node && yarn build-incremental",
     "build-all-profile-web": "yarn build-profile-conway_geom-web && yarn build-incremental",
     "build-all-release-node": "yarn build-conway_geom-node && yarn build-incremental",

--- a/scripts/fetch-prebuilt-wasm.cjs
+++ b/scripts/fetch-prebuilt-wasm.cjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Populate the conway-geom WASM binaries (the `Dist/` bundle) from the
+ * published `@bldrs-ai/conway` npm package, so `yarn test` runs without the
+ * heavy EMSDK/GENie native build.
+ *
+ * Why this exists
+ * ---------------
+ * Jest runs against `compiled/` and the compiled conway-geom interface
+ * (`compiled/dependencies/conway-geom/interface/conway_geometry.js`) loads
+ * `../Dist/ConwayGeomWasmNodeMT.js` at init. Those `Dist/*.js` + `*.wasm`
+ * binaries are produced only by the native toolchain (`yarn build-GHA-all`,
+ * needs EMSDK) — a fresh checkout has just the committed `.d.ts`, so any test
+ * that touches geometry dies with `Cannot find module '../Dist/...'`. The
+ * published package already ships those binaries, so for the common
+ * dev-container case (run the suite, don't rebuild the C++) we can just lift
+ * them out of the tarball.
+ *
+ * Caveat: this is the *last published* build. The WASM is a function of the
+ * conway-geom submodule SHA; if you've changed that submodule (or the native
+ * binding), the prebuilt bundle won't match — do a real `yarn build-*` instead.
+ * Pin a specific build with CONWAY_PREBUILT_WASM_VERSION; force a refresh with
+ * `--force` (or FORCE=1).
+ */
+const { execFileSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const PACKAGE = '@bldrs-ai/conway'
+const VERSION = process.env.CONWAY_PREBUILT_WASM_VERSION || 'latest'
+const FORCE = process.argv.includes('--force') || process.env.FORCE === '1'
+
+const REPO_ROOT = path.resolve(__dirname, '..')
+// Path inside the tarball, and the two in-repo Dist locations to mirror it to:
+// `compiled/` is what the tests load; the source-side `Dist/` is where a real
+// build emits, kept in sync so non-compiled tooling resolves too.
+const DIST_IN_TARBALL = 'package/compiled/dependencies/conway-geom/Dist'
+const DIST_TARGETS = [
+  path.join(REPO_ROOT, 'compiled', 'dependencies', 'conway-geom', 'Dist'),
+  path.join(REPO_ROOT, 'dependencies', 'conway-geom', 'Dist'),
+]
+// The MT node build is the module the jest geometry path actually imports;
+// its presence is our "already populated" sentinel.
+const SENTINEL = 'ConwayGeomWasmNodeMT.js'
+
+
+/** @return {void} */
+function main() {
+  const primaryTarget = DIST_TARGETS[0]
+
+  if (!FORCE && fs.existsSync(path.join(primaryTarget, SENTINEL))) {
+    console.log(`[prebuilt-wasm] ${SENTINEL} already present — skipping ` +
+      `(use --force or FORCE=1 to refresh).`)
+    return
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'conway-wasm-'))
+
+  try {
+    console.log(`[prebuilt-wasm] fetching ${PACKAGE}@${VERSION} ...`)
+    // `npm pack` resolves the registry/auth for us and writes a .tgz. Registry
+    // traffic goes direct (registry.npmjs.org), not through the geometry build.
+    const packOut = execFileSync(
+        'npm',
+        ['pack', `${PACKAGE}@${VERSION}`, '--silent', '--pack-destination', tmpDir],
+        { cwd: tmpDir, encoding: 'utf8' })
+
+    const tgz = packOut.trim().split('\n').pop().trim()
+    const tgzPath = path.join(tmpDir, tgz)
+
+    // Extract only the Dist bundle from the tarball.
+    execFileSync(
+        'tar',
+        ['-xzf', tgzPath, '-C', tmpDir, DIST_IN_TARBALL],
+        { stdio: 'inherit' })
+
+    const extractedDist = path.join(tmpDir, DIST_IN_TARBALL)
+    const files = fs.readdirSync(extractedDist)
+
+    if (files.length === 0) {
+      throw new Error(`no Dist files in ${PACKAGE}@${VERSION} tarball`)
+    }
+
+    for (const target of DIST_TARGETS) {
+      fs.mkdirSync(target, { recursive: true })
+      for (const file of files) {
+        fs.copyFileSync(path.join(extractedDist, file), path.join(target, file))
+      }
+    }
+
+    console.log(`[prebuilt-wasm] installed ${files.length} file(s) ` +
+      `(${files.join(', ')}) into:`)
+    for (const target of DIST_TARGETS) {
+      console.log(`  - ${path.relative(REPO_ROOT, target)}`)
+    }
+    console.log('[prebuilt-wasm] done. NOTE: this is the last-published build; ' +
+      'rebuild from source if you changed the conway-geom submodule.')
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+}
+
+main()


### PR DESCRIPTION
## Problem

The jest suite runs against `compiled/`, and the compiled conway-geom interface (`compiled/dependencies/conway-geom/interface/conway_geometry.js`) loads `../Dist/ConwayGeomWasmNodeMT.js` at init. Those `Dist/*.js` + `.wasm` binaries are produced only by the EMSDK/GENie native build, so a fresh checkout that hasn't run it fails **every geometry test** with:

```
Cannot find module '../Dist/ConwayGeomWasmNodeMT.js'
```

Contributors doing TS-only work (Conway API, tools, compat surface) had to stand up the whole native toolchain just to run the suite.

## Change

- **`scripts/fetch-prebuilt-wasm.cjs`** + **`yarn wasm-prebuilt`**: `npm pack`s the last-published `@bldrs-ai/conway`, lifts the `compiled/dependencies/conway-geom/Dist/*` bundle out of the tarball, and mirrors it into the repo's compiled + source Dist dirs.
  - Idempotent — skips when present (`--force` / `FORCE=1` to refresh).
  - Version-pinnable via `CONWAY_PREBUILT_WASM_VERSION` (default `latest`).
  - Registry traffic is plain `npm` (direct to `registry.npmjs.org`), independent of the native geometry build.
- **`yarn setup`** now runs the full TS build + this fetch:
  `install → submodule-update → extract-wasm-dependencies → build-incremental → wasm-prebuilt`
  so a cold checkout goes **`yarn setup && yarn test` green with no EMSDK**.
- **README** documents the no-EMSDK path + the caveat.

## Caveat (documented in README + the script header)

The bundle is the *last-published* build, which is a function of the `conway-geom` submodule SHA. It's a convenience for TS-only work — if you change that submodule (or the native binding) you must do a real `yarn build` for matching binaries.

## Validation

Locally: wiped the WASM `Dist/`, ran `yarn wasm-prebuilt` (fetched the 5 files from npm), and the AP214 geometry tests passed. Ran the ordered tail `build-incremental → wasm-prebuilt → jest` clean, and the pre-commit gate (full `yarn lint && yarn test`) passed against the fetched binaries. No product code changes — build/setup tooling + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfHL21ghUKsAq4xBCNFLdi)_