### PR TITLE
Spatial structure 'names' mode + ReleaseEntityCache (lazy properties, step 1)

### DIFF
--- a/src/compat/web-ifc/ap214_properties.ts
+++ b/src/compat/web-ifc/ap214_properties.ts
@@ -10,7 +10,7 @@ import {
 import EntityTypesAP214 from '../../AP214E3_2010/AP214E3_2010_gen/entity_types_ap214.gen'
 import AP214StepModel from '../../AP214E3_2010/ap214_step_model'
 import { IfcApiProxyAP214 } from './ifc_api_proxy_ap214'
-import { Node } from './properties_passthrough'
+import { IncludeProperties, Node } from './properties_passthrough'
 
 
 /**
@@ -281,7 +281,7 @@ export class AP214Properties {
    * @return {Promise<Node>} The root node. A single-root file returns its root
    * directly; a multi-root file is wrapped in a synthetic container root.
    */
-  async getSpatialStructure( includeProperties?: boolean | 'names' ): Promise<Node> {
+  async getSpatialStructure( includeProperties?: IncludeProperties ): Promise<Node> {
 
     const roots = this.productStructure()
 
@@ -340,7 +340,7 @@ export class AP214Properties {
    */
   private async toSpatialNode(
       node: ProductStructureNode,
-      includeProperties?: boolean | 'names' ): Promise<AP214Node> {
+      includeProperties?: IncludeProperties ): Promise<AP214Node> {
 
     const children = await Promise.all(
         node.children.map( ( childNode ) => this.toSpatialNode( childNode, includeProperties ) ) )
@@ -354,8 +354,11 @@ export class AP214Properties {
       children,
     }
 
-    // `'names'` is satisfied by the unconditional Name handle above.
-    if ( includeProperties === true ) {
+    if ( includeProperties === 'names' ) {
+      // Satisfied by the unconditional Name handle above.
+    } else if ( includeProperties ) {
+      // Truthy semantics match the IFC path (web-ifc parity for untyped
+      // JS callers passing truthy non-booleans).
       const properties = await this.getItemProperties( node.expressID )
       spatialNode = { ...properties, ...spatialNode }
     }

--- a/src/compat/web-ifc/ap214_properties.ts
+++ b/src/compat/web-ifc/ap214_properties.ts
@@ -281,7 +281,7 @@ export class AP214Properties {
    * @return {Promise<Node>} The root node. A single-root file returns its root
    * directly; a multi-root file is wrapped in a synthetic container root.
    */
-  async getSpatialStructure( includeProperties?: boolean ): Promise<Node> {
+  async getSpatialStructure( includeProperties?: boolean | 'names' ): Promise<Node> {
 
     const roots = this.productStructure()
 
@@ -340,7 +340,7 @@ export class AP214Properties {
    */
   private async toSpatialNode(
       node: ProductStructureNode,
-      includeProperties?: boolean ): Promise<AP214Node> {
+      includeProperties?: boolean | 'names' ): Promise<AP214Node> {
 
     const children = await Promise.all(
         node.children.map( ( childNode ) => this.toSpatialNode( childNode, includeProperties ) ) )
@@ -354,7 +354,8 @@ export class AP214Properties {
       children,
     }
 
-    if ( includeProperties ) {
+    // `'names'` is satisfied by the unconditional Name handle above.
+    if ( includeProperties === true ) {
       const properties = await this.getItemProperties( node.expressID )
       spatialNode = { ...properties, ...spatialNode }
     }

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -265,6 +265,29 @@ export class IfcAPI {
   }
 
   /**
+   * Conway extension (no web-ifc equivalent): drop the model's
+   * materialised entity/descriptor caches, returning that memory to the
+   * JS heap. Entities and attributes rematerialise transparently on the
+   * next property access, so callers can invoke this between UI
+   * interactions to keep the property working set bounded to what the
+   * active UI is touching.
+   *
+   * @param modelID
+   */
+  ReleaseEntityCache(modelID: number): void {
+
+    const result = this.models.get(modelID)
+
+    if (result === void 0) {
+
+      Logger.error('[ReleaseEntityCache]: model === undefined')
+      return
+    }
+
+    result.releaseEntityCache?.()
+  }
+
+  /**
    *
    * @param modelID
    * @return {Vector<LoaderError>}

--- a/src/compat/web-ifc/ifc_api_model_passthrough.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough.ts
@@ -17,4 +17,10 @@ export interface IfcApiModelPassthrough {
   flattenLine(line: any): void
   getLine(expressID: number, flatten?: boolean): string | void
   getGeometry(geometryExpressID: number): IfcGeometry
+
+  /**
+   * Optional: drop the model's materialised entity/descriptor caches,
+   * returning that memory. Entities rematerialise on next access.
+   */
+  releaseEntityCache?(): void
 }

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -63,6 +63,15 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
   }
 
   /**
+   * Drop this model's materialised entity/descriptor cache (and lazily
+   * rebuilt vtable data), returning that memory to the JS heap. Entities
+   * rematerialise transparently on next access.
+   */
+  releaseEntityCache(): void {
+    this.model[0].invalidate(true)
+  }
+
+  /**
    * Contains all the logic and methods regarding properties, psets, qsets, etc.
    */
   properties = new AP214Properties(this)

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -16,6 +16,7 @@ import {
   Vector,
 } from './ifc_api'
 import { IfcApiModelPassthrough } from './ifc_api_model_passthrough'
+import { NodeValueHandle } from './properties_passthrough'
 import * as glmatrix from 'gl-matrix'
 import { IfcProperties } from './ifc_properties'
 import Logger from '../../logging/logger'
@@ -407,9 +408,10 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   /**
    * Light attribute read: Name / LongName / GlobalId as web-ifc value
    * handles, WITHOUT materialising the entity's full flattened record.
-   * Reads go through the typed entity's lazy per-field getters, so only
-   * these attributes' vtable slots are decoded. Used by the spatial
-   * structure's `'names'` mode.
+   * Reads go through the typed entity's lazy per-field getters — the
+   * first access tokenizes the record's field offsets into the shared
+   * vtable, but only these attributes' values are deserialized. Used by
+   * the spatial structure's `'names'` mode.
    *
    * @param expressID
    * @return {object} `{ Name?, LongName?, GlobalId? }` string handles
@@ -417,14 +419,14 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * and is non-null on the entity.
    */
   getLineNameAttributes(expressID: number):
-    { Name?: { type: number, value: string },
-      LongName?: { type: number, value: string },
-      GlobalId?: { type: number, value: string } } {
+    { Name?: NodeValueHandle,
+      LongName?: NodeValueHandle,
+      GlobalId?: NodeValueHandle } {
 
     const result: {
-      Name?: { type: number, value: string },
-      LongName?: { type: number, value: string },
-      GlobalId?: { type: number, value: string } } = {}
+      Name?: NodeValueHandle,
+      LongName?: NodeValueHandle,
+      GlobalId?: NodeValueHandle } = {}
 
     const entity = this.model[0].getElementByExpressID(expressID) as any
 
@@ -435,29 +437,22 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // web-ifc tape type 1 = string; ifclib's deref switches on this code.
     const WEB_IFC_STRING_TYPE = 1
 
-    // Defensive per-attribute reads: getters throw on malformed records
-    // when the model's nullOnErrors is off, and LongName only exists on
-    // spatial-structure entity types.
-    try {
-      const name = entity.Name
-      if (typeof name === 'string') {
-        result.Name = { type: WEB_IFC_STRING_TYPE, value: name }
-      }
-    } catch (e) { /* attribute unreadable — omit */ }
+    // Absent attributes (e.g. LongName on non-spatial types) read as
+    // undefined and are omitted via the typeof check. The catch guards
+    // malformed records: field extraction throws on truncated records
+    // regardless of the model's nullOnErrors setting.
+    for (const attribute of ['Name', 'LongName', 'GlobalId'] as const) {
+      try {
+        const value = entity[attribute]
 
-    try {
-      const longName = entity.LongName
-      if (typeof longName === 'string') {
-        result.LongName = { type: WEB_IFC_STRING_TYPE, value: longName }
+        if (typeof value === 'string') {
+          result[attribute] = { type: WEB_IFC_STRING_TYPE, value }
+        }
+      } catch (e) {
+        Logger.warning(
+            `[getLineNameAttributes]: unreadable ${attribute} for expressID: ${expressID}`)
       }
-    } catch (e) { /* attribute absent on this type — omit */ }
-
-    try {
-      const globalId = entity.GlobalId
-      if (typeof globalId === 'string') {
-        result.GlobalId = { type: WEB_IFC_STRING_TYPE, value: globalId }
-      }
-    } catch (e) { /* attribute unreadable — omit */ }
+    }
 
     return result
   }

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -405,6 +405,75 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   }
 
   /**
+   * Light attribute read: Name / LongName / GlobalId as web-ifc value
+   * handles, WITHOUT materialising the entity's full flattened record.
+   * Reads go through the typed entity's lazy per-field getters, so only
+   * these attributes' vtable slots are decoded. Used by the spatial
+   * structure's `'names'` mode.
+   *
+   * @param expressID
+   * @return {object} `{ Name?, LongName?, GlobalId? }` string handles
+   * (`{type: 1, value}`), each present only when the attribute exists
+   * and is non-null on the entity.
+   */
+  getLineNameAttributes(expressID: number):
+    { Name?: { type: number, value: string },
+      LongName?: { type: number, value: string },
+      GlobalId?: { type: number, value: string } } {
+
+    const result: {
+      Name?: { type: number, value: string },
+      LongName?: { type: number, value: string },
+      GlobalId?: { type: number, value: string } } = {}
+
+    const entity = this.model[0].getElementByExpressID(expressID) as any
+
+    if (entity === void 0) {
+      return result
+    }
+
+    // web-ifc tape type 1 = string; ifclib's deref switches on this code.
+    const WEB_IFC_STRING_TYPE = 1
+
+    // Defensive per-attribute reads: getters throw on malformed records
+    // when the model's nullOnErrors is off, and LongName only exists on
+    // spatial-structure entity types.
+    try {
+      const name = entity.Name
+      if (typeof name === 'string') {
+        result.Name = { type: WEB_IFC_STRING_TYPE, value: name }
+      }
+    } catch (e) { /* attribute unreadable — omit */ }
+
+    try {
+      const longName = entity.LongName
+      if (typeof longName === 'string') {
+        result.LongName = { type: WEB_IFC_STRING_TYPE, value: longName }
+      }
+    } catch (e) { /* attribute absent on this type — omit */ }
+
+    try {
+      const globalId = entity.GlobalId
+      if (typeof globalId === 'string') {
+        result.GlobalId = { type: WEB_IFC_STRING_TYPE, value: globalId }
+      }
+    } catch (e) { /* attribute unreadable — omit */ }
+
+    return result
+  }
+
+  /**
+   * Drop this model's materialised entity/descriptor cache (and lazily
+   * rebuilt vtable data), returning that memory to the JS heap. Entities
+   * and attributes rematerialise transparently on next access, so this is
+   * safe to call between UI interactions to keep the property working set
+   * bounded to what the active UI has touched.
+   */
+  releaseEntityCache(): void {
+    this.model[0].invalidate(true)
+  }
+
+  /**
    *
    * @param modelID
    * @return {Vector<LoaderError>}

--- a/src/compat/web-ifc/ifc_properties.ts
+++ b/src/compat/web-ifc/ifc_properties.ts
@@ -11,7 +11,7 @@ import {
   IFCRELDEFINESBYPROPERTIES, IFCRELDEFINESBYTYPE,
 } from './ifc2x4'
 import { IfcApiProxyIfc } from './ifc_api_proxy_ifc';
-import { Node, PropertiesPassthrough } from './properties_passthrough';
+import { IncludeProperties, Node, PropertiesPassthrough } from './properties_passthrough';
 
 import { IfcElements, IfcTypesMap } from './types-map'
 
@@ -83,12 +83,15 @@ export class IfcProperties implements PropertiesPassthrough {
     return await this.getProperty(elementID, recursive, PropsNames.materials)
   }
 
-  async getSpatialStructure(includeProperties?: boolean): Promise< Node > {
+  async getSpatialStructure(includeProperties?: IncludeProperties): Promise< Node > {
     await this.getAllTypesOfModel()
     const chunks = await this.getSpatialTreeChunks()
     const allLines = await this.api.getLineIDsWithType(IFCPROJECT)
     const projectID = allLines.get(0)
     const project = IfcProperties.newIfcProject(projectID)
+    if (includeProperties === 'names') {
+      Object.assign(project, this.api.getLineNameAttributes(projectID))
+    }
     await this.getSpatialNode(project, chunks, includeProperties)
     this.cleanupTypes()
     return project
@@ -144,12 +147,12 @@ export class IfcProperties implements PropertiesPassthrough {
     }
   }
 
-  private async getSpatialNode(node: Node, treeChunks: any, includeProperties?: boolean) {
+  private async getSpatialNode(node: Node, treeChunks: any, includeProperties?: IncludeProperties) {
     await this.getChildren(node, treeChunks, PropsNames.aggregates, includeProperties)
     await this.getChildren(node, treeChunks, PropsNames.spatial, includeProperties)
   }
 
-  private async getChildren(node: Node, treeChunks: any, propNames: pName, includeProperties?: boolean) {
+  private async getChildren(node: Node, treeChunks: any, propNames: pName, includeProperties?: IncludeProperties) {
     const children = treeChunks[node.expressID]
     if (children == undefined) {
       return
@@ -159,7 +162,11 @@ export class IfcProperties implements PropertiesPassthrough {
     for (let i = 0; i < children.length; i++) {
       const child = children[i]
       let node = this.newNode(child)
-      if (includeProperties) {
+      if (includeProperties === 'names') {
+        // Light mode: Name/LongName/GlobalId handles only — decodes just
+        // those vtable slots instead of flattening the whole record.
+        Object.assign(node, this.api.getLineNameAttributes(node.expressID))
+      } else if (includeProperties) {
         const properties = await this.getItemProperties(node.expressID) as any
         node = {...properties, ...node}
       }

--- a/src/compat/web-ifc/ifc_properties_names_mode.test.ts
+++ b/src/compat/web-ifc/ifc_properties_names_mode.test.ts
@@ -1,0 +1,139 @@
+// Tests for the spatial structure's `'names'` mode and the
+// ReleaseEntityCache extension.
+//
+// `'names'` returns nodes carrying only Name/LongName/GlobalId value
+// handles (read via the typed entities' lazy per-field getters), where
+// `true` spreads each node's full flattened attribute record — the
+// web-ifc-era eager visit Share is moving off of. Parity requirement:
+// `true`-mode output is unchanged by the feature, and `'names'` nodes
+// agree with `true` nodes on the attributes they do carry.
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { IfcAPI } from './ifc_api'
+import { Node } from './properties_passthrough'
+
+const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
+
+let api: IfcAPI
+let modelID: number
+
+beforeAll(async () => {
+  api = new IfcAPI()
+  await api.Init()
+
+  const buffer = new Uint8Array(fs.readFileSync('data/index.ifc'))
+
+  modelID = api.OpenModel(buffer, SETTINGS)
+}, 120000)
+
+/** Flatten a spatial tree into a node list, depth first. */
+function collect(root: Node): Node[] {
+  const out: Node[] = []
+  const stack: Node[] = [root]
+
+  while (stack.length > 0) {
+    const node = stack.pop()!
+
+    out.push(node)
+    stack.push(...(node.children ?? []))
+  }
+  return out
+}
+
+describe('getSpatialStructure names mode', () => {
+
+  test('names mode returns name handles without full records', async () => {
+    const tree = await api.properties.getSpatialStructure(modelID, 'names')
+
+    if (tree === undefined) {
+      throw new Error('getSpatialStructure returned undefined')
+    }
+
+    const nodes = collect(tree)
+
+    expect(nodes.length).toBeGreaterThan(1)
+
+    // At least one node carries a Name handle in web-ifc shape.
+    const named = nodes.filter((n) => n.Name !== undefined)
+
+    expect(named.length).toBeGreaterThan(0)
+    for (const node of named) {
+      expect(node.Name).toEqual({ type: 1, value: expect.any(String) })
+    }
+
+    // Non-project nodes are products with GlobalIds.
+    const withGlobalId = nodes.filter((n) => n.GlobalId !== undefined)
+
+    expect(withGlobalId.length).toBeGreaterThan(0)
+
+    // Light means light: no node carries full-record fields that only the
+    // flattened `true` mode spreads in (e.g. OwnerHistory / Description).
+    for (const node of nodes) {
+      expect((node as any).OwnerHistory).toBeUndefined()
+      expect((node as any).Description).toBeUndefined()
+    }
+  }, 120000)
+
+  test('names mode agrees with true mode where they overlap', async () => {
+    const namesTree = await api.properties.getSpatialStructure(modelID, 'names')
+    const fullTree = await api.properties.getSpatialStructure(modelID, true)
+
+    if (namesTree === undefined || fullTree === undefined) {
+      throw new Error('getSpatialStructure returned undefined')
+    }
+
+    const namesByID = new Map(collect(namesTree).map((n) => [n.expressID, n]))
+    const fullNodes = collect(fullTree)
+
+    // Same tree shape.
+    expect(namesByID.size).toBe(fullNodes.length)
+
+    // Full mode still carries full records (parity with the old behavior)...
+    const fullWithOwnerHistory =
+      fullNodes.filter((n) => (n as any).OwnerHistory !== undefined)
+
+    expect(fullWithOwnerHistory.length).toBeGreaterThan(0)
+
+    // ...and wherever full mode has a Name value, names mode has the same one.
+    for (const fullNode of fullNodes) {
+      const fullName = (fullNode as any).Name
+
+      if (fullName === null || fullName === undefined) {
+        continue
+      }
+
+      const namesNode = namesByID.get(fullNode.expressID)!
+
+      expect(namesNode.Name?.value).toBe(fullName.value)
+    }
+  }, 120000)
+
+  test('ReleaseEntityCache frees and property access rematerialises', async () => {
+    const before: any =
+      await api.properties.getItemProperties(modelID, await rootID())
+
+    api.ReleaseEntityCache(modelID)
+
+    const after: any =
+      await api.properties.getItemProperties(modelID, await rootID())
+
+    expect(after).toEqual(before)
+
+    // The spatial structure still resolves post-release too.
+    const tree = await api.properties.getSpatialStructure(modelID, 'names')
+
+    expect(tree?.children.length).toBeGreaterThan(0)
+  }, 120000)
+})
+
+/** Get the IfcProject root express ID. */
+async function rootID(): Promise<number> {
+  const tree = await api.properties.getSpatialStructure(modelID)
+
+  if (tree === undefined) {
+    throw new Error('getSpatialStructure returned undefined')
+  }
+  return tree.expressID
+}

--- a/src/compat/web-ifc/properties.ts
+++ b/src/compat/web-ifc/properties.ts
@@ -3,6 +3,7 @@ import {
   IfcAPI,
 } from './ifc_api'
 
+import { IncludeProperties } from './properties_passthrough'
 import { IfcTypesMap } from './types-map'
 
 export class Properties {
@@ -32,7 +33,7 @@ export class Properties {
     return await this.api.getPassthrough( modelID )?.properties.getMaterialsProperties( elementID, recursive )
   }
 
-  async getSpatialStructure(modelID: number, includeProperties?: boolean | 'names') {
+  async getSpatialStructure(modelID: number, includeProperties?: IncludeProperties) {
 
     return await this.api.getPassthrough( modelID )?.properties.getSpatialStructure( includeProperties )
   }

--- a/src/compat/web-ifc/properties.ts
+++ b/src/compat/web-ifc/properties.ts
@@ -32,7 +32,7 @@ export class Properties {
     return await this.api.getPassthrough( modelID )?.properties.getMaterialsProperties( elementID, recursive )
   }
 
-  async getSpatialStructure(modelID: number, includeProperties?: boolean) {
+  async getSpatialStructure(modelID: number, includeProperties?: boolean | 'names') {
 
     return await this.api.getPassthrough( modelID )?.properties.getSpatialStructure( includeProperties )
   }

--- a/src/compat/web-ifc/properties_passthrough.ts
+++ b/src/compat/web-ifc/properties_passthrough.ts
@@ -1,8 +1,34 @@
+/**
+ * A web-ifc tape value handle — `{ type: 1, value: 'str' }` for strings.
+ * Consumers (e.g. `@bldrs-ai/ifclib`'s `deref`) switch on the tape type
+ * code, so bare `{ value }` objects are not interchangeable with these.
+ */
+export interface NodeValueHandle {
+  type: number
+  value: string | number
+}
+
 export interface Node {
   expressID: number
   type: string
   children: Node[]
+
+  // Present in the `'names'` spatial-structure mode (and, along with the
+  // rest of the flattened attribute record, in the `true` mode).
+  Name?: NodeValueHandle
+  LongName?: NodeValueHandle
+  GlobalId?: NodeValueHandle
 }
+
+/**
+ * Spatial-structure property inclusion mode:
+ * - `false`/`undefined` — bare nodes (expressID/type/children).
+ * - `'names'` — bare nodes plus Name/LongName/GlobalId value handles,
+ *   read without materialising each node's full attribute record.
+ * - `true` — full flattened attribute record spread into each node
+ *   (web-ifc parity behavior).
+ */
+export type IncludeProperties = boolean | 'names'
 
 export interface PropertiesPassthrough {
 
@@ -16,8 +42,7 @@ export interface PropertiesPassthrough {
 
   getMaterialsProperties(elementID: number, recursive?: boolean): Promise< any[] >
 
-  getSpatialStructure(includeProperties?: boolean): Promise< Node >
+  getSpatialStructure(includeProperties?: IncludeProperties): Promise< Node >
 
   getAllItemsOfType(type: number, verbose: boolean): Promise< any[] >
 }
-


### PR DESCRIPTION
Step 1 (conway side) of the lazy/incremental property-load track. Companion Share PR (flip `CadView` to `'names'` + consumer audit) will follow once this releases and will link back here.

## Problem
Share's load path inherited web-ifc-three's eager visit: `getSpatialStructure(modelID, /*includeProperties=*/true)` inlines every spatial node's **full flattened attribute record** at load, materialising O(products) records the UI may never look at — then Share retains them all. The on-demand path (`getItemProperties` + ifclib `deref` per opened Properties-panel branch) has always been incremental; the eager visit is vestigial. What the load-time consumers (NavTree, search index) actually need per node is just names.

## Change
- **`getSpatialStructure(modelID, 'names')`** — new middle mode: nodes carry only `Name`/`LongName`/`GlobalId` as web-ifc value handles (`{type: 1, value}`), read via the typed entities' lazy per-field getters, so only those vtable slots are decoded (no whole-record flatten). `true` mode is **byte-for-byte unchanged** (web-ifc parity); `false` unchanged. AP214 gets the same signature — `'names'` is already satisfied there by its unconditional `Name` handles.
- **`IfcAPI.ReleaseEntityCache(modelID)`** — conway extension: drops the model's materialised entity/descriptor caches via `invalidate(true)`, which since #372 (SoA descriptors) actually returns the memory. Callers can bound the property working set to what the active UI is touching; entities rematerialise transparently on next access.

## Verification
- 3 new tests (`ifc_properties_names_mode.test.ts`): names-mode shape (handles present, no full-record fields), names↔true agreement on overlapping attributes + true-mode parity, and release→rematerialise round-trip.
- Full suite **146/146** green. No geometry paths touched (digest gate unaffected by construction).

## Related
- #371 / #372 — SoA descriptors (what makes `ReleaseEntityCache` actually free memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_