### PR TITLE
CI: pin perf-three jobs to Node 20 so native gl/canvas addons build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -501,10 +501,16 @@ jobs:
           submodules: false
           fetch-depth: 1
 
+      # Unlike the other jobs (pure JS/wasm on Node 26), perf builds
+      # headless-three's native addons — `gl` and `canvas`. Neither ships a
+      # prebuilt for Node 26, and `gl` won't even compile against Node 26's V8
+      # (GetAlignedPointerFromInternalField signature change). Pin Node 20,
+      # which has prebuilt binaries for both; it's also the runtime the 1.361
+      # perf baseline was measured under, so the comparison stays apples-to-apples.
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '26'
+          node-version: '20'
 
       - name: Download conway candidate tarball
         uses: actions/download-artifact@v4
@@ -808,10 +814,12 @@ jobs:
           submodules: false
           fetch-depth: 1
 
+      # See the public perf job — Node 20 so headless-three's native `gl` /
+      # `canvas` addons resolve prebuilts instead of failing to compile on Node 26.
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '26'
+          node-version: '20'
 
       - name: Download conway candidate tarball
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Follow-up to #366

#366 fixed the `canvas` build (pixman dev headers), which got that step green — but it exposed the next layer. `Install H3 + build` still fails, now on the **`gl` (headless-gl)** native addon:

```
../src/native/bindings.cc: GetAlignedPointerFromInternalField ... candidate expects 3 arguments, 1 provided
make: *** [webgl.target.mk:136 ...] Error 1
cwd .../h3/node_modules/gl   node -v v26.5.0
```

`gl`'s source uses a V8 embedder API that Node 26 removed, so it can't compile at all.

## Root cause

All CI jobs pin `node-version: '26'`. The build/regression/publish jobs are pure JS/wasm and are fine on 26. But the perf jobs build headless-three's **native** addons (`gl`, `canvas`) — and **neither ships a prebuilt for Node 26**, forcing a source compile. canvas then needed pixman (fixed in #366); `gl` won't compile against Node 26's V8 at all. This is why perf-three broke around 1.362 (when Node was bumped to 26): before that, prebuilts were used and no native compile happened.

## Fix

Pin **only the two perf-three jobs** to `node-version: '20'`, which has prebuilt binaries for both `gl` and `canvas` — no source compile, both failure modes gone. `build` / `run-ifc-regression` / `auto-publish` stay on Node 26. Node 20 is also the runtime the 1.361 perf baseline was measured under, keeping the delta apples-to-apples.

The canvas-deps step from #366 is retained as harmless belt-and-suspenders (it's a fast no-op when a prebuilt is used).

## Verification

On merge, the push-to-main run should get perf-three fully green and post the restored delta report (abs + Δ% per model vs 1.361.1150 baseline) to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_