### PR TITLE
CI: restore perf-three by installing canvas build deps before H3 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -529,6 +529,18 @@ jobs:
             fs.writeFileSync('h3/package.json', JSON.stringify(p, null, 2) + '\n');
           "
 
+      # headless-three pulls in `canvas`, which has no prebuilt binary for this
+      # runner's Node, so the `yarn install` below compiles it from source. Its
+      # node-gyp build needs cairo/pixman/pango/etc. dev headers present *before*
+      # install — the GL libraries installed further down (for headless-gl) come
+      # too late and don't include these. Without this, `yarn install` dies with
+      # "Package pixman-1 was not found" and every perf run is skipped.
+      - name: Install canvas native build dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q pkg-config build-essential \
+            libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev libpixman-1-dev
+
       - name: Install H3 + build
         working-directory: h3
         run: |
@@ -823,6 +835,15 @@ jobs:
             p.resolutions = Object.assign({}, p.resolutions, { '@bldrs-ai/conway': 'file:' + process.env.CANDIDATE_TGZ });
             fs.writeFileSync('h3/package.json', JSON.stringify(p, null, 2) + '\n');
           "
+
+      # See the public perf job — canvas compiles from source here and needs
+      # cairo/pixman/pango dev headers before `yarn install`, ahead of the
+      # GL libraries installed further down.
+      - name: Install canvas native build dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q pkg-config build-essential \
+            libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev libpixman-1-dev
 
       - name: Install H3 + build
         working-directory: h3


### PR DESCRIPTION
## Problem

The `perf-three-public` / `perf-three-private` jobs — which compute the cross-version performance deltas — have been **failing on every release since ~1.362**, so the perf corpus hasn't updated. The last good snapshot was `1.361.1150`; the entire AFTP + emsdk-6 + `GROWABLE_ARRAYBUFFERS=0` arc landed during the blackout without any perf-three deltas being recorded.

Both jobs die at **"Install H3 + build"**:

```
Package pixman-1 was not found in the pkg-config search path.
gyp: Call to 'pkg-config pixman-1 --libs' returned exit status 1
gyp ERR! $npm_package_name canvas   $npm_package_version 3.1.0
```

`headless-three` pulls in `canvas`, which no longer ships a prebuilt binary for the runner's Node, so `yarn install` compiles it from source. `node-gyp` needs cairo/pixman/pango dev headers present **before** install, but the only `apt-get` step ran *afterward* (and installed just the headless-gl libraries). The build failed, so every downstream perf step was skipped: no delta computed, no comment posted, no CSV uploaded.

## Fix

Add an **"Install canvas native build dependencies"** step before "Install H3 + build" in both perf jobs, installing `libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev libpixman-1-dev`. This is a CI-only change — no engine, WASM, or published-package code is touched.

## Verification

Triggering a `workflow_dispatch` run on this branch to confirm perf-three builds and posts a fresh delta report (absolute numbers + per-model deltas vs baseline) against the accumulated optimization work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_