### PR TITLE
Fix STEP decode on Emscripten 6 resizable wasm heap (see-through geometry in Chrome/Firefox)

### DIFF
--- a/src/step/parsing/decode_utf8.test.ts
+++ b/src/step/parsing/decode_utf8.test.ts
@@ -1,0 +1,69 @@
+import {describe, expect, test} from '@jest/globals'
+import { decodeUtf8 } from './decode_utf8'
+
+
+/**
+ * Build a Uint8Array view whose backing buffer is a *resizable* ArrayBuffer —
+ * the shape the Emscripten 6.0.2 browser wasm heap presents, and which strict
+ * browsers' TextDecoder.decode() rejects.
+ *
+ * @param text ASCII text to encode into the view.
+ * @return A subarray view over a resizable ArrayBuffer.
+ */
+function resizableView(text: string): Uint8Array {
+  const bytes = new TextEncoder().encode(text)
+  // The 2-arg resizable-ArrayBuffer constructor (ES2024) may predate the TS lib
+  // in use; construct it through a cast so this compiles regardless.
+  const ResizableArrayBuffer =
+    ArrayBuffer as { new(byteLength: number, options: {maxByteLength: number}): ArrayBuffer }
+  // eslint-disable-next-line no-magic-numbers
+  const rab = new ResizableArrayBuffer(bytes.length, {maxByteLength: bytes.length * 2})
+  const view = new Uint8Array(rab)
+  view.set(bytes)
+  return view.subarray(0, bytes.length)
+}
+
+describe('decodeUtf8', () => {
+
+  test('decodes a plain (non-resizable) buffer view', () => {
+    const view = new TextEncoder().encode('ADVANCED_FACE')
+    expect(decodeUtf8(view)).toBe('ADVANCED_FACE')
+  })
+
+  test('decodes a view over a resizable ArrayBuffer without throwing', () => {
+    // A raw TextDecoder.decode() on this view throws a TypeError in Firefox and
+    // Chrome ("can't be a resizable ArrayBuffer"); decodeUtf8 must not.
+    const view = resizableView('SURFACE_STYLE_FILL_AREA')
+    expect((view.buffer as {resizable?: boolean}).resizable).toBe(true)
+    expect(decodeUtf8(view)).toBe('SURFACE_STYLE_FILL_AREA')
+  })
+
+  test('survives a strict TextDecoder that rejects resizable buffers', () => {
+    // Simulate the browser: make decode() throw when the view is resizable-backed.
+    const proto = TextDecoder.prototype as { decode: TextDecoder['decode'] }
+    const real = proto.decode
+    proto.decode = function decode(this: TextDecoder, input?: BufferSource, opts?: TextDecodeOptions): string {
+      const buffer = (input as ArrayBufferView | undefined)?.buffer as
+        (ArrayBuffer & {resizable?: boolean}) | undefined
+      if (buffer?.resizable === true) {
+        throw new TypeError("TextDecoder.decode: ArrayBufferView ... can't be a resizable ArrayBuffer")
+      }
+      return real.call(this, input as BufferSource, opts)
+    }
+    try {
+      const view = resizableView('ADVANCED')
+      // A decode through the now-strict prototype throws, like the browser
+      // (the old, face-dropping path)…
+      expect(() => new TextDecoder().decode(view)).toThrow(TypeError)
+      // …decodeUtf8 copies out and succeeds.
+      expect(decodeUtf8(view)).toBe('ADVANCED')
+    } finally {
+      proto.decode = real
+    }
+  })
+
+  test('preserves non-ASCII UTF-8 through the copy path', () => {
+    const view = resizableView('café — Ω')
+    expect(decodeUtf8(view)).toBe('café — Ω')
+  })
+})

