### PR TITLE
Fix perf-three pipeline (stale CSVs, dead renders) and add STEP models to regression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -443,7 +443,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ## IFC Regression Results
+            ## Regression Results (IFC + STEP)
 
             **Models:** `test-models` @ `${{ steps.tmsha.outputs.sha }}` (ref `${{ env.TEST_MODELS_REF }}`)
 
@@ -530,6 +530,9 @@ jobs:
         run: |
           yarn install
           yarn build
+          # The bundled server resolves the conway wasm from <cwd>/Dist at
+          # runtime; without this every render 500s with ERR_MODULE_NOT_FOUND.
+          ln -sfn node_modules/@bldrs-ai/conway/compiled/dependencies/conway-geom/Dist Dist
 
       # Safety check: if the resolutions override didn't take effect, H3 would
       # silently benchmark whatever conway version its lockfile pins instead of
@@ -547,6 +550,15 @@ jobs:
             echo "::error::yarn resolutions override did not take effect. Expected '$EXPECTED', got '$ACTUAL'."
             exit 1
           fi
+
+      # headless-gl (the `gl` package H3 renders through) needs an X/GLX
+      # display; without one every render dies with "Could not open the
+      # default X display" (see H3's own Dockerfile, which runs under
+      # xvfb-run).
+      - name: Install Xvfb
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q xvfb
 
       - name: Restore Test Models Cache
         id: cache-test-models
@@ -566,14 +578,20 @@ jobs:
           git -C test-models checkout "$SHA"
 
       - name: Run H3 benchmark (public)
+        env:
+          # Keep outputs OUT of the test-models checkout: it contains
+          # committed benchmark snapshot CSVs, and reporting used to pick
+          # those up instead of this run's results.
+          BENCHMARK_OUTPUT_DIR: ${{ runner.temp }}/bench-public
         run: |
-          node scripts/benchmark.cjs ./h3 ./test-models
+          xvfb-run -a --server-args="-screen 0 1024x768x24 +extension GLX +render -noreset" \
+            node scripts/benchmark.cjs ./h3 ./test-models
 
       - name: Locate detail CSV
         id: detail
         run: |
-          # benchmark.cjs writes to <modelDir>/benchmarks/<engine>_<modelDirName>/performance-detail.csv
-          CSV=$(find test-models/benchmarks -name performance-detail.csv -type f | head -1)
+          # benchmark.cjs writes to $BENCHMARK_OUTPUT_DIR/<engine>_<modelDirName>/performance-detail.csv
+          CSV=$(find "${{ runner.temp }}/bench-public" -name performance-detail.csv -type f | head -1)
           test -n "$CSV" || { echo "::error::performance-detail.csv not produced"; exit 1; }
           echo "csv=${CSV}" >> "$GITHUB_OUTPUT"
 
@@ -779,6 +797,9 @@ jobs:
         run: |
           yarn install
           yarn build
+          # The bundled server resolves the conway wasm from <cwd>/Dist at
+          # runtime; without this every render 500s with ERR_MODULE_NOT_FOUND.
+          ln -sfn node_modules/@bldrs-ai/conway/compiled/dependencies/conway-geom/Dist Dist
 
       - name: Verify candidate conway is resolved in H3
         env:
@@ -793,6 +814,12 @@ jobs:
             exit 1
           fi
 
+      # headless-gl needs an X/GLX display; see the public perf job.
+      - name: Install Xvfb
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q xvfb
+
       - name: Clone private test models
         env:
           GH_TOKEN: ${{ secrets.TEST_MODELS_PRIVATE_TOKEN }}
@@ -801,13 +828,18 @@ jobs:
             "https://x-access-token:${GH_TOKEN}@github.com/bldrs-ai/test-models-private.git" test-models-private
 
       - name: Run H3 benchmark (private)
+        env:
+          # Keep outputs OUT of the model checkout (it may contain committed
+          # benchmark snapshot CSVs that reporting would pick up instead).
+          BENCHMARK_OUTPUT_DIR: ${{ runner.temp }}/bench-private
         run: |
