### PR TITLE
Fix see-through geometry: shim TextDecoder for the wasm glue's resizable-heap decodes

### DIFF
--- a/src/step/parsing/decode_utf8.test.ts
+++ b/src/step/parsing/decode_utf8.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from '@jest/globals'
-import { decodeUtf8 } from './decode_utf8'
+import { decodeUtf8, installResizableTextDecoderShim } from './decode_utf8'
 
 
 /**
@@ -65,5 +65,33 @@ describe('decodeUtf8', () => {
   test('preserves non-ASCII UTF-8 through the copy path', () => {
     const view = resizableView('café — Ω')
     expect(decodeUtf8(view)).toBe('café — Ω')
+  })
+
+  test('global shim rescues decodes we do not own (e.g. the wasm glue)', () => {
+    // The wasm glue's UTF8ToString / embind string returns call
+    // TextDecoder.prototype.decode directly on resizable-heap views — we can't
+    // route those through decodeUtf8. The global shim must intercept them.
+    const proto = TextDecoder.prototype as { decode: TextDecoder['decode'] }
+    const realDecode = proto.decode
+    // Simulate a strict browser: the base decode throws on a resizable view.
+    proto.decode = function strict(this: TextDecoder, input?: BufferSource, opts?: TextDecodeOptions): string {
+      const buffer = (ArrayBuffer.isView(input) ? input.buffer : input) as
+        { resizable?: boolean } | undefined
+      if (buffer?.resizable === true) {
+        throw new TypeError("TextDecoder.decode: ... can't be a resizable ArrayBuffer")
+      }
+      return realDecode.call(this, input as BufferSource, opts)
+    }
+    try {
+      const view = resizableView('ADVANCED_FACE_STRING_VALUE')
+      // Before the shim, a raw decode (the glue's path) throws.
+      expect(() => proto.decode.call(new TextDecoder(), view)).toThrow(TypeError)
+      // Install the shim on top of the strict base.
+      installResizableTextDecoderShim()
+      // Now the same raw decode is intercepted, copied out, and succeeds.
+      expect(new TextDecoder().decode(view)).toBe('ADVANCED_FACE_STRING_VALUE')
+    } finally {
+      proto.decode = realDecode
+    }
   })
 })

--- a/src/step/parsing/decode_utf8.ts
+++ b/src/step/parsing/decode_utf8.ts
@@ -1,17 +1,23 @@
 /**
- * UTF-8 decoding for STEP bytes that may live in the wasm heap.
+ * UTF-8 decoding compat for the Emscripten 6.0.2 resizable wasm heap.
  *
  * Under Emscripten 6.0.2 the browser wasm heap is exposed as a *resizable*
- * ArrayBuffer (or a growable SharedArrayBuffer on the threaded build). Strict
- * browsers' `TextDecoder.decode()` throws a TypeError when handed a view backed
- * by such a buffer ("...can't be a resizable ArrayBuffer"). When STEP entity
- * string/enum bytes are decoded straight from a heap view, that throw is caught
- * upstream as an extraction error and the affected face/style is silently
- * dropped — producing see-through geometry in Chrome/Firefox, while Safari
- * (which tolerates it) and Node (lenient) render correctly.
+ * ArrayBuffer (a growable SharedArrayBuffer on the threaded build — see
+ * `wasmMemory.toResizableBuffer()` in the generated glue). Strict browsers'
+ * `TextDecoder.decode()` throws a TypeError when handed a view backed by such a
+ * buffer ("...can't be a resizable ArrayBuffer"). Anything that decodes a heap
+ * view then throws and, when that happens inside geometry extraction, the face
+ * is silently dropped — producing see-through models in Chrome/Firefox, while
+ * Safari (which tolerates it) and Node (whose heap is not resizable) are fine.
  *
- * `decodeUtf8` copies the view out of a resizable/growable buffer before
- * decoding; Node, Safari, and pre-6 builds keep the zero-copy fast path.
+ * Two decoders hit this:
+ *   1. Our own STEP string/enum decodes — routed through `decodeUtf8` below.
+ *   2. Emscripten's `UTF8ToString` / embind `std::string` returns in the wasm
+ *      glue, which we do NOT own — covered by the global prototype shim, since
+ *      the glue calls `TextDecoder.prototype.decode` like everyone else.
+ *
+ * Both copy the bytes out of a resizable/growable buffer first; plain buffers
+ * (Node, Safari, pre-6 builds) keep the zero-copy fast path.
  */
 
 const decoder = new TextDecoder()
@@ -21,7 +27,7 @@ const decoder = new TextDecoder()
  *
  * `resizable` (ArrayBuffer) and `growable` (SharedArrayBuffer) are the buffer
  * shapes strict engines refuse; both are absent (undefined) on plain buffers,
- * so this stays false — and the caller stays zero-copy — everywhere except the
+ * so this stays false — and callers stay zero-copy — everywhere except the
  * Emscripten 6 browser heap.
  *
  * @param buffer The backing buffer of a byte view.