--- a/src/step/parsing/decode_utf8.ts
+++ b/src/step/parsing/decode_utf8.ts
@@ -1,0 +1,44 @@
+/**
+ * UTF-8 decoding for STEP bytes that may live in the wasm heap.
+ *
+ * Under Emscripten 6.0.2 the browser wasm heap is exposed as a *resizable*
+ * ArrayBuffer (or a growable SharedArrayBuffer on the threaded build). Strict
+ * browsers' `TextDecoder.decode()` throws a TypeError when handed a view backed
+ * by such a buffer ("...can't be a resizable ArrayBuffer"). When STEP entity
+ * string/enum bytes are decoded straight from a heap view, that throw is caught
+ * upstream as an extraction error and the affected face/style is silently
+ * dropped — producing see-through geometry in Chrome/Firefox, while Safari
+ * (which tolerates it) and Node (lenient) render correctly.
+ *
+ * `decodeUtf8` copies the view out of a resizable/growable buffer before
+ * decoding; Node, Safari, and pre-6 builds keep the zero-copy fast path.
+ */
+
+const decoder = new TextDecoder()
+
+/**
+ * Whether `TextDecoder.decode()` may reject a view backed by this buffer.
+ *
+ * `resizable` (ArrayBuffer) and `growable` (SharedArrayBuffer) are the buffer
+ * shapes strict engines refuse; both are absent (undefined) on plain buffers,
+ * so this stays false — and the caller stays zero-copy — everywhere except the
+ * Emscripten 6 browser heap.
+ *
+ * @param buffer The backing buffer of a byte view.
+ * @return True when the view must be copied before decoding.
+ */
+function decodeNeedsCopy(buffer: ArrayBufferLike): boolean {
+  const b = buffer as { resizable?: boolean; growable?: boolean }
+  return b.resizable === true || b.growable === true
+}
+
+/**
+ * UTF-8 decode a byte view, tolerating wasm-heap-backed resizable/growable
+ * buffers that `TextDecoder.decode()` would otherwise reject.
+ *
+ * @param view The bytes to decode.
+ * @return The decoded string.
+ */
+export function decodeUtf8(view: Uint8Array): string {
+  return decoder.decode(decodeNeedsCopy(view.buffer) ? view.slice() : view)
+}

--- a/src/step/parsing/step_parser.ts
+++ b/src/step/parsing/step_parser.ts
@@ -9,6 +9,7 @@ import {
 } from '../../parsing/token_parsing'
 import StepAttributeMap, { ATTRIBUTE_PARSE_TYPE } from './step_attribute_map'
 import StepCommentParser from './step_comment_parser'
+import { decodeUtf8 } from './decode_utf8'
 import { stepExtractString } from './step_deserialization_functions'
 import StepEntityIdentifierParser from './step_entity_identifier_parser'
 import StepEnumParser from './step_enum_parser'