-          node scripts/benchmark.cjs ./h3 ./test-models-private
+          xvfb-run -a --server-args="-screen 0 1024x768x24 +extension GLX +render -noreset" \
+            node scripts/benchmark.cjs ./h3 ./test-models-private
 
       - name: Locate detail CSV
         id: detail
         run: |
-          CSV=$(find test-models-private/benchmarks -name performance-detail.csv -type f | head -1)
+          CSV=$(find "${{ runner.temp }}/bench-private" -name performance-detail.csv -type f | head -1)
           test -n "$CSV" || { echo "::error::performance-detail.csv not produced"; exit 1; }
           echo "csv=${CSV}" >> "$GITHUB_OUTPUT"
 

--- a/scripts/benchmark.cjs
+++ b/scripts/benchmark.cjs
@@ -154,22 +154,16 @@ async function main() {
   // Determine engine version
   let engineVersion = "";
   if (isEngineConway) {
+    // Read the INSTALLED package's version. `yarn list` reports the lockfile
+    // dependency string, which is wrong when CI overrides conway via yarn
+    // resolutions (it kept reporting the pinned version, so benchmark output
+    // dirs collided with committed snapshot dirs in the model repos).
     try {
-      const yarnListOutput = execSync(
-        `yarn list --pattern @bldrs-ai/conway --json`,
-        { cwd: serverDir, stdio: ['pipe','pipe','pipe'] }
-      ).toString();
-      const matchedLines = yarnListOutput
-        .split(/\r?\n/)
-        .filter((line) => line.includes('@bldrs-ai/conway@'));
-      if (matchedLines.length > 0) {
-        const jsonLine = JSON.parse(matchedLines[0]);
-        const name = jsonLine.data.trees[0].name; // e.g., "@bldrs-ai/conway@0.1.560"
-        const parts = name.split('@');
-        engineVersion = parts[2] || '';
-      }
+      const installedPkg = path.join(
+        serverDir, 'node_modules', '@bldrs-ai', 'conway', 'package.json');
+      engineVersion = JSON.parse(fs.readFileSync(installedPkg, 'utf8')).version || 'unknown';
     } catch (e) {
-      console.error('Failed to get @bldrs-ai/conway version from yarn list. Using fallback "unknown".', e);
+      console.error('Failed to read installed @bldrs-ai/conway version. Using fallback "unknown".', e);
       engineVersion = 'unknown';
     }
   } else {
@@ -211,8 +205,13 @@ async function main() {
   // Test run name for the benchmarks folder.
   const testRunName = `${engineStr}_${modelDirName}`;
 
-  // Construct output directory for logs/CSVs.
-  const outputBase = path.join(modelDir, 'benchmarks');
+  // Construct output directory for logs/CSVs. BENCHMARK_OUTPUT_DIR routes
+  // outputs OUT of the model directory: the model repos contain committed
+  // benchmark snapshots under <modelDir>/benchmarks, and writing (or
+  // reporting) there let CI pick up stale committed CSVs instead of this
+  // run's results.
+  const outputBase = process.env.BENCHMARK_OUTPUT_DIR ||
+    path.join(modelDir, 'benchmarks');
   const outputDir = path.join(outputBase, testRunName);
   fs.mkdirSync(outputDir, { recursive: true });
 
@@ -237,6 +236,8 @@ async function main() {
   });
 
   let allStatus = 'OK';
+  let okCount = 0;
+  let failCount = 0;
   const startTime = Date.now();
 
   // Array to hold entries for the HTML report.
@@ -247,24 +248,39 @@ async function main() {
     fs.appendFileSync(filename, line + "\n", 'utf8');
   }
 
-  // Function to recursively get all IFC files.
-  function getIfcFiles(directory) {
+  // Model types to benchmark. Defaults to IFC only; set BENCHMARK_EXTS
+  // (e.g. "ifc,stp,step") to include STEP models under <modelDir>/step once
+  // the render server supports them.
+  const modelExts = (process.env.BENCHMARK_EXTS || 'ifc')
+    .split(',')
+    .map((e) => e.trim().toLowerCase().replace(/^\./, ''))
+    .filter(Boolean);
+
+  // Function to recursively get all model files with the requested extensions.
+  function getModelFiles(directory) {
     let results = [];
     if (!fs.existsSync(directory)) return results;
     const list = fs.readdirSync(directory, { withFileTypes: true });
     list.forEach((dirent) => {
       const fullPath = path.join(directory, dirent.name);
       if (dirent.isDirectory()) {
-        results = results.concat(getIfcFiles(fullPath));
-      } else if (dirent.isFile() && dirent.name.endsWith('.ifc')) {
-        results.push(fullPath);
+        results = results.concat(getModelFiles(fullPath));
+      } else if (dirent.isFile()) {
+        const ext = path.extname(dirent.name).toLowerCase().replace(/^\./, '');
+        if (modelExts.includes(ext)) {
+          results.push(fullPath);
+        }
       }
     });
     return results;
   }
 
-  const ifcRoot = path.join(modelDir, 'ifc');
-  const allIfcFiles = getIfcFiles(ifcRoot);
+  // IFC models live under <modelDir>/ifc, STEP models under <modelDir>/step.
+  const modelRoots = [path.join(modelDir, 'ifc')];
+  if (modelExts.includes('stp') || modelExts.includes('step')) {
+    modelRoots.push(path.join(modelDir, 'step'));
+  }
+  const allIfcFiles = modelRoots.flatMap((root) => getModelFiles(root));
 
   for (const filePath of allIfcFiles) {
     const baseFilename = path.basename(filePath);
@@ -288,8 +304,10 @@ async function main() {
     const encodedFileName = encodeFileName(baseFilename);
     const url = `file://${filePath}`; // local file path
 
-    // --- Save the output PNG in the same directory as the IFC file ---
-    const outputPng = path.join(path.dirname(filePath), `${baseFilename}-fit.png`);
+    // --- Save the output PNG in the benchmark output directory ---
+    // (writing next to the model files pollutes the cached/committed model
+    // repo checkout in CI).
+    const outputPng = path.join(outputDir, `${baseFilename}-fit.png`);
 
     let curlSuccess = true;
     const renderEndpoint = 'http://localhost:8001/renderPanoramic';
@@ -404,6 +422,16 @@ async function main() {
       ].join(',');
       appendLineToFile(newResults, line);
 
+      if (loadStatus === 'OK') {
+        okCount++;
+      } else {
+        failCount++;
+      }
+      console.log(
+        `[${okCount + failCount}/${allIfcFiles.length}] ${loadStatus} ` +
+        `${baseFilename} parse=${parseTimeMs}ms geometry=${geometryTimeMs}ms ` +
+        `total=${totalTimeMs}ms`);
+
       // --- RECORD THE HTML ENTRY ---
       if (fs.existsSync(outputPng)) {
         // Compute a relative path from outputDir to the image.
@@ -422,6 +450,11 @@ async function main() {
       allStatus = 'fail';
       const failLine = `${timestamp},FAIL,${unameVal},N/A,${baseFilename},N/A,N/A,N/A,N/A,N/A,N/A,N/A,N/A,N/A,N/A`;
       appendLineToFile(newResults, failLine);
+
+      failCount++;
+      console.log(
+        `[${okCount + failCount}/${allIfcFiles.length}] FAIL ${baseFilename} ` +
+        `(render request failed - see ${tempServerOutputFile})`);
     }
 
     // Kill the server.
@@ -438,6 +471,19 @@ async function main() {
   const endTime = Date.now();
   const deltaTimeSec = ((endTime - startTime) / 1000).toFixed(2);
   appendLineToFile(basicStatsFilename, `${allStatus}, ${deltaTimeSec}s, ALL_FILES`);
+
+  console.log(
+    `Benchmark complete: ${okCount} OK, ${failCount} FAIL of ` +
+    `${allIfcFiles.length} models in ${deltaTimeSec}s. Results: ${newResults}`);
+
+  // A run where nothing rendered is a broken harness (server failed to
+  // start, missing display, bad wasm path, ...), not a measurement. Fail
+  // loudly instead of letting CI report garbage.
+  if (okCount === 0 && allIfcFiles.length > 0) {
+    console.error(
+      'Benchmark produced no successful measurements; failing the run.');
+    process.exitCode = 1;
+  }
 
   // Delta CSV generation (if applicable).
   let oldVersion = '';

--- a/src/AP214E3_2010/ap214_regression_main.ts
+++ b/src/AP214E3_2010/ap214_regression_main.ts
@@ -1,0 +1,392 @@
+import { exit } from 'process'
+import AP214StepParser from './ap214_step_parser'
+import AP214StepModel from './ap214_step_model'
+import { AP214GeometryExtraction } from './ap214_geometry_extraction'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ParseResult } from '../step/parsing/step_parser'
+import yargs from 'yargs/yargs'
+import fs from 'fs'
+import fsPromises from 'fs/promises'
+import path from 'path'
+import crypto from 'crypto'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import Logger from '../logging/logger'
+import Environment from '../utilities/environment'
+import { ExtractResult } from '../core/shared_constants'
+import { CanonicalMeshType } from '../core/canonical_mesh'
+import EntityTypesAP214 from './AP214E3_2010_gen/entity_types_ap214.gen'
+import { Console } from 'console'
+
+
+const conwayGeom = new ConwayGeometry()
+
+main()
+
+/**
+ * Encapsultes a string in a CSV safe way.
+ *
+ * @param from
+ * @return {string}
+ */
+function csvSafeString( from: string ): string {
+
+  if ( from.includes( '\n' ) ||
+    from.includes( '\r') ||
+    from.includes( '"') ||
+    from.includes( ',' ) ) {
+
+    return `"${from.replaceAll( '"', '""' )}"`
+  }
+
+  return from
+}
+
+// Bytes per megabyte for memory-stat formatting in the perf CSV.
+// eslint-disable-next-line no-magic-numbers
+const BYTES_PER_MB = 1024 * 1024
+
+// Fixed-point precision for perf MB values.
+// eslint-disable-next-line no-magic-numbers
+const PERF_MB_PRECISION = 2
+
+/**
+ * Write a single-row per-file perf CSV at the given path, matching the
+ * column layout of the IFC regression child so the batch aggregator can
+ * merge STEP and IFC rows into one perf CSV. No-op when perfPath is empty.
+ *
+ * @param perfPath Path to write the CSV to. Empty string disables.
+ * @param stepFile Source STEP file path (basename used as the row key).
+ * @param status OK or FAIL.
+ * @param parseTimeMs Parse stage duration in ms.
+ * @param geometryTimeMs Geometry extraction duration in ms.
+ * @param totalTimeMs Sum of parse + geometry in ms.
+ */
+async function writePerfCsvIfRequested(
+    perfPath: string,
+    stepFile: string,
+    status: 'OK' | 'FAIL',
+    parseTimeMs: number,
+    geometryTimeMs: number,
+    totalTimeMs: number,
+): Promise<void> {
+
+  if ( perfPath.length === 0 ) {
+    return
+  }
+
+  const mem = process.memoryUsage()
+  const rssMb = ( mem.rss / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
+  const heapUsedMb = ( mem.heapUsed / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
+  const heapTotalMb = ( mem.heapTotal / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
+
+  const fileName = csvSafeString( path.basename( stepFile ) )
+
+  const header =
+    'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,rssMb,heapUsedMb,heapTotalMb\n'
+  const row =
+    `${fileName},${status},${parseTimeMs},${geometryTimeMs},${totalTimeMs},` +
+    `${rssMb},${heapUsedMb},${heapTotalMb}\n`
+
+  try {
+    await fsPromises.writeFile( perfPath, header + row )
+  } catch ( e ) {
+    // Perf is best-effort; never fail the regression run because of a perf write.
+    console.error( `Failed to write perf CSV at ${perfPath}:`, e )
+  }
+}
+
+/**
+ * Display errors and dump errors to stderr in the batch runner's
+ * `message,count,expressids,file` CSV format.
+ *
+ * @param filePath
+ */
+function displayErrors( filePath: string ) {
+
+  const fileName = csvSafeString( path.basename( filePath ) )
+
+  if ( Logger.getLogs().length > 0 ) {
+    Logger.displayLogs()
+
+    const errors = Logger.getErrors()
+
+    if ( errors.length > 0 ) {
+      const errConsole = new Console( process.stderr )
+
+      errConsole.log( 'message,count,expressids,file' )
+
+      for ( const error of errors ) {
+
+        errConsole.log( `${csvSafeString(error.message)},${error.count},${csvSafeString( Array.from(error.expressIDs.keys()).join(' ') ) },${fileName}`)
+      }
+    }
+  }
+}
+
+/**
+ * Generalised error handling wrapper
+ */
+async function main() {
+
+  try {
+
+    await conwayGeom.initialize()
+
+    Environment.checkEnvironment()
+    Logger.initializeWasmCallbacks()
+
+    doWork()
+  } catch (error) {
+    console.error('An error occurred:', error)
+  }
+}
+
+/**
+ * Actual execution function.
+ */
+function doWork() {
+  const SKIP_PARAMS = 2
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const args = yargs(process.argv.slice(SKIP_PARAMS))
+      .command('$0 <filename> [output]', 'Digest a STEP (AP214) file', (yargs2) => {
+        yargs2.option('strict', {
+
+          describe: 'Makes parser/reference errors on nullable fields return null instead of an error',
+          type: 'boolean',
+          alias: 's',
+          default: false,
+        })
+        yargs2.option('digest', {
+
+          describe: 'Output a digest ',
+          type: 'boolean',
+          alias: 'd',
+          default: false,
+        })
+        yargs2.option('perf', {
+
+          describe:
+            'Write a single-row perf CSV (parse/geometry/total time + memory) at this path',
+          type: 'string',
+          alias: 'p',
+          default: '',
+        })
+
+        yargs2.positional('filename', { describe: 'STEP (AP214) File Path', type: 'string' })
+        yargs2.positional('output', { describe: 'Output path', type: 'string' })
+
+      }, async (argv) => {
+        const stepFile = argv['filename'] as string
+        const outputPath =
+            argv['output'] as string ??
+            path.join( path.dirname( stepFile ), path.parse( stepFile ).name )
+
+        let stepBuffer: Buffer | undefined
+
+        const strict = (argv['strict'] as boolean | undefined) ?? false
+        const digest = (argv['digest'] as boolean | undefined) ?? false
+        const perfPath = (argv['perf'] as string | undefined) ?? ''
+
+        try {
+          stepBuffer = fs.readFileSync(stepFile)
+        } catch {
+          Logger.error(
+              'Couldn\'t read file, check that it is accessible at the specified path.')
+          displayErrors(stepFile)
+          exit()
+        }
+
+        if (stepBuffer === void 0) {
+          Logger.error(
+              'Couldn\'t read file, check that it is accessible at the specified path.')
+          displayErrors(stepFile)
+          exit()
+        }
+
+        const parser = AP214StepParser.Instance
+        const bufferInput = new ParsingBuffer(stepBuffer)
+
+        const parseStartMs = Date.now()
+
+        const result0 = parser.parseHeader(bufferInput)[ 1 ]
+
+        switch (result0) {
+          case ParseResult.COMPLETE:
+
+            break
+
+          case ParseResult.INCOMPLETE:
+
+            Logger.warning('Parse incomplete but no errors')
+            break
+
+          case ParseResult.INVALID_STEP:
+
+            Logger.error('Invalid STEP detected in parse, but no syntax error detected')
+            break
+
+          case ParseResult.MISSING_TYPE:
+
+            Logger.error('Missing STEP type, but no syntax error detected')
+            break
+
+          case ParseResult.SYNTAX_ERROR:
+
+            Logger.error(`Syntax error detected on line ${bufferInput.lineCount}`)
+            break
+
+          default:
+        }
+
+        const [result1, model] = parser.parseDataToModel(bufferInput)
+
+        switch (result1) {
+          case ParseResult.COMPLETE:
+
+            break
+
+          case ParseResult.INCOMPLETE:
+
+            Logger.warning('Parse incomplete but no errors')
+            break
+
+          case ParseResult.INVALID_STEP:
+
+            Logger.error('Invalid STEP detected in parse, but no syntax error detected')
+            break
+
+          case ParseResult.MISSING_TYPE:
+
+            Logger.error('Missing STEP type, but no syntax error detected')
+            break
+
+          case ParseResult.SYNTAX_ERROR:
+
+            Logger.error(`Syntax error detected on line ${bufferInput.lineCount}`)
+            break
+
+          default:
+        }
+
+        const parseEndMs = Date.now()
+        const parseTimeMs = parseEndMs - parseStartMs
+
+        if (model === void 0) {
+          await writePerfCsvIfRequested(
+              perfPath, stepFile, 'FAIL', parseTimeMs, 0, parseTimeMs)
+          displayErrors(stepFile)
+          return
+        }
+
+        model.nullOnErrors = !strict
+
+        const geomStartMs = Date.now()
+        const extraction = geometryExtraction(model)
+        const geomEndMs = Date.now()
+        const geometryTimeMs = geomEndMs - geomStartMs
+        const totalTimeMs = geomEndMs - parseStartMs
+
+        const perfStatus = extraction === void 0 ? 'FAIL' : 'OK'
+        await writePerfCsvIfRequested(
+            perfPath, stepFile, perfStatus, parseTimeMs, geometryTimeMs, totalTimeMs)
+
+        if ( extraction === void 0 ) {
+          Logger.error( 'Couldn\'t extract geometry')
+        } else if ( digest ) {
+
+          // Digest layout matches the IFC regression digest
+          // (ID,Hash,Type,Operand 1,Operand2,Void) so the same diff/bless
+          // tooling applies. STEP digests cover final meshes and memoized
+          // curves; AP214 has no void/CSG-operand columns to fill.
+          const csvLines: [number | string, string][] = []
+
+          const csvPath       = `${outputPath}.csv`
+          const csvFileHandle = await fsPromises.open( csvPath, 'w' )
+
+          await csvFileHandle.write( `ID,Hash,Type,Operand 1,Operand2,Void\n` )
+
+          for ( const mesh of model.geometry ) {
+
+            if ( mesh.type !== CanonicalMeshType.BUFFER_GEOMETRY ) {
+              continue
+            }
+
+            const objContents = mesh.geometry.dumpToOBJ( '' )
+            const hash =
+              crypto.createHash( 'sha1' ).update( objContents ).digest( 'hex' )
+
+            const element = model.getElementByLocalID( mesh.localID )
+            const rowID = element?.expressID ?? mesh.localID
+            const typeName =
+              element !== void 0 ? EntityTypesAP214[element.type] : ''
+
+            csvLines.push([rowID, `${rowID},${hash},${typeName},,,FALSE\n`])
+          }
+
+          for ( const [curveItem, objContents] of model.curves.objs() ) {
+
+            const hash =
+              crypto.createHash( 'sha1' ).update( objContents ).digest( 'hex' )
+
+            const rowID = curveItem.expressID ?? curveItem.toString()
+
+            csvLines.push([rowID,
+              `${rowID},${hash},${EntityTypesAP214[curveItem.type]},,,\n`])
+          }
+
+          csvLines.sort( ( a, b ) => {
+
+            const a0 = a[0]
+            const b0 = b[0]
+
+            if ( typeof a0 === 'number' ) {
+
+              if ( typeof b0 === 'number' ) {
+                return a0 - b0
+              }
+
+              return -1
+            }
+
+            if ( typeof b0 === 'number' ) {
+
+              return 1
+            }
+
+            return a0.localeCompare( b0 )
+          } )
+
+          // Note, we cast to any here because the writeFile supports an
+          // iterable but the typescript bindings don't have the option
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await csvFileHandle.writeFile( csvLines.map( ( line ) => line[ 1 ]) as any )
+
+          await csvFileHandle.close()
+        }
+
+        displayErrors(stepFile)
+      })
+      .help().argv
+}
+
+/**
+ * Function to extract geometry from an AP214StepModel.
+ *
+ * @param model
+ * @return {AP214GeometryExtraction | undefined} The extraction, or undefined
+ * on failure.
+ */
+function geometryExtraction(model: AP214StepModel): AP214GeometryExtraction | undefined {
+
+  const conwayModel = new AP214GeometryExtraction(conwayGeom, model)
+
+  const [extractionResult] = conwayModel.extractAP214GeometryData(false)
+
+  if (extractionResult !== ExtractResult.COMPLETE) {
+    console.error('Could not extract geometry, exiting...')
+    return void 0
+  }
+
+  return conwayModel
+}

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -276,7 +276,13 @@ async function runForFile(filePath: string,
 
   const perfFlag = perfPath ? ` --perf "${perfPath}"` : ''
 
-  const safeExecCommand = `node --experimental-specifier-resolution=node ./compiled/src/ifc/ifc_regression_main.js -d${perfFlag} "${filePath}" "${outputPath}"`
+  // STEP (AP214) models are digested by the AP214 pipeline, IFC models by
+  // the IFC pipeline; both children emit the same digest/error/perf formats.
+  const childScript = isStepFile(filePath) ?
+    './compiled/src/AP214E3_2010/ap214_regression_main.js' :
+    './compiled/src/ifc/ifc_regression_main.js'
+
+  const safeExecCommand = `node --experimental-specifier-resolution=node ${childScript} -d${perfFlag} "${filePath}" "${outputPath}"`
 
   console.log(`Current File: ${filePath}`)
 
@@ -323,6 +329,33 @@ async function runForFile(filePath: string,
   }
 }
 
+// Model files the regression harness understands: IFC plus STEP AP214.
+const SUPPORTED_MODEL_EXTENSIONS = ['.ifc', '.stp', '.step']
+
+/**
+ * Whether this is a STEP (AP214) model file by extension.
+ *
+ * @param filePath
+ * @return {boolean}
+ */
+function isStepFile( filePath: string ): boolean {
+
+  const extension = path.extname( filePath ).toLowerCase()
+
+  return extension === '.stp' || extension === '.step'
+}
+
+/**
+ * Whether this file is a supported model type (IFC or STEP), by extension.
+ *
+ * @param filePath
+ * @return {boolean}
+ */
+function isSupportedModelFile( filePath: string ): boolean {
+
+  return SUPPORTED_MODEL_EXTENSIONS.includes( path.extname( filePath ).toLowerCase() )
+}
+
 /**
  * Recursively collect all IFC file paths (instead of processing them immediately).
  *
@@ -358,7 +391,7 @@ async function collectIFCFiles(
 
       if (item.isDirectory()) {
         await recursiveWalk(resolved)
-      } else if (path.extname(resolved).toLowerCase() === '.ifc') {
+      } else if (isSupportedModelFile(resolved)) {
         ifcFiles.push(resolved)
       }
     }
@@ -426,11 +459,11 @@ async function processIFCFilesInParallel(
           `Starting task for "${path.basename(ifcPath)}". Active tasks: ${activeTasks}`,
       )
       const perfChildPath = perfDir ?
-        path.join(perfDir, `${path.basename(ifcPath, '.ifc')}.perf.csv`) :
+        path.join(perfDir, `${path.parse(ifcPath).name}.perf.csv`) :
         undefined
       const fileResults = await runForFile(
           ifcPath,
-          path.join(outputPath, path.basename(ifcPath, '.ifc')),
+          path.join(outputPath, path.parse(ifcPath).name),
           maxTimeout,
           perfChildPath,
       )
@@ -504,13 +537,13 @@ async function recursiveWalk(
     if (item.isDirectory()) {
       await recursiveWalk(resolved, excludeRegex, outputPath,
           errorLines, fileLines, failedLines, maxTimeout, perfDir)
-    } else if (path.extname(resolved).toLowerCase() === '.ifc') {
+    } else if (isSupportedModelFile(resolved)) {
       const perfChildPath = perfDir ?
-        path.join(perfDir, `${path.basename(resolved, '.ifc')}.perf.csv`) :
+        path.join(perfDir, `${path.parse(resolved).name}.perf.csv`) :
         undefined
       const fileResults = await runForFile(
           resolved,
-          path.join(outputPath, path.basename(resolved, '.ifc')),
+          path.join(outputPath, path.parse(resolved).name),
           maxTimeout,
           perfChildPath,
       )


### PR DESCRIPTION
## Summary

The perf deltas posted on PRs for `test-models` and `test-models-private` have been frozen at 0.00% — every run compared the same committed CSV snapshot against itself. This PR fixes the three stacked defects that caused that, and adds all STEP models in `test-models` / `test-models-private` to the regression suite alongside IFC.

### Perf pipeline defects fixed

1. **Every headless-three render was silently failing.** The H3 server needs a `Dist` symlink to conway's wasm next to its cwd (`ERR_MODULE_NOT_FOUND` otherwise) and an X display for ANGLE/GLX (`ANGLE Display::initialize error 12289: Could not open the default X display` on the bare runner — H3's own Dockerfile uses `xvfb-run`). The workflow now creates the symlink and runs the benchmark under `xvfb-run`. `benchmark.cjs` also now prints per-model OK/FAIL lines and sets a nonzero exit code when *zero* models render, so this failure mode can never be silent again.

2. **The "Locate CSV" step picked a committed snapshot, not the fresh run.** `find test-models/benchmarks -name performance-detail.csv | head -1` matched one of the 15 CSVs committed in the test-models repo (`conway0.9.789_test-models/…`), so the delta was snapshot-vs-snapshot ⇒ 0.00%. Fresh results now go to `BENCHMARK_OUTPUT_DIR` under `${{ runner.temp }}/bench-*`, outside the repo checkout, and the locate step searches only there.

3. **Wrong engine version in the output dir name.** `benchmark.cjs` derived the version from `yarn list`, which reports the lockfile pin (0.23.940), not the `resolutions`-overridden candidate tarball. It now reads `node_modules/@bldrs-ai/conway/package.json` directly.

### STEP models added to regression

- New `src/AP214E3_2010/ap214_regression_main.ts` child: parses + extracts geometry for a STEP (AP214) file, emits the same digest CSV layout as the IFC child (`ID,Hash,Type,Operand 1,Operand2,Void`, sha1 of mesh OBJ dumps + memoized curves) and the same single-row perf CSV, so the existing diff/aggregation tooling applies unchanged.
- `ifc_regression_batch_main.ts` now walks `.ifc`, `.stp`, and `.step` files and dispatches each to the right child. STEP rows land in the same `main.csv` / `perf.csv` / `changes.csv` outputs, in the same regression jobs that already run for IFC (public + private).

**Why STEP is not in perf-three yet:** headless-three at the pinned SHA (76f9ab6) has no `.stp`/`.step` loader in `src/Filetype.js`, so those renders can't succeed. STEP perf is covered by the regression `perf.csv` (real conway loads with parse/geometry/total timings). `benchmark.cjs` accepts `BENCHMARK_EXTS=ifc,stp,step` and already knows the `step/` model root, so enabling it is a one-line env change once H3 gains a STEP loader.

### Follow-up

STEP digest baselines don't exist yet in test-models(-private) `regression/test_models`, so the first runs will report STEP files as new/added rather than diffed; blessing baselines is a commit to those repos after this lands.

## Verification (all local)

- AP214 child on `supercap.step`: `supercap.step,OK,56,299,355` perf row + 1168-row digest CSV.
- Batch runner over a mixed tree (`ifc/box.ifc` + `step/supercap.step`): merged `perf.csv` with both rows, digests written for both.
- Fixed `benchmark.cjs` under `xvfb-run` with the `Dist` symlink: `[1/1] OK box.ifc parse=2ms geometry=8ms total=11ms`, CSV written to `benchout/conway1.356.1126_minimodels/` (correct version in path).
- Reproduced both render-failure modes locally (missing symlink → `ERR_MODULE_NOT_FOUND`; no X display → ANGLE 12289) to confirm the workflow fixes address the real causes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_