### PR TITLE
CI: roll Node 20 → 26 across all jobs; drop the temporary npm 11.x pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '26'
           cache: 'yarn'
 
       - name: Compute conway-geom submodule SHA
@@ -227,7 +227,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '26'
           cache: 'yarn'
 
       - name: Compute conway-geom submodule SHA
@@ -504,7 +504,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '26'
 
       - name: Download conway candidate tarball
         uses: actions/download-artifact@v4
@@ -799,7 +799,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '26'
 
       - name: Download conway candidate tarball
         uses: actions/download-artifact@v4
@@ -1119,16 +1119,16 @@ jobs:
       - name: Setup Node with npm registry
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '26'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
-      # Trusted Publishing requires npm >= 11.5.1. Node 20 ships with npm 10.x,
-      # so upgrade the global npm binary before the publish step. Pin to the 11.x
-      # line: npm@latest is now 12.x, which requires Node >= 22 (EBADENGINE on
-      # Node 20). 11.x has OIDC trusted publishing and runs on Node 20.
+      # Trusted Publishing requires npm >= 11.5.1. Node 26 ships an older npm,
+      # so upgrade the global npm binary before the publish step. On Node 26 the
+      # current npm@latest (12.x) installs cleanly and has OIDC, so the earlier
+      # 11.x pin (needed while this job ran Node 20) is no longer required.
       - name: Upgrade npm to a version that supports OIDC
-        run: npm install -g 'npm@^11.5.1'
+        run: npm install -g npm@latest
 
       - name: Compute next version
         id: ver


### PR DESCRIPTION
Follow-up to #361 (which pinned `npm@^11.5.1` to unblock publishing on Node 20). This does the real fix.

## Why

Node 20 is **EOL (April 2026)** and GHA runners are already force-migrating actions off it (the deprecation warnings in recent run logs). Pinning npm just defers the same class of break. Moving to a current runtime fixes it properly.

## What

- All **five** `setup-node` steps → **Node 26**: `build`, `run-ifc-regression`, `perf-three-public`, `perf-three-private`, `auto-publish`. Node 26 is Current now, goes **LTS this October**, and npm 12's own `engines` already list `>=26.0.0`.
- **Revert the npm pin**: with the publish job on Node 26, `npm@latest` (12.x) installs cleanly and has OIDC trusted publishing, so `npm install -g 'npm@^11.5.1'` → `npm@latest`. The workaround from #361 is no longer needed.
- `package.json` `engines.node` (`>=16`) left as-is — that's the *consumer* floor for the published package, orthogonal to the CI runtime.

## Validation scope (please note before merging)

Only `build` + `run-ifc-regression` run on PRs. `perf-three-public/private` and `auto-publish` are `push`-to-`main` / `workflow_dispatch` only, so **this PR's CI does not exercise the native `gl` rebuild or the headless-three build on Node 26** — those are the highest-risk spots for a Node major bump (node-gyp / N-API). Two mitigations:

- `auto-publish` `needs: [build, run-ifc-regression]` — **not** the perf jobs — so a `gl`-on-26 hiccup in perf would **not** block publishing.
- The perf jobs already have a "rebuild gl from source if prebuilt is broken" fallback.

If you want the native builds validated before merge, trigger a `workflow_dispatch` run of CI on this branch (Actions → CI → Run workflow) — that exercises the perf jobs on Node 26. Otherwise the first `main` push after merge is the real proving ground, with publishing insulated as noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_