@@ -33,6 +39,17 @@ function decodeNeedsCopy(buffer: ArrayBufferLike): boolean {
 }
 
 /**
+ * Copy an array-buffer view into a fresh, plain (non-resizable) `Uint8Array`.
+ *
+ * @param view The view to copy.
+ * @return A plain-buffer copy of the view's bytes.
+ */
+function copyOutOfResizable(view: ArrayBufferView): Uint8Array {
+  return new Uint8Array(
+      view.buffer as ArrayBufferLike, view.byteOffset, view.byteLength).slice()
+}
+
+/**
  * UTF-8 decode a byte view, tolerating wasm-heap-backed resizable/growable
  * buffers that `TextDecoder.decode()` would otherwise reject.
  *
@@ -41,4 +58,37 @@ function decodeNeedsCopy(buffer: ArrayBufferLike): boolean {
  */
 export function decodeUtf8(view: Uint8Array): string {
   return decoder.decode(decodeNeedsCopy(view.buffer) ? view.slice() : view)
+}
+
+let shimInstalled = false
+
+/**
+ * Install a global, idempotent `TextDecoder.prototype.decode` shim that copies a
+ * view out of a resizable/growable buffer before decoding. This covers decodes
+ * we do not own — chiefly Emscripten's `UTF8ToString` and embind `std::string`
+ * returns in the wasm glue, which read straight from the resizable wasm heap and
+ * would otherwise throw mid-extraction and drop geometry. A no-op where
+ * `TextDecoder` is absent or the buffer is plain.
+ */
+export function installResizableTextDecoderShim(): void {
+  if (shimInstalled || typeof TextDecoder === 'undefined') {
+    return
+  }
+  shimInstalled = true
+
+  const proto = TextDecoder.prototype as { decode: TextDecoder['decode'] }
+  const original = proto.decode
+
+  proto.decode = function decode(
+      this: TextDecoder, input?: BufferSource, options?: TextDecodeOptions): string {
+    if (input !== undefined) {
+      const buffer = (ArrayBuffer.isView(input) ? input.buffer : input) as ArrayBufferLike
+      if (decodeNeedsCopy(buffer)) {
+        input = ArrayBuffer.isView(input) ?
+          copyOutOfResizable(input) :
+          new Uint8Array(input as ArrayBufferLike).slice()
+      }
+    }
+    return original.call(this, input as BufferSource, options)
+  }
 }

--- a/src/step/parsing/step_string_parser.ts
+++ b/src/step/parsing/step_string_parser.ts
@@ -1,6 +1,12 @@
 import ParsingConstants from '../../parsing/parsing_constants'
 import ParsingDfa16Table from '../../parsing/parsing_dfa_16table'
-import { decodeUtf8 } from './decode_utf8'
+import { decodeUtf8, installResizableTextDecoderShim } from './decode_utf8'
+
+// Emscripten 6's browser wasm heap is a resizable ArrayBuffer, on which strict
+// browsers' TextDecoder.decode() throws — including the glue's own UTF8ToString
+// during geometry extraction. Install the global copy-first shim as the STEP
+// pipeline loads, before any heap-string decode. Idempotent.
+installResizableTextDecoderShim()
 
 /**
  * Enum representing the state machine of the string parser DFA.


### PR DESCRIPTION
Follow-up to #363, which didn't fully resolve the see-through geometry.

## Why #363 wasn't enough

#363 routed conway's **own** STEP string decodes through `decodeUtf8`. But the see-through boards persisted in Chrome/Firefox — because the throwing decode **isn't ours**. Under Emscripten 6.0.2 the browser wasm heap is a *resizable* `ArrayBuffer` (`wasmMemory.toResizableBuffer()` in the generated glue), and Emscripten's own `UTF8ToString` / embind `std::string` returns call `TextDecoder.decode()` straight on that heap. Strict browsers throw there, so when `extractAdvancedFace` reads a string back from wasm, the face is dropped:

```
Error extracting face ADVANCED_FACE - TextDecoder.decode: ArrayBufferView ...
can't be a resizable ArrayBuffer  ->  THREE.BufferGeometry ... position has NaN
```

Engine-dependent, exactly as reported: **Safari** tolerates (opaque, full 74.7 MB), **Chrome** drops ~12% (65.8 MB, see-through), **Firefox** fails; **Node** is lenient so the digest suite never moved.

## The fix (right altitude this time)

A global, idempotent `TextDecoder.prototype.decode` shim that copies a view out of a resizable/growable buffer before decoding. Because the glue calls the same prototype method, this covers the decodes we don't own; conway's `decodeUtf8` stays for local clarity. Installed as the STEP pipeline loads — before any extraction-time heap-string decode.

## Verification

- **New unit test** simulates a strict decoder and proves the shim rescues a raw (glue-style) decode of a resizable-backed view.
- **Headless Chromium**: confirmed a resizable-source view copied via `.slice()` yields a plain, **non-resizable** `ArrayBuffer` — the exact property strict engines accept.
- `Arty_Z7` digest **byte-identical**; full suite (143 tests) + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_