@@ -95,7 +96,6 @@ export interface StepHeader {
 
 export type HeaderParseResult = [StepHeader, ParseResult]
 
-const textDecoder = new TextDecoder()
 
 /**
  * Parser base for header parsing.
@@ -184,7 +184,7 @@ export class StepHeaderParser {
         return syntaxError()
       }
 
-      const headerID = textDecoder.decode(input.buffer.subarray(startIdentifier, input.cursor))
+      const headerID = decodeUtf8(input.buffer.subarray(startIdentifier, input.cursor))
 
       let firstAttribute = true
 
@@ -287,7 +287,7 @@ export class StepHeaderParser {
 
       whitespace()
 
-      const headerBlock = textDecoder.decode(input.buffer.subarray(startBlock, input.cursor))
+      const headerBlock = decodeUtf8(input.buffer.subarray(startBlock, input.cursor))
 
       headers.headers.set(headerID, headerBlock)
 
@@ -943,7 +943,7 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
 
             // do not include the trailing period delimiter
             const subArray = input.buffer.subarray(startEnum_ + 1, input.cursor - 1)
-            const enumString = new TextDecoder().decode(subArray)
+            const enumString = decodeUtf8(subArray)
 
             arg_ = {
               type: 3,
@@ -1132,7 +1132,7 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
 
           // do not include the trailing period delimiter
           const subArray = input.buffer.subarray(startEnum_ + 1, input.cursor - 1)
-          const enumString = new TextDecoder().decode(subArray)
+          const enumString = decodeUtf8(subArray)
 
           arg = {
             type: 3,

--- a/src/step/parsing/step_string_parser.ts
+++ b/src/step/parsing/step_string_parser.ts
@@ -1,5 +1,6 @@
 import ParsingConstants from '../../parsing/parsing_constants'
 import ParsingDfa16Table from '../../parsing/parsing_dfa_16table'
+import { decodeUtf8 } from './decode_utf8'
 
 /**
  * Enum representing the state machine of the string parser DFA.
@@ -27,7 +28,6 @@ const FOUR = ParsingConstants.ZERO + 4
 const ZERO = ParsingConstants.ZERO
 const NINE = ParsingConstants.NINE
 
-const decoder = new TextDecoder()
 
  
 const ISO8859Table = [['¡', '¢', '£', '¤', '¥', '¦', '§', '¨', '©', 'ª', '«', '¬', '­', '®', '¯', '°', '±', '²', '³', '´', 'µ', '¶', '·', '¸', '¹', 'º', '»', '¼', '½', '¾', '¿', 'À', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Æ', 'Ç', 'È', 'É', 'Ê', 'Ë', 'Ì', 'Í', 'Î', 'Ï', 'Ð', 'Ñ', 'Ò', 'Ó', 'Ô', 'Õ', 'Ö', '×', 'Ø', 'Ù', 'Ú', 'Û', 'Ü', 'Ý', 'Þ', 'ß', 'à', 'á', 'â', 'ã', 'ä', 'å', 'æ', 'ç', 'è', 'é', 'ê', 'ë', 'ì', 'í', 'î', 'ï', 'ð', 'ñ', 'ò', 'ó', 'ô', 'õ', 'ö', '÷', 'ø', 'ù', 'ú', 'û', 'ü', 'ý', 'þ'], ['Ą', '˘', 'Ł', '¤', 'Ľ', 'Ś', '§', '¨', 'Š', 'Ş', 'Ť', 'Ź', '­', 'Ž', 'Ż', '°', 'ą', '˛', 'ł', '´', 'ľ', 'ś', 'ˇ', '¸', 'š', 'ş', 'ť', 'ź', '˝', 'ž', 'ż', 'Ŕ', 'Á', 'Â', 'Ă', 'Ä', 'Ĺ', 'Ć', 'Ç', 'Č', 'É', 'Ę', 'Ë', 'Ě', 'Í', 'Î', 'Ď', 'Đ', 'Ń', 'Ň', 'Ó', 'Ô', 'Ő', 'Ö', '×', 'Ř', 'Ů', 'Ú', 'Ű', 'Ü', 'Ý', 'Ţ', 'ß', 'ŕ', 'á', 'â', 'ă', 'ä', 'ĺ', 'ć', 'ç', 'č', 'é', 'ę', 'ë', 'ě', 'í', 'î', 'ď', 'đ', 'ń', 'ň', 'ó', 'ô', 'ő', 'ö', '÷', 'ř', 'ů', 'ú', 'ű', 'ü', 'ý', 'ţ'], ['Ħ', '˘', '£', '¤', '', 'Ĥ', '§', '¨', 'İ', 'Ş', 'Ğ', 'Ĵ', '­', '', 'Ż', '°', 'ħ', '²', '³', '´', 'µ', 'ĥ', '·', '¸', 'ı', 'ş', 'ğ', 'ĵ', '½', '', 'ż', 'À', 'Á', 'Â', '', 'Ä', 'Ċ', 'Ĉ', 'Ç', 'È', 'É', 'Ê', 'Ë', 'Ì', 'Í', 'Î', 'Ï', '', 'Ñ', 'Ò', 'Ó', 'Ô', 'Ġ', 'Ö', '×', 'Ĝ', 'Ù', 'Ú', 'Û', 'Ü', 'Ŭ', 'Ŝ', 'ß', 'à', 'á', 'â', '', 'ä', 'ċ', 'ĉ', 'ç', 'è', 'é', 'ê', 'ë', 'ì', 'í', 'î', 'ï', '', 'ñ', 'ò', 'ó', 'ô', 'ġ', 'ö', '÷', 'ĝ', 'ù', 'ú', 'û', 'ü', 'ŭ', 'ŝ'], ['Ą', 'ĸ', 'Ŗ', '¤', 'Ĩ', 'Ļ', '§', '¨', 'Š', 'Ē', 'Ģ', 'Ŧ', '­', 'Ž', '¯', '°', 'ą', '˛', 'ŗ', '´', 'ĩ', 'ļ', 'ˇ', '¸', 'š', 'ē', 'ģ', 'ŧ', 'Ŋ', 'ž', 'ŋ', 'Ā', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Æ', 'Į', 'Č', 'É', 'Ę', 'Ë', 'Ė', 'Í', 'Î', 'Ī', 'Đ', 'Ņ', 'Ō', 'Ķ', 'Ô', 'Õ', 'Ö', '×', 'Ø', 'Ų', 'Ú', 'Û', 'Ü', 'Ũ', 'Ū', 'ß', 'ā', 'á', 'â', 'ã', 'ä', 'å', 'æ', 'į', 'č', 'é', 'ę', 'ë', 'ė', 'í', 'î', 'ī', 'đ', 'ņ', 'ō', 'ķ', 'ô', 'õ', 'ö', '÷', 'ø', 'ų', 'ú', 'û', 'ü', 'ũ', 'ū'], ['Ё', 'Ђ', 'Ѓ', 'Є', 'Ѕ', 'І', 'Ї', 'Ј', 'Љ', 'Њ', 'Ћ', 'Ќ', '­', 'Ў', 'Џ', 'А', 'Б', 'В', 'Г', 'Д', 'Е', 'Ж', 'З', 'И', 'Й', 'К', 'Л', 'М', 'Н', 'О', 'П', 'Р', 'С', 'Т', 'У', 'Ф', 'Х', 'Ц', 'Ч', 'Ш', 'Щ', 'Ъ', 'Ы', 'Ь', 'Э', 'Ю', 'Я', 'а', 'б', 'в', 'г', 'д', 'е', 'ж', 'з', 'и', 'й', 'к', 'л', 'м', 'н', 'о', 'п', 'р', 'с', 'т', 'у', 'ф', 'х', 'ц', 'ч', 'ш', 'щ', 'ъ', 'ы', 'ь', 'э', 'ю', 'я', '№', 'ё', 'ђ', 'ѓ', 'є', 'ѕ', 'і', 'ї', 'ј', 'љ', 'њ', 'ћ', 'ќ', '§', 'ў'], ['', '', '', '¤', '', '', '', '', '', '', '', '،', '­', '', '', '', '', '', '', '', '', '', '', '', '', '', '؛', '', '', '', '؟', '', 'ء', 'آ', 'أ', 'ؤ', 'إ', 'ئ', 'ا', 'ب', 'ة', 'ت', 'ث', 'ج', 'ح', 'خ', 'د', 'ذ', 'ر', 'ز', 'س', 'ش', 'ص', 'ض', 'ط', 'ظ', 'ع', 'غ', '', '', '', '', '', 'ـ', 'ف', 'ق', 'ك', 'ل', 'م', 'ن', 'ه', 'و', 'ى', 'ي', 'ً', 'ٌ', 'ٍ', 'َ', 'ُ', 'ِ', 'ّ', 'ْ', '', '', '', '', '', '', '', '', '', '', '', ''], ['ʽ', 'ʼ', '£', '', '', '¦', '§', '¨', '©', '', '«', '¬', '­', '', '―', '°', '±', '²', '³', '΄', '΅', 'Ά', '·', 'Έ', 'Ή', 'Ί', '»', 'Ό', '½', 'Ύ', 'Ώ', 'ΐ', 'Α', 'Β', 'Γ', 'Δ', 'Ε', 'Ζ', 'Η', 'Θ', 'Ι', 'Κ', 'Λ', 'Μ', 'Ν', 'Ξ', 'Ο', 'Π', 'Ρ', '', 'Σ', 'Τ', 'Υ', 'Φ', 'Χ', 'Ψ', 'Ω', 'Ϊ', 'Ϋ', 'ά', 'έ', 'ή', 'ί', 'ΰ', 'α', 'β', 'γ', 'δ', 'ε', 'ζ', 'η', 'θ', 'ι', 'κ', 'λ', 'μ', 'ν', 'ξ', 'ο', 'π', 'ρ', 'ς', 'σ', 'τ', 'υ', 'φ', 'χ', 'ψ', 'ω', 'ϊ', 'ϋ', 'ό', 'ύ', 'ώ'], ['', '¢', '£', '¤', '¥', '¦', '§', '¨', '©', '×', '«', '¬', '­', '®', '‾', '°', '±', '²', '³', '´', 'µ', '¶', '·', '¸', '¹', '÷', '»', '¼', '½', '¾', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '‗', 'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט', 'י', 'ך', 'כ', 'ל', 'ם', 'מ', 'ן', 'נ', 'ס', 'ע', 'ף', 'פ', 'ץ', 'צ', 'ק', 'ר', 'ש', 'ת', '', '', '', ''], ['¡', '¢', '£', '¤', '¥', '¦', '§', '¨', '©', 'ª', '«', '¬', '­', '®', '¯', '°', '±', '²', '³', '´', 'µ', '¶', '·', '¸', '¹', 'º', '»', '¼', '½', '¾', '¿', 'À', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Æ', 'Ç', 'È', 'É', 'Ê', 'Ë', 'Ì', 'Í', 'Î', 'Ï', 'Ğ', 'Ñ', 'Ò', 'Ó', 'Ô', 'Õ', 'Ö', '×', 'Ø', 'Ù', 'Ú', 'Û', 'Ü', 'İ', 'Ş', 'ß', 'à', 'á', 'â', 'ã', 'ä', 'å', 'æ', 'ç', 'è', 'é', 'ê', 'ë', 'ì', 'í', 'î', 'ï', 'ğ', 'ñ', 'ò', 'ó', 'ô', 'õ', 'ö', '÷', 'ø', 'ù', 'ú', 'û', 'ü', 'ı', 'ş']]
@@ -117,7 +117,7 @@ export default class StepStringParser extends ParsingDfa16Table {
               result ??= ''
 
               if (cursor > reificationIndex) {
-                result += decoder.decode(input.subarray(reificationIndex, cursor - 1))
+                result += decodeUtf8(input.subarray(reificationIndex, cursor - 1))
               }
 
               result += '\''
@@ -127,7 +127,7 @@ export default class StepStringParser extends ParsingDfa16Table {
             } else {
               result ??= ''
 
-              result += decoder.decode(input.subarray(reificationIndex, cursor))
+              result += decodeUtf8(input.subarray(reificationIndex, cursor))
 
               return result
             }
@@ -165,7 +165,7 @@ export default class StepStringParser extends ParsingDfa16Table {
 
               if (nextChar2 !== BSLASH) {
                 result ??= ''
-                result += decoder.decode(input.subarray(reificationIndex, cursor))
+                result += decodeUtf8(input.subarray(reificationIndex, cursor))
                 cursor = nextCursor2 + 1
                 break
               }
@@ -183,7 +183,7 @@ export default class StepStringParser extends ParsingDfa16Table {
               }
 
               result ??= ''
-              result += decoder.decode(input.subarray(reificationIndex, cursor))
+              result += decodeUtf8(input.subarray(reificationIndex, cursor))
 
               codePage = nextChar3 - A
 
@@ -202,7 +202,7 @@ export default class StepStringParser extends ParsingDfa16Table {
 
               if (nextChar2 !== BSLASH) {
                 result ??= ''
-                result += decoder.decode(input.subarray(reificationIndex, cursor))
+                result += decodeUtf8(input.subarray(reificationIndex, cursor))
                 cursor = nextCursor2 + 1
                 break
               }
@@ -216,7 +216,7 @@ export default class StepStringParser extends ParsingDfa16Table {
               const nextChar3 = input[nextCursor3]
 
               result ??= ''
-              result += decoder.decode(input.subarray(reificationIndex, cursor))
+              result += decodeUtf8(input.subarray(reificationIndex, cursor))
 
               /* eslint-disable no-magic-numbers */
               if (nextChar3 < 0x7F) {
@@ -242,7 +242,7 @@ export default class StepStringParser extends ParsingDfa16Table {
               const nextChar2 = input[nextCursor2]
 
               result ??= ''
-              result += decoder.decode(input.subarray(reificationIndex, cursor))
+              result += decodeUtf8(input.subarray(reificationIndex, cursor))
 
               const hexParserTil0 = (count: number) => {
 


### PR DESCRIPTION
## The bug

Under Emscripten 6.0.2 (shipped in the 3.1.x→6.0.2 upgrade, #359) the browser wasm heap is exposed as a **resizable `ArrayBuffer`** (a growable `SharedArrayBuffer` on the threaded build). Strict browsers' `TextDecoder.decode()` **throws a `TypeError`** when handed a view backed by such a buffer:

```
Error extracting face ADVANCED_FACE - TextDecoder.decode: ArrayBufferView ...
can't be a resizable ArrayBuffer
  -> THREE.BufferGeometry position attribute has NaN values
```

The STEP parsers decode entity string/enum bytes **straight from a heap view**, so that throw was caught upstream as an extraction error and the affected face/style was **silently dropped** — producing see-through geometry.

It was engine-dependent, which is why it slipped through:
- **Safari** tolerates it → full, correct geometry (74.7 MB)
- **Chrome/Brave** partially reject → ~12% of geometry dropped (65.8 MB) → boards render transparent
- **Firefox** rejects hard → load fails
- **Node** is lenient → NodeMT output stayed **byte-identical**, so the regression digest suite never caught it

It is **unrelated to the AFTP arena / parallel path** — both produce identical, opaque geometry in NodeMT.

## The fix

A new `decodeUtf8()` helper copies the view out of a resizable/growable buffer before decoding; Node, Safari, and pre-6 builds keep the zero-copy fast path. Every STEP-parser decode site (7 in `step_string_parser.ts`, 4 in `step_parser.ts`) routes through it.

## Verification

- `Arty_Z7` regression digest **byte-identical** after the change (no output change on the lenient path).
- New unit test (`decode_utf8.test.ts`) **reproduces the strict-browser throw** on a resizable-backed view and confirms `decodeUtf8` survives it and decodes correctly (incl. non-ASCII).
- Full suite green (142 tests), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_