### PR TITLE
CI: pin auto-publish npm upgrade to 11.x (npm@latest is now Node-22-only 12.x)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1124,9 +1124,11 @@ jobs:
           cache: 'yarn'
 
       # Trusted Publishing requires npm >= 11.5.1. Node 20 ships with npm 10.x,
-      # so upgrade the global npm binary before the publish step.
+      # so upgrade the global npm binary before the publish step. Pin to the 11.x
+      # line: npm@latest is now 12.x, which requires Node >= 22 (EBADENGINE on
+      # Node 20). 11.x has OIDC trusted publishing and runs on Node 20.
       - name: Upgrade npm to a version that supports OIDC
-        run: npm install -g npm@latest
+        run: npm install -g 'npm@^11.5.1'
 
       - name: Compute next version
         id: ver


### PR DESCRIPTION
## Problem

The `auto-publish` job fails at **"Upgrade npm to a version that supports OIDC"** (`npm install -g npm@latest`), so publishing never runs. `npm@latest` has rolled to **12.0.0**, whose `engines` require Node `^22.22.2 || ^24.15.0 || >=26.0.0`, but the job pins **Node 20**:

```
npm error code EBADENGINE
npm error Not compatible with your version of node/npm: npm@12.0.0
npm error Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

This is a moving-target break (unrelated to any repo change) that fails **every** merge to `main` until pinned; re-running doesn't help since it re-resolves npm@12. It surfaced on the EMSDK 6.0.2 release merge ([run 29097568513](https://github.com/bldrs-ai/conway/actions/runs/29097568513)) — where `build`, `test`, `run-ifc-regression`, and the Tier-A geometry goldens all passed, so the release itself is sound.

## Fix

Pin the upgrade to the 11.x line, which the step's own comment already documents as the OIDC floor:

```diff
-        run: npm install -g npm@latest
+        run: npm install -g 'npm@^11.5.1'
```

npm 11.x has OIDC trusted publishing and runs on Node 20 (`engines: ^20.17.0 || >=22`), so publish works again with no other change.

## Follow-up (not here)

Node 20 is being deprecated on GHA runners (the run logs warn about it). Bumping the publish job to Node 22 and returning to `npm@latest` is the eventual cleanup — a separate, larger change. This pin is the minimal fix to restore publishing now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_