### PR TITLE
Windowed source-buffer provider + external-store spill (lazy properties, step 3)

### DIFF
--- a/src/compat/web-ifc/ap214_properties.ts
+++ b/src/compat/web-ifc/ap214_properties.ts
@@ -402,6 +402,17 @@ export class AP214Properties {
    * - `propertyByItemId_` — representation-item id → property (so a pset's
    *   `HasProperties` reference resolves back to its key/value).
    */
+  /**
+   * Build the property/structure indexes NOW (they are otherwise built
+   * lazily on first property access). Called before a source-buffer
+   * spill: the index build is a full-model sweep of synchronous record
+   * reads, so it must run while the source is resident — after it,
+   * post-spill property reads are pure map lookups.
+   */
+  public primeIndexes(): void {
+    this.buildIndexes()
+  }
+
   private buildIndexes(): void {
 
     if ( this.structureRoots_ !== void 0 ) {

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -4,6 +4,7 @@ import {versionString} from '../../version/version'
 import Logger from '../../logging/logger'
 import Environment from '../../utilities/environment'
 import * as glmatrix from 'gl-matrix'
+import { StepExternalByteStore } from '../../step/step_buffer_provider'
 import { IfcApiModelPassthrough } from './ifc_api_model_passthrough'
 import { IfcApiModelPassthroughFactory } from './ifc_api_model_passthrough_factory'
 import { Properties } from './properties'
@@ -285,6 +286,46 @@ export class IfcAPI {
     }
 
     result.releaseEntityCache?.()
+  }
+
+  /**
+   * Conway extension: release the model's resident source buffer and
+   * serve subsequent record reads through fixed-size windows paged in
+   * from an external byte store (which must hold exactly the model's
+   * source bytes — e.g. the original file already sitting in OPFS).
+   *
+   * After a spill, asynchronous property APIs page ranges in on
+   * demand; SYNCHRONOUS record reads (getLine on the passthrough)
+   * require the range to be resident and throw otherwise. Call this
+   * only after load-time sweeps (geometry extraction, spatial tree,
+   * GLB property capture) are done.
+   *
+   * @param modelID The model to spill.
+   * @param store The external byte store holding the source bytes.
+   * @param chunkBytes Optional window size in bytes (default 4MiB).
+   * @param maxResidentChunks Optional residency cap (default 16 windows).
+   * @return {boolean} True when the spill happened.
+   */
+  SpillModelSource(
+      modelID: number,
+      store: StepExternalByteStore,
+      chunkBytes?: number,
+      maxResidentChunks?: number ): boolean {
+
+    const result = this.models.get(modelID)
+
+    if (result === void 0) {
+
+      Logger.error('[SpillModelSource]: model === undefined')
+      return false
+    }
+
+    if (result.spillSourceToExternalStore === void 0) {
+      return false
+    }
+
+    result.spillSourceToExternalStore(store, chunkBytes, maxResidentChunks)
+    return true
   }
 
   /**

--- a/src/compat/web-ifc/ifc_api_model_passthrough.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough.ts
@@ -1,3 +1,4 @@
+import { StepExternalByteStore } from '../../step/step_buffer_provider'
 import { FlatMesh, IfcGeometry, RawLineData, Vector } from './ifc_api'
 import { PropertiesPassthrough } from './properties_passthrough'
 
@@ -23,4 +24,25 @@ export interface IfcApiModelPassthrough {
    * returning that memory. Entities rematerialise on next access.
    */
   releaseEntityCache?(): void
+
+  /**
+   * Optional: true when the model's source bytes are spilled to an
+   * external store and served through on-demand windows.
+   */
+  readonly sourceIsExternal?: boolean
+
+  /**
+   * Optional: release the resident source buffer, serving subsequent
+   * record reads through windows paged from the given external store.
+   */
+  spillSourceToExternalStore?(
+    store: StepExternalByteStore,
+    chunkBytes?: number,
+    maxResidentChunks?: number ): void
+
+  /**
+   * Optional: page in the byte range backing a record so a following
+   * synchronous read succeeds. Fast no-op while fully resident.
+   */
+  ensureLineResident?( expressID: number ): Promise< void >
 }

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -13,6 +13,7 @@ import {
   RawLineData,
   Vector,
 } from './ifc_api'
+import { StepExternalByteStore } from '../../step/step_buffer_provider'
 import { IfcApiModelPassthrough } from './ifc_api_model_passthrough'
 import * as glmatrix from 'gl-matrix'
 import Logger from '../../logging/logger'
@@ -69,6 +70,43 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
    */
   releaseEntityCache(): void {
     this.model[0].invalidate(true)
+  }
+
+  /**
+   * Are the model's source bytes spilled to an external store (served
+   * through on-demand windows) rather than fully resident?
+   *
+   * @return {boolean} True after spillSourceToExternalStore.
+   */
+  get sourceIsExternal(): boolean {
+    return this.model[0].isSourceExternal
+  }
+
+  /**
+   * Release the resident source buffer and serve subsequent record
+   * reads through fixed-size windows paged in from the given external
+   * store — see StepModelBase.spillSourceToExternalStore.
+   *
+   * @param store The external byte store.
+   * @param chunkBytes Optional window size in bytes.
+   * @param maxResidentChunks Optional residency cap in windows.
+   */
+  spillSourceToExternalStore(
+      store: StepExternalByteStore,
+      chunkBytes?: number,
+      maxResidentChunks?: number ): void {
+    this.model[0].spillSourceToExternalStore(store, chunkBytes, maxResidentChunks)
+  }
+
+  /**
+   * Page in the byte range backing a record so a following synchronous
+   * read succeeds. Fast no-op while the source is fully resident.
+   *
+   * @param expressID The record's express ID.
+   * @return {Promise<void>} Resolves when resident.
+   */
+  async ensureLineResident(expressID: number): Promise<void> {
+    await this.model[0].ensureResidentByExpressID(expressID)
   }
 
   /**

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -87,6 +87,12 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
    * reads through fixed-size windows paged in from the given external
    * store — see StepModelBase.spillSourceToExternalStore.
    *
+   * AP214 property access is served from indexes built by a one-time
+   * full-model sweep of synchronous reads, so they are primed here
+   * while the source is still resident; post-spill property reads are
+   * then pure map lookups. (`getAllItemsOfType(_, verbose=true)` still
+   * reads raw lines synchronously and is not supported post-spill.)
+   *
    * @param store The external byte store.
    * @param chunkBytes Optional window size in bytes.
    * @param maxResidentChunks Optional residency cap in windows.
@@ -95,6 +101,7 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
       store: StepExternalByteStore,
       chunkBytes?: number,
       maxResidentChunks?: number ): void {
+    this.properties.primeIndexes()
     this.model[0].spillSourceToExternalStore(store, chunkBytes, maxResidentChunks)
   }
 

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -15,6 +15,7 @@ import {
   RawLineData,
   Vector,
 } from './ifc_api'
+import { StepExternalByteStore } from '../../step/step_buffer_provider'
 import { IfcApiModelPassthrough } from './ifc_api_model_passthrough'
 import { NodeValueHandle } from './properties_passthrough'
 import * as glmatrix from 'gl-matrix'
@@ -466,6 +467,50 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    */
   releaseEntityCache(): void {
     this.model[0].invalidate(true)
+  }
+
+  /**
+   * Are the model's source bytes spilled to an external store (served
+   * through on-demand windows) rather than fully resident?
+   *
+   * @return {boolean} True after spillSourceToExternalStore.
+   */
+  get sourceIsExternal(): boolean {
+    return this.model[0].isSourceExternal
+  }
+
+  /**
+   * Release the resident source buffer and serve subsequent record
+   * reads through fixed-size windows paged in from the given external
+   * store (which must hold exactly the model's source bytes — e.g.
+   * the original file already sitting in OPFS). See
+   * StepModelBase.spillSourceToExternalStore.
+   *
+   * @param store The external byte store.
+   * @param chunkBytes Optional window size in bytes.
+   * @param maxResidentChunks Optional residency cap in windows.
+   */
+  spillSourceToExternalStore(
+      store: StepExternalByteStore,
+      chunkBytes?: number,
+      maxResidentChunks?: number ): void {
+    this.model[0].spillSourceToExternalStore(store, chunkBytes, maxResidentChunks)
+  }
+
+  /**
+   * Page in the byte range backing a record so a following synchronous
+   * read (getLine / attribute access) succeeds. Fast no-op while the
+   * source is fully resident.
+   *
+   * Note: covers the record itself (including its inline elements),
+   * NOT entities it merely references — recursive flattening across
+   * references needs each referenced record ensured in turn.
+   *
+   * @param expressID The record's express ID.
+   * @return {Promise<void>} Resolves when resident.
+   */
+  async ensureLineResident(expressID: number): Promise<void> {
+    await this.model[0].ensureResidentByExpressID(expressID)
   }
 
   /**

--- a/src/compat/web-ifc/ifc_properties.ts
+++ b/src/compat/web-ifc/ifc_properties.ts
@@ -67,7 +67,26 @@ export class IfcProperties implements PropertiesPassthrough {
     return IfcTypesMap[type]
   }
 
+  /**
+   * Page in the byte range backing a record before a synchronous read,
+   * when the model's source has been spilled to an external store.
+   * Fast no-op (no promise allocation) while fully resident.
+   *
+   * @param id The record's express ID.
+   */
+  private async ensureLine(id: number) {
+    if (this.api.sourceIsExternal) {
+      await this.api.ensureLineResident(id)
+    }
+  }
+
   async getItemProperties(id: number, recursive = false) {
+    // NOTE: with a spilled source, `recursive` flattening follows
+    // references synchronously and only this record's range is
+    // ensured here — recursive reads on spilled models require the
+    // closure to be resident. No lazy-load consumer uses recursive
+    // reads; revisit if one appears.
+    await this.ensureLine(id)
     return this.api.getLine(id, recursive)
   }
 
@@ -90,6 +109,7 @@ export class IfcProperties implements PropertiesPassthrough {
     const projectID = allLines.get(0)
     const project = IfcProperties.newIfcProject(projectID)
     if (includeProperties === 'names') {
+      await this.ensureLine(projectID)
       Object.assign(project, this.api.getLineNameAttributes(projectID))
     }
     await this.getSpatialNode(project, chunks, includeProperties)
@@ -108,6 +128,7 @@ export class IfcProperties implements PropertiesPassthrough {
     }
     const result: any[] = []
     for (let i = 0; i < items.length; i++) {
+      await this.ensureLine(items[i])
       result.push(await this.api.getLine(items[i]))
     }
     return result
@@ -117,6 +138,7 @@ export class IfcProperties implements PropertiesPassthrough {
     const propSetIds = await this.getAllRelatedItemsOfType(elementID, propName)
     const result: any[] = []
     for (let i = 0; i < propSetIds.length; i++) {
+      await this.ensureLine(propSetIds[i])
       result.push(await this.api.getLine(propSetIds[i], recursive))
     }
     return result
@@ -125,6 +147,7 @@ export class IfcProperties implements PropertiesPassthrough {
   private async getChunks(chunks: any, propNames: pName) {
     const relation = await this.api.getLineIDsWithType(propNames.name)
     for (let i = 0; i < relation.size(); i++) {
+      await this.ensureLine(relation.get(i))
       const rel = await this.api.getLine(relation.get(i), false)
       this.saveChunk(chunks, propNames, rel)
     }
@@ -165,6 +188,7 @@ export class IfcProperties implements PropertiesPassthrough {
       if (includeProperties === 'names') {
         // Light mode: Name/LongName/GlobalId handles only — decodes just
         // those vtable slots instead of flattening the whole record.
+        await this.ensureLine(node.expressID)
         Object.assign(node, this.api.getLineNameAttributes(node.expressID))
       } else if (includeProperties) {
         const properties = await this.getItemProperties(node.expressID) as any
@@ -220,6 +244,7 @@ export class IfcProperties implements PropertiesPassthrough {
     const lines = await this.api.getLineIDsWithType(propNames.name)
     const IDs: number[] = []
     for (let i = 0; i < lines.size(); i++) {
+      await this.ensureLine(lines.get(i))
       const rel = await this.api.getLine(lines.get(i))
       const isRelated = IfcProperties.isRelated(id, rel, propNames)
       if (isRelated) {

--- a/src/compat/web-ifc/ifc_spill_source.test.ts
+++ b/src/compat/web-ifc/ifc_spill_source.test.ts
@@ -1,0 +1,158 @@
+/* eslint-disable no-magic-numbers */
+// Integration tests for source-buffer spill (windowed residency).
+//
+// Parity requirement: after `SpillModelSource`, every record decodes
+// byte-for-byte identically through the windowed provider — the async
+// property APIs page ranges in via `ensureResident` and produce the
+// same output as the fully-resident model. Tiny chunks + a tiny
+// residency cap force straddling records and LRU eviction on the
+// small fixture.
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { InMemoryStepByteStore } from '../../step/step_buffer_provider'
+import { IfcAPI } from './ifc_api'
+
+const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
+
+// Tiny windows so the fixture exercises chunk straddles + eviction.
+const CHUNK_BYTES = 512
+const MAX_RESIDENT_CHUNKS = 3
+
+let api: IfcAPI
+let buffer: Uint8Array
+
+/** Open a fresh model from the shared fixture bytes. */
+function openModel(): number {
+  return api.OpenModel(buffer, SETTINGS)
+}
+
+beforeAll(async () => {
+  api = new IfcAPI()
+  await api.Init()
+
+  buffer = new Uint8Array(fs.readFileSync('data/index.ifc'))
+}, 120000)
+
+describe('SpillModelSource', () => {
+
+  test('property reads are identical before and after a spill', async () => {
+    const modelID = openModel()
+    const passthrough = api.getPassthrough(modelID)!
+
+    // Snapshot every record through the resident path first.
+    const lineIDs = passthrough.getAllLines()
+    const before = new Map<number, any>()
+
+    for (let i = 0; i < lineIDs.size(); i++) {
+      const expressID = lineIDs.get(i)
+
+      before.set(expressID, await api.properties.getItemProperties(modelID, expressID))
+    }
+
+    expect(before.size).toBeGreaterThan(10)
+
+    const spilled = api.SpillModelSource(
+        modelID, new InMemoryStepByteStore(buffer), CHUNK_BYTES, MAX_RESIDENT_CHUNKS)
+
+    expect(spilled).toBe(true)
+
+    // Every record decodes identically through windows. Iterating in
+    // the same order with a 3-chunk cap forces continuous paging.
+    for (const [expressID, expected] of before) {
+      const after = await api.properties.getItemProperties(modelID, expressID)
+
+      expect(after).toEqual(expected)
+    }
+
+    api.CloseModel(modelID)
+  }, 120000)
+
+  test('spatial tree (names mode) and property sets survive a spill', async () => {
+    const modelID = openModel()
+
+    const treeBefore = await api.properties.getSpatialStructure(modelID, 'names')
+    const psetsBeforeByProduct = new Map<number, any>()
+
+    // Snapshot psets for a handful of products found in the tree.
+    const stack = [treeBefore]
+    const productIDs: number[] = []
+
+    while (stack.length > 0 && productIDs.length < 8) {
+      const node = stack.pop()! as any
+
+      if (typeof node.expressID === 'number') {
+        productIDs.push(node.expressID)
+      }
+      stack.push(...(node.children ?? []))
+    }
+
+    for (const id of productIDs) {
+      psetsBeforeByProduct.set(id, await api.properties.getPropertySets(modelID, id))
+    }
+
+    api.SpillModelSource(
+        modelID, new InMemoryStepByteStore(buffer), CHUNK_BYTES, MAX_RESIDENT_CHUNKS)
+
+    const treeAfter = await api.properties.getSpatialStructure(modelID, 'names')
+
+    expect(treeAfter).toEqual(treeBefore)
+
+    for (const [id, expected] of psetsBeforeByProduct) {
+      expect(await api.properties.getPropertySets(modelID, id)).toEqual(expected)
+    }
+
+    api.CloseModel(modelID)
+  }, 120000)
+
+  test('synchronous reads without ensureResident throw after a spill', () => {
+    const modelID = openModel()
+    const passthrough = api.getPassthrough(modelID)! as any
+
+    const lineIDs = passthrough.getAllLines()
+    const firstID = lineIDs.get(0)
+
+    // Resident: sync getLine works.
+    expect(passthrough.getLine(firstID)).toBeDefined()
+
+    api.SpillModelSource(
+        modelID, new InMemoryStepByteStore(buffer), CHUNK_BYTES, MAX_RESIDENT_CHUNKS)
+
+    // Spilled + nothing resident: the sync path must fail loudly, not
+    // silently return wrong bytes.
+    expect(() => passthrough.getLine(firstID)).toThrow(/not resident/)
+
+    api.CloseModel(modelID)
+  }, 120000)
+
+  test('spill rejects a store whose size does not match the source', () => {
+    const modelID = openModel()
+
+    const wrongStore = new InMemoryStepByteStore(buffer.subarray(0, buffer.byteLength - 1))
+
+    expect(() => api.getPassthrough(modelID)!
+        .spillSourceToExternalStore!(wrongStore, CHUNK_BYTES, MAX_RESIDENT_CHUNKS))
+        .toThrow(/does not match/)
+
+    api.CloseModel(modelID)
+  }, 120000)
+
+  test('ReleaseEntityCache keeps working on a spilled model', async () => {
+    const modelID = openModel()
+    const passthrough = api.getPassthrough(modelID)!
+
+    const lineIDs = passthrough.getAllLines()
+    const someID = lineIDs.get(Math.floor(lineIDs.size() / 2))
+
+    const expected = await api.properties.getItemProperties(modelID, someID)
+
+    api.SpillModelSource(
+        modelID, new InMemoryStepByteStore(buffer), CHUNK_BYTES, MAX_RESIDENT_CHUNKS)
+    api.ReleaseEntityCache(modelID)
+
+    expect(await api.properties.getItemProperties(modelID, someID)).toEqual(expected)
+
+    api.CloseModel(modelID)
+  }, 120000)
+})

--- a/src/step/step_buffer_provider.test.ts
+++ b/src/step/step_buffer_provider.test.ts
@@ -155,6 +155,45 @@ describe('WindowedStepBufferProvider', () => {
     expect(provider.residentBytes).toBeLessThanOrEqual(48)
   })
 
+  test('an overlapping ensure cannot evict chunks another in-flight ensure covers', async () => {
+    // Regression pin for the ensure/acquire interleave: caller A
+    // ensures chunk 3, and while A's continuation hasn't acquired yet,
+    // caller B's ensure (different range) triggers eviction. B must
+    // not evict A's pinned chunk even when everything older than it is
+    // B's own (protected) range.
+    const bytes = makeBytes(160)
+
+    let releaseRead: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => {
+      releaseRead = resolve
+    })
+
+    const slowStore: StepExternalByteStore = {
+      byteLength: bytes.byteLength,
+      async read(offset: number, length: number): Promise< Uint8Array > {
+        // Only chunk 3 (offset 48) is slow, so B's ensure completes
+        // while A's is still in flight.
+        if (offset === 48) {
+          await gate
+        }
+        return bytes.slice(offset, offset + length)
+      },
+    }
+
+    const provider = new WindowedStepBufferProvider(slowStore, 16, 2)
+
+    const ensureA = provider.ensureResident(48, 8)   // chunk 3, gated
+
+    releaseRead!()
+
+    // B loads two chunks — with cap 2 this forces eviction pressure
+    // right as A's chunk lands.
+    await provider.ensureResident(0, 24)             // chunks 0,1
+    await ensureA
+
+    expect(() => provider.acquire(48, 8)).not.toThrow()
+  })
+
   test('a range needed by the current ensure is never evicted by it', async () => {
     const bytes = makeBytes(160)
     // Cap of 2 but the range needs 3 chunks — all three must survive

--- a/src/step/step_buffer_provider.test.ts
+++ b/src/step/step_buffer_provider.test.ts
@@ -1,0 +1,168 @@
+/* eslint-disable no-magic-numbers */
+// Unit tests for the STEP source-buffer residency providers.
+//
+// The windowed provider is exercised with deliberately tiny chunks so
+// straddling records, LRU eviction, and in-flight de-duplication all
+// trigger on small fixtures.
+import { describe, expect, test } from '@jest/globals'
+
+import {
+  InMemoryStepByteStore,
+  ResidentStepBufferProvider,
+  StepBufferNotResidentError,
+  StepExternalByteStore,
+  stepBufferBase,
+  WindowedStepBufferProvider,
+} from './step_buffer_provider'
+
+
+/** Build test bytes 0..n-1 mod 256 so any slice is content-checkable. */
+function makeBytes(count: number): Uint8Array {
+  const bytes = new Uint8Array(count)
+
+  for (let where = 0; where < count; ++where) {
+    bytes[where] = where % 256
+  }
+  return bytes
+}
+
+describe('ResidentStepBufferProvider', () => {
+
+  test('acquires the whole buffer at offset 0 and is always resident', async () => {
+    const bytes = makeBytes(64)
+    const provider = new ResidentStepBufferProvider(bytes)
+
+    expect(provider.byteLength).toBe(64)
+    expect(provider.residentBytes).toBe(64)
+
+    const acquisition = provider.acquire()
+
+    expect(acquisition.buffer).toBe(bytes)
+    expect(acquisition.offset).toBe(0)
+    expect(stepBufferBase(acquisition.buffer)).toBe(0)
+
+    await expect(provider.ensureResident()).resolves.toBeUndefined()
+  })
+})
+
+describe('WindowedStepBufferProvider', () => {
+
+  test('throws StepBufferNotResidentError before ensureResident', () => {
+    const provider = new WindowedStepBufferProvider(
+        new InMemoryStepByteStore(makeBytes(100)), 16, 4)
+
+    expect(() => provider.acquire(0, 8)).toThrow(StepBufferNotResidentError)
+  })
+
+  test('serves a single-chunk range as a view over the chunk', async () => {
+    const bytes = makeBytes(100)
+    const provider = new WindowedStepBufferProvider(new InMemoryStepByteStore(bytes), 16, 4)
+
+    await provider.ensureResident(20, 8)
+
+    const acquisition = provider.acquire(20, 8)
+
+    // Chunk index 1 covers [16, 32).
+    expect(acquisition.offset).toBe(16)
+    expect(stepBufferBase(acquisition.buffer)).toBe(16)
+    expect(Array.from(acquisition.buffer.subarray(20 - 16, 28 - 16)))
+        .toEqual(Array.from(bytes.subarray(20, 28)))
+  })
+
+  test('merges a straddling range into a per-record copy based at the range', async () => {
+    const bytes = makeBytes(100)
+    const provider = new WindowedStepBufferProvider(new InMemoryStepByteStore(bytes), 16, 8)
+
+    // [12, 40) spans chunks 0, 1 and 2.
+    await provider.ensureResident(12, 28)
+
+    const acquisition = provider.acquire(12, 28)
+
+    expect(acquisition.offset).toBe(12)
+    expect(stepBufferBase(acquisition.buffer)).toBe(12)
+    expect(acquisition.buffer.byteLength).toBe(28)
+    expect(Array.from(acquisition.buffer)).toEqual(Array.from(bytes.subarray(12, 40)))
+  })
+
+  test('clamps the final short chunk', async () => {
+    const bytes = makeBytes(20)
+    const provider = new WindowedStepBufferProvider(new InMemoryStepByteStore(bytes), 16, 4)
+
+    await provider.ensureResident(16, 4)
+
+    const acquisition = provider.acquire(16, 4)
+
+    expect(acquisition.offset).toBe(16)
+    expect(acquisition.buffer.byteLength).toBe(4)
+    expect(Array.from(acquisition.buffer)).toEqual(Array.from(bytes.subarray(16, 20)))
+  })
+
+  test('evicts least-recently-used chunks beyond the cap, sparing the current range', async () => {
+    const bytes = makeBytes(160)
+    const provider = new WindowedStepBufferProvider(new InMemoryStepByteStore(bytes), 16, 2)
+
+    await provider.ensureResident(0, 8)    // chunk 0
+    await provider.ensureResident(16, 8)   // chunk 1
+    await provider.ensureResident(32, 8)   // chunk 2 → chunk 0 evicted
+
+    expect(provider.residentChunkCount).toBe(2)
+    expect(() => provider.acquire(0, 8)).toThrow(StepBufferNotResidentError)
+    expect(() => provider.acquire(16, 8)).not.toThrow()
+    expect(() => provider.acquire(32, 8)).not.toThrow()
+
+    // Touch chunk 1 (recency), then load chunk 4 — chunk 2 goes, not 1.
+    provider.acquire(16, 8)
+    await provider.ensureResident(64, 8)
+
+    expect(() => provider.acquire(16, 8)).not.toThrow()
+    expect(() => provider.acquire(32, 8)).toThrow(StepBufferNotResidentError)
+  })
+
+  test('de-duplicates concurrent in-flight chunk loads', async () => {
+    const bytes = makeBytes(64)
+    let reads = 0
+
+    const countingStore: StepExternalByteStore = {
+      byteLength: bytes.byteLength,
+      read(offset: number, length: number): Promise< Uint8Array > {
+        ++reads
+        return Promise.resolve(bytes.slice(offset, offset + length))
+      },
+    }
+
+    const provider = new WindowedStepBufferProvider(countingStore, 16, 4)
+
+    await Promise.all([
+      provider.ensureResident(0, 8),
+      provider.ensureResident(4, 8),
+      provider.ensureResident(8, 8),
+    ])
+
+    expect(reads).toBe(1)
+    expect(provider.residentChunkCount).toBe(1)
+  })
+
+  test('residentBytes tracks the resident working set', async () => {
+    const bytes = makeBytes(64)
+    const provider = new WindowedStepBufferProvider(new InMemoryStepByteStore(bytes), 16, 2)
+
+    expect(provider.residentBytes).toBe(0)
+
+    await provider.ensureResident(0, 40)  // chunks 0,1,2 → cap 2 evicts one
+
+    expect(provider.residentChunkCount).toBeLessThanOrEqual(3)
+    expect(provider.residentBytes).toBeGreaterThan(0)
+    expect(provider.residentBytes).toBeLessThanOrEqual(48)
+  })
+
+  test('a range needed by the current ensure is never evicted by it', async () => {
+    const bytes = makeBytes(160)
+    // Cap of 2 but the range needs 3 chunks — all three must survive
+    // long enough for the acquire that follows.
+    const provider = new WindowedStepBufferProvider(new InMemoryStepByteStore(bytes), 16, 2)
+
+    await provider.ensureResident(0, 48)
+
+    expect(() => provider.acquire(0, 48)).not.toThrow()
+  })
+})

--- a/src/step/step_buffer_provider.ts
+++ b/src/step/step_buffer_provider.ts
@@ -289,6 +289,15 @@ export class WindowedStepBufferProvider implements StepBufferProvider {
   private readonly loading_ = new Map< number, Promise< Uint8Array > >()
 
   /**
+   * Chunks covered by an `ensureResident` call that hasn't returned
+   * yet, refcounted. Eviction skips them: an overlapping ensure for a
+   * different range must not evict chunks another caller has ensured
+   * but not yet synchronously acquired (the acquire happens in the
+   * caller's continuation, which can interleave with this one).
+   */
+  private readonly ensurePins_ = new Map< number, number >()
+
+  /**
    * Construct this over an external byte store.
    *
    * @param store_ The store holding the source bytes.
@@ -428,63 +437,87 @@ export class WindowedStepBufferProvider implements StepBufferProvider {
     const firstChunk = Math.floor( address / chunkBytes )
     const lastChunk  = Math.floor( ( address + Math.max( length, 1 ) - 1 ) / chunkBytes )
 
-    const loads: Promise< void >[] = []
-
+    // Pin this call's chunks against eviction by overlapping ensures
+    // until we return — the caller's synchronous acquire runs in its
+    // continuation, which can interleave with other ensures' evictions.
     for ( let chunkIndex = firstChunk; chunkIndex <= lastChunk; ++chunkIndex ) {
-
-      const resident = this.chunks_.get( chunkIndex )
-
-      if ( resident !== void 0 ) {
-
-        this.touch_( chunkIndex, resident )
-        continue
-      }
-
-      let inflight = this.loading_.get( chunkIndex )
-
-      if ( inflight === void 0 ) {
-
-        const chunkBase   = chunkIndex * chunkBytes
-        const chunkLength = Math.min( chunkBytes, this.store_.byteLength - chunkBase )
-
-        inflight = this.store_.read( chunkBase, chunkLength ).then( ( chunk ) => {
-
-          tagBufferBase( chunk, chunkBase )
-
-          this.chunks_.set( chunkIndex, chunk )
-          this.loading_.delete( chunkIndex )
-
-          return chunk
-        }, ( error ) => {
-
-          this.loading_.delete( chunkIndex )
-          throw error
-        })
-
-        this.loading_.set( chunkIndex, inflight )
-      }
-
-      loads.push( inflight.then( () => void 0 ) )
+      this.ensurePins_.set( chunkIndex, ( this.ensurePins_.get( chunkIndex ) ?? 0 ) + 1 )
     }
 
-    if ( loads.length > 0 ) {
-      await Promise.all( loads )
-    }
+    try {
 
-    // Evict beyond the cap, oldest first, sparing this call's range.
-    if ( this.chunks_.size > this.maxResidentChunks_ ) {
+      const loads: Promise< void >[] = []
 
-      for ( const candidate of this.chunks_.keys() ) {
+      for ( let chunkIndex = firstChunk; chunkIndex <= lastChunk; ++chunkIndex ) {
 
-        if ( this.chunks_.size <= this.maxResidentChunks_ ) {
-          break
-        }
+        const resident = this.chunks_.get( chunkIndex )
 
-        if ( candidate >= firstChunk && candidate <= lastChunk ) {
+        if ( resident !== void 0 ) {
+
+          this.touch_( chunkIndex, resident )
           continue
         }
 
-        this.chunks_.delete( candidate )
+        let inflight = this.loading_.get( chunkIndex )
+
+        if ( inflight === void 0 ) {
+
+          const chunkBase   = chunkIndex * chunkBytes
+          const chunkLength = Math.min( chunkBytes, this.store_.byteLength - chunkBase )
+
+          inflight = this.store_.read( chunkBase, chunkLength ).then( ( chunk ) => {
+
+            tagBufferBase( chunk, chunkBase )
+
+            this.chunks_.set( chunkIndex, chunk )
+            this.loading_.delete( chunkIndex )
+
+            return chunk
+          }, ( error ) => {
+
+            this.loading_.delete( chunkIndex )
+            throw error
+          })
+
+          this.loading_.set( chunkIndex, inflight )
+        }
+
+        loads.push( inflight.then( () => void 0 ) )
+      }
+
+      if ( loads.length > 0 ) {
+        await Promise.all( loads )
+      }
+
+      // Evict beyond the cap, oldest first, sparing pinned chunks
+      // (this call's own range is pinned above).
+      if ( this.chunks_.size > this.maxResidentChunks_ ) {
+
+        for ( const candidate of this.chunks_.keys() ) {
+
+          if ( this.chunks_.size <= this.maxResidentChunks_ ) {
+            break
+          }
+
+          if ( ( this.ensurePins_.get( candidate ) ?? 0 ) > 0 ) {
+            continue
+          }
+
+          this.chunks_.delete( candidate )
+        }
+      }
+
+    } finally {
+
+      for ( let chunkIndex = firstChunk; chunkIndex <= lastChunk; ++chunkIndex ) {
+
+        const pins = this.ensurePins_.get( chunkIndex ) ?? 0
+
+        if ( pins <= 1 ) {
+          this.ensurePins_.delete( chunkIndex )
+        } else {
+          this.ensurePins_.set( chunkIndex, pins - 1 )
+        }
       }
     }
   }

--- a/src/step/step_buffer_provider.ts
+++ b/src/step/step_buffer_provider.ts
@@ -1,0 +1,491 @@
+/**
+ * Source-buffer residency for STEP models.
+ *
+ * A parsed model's descriptors index the raw STEP text by absolute
+ * `[address, address + length)` byte ranges (the SoA `address_` /
+ * `length_` columns). Historically the whole source buffer stayed
+ * resident for the model's lifetime so any range could be read
+ * synchronously. That pins the full file (hundreds of MB on large
+ * models) for property access patterns that only ever touch a tiny
+ * fraction of it after load.
+ *
+ * A {@link StepBufferProvider} abstracts "give me the bytes for this
+ * range" behind two operations:
+ *
+ *  - `acquire(address, length)` — SYNCHRONOUS. Returns a byte view
+ *    containing the range plus the absolute address of the view's
+ *    first byte, so callers can translate between absolute addresses
+ *    and view-relative cursors. Throws
+ *    {@link StepBufferNotResidentError} when the range is not
+ *    resident — synchronous extraction paths never wait.
+ *  - `ensureResident(address, length)` — ASYNCHRONOUS. Pages the
+ *    range in (from an external store) so a following `acquire`
+ *    succeeds. Async API surfaces (the web-ifc shim's property
+ *    methods) call this before entering synchronous extraction.
+ *
+ * Two implementations:
+ *
+ *  - {@link ResidentStepBufferProvider} wraps the fully-resident
+ *    source buffer. `acquire` returns the whole buffer with offset 0
+ *    (so view-relative cursors ARE absolute addresses) and
+ *    `ensureResident` resolves immediately. This is the default and
+ *    matches the historical behaviour bit-for-bit.
+ *  - {@link WindowedStepBufferProvider} pages fixed-size chunks from
+ *    a {@link StepExternalByteStore} with an LRU residency cap.
+ *    Records contained in one chunk are served as a view over it;
+ *    records straddling chunks get a per-record merged copy. Eviction
+ *    is advisory — descriptors that captured a chunk keep it alive
+ *    via their own reference, so correctness never depends on the
+ *    residency set; only memory does.
+ *
+ * The external store itself is environment-provided (OPFS in the
+ * browser, a file or memory in node) — this module only defines the
+ * read contract plus an in-memory implementation used by tests and
+ * small models.
+ */
+
+/* Chunk sizing: large enough that virtually every record is served
+ * zero-copy from a single chunk (STEP records are bytes-to-KBs;
+ * pathological geometry records reach single-digit MBs), small enough
+ * that the default residency cap keeps the working set modest. */
+// eslint-disable-next-line no-magic-numbers -- byte-size arithmetic (4MiB)
+const DEFAULT_CHUNK_BYTES = 4 * 1024 * 1024
+const DEFAULT_MAX_RESIDENT_CHUNKS = 16
+
+/**
+ * Brand carrying the absolute source address of a view's first byte.
+ * Cursors recorded against a windowed view are view-relative; adding
+ * the view's base converts them back to absolute source addresses
+ * (inline-element lookups are keyed by parse-time absolute address).
+ * Attached as a non-enumerable property so views flow through
+ * existing code untouched; absent (fully-resident source buffer,
+ * chunk 0) means base 0.
+ */
+const STEP_BUFFER_BASE: unique symbol = Symbol( 'stepBufferBase' )
+
+/**
+ * Get the absolute source address of `buffer[ 0 ]`.
+ *
+ * @param buffer A view handed out by a {@link StepBufferProvider}.
+ * @return {number} The base address (0 for the resident source buffer).
+ */
+export function stepBufferBase( buffer: Uint8Array ): number {
+  return ( buffer as { [STEP_BUFFER_BASE]?: number } )[ STEP_BUFFER_BASE ] ?? 0
+}
+
+/**
+ * Tag a view with its absolute base address (no-op for base 0, which
+ * is the default reading).
+ *
+ * @param buffer The view to tag.
+ * @param base The absolute source address of `buffer[ 0 ]`.
+ * @return {Uint8Array} The same view.
+ */
+function tagBufferBase( buffer: Uint8Array, base: number ): Uint8Array {
+
+  if ( base !== 0 ) {
+    Object.defineProperty( buffer, STEP_BUFFER_BASE, { value: base } )
+  }
+
+  return buffer
+}
+
+/**
+ * Read contract for the spilled source bytes. Implementations must
+ * return exactly the requested range (clamped reads are the caller's
+ * responsibility — the provider never requests past `byteLength`).
+ */
+export interface StepExternalByteStore {
+
+  /** Total size of the stored byte sequence. */
+  readonly byteLength: number
+
+  /**
+   * Read `length` bytes starting at `offset`.
+   *
+   * @param offset Absolute offset of the first byte to read.
+   * @param length Number of bytes to read.
+   * @return {Promise< Uint8Array >} The bytes — a standalone array
+   * (byteOffset 0) of exactly `length` bytes.
+   */
+  read( offset: number, length: number ): Promise< Uint8Array >
+}
+
+/**
+ * In-memory {@link StepExternalByteStore}. Used by tests and as a
+ * degenerate store when the caller wants windowed accounting without
+ * real external storage.
+ */
+export class InMemoryStepByteStore implements StepExternalByteStore {
+
+  /**
+   * Construct this around a byte array (not copied).
+   *
+   * @param bytes_ The backing bytes.
+   */
+  constructor( private readonly bytes_: Uint8Array ) {}
+
+  /**
+   * Total size of the stored byte sequence.
+   *
+   * @return {number} The byte length.
+   */
+  public get byteLength(): number {
+    return this.bytes_.byteLength
+  }
+
+  /**
+   * Read a range as a standalone copy.
+   *
+   * @param offset Absolute offset of the first byte to read.
+   * @param length Number of bytes to read.
+   * @return {Promise< Uint8Array >} The bytes.
+   */
+  public read( offset: number, length: number ): Promise< Uint8Array > {
+    return Promise.resolve( this.bytes_.slice( offset, offset + length ) )
+  }
+}
+
+/**
+ * Result of a synchronous range acquisition: a byte view containing
+ * the requested range and the absolute address of `buffer[ 0 ]`.
+ * `address - offset` converts an absolute address into an index into
+ * `buffer`. The buffer is always standalone (byteOffset 0) or the
+ * original resident source buffer — both satisfy the extraction
+ * layer's `new DataView( buffer.buffer )` zero-offset assumption.
+ */
+export interface StepBufferAcquisition {
+  buffer: Uint8Array
+  offset: number
+}
+
+/**
+ * Thrown by {@link StepBufferProvider.acquire} when the requested
+ * range is not resident. Reaching this means a synchronous extraction
+ * ran without a preceding `ensureResident` — a caller-side sequencing
+ * bug, not a recoverable data condition.
+ */
+export class StepBufferNotResidentError extends Error {
+
+  /**
+   * Construct this for a byte range.
+   *
+   * @param address Absolute start of the range.
+   * @param length Length of the range.
+   */
+  constructor( public readonly address: number, public readonly length: number ) {
+    super(
+        `STEP source range [${address}, ${address + length}) is not resident — ` +
+        'call ensureResident before synchronous extraction' )
+    this.name = 'StepBufferNotResidentError'
+  }
+}
+
+/**
+ * Residency provider for a model's source bytes.
+ */
+export interface StepBufferProvider {
+
+  /** Total logical size of the source bytes. */
+  readonly byteLength: number
+
+  /** Bytes currently held resident by the provider itself. */
+  readonly residentBytes: number
+
+  /**
+   * Synchronously acquire a view containing a byte range.
+   *
+   * @param address Absolute start of the range.
+   * @param length Length of the range.
+   * @throws { StepBufferNotResidentError } When the range isn't resident.
+   * @return {StepBufferAcquisition} The view and its base address.
+   */
+  acquire( address: number, length: number ): StepBufferAcquisition
+
+  /**
+   * Make a byte range resident so a following {@link acquire} succeeds.
+   *
+   * @param address Absolute start of the range.
+   * @param length Length of the range.
+   * @return {Promise< void >} Resolves when resident.
+   */
+  ensureResident( address: number, length: number ): Promise< void >
+}
+
+/**
+ * Provider over a fully-resident source buffer — the default, and
+ * bit-for-bit the historical behaviour: acquisitions are the source
+ * buffer itself at offset 0, so view-relative cursors are absolute
+ * addresses and nothing changes for existing extraction code.
+ */
+export class ResidentStepBufferProvider implements StepBufferProvider {
+
+  /**
+   * Construct this over the resident source buffer.
+   *
+   * @param buffer_ The full source bytes.
+   */
+  constructor( private readonly buffer_: Uint8Array ) {}
+
+  /**
+   * Total logical size of the source bytes.
+   *
+   * @return {number} The byte length.
+   */
+  public get byteLength(): number {
+    return this.buffer_.byteLength
+  }
+
+  /**
+   * Bytes currently held resident — the whole buffer.
+   *
+   * @return {number} The byte length.
+   */
+  public get residentBytes(): number {
+    return this.buffer_.byteLength
+  }
+
+  /**
+   * Acquire the whole buffer at offset 0.
+   *
+   * @return {StepBufferAcquisition} The acquisition.
+   */
+  public acquire(): StepBufferAcquisition {
+    return { buffer: this.buffer_, offset: 0 }
+  }
+
+  /**
+   * Always resident.
+   *
+   * @return {Promise< void >} Resolved promise.
+   */
+  public ensureResident(): Promise< void > {
+    return Promise.resolve()
+  }
+}
+
+/**
+ * Provider that pages fixed-size chunks from an external store with
+ * an LRU residency cap.
+ *
+ * Concurrency note: `ensureResident` de-duplicates in-flight chunk
+ * loads, so overlapping property reads for neighbouring records fetch
+ * each chunk once. Eviction only drops the provider's own reference —
+ * any descriptor that acquired a view over the chunk keeps that chunk
+ * alive independently, so previously-materialised entities keep
+ * working after eviction (they just pin their chunk until the
+ * descriptor cache is invalidated).
+ */
+export class WindowedStepBufferProvider implements StepBufferProvider {
+
+  private readonly chunkBytes_: number
+
+  private readonly maxResidentChunks_: number
+
+  /** Resident chunks by chunk index; Map order doubles as LRU order. */
+  private readonly chunks_ = new Map< number, Uint8Array >()
+
+  /** In-flight chunk loads, de-duplicated by chunk index. */
+  private readonly loading_ = new Map< number, Promise< Uint8Array > >()
+
+  /**
+   * Construct this over an external byte store.
+   *
+   * @param store_ The store holding the source bytes.
+   * @param chunkBytes Chunk size in bytes (default 4MiB).
+   * @param maxResidentChunks LRU residency cap in chunks (default 16).
+   */
+  constructor(
+      private readonly store_: StepExternalByteStore,
+      chunkBytes: number = DEFAULT_CHUNK_BYTES,
+      maxResidentChunks: number = DEFAULT_MAX_RESIDENT_CHUNKS ) {
+
+    if ( chunkBytes <= 0 || !Number.isInteger( chunkBytes ) ) {
+      throw new Error( `Invalid chunkBytes ${chunkBytes}` )
+    }
+
+    this.chunkBytes_        = chunkBytes
+    this.maxResidentChunks_ = Math.max( 1, maxResidentChunks )
+  }
+
+  /**
+   * Total logical size of the source bytes.
+   *
+   * @return {number} The byte length.
+   */
+  public get byteLength(): number {
+    return this.store_.byteLength
+  }
+
+  /**
+   * Bytes currently held resident by the provider.
+   *
+   * @return {number} The resident byte count.
+   */
+  public get residentBytes(): number {
+
+    let total = 0
+
+    for ( const chunk of this.chunks_.values() ) {
+      total += chunk.byteLength
+    }
+
+    return total
+  }
+
+  /**
+   * Number of resident chunks (telemetry/tests).
+   *
+   * @return {number} The chunk count.
+   */
+  public get residentChunkCount(): number {
+    return this.chunks_.size
+  }
+
+  /**
+   * Touch a chunk for LRU recency.
+   *
+   * @param chunkIndex The chunk to touch.
+   * @param chunk The chunk bytes.
+   */
+  private touch_( chunkIndex: number, chunk: Uint8Array ): void {
+    this.chunks_.delete( chunkIndex )
+    this.chunks_.set( chunkIndex, chunk )
+  }
+
+  /**
+   * Synchronously acquire a view containing a byte range.
+   *
+   * Single-chunk ranges are served as the chunk itself (zero copy);
+   * straddling ranges get a standalone merged copy spanning exactly
+   * the requested range.
+   *
+   * @param address Absolute start of the range.
+   * @param length Length of the range.
+   * @throws { StepBufferNotResidentError } When any covering chunk isn't resident.
+   * @return {StepBufferAcquisition} The view and its base address.
+   */
+  public acquire( address: number, length: number ): StepBufferAcquisition {
+
+    const chunkBytes = this.chunkBytes_
+    const firstChunk = Math.floor( address / chunkBytes )
+    const lastChunk  = Math.floor( ( address + Math.max( length, 1 ) - 1 ) / chunkBytes )
+
+    if ( firstChunk === lastChunk ) {
+
+      const chunk = this.chunks_.get( firstChunk )
+
+      if ( chunk === void 0 ) {
+        throw new StepBufferNotResidentError( address, length )
+      }
+
+      this.touch_( firstChunk, chunk )
+
+      return { buffer: chunk, offset: firstChunk * chunkBytes }
+    }
+
+    // Straddling range — merge the covering chunks' slices into a
+    // standalone per-record copy. Rare (records are usually far
+    // smaller than a chunk) and bounded by the record size.
+    const merged = tagBufferBase( new Uint8Array( length ), address )
+
+    for ( let chunkIndex = firstChunk; chunkIndex <= lastChunk; ++chunkIndex ) {
+
+      const chunk = this.chunks_.get( chunkIndex )
+
+      if ( chunk === void 0 ) {
+        throw new StepBufferNotResidentError( address, length )
+      }
+
+      this.touch_( chunkIndex, chunk )
+
+      const chunkBase  = chunkIndex * chunkBytes
+      const copyFrom   = Math.max( address, chunkBase )
+      const copyTo     = Math.min( address + length, chunkBase + chunk.byteLength )
+
+      if ( copyTo > copyFrom ) {
+        merged.set(
+            chunk.subarray( copyFrom - chunkBase, copyTo - chunkBase ),
+            copyFrom - address )
+      }
+    }
+
+    return { buffer: merged, offset: address }
+  }
+
+  /**
+   * Make a byte range resident, paging missing chunks from the store
+   * and evicting least-recently-used chunks beyond the cap (never the
+   * chunks needed by this call).
+   *
+   * @param address Absolute start of the range.
+   * @param length Length of the range.
+   * @return {Promise< void >} Resolves when resident.
+   */
+  public async ensureResident( address: number, length: number ): Promise< void > {
+
+    const chunkBytes = this.chunkBytes_
+    const firstChunk = Math.floor( address / chunkBytes )
+    const lastChunk  = Math.floor( ( address + Math.max( length, 1 ) - 1 ) / chunkBytes )
+
+    const loads: Promise< void >[] = []
+
+    for ( let chunkIndex = firstChunk; chunkIndex <= lastChunk; ++chunkIndex ) {
+
+      const resident = this.chunks_.get( chunkIndex )
+
+      if ( resident !== void 0 ) {
+
+        this.touch_( chunkIndex, resident )
+        continue
+      }
+
+      let inflight = this.loading_.get( chunkIndex )
+
+      if ( inflight === void 0 ) {
+
+        const chunkBase   = chunkIndex * chunkBytes
+        const chunkLength = Math.min( chunkBytes, this.store_.byteLength - chunkBase )
+
+        inflight = this.store_.read( chunkBase, chunkLength ).then( ( chunk ) => {
+
+          tagBufferBase( chunk, chunkBase )
+
+          this.chunks_.set( chunkIndex, chunk )
+          this.loading_.delete( chunkIndex )
+
+          return chunk
+        }, ( error ) => {
+
+          this.loading_.delete( chunkIndex )
+          throw error
+        })
+
+        this.loading_.set( chunkIndex, inflight )
+      }
+
+      loads.push( inflight.then( () => void 0 ) )
+    }
+
+    if ( loads.length > 0 ) {
+      await Promise.all( loads )
+    }
+
+    // Evict beyond the cap, oldest first, sparing this call's range.
+    if ( this.chunks_.size > this.maxResidentChunks_ ) {
+
+      for ( const candidate of this.chunks_.keys() ) {
+
+        if ( this.chunks_.size <= this.maxResidentChunks_ ) {
+          break
+        }
+
+        if ( candidate >= firstChunk && candidate <= lastChunk ) {
+          continue
+        }
+
+        this.chunks_.delete( candidate )
+      }
+    }
+  }
+}

--- a/src/step/step_entity_base.ts
+++ b/src/step/step_entity_base.ts
@@ -14,6 +14,7 @@ import {
   stepExtractReference,
   stepExtractString,
 } from './parsing/step_deserialization_functions'
+import { stepBufferBase } from './step_buffer_provider'
 import { StepEntityConstructorAbstract } from './step_entity_constructor'
 import StepEntityInternalReference,
 { StepEntityInternalReferencePrivate } from './step_entity_internal_reference'
@@ -31,6 +32,31 @@ enum IfcTokenType {
   SET_BEGIN,
   SET_END,
   LINE_END
+}
+
+/**
+ * Extract an inline element's ABSOLUTE source address at a cursor.
+ *
+ * `stepExtractInlineElemement` returns a cursor relative to the view
+ * it parses — with a windowed buffer provider that view may not start
+ * at source address 0, while the model's inline-element index is
+ * keyed by parse-time absolute address. Adding the view's base
+ * (0 for the fully-resident buffer) restores the absolute key.
+ *
+ * @param buffer The view to parse.
+ * @param cursor The view-relative cursor to parse at.
+ * @param endCursor The view-relative end bound.
+ * @return {number | undefined} The absolute inline-element address,
+ * or undefined if there is no inline element at the cursor.
+ */
+function extractInlineElementAddress(
+    buffer: Uint8Array,
+    cursor: number,
+    endCursor: number ): number | undefined {
+
+  const relative = stepExtractInlineElemement( buffer, cursor, endCursor )
+
+  return relative === void 0 ? void 0 : relative + stepBufferBase( buffer )
 }
 
 /**
@@ -248,8 +274,6 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
         throw new Error('Value in STEP was incorrectly typed')
       }
 
-      const buffer    = this.buffer
-
       if ( !this.model.nullOnErrors && stepExtractOptional(buffer, cursor, endCursor) !== null ) {
         throw new Error('Value in STEP was incorrectly typed')
       }
@@ -384,15 +408,16 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
     depth: number,
     optional: boolean): StepEntityBase<EntityTypeIDs> | null {
 
-    const cursor    = this.getOffsetCursor( offset, baseOffset, depth )
-    const buffer    = this.buffer
-    const endCursor = buffer.length
+    // Use the tuple form so the buffer is the SAME view the cursor was
+    // recorded against — with a windowed provider, `this.buffer` and a
+    // multi-class reference's buffer can be different windows.
+    const [cursor, endCursor, buffer] = this.getOffsetAndEndCursor( offset, baseOffset, depth )
 
     const expressID = stepExtractReference(buffer, cursor, endCursor)
     const value: StepEntityBase<EntityTypeIDs> | undefined =
       expressID !== void 0 ? this.model.getElementByExpressID(expressID) :
         (this.model.getInlineElementByAddress(
-            stepExtractInlineElemement(buffer, cursor, endCursor)))
+            extractInlineElementAddress(buffer, cursor, endCursor)))
 
     if (value === void 0) {
       if (!optional) {
@@ -470,8 +495,10 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
     const internalReference = this.internalReference_ as
     Required<StepEntityInternalReference<EntityTypeIDs>>
 
-    const cursor = internalReference.address
     const buffer = internalReference.buffer
+    // `address` is absolute; the buffer view may be a window that
+    // doesn't start at source address 0 — translate via its base.
+    const cursor = internalReference.address - stepBufferBase(buffer)
     const endCursor = cursor + internalReference.length
 
     // include the Open parenthesis + ending semicolon
@@ -496,7 +523,7 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
     const value: StepEntityBase<EntityTypeIDs> | undefined =
       expressID !== void 0 ? this.model.getElementByExpressID(expressID) :
         (this.model.getInlineElementByAddress(
-            stepExtractInlineElemement(buffer, cursor, endCursor)))
+            extractInlineElementAddress(buffer, cursor, endCursor)))
 
     return value
   }
@@ -692,7 +719,7 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
     const value =
       expressID !== void 0 ? model.getTypedElementByExpressID(expressID, entityConstructor) :
         model.getTypedInlineElementByAddress(
-            stepExtractInlineElemement( buffer, cursor, endCursor ), entityConstructor )
+            extractInlineElementAddress( buffer, cursor, endCursor ), entityConstructor )
 
     if (value === void 0) {
       if (!optional) {
@@ -736,7 +763,7 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
     const value =
       expressID !== void 0 ? model.getTypedElementByExpressID( expressID, entityConstructor ) :
       model.getTypedInlineElementByAddress(
-          stepExtractInlineElemement( buffer, cursor, endCursor ), entityConstructor )
+          extractInlineElementAddress( buffer, cursor, endCursor ), entityConstructor )
 
     if ( value === void 0 ) {
       return
@@ -828,7 +855,10 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
       throw new Error( 'Couldn\'t read field due to too few fields in record' )
     }
 
-    const buffer     = this.buffer
+    // Read through the SAME reference the vtable cursors came from —
+    // with a windowed provider, `this.buffer` and a multi-class
+    // reference's buffer can be different windows.
+    const buffer     = internalReference.buffer
     const vtableSlot = internalReference.vtableIndex + offset
     const cursor     = internalReference.vtable[ vtableSlot ]
     const nextSlot   = vtableSlot + 1
@@ -1048,18 +1078,23 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
 
     if ( multiReference !== void 0 ) {
 
-      const classReference = multiReference[depth] 
+      const classReference = multiReference[depth]
 
       if ( classReference.vtableIndex === void 0 ) {
 
         const populated = this.model.populateVtableEntryRaw( classReference )
-        
+
         if (!populated) {
           throw new Error('Entity does not have matching table entry to read from model')
         }
-
-        this.internalReference_.buffer = classReference.buffer
       }
+
+      // Sync on EVERY access (not just first populate): generated
+      // getters read `this.buffer` right after resolving a cursor for
+      // this depth, and with a windowed provider each class reference
+      // can hold a different window — `this.buffer` must always be the
+      // view the depth's cursors were recorded against.
+      this.internalReference_.buffer = classReference.buffer
 
       return classReference as Required< StepEntityInternalReference<EntityTypeIDs> >
     }

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -1,4 +1,10 @@
 import { StepIndexEntry } from './parsing/step_parser'
+import {
+  ResidentStepBufferProvider,
+  StepBufferProvider,
+  StepExternalByteStore,
+  WindowedStepBufferProvider,
+} from './step_buffer_provider'
 import StepVtableBuilder from './parsing/step_vtable_builder'
 import StepEntityBase from './step_entity_base'
 import StepEntitySchema from './step_entity_schema'
@@ -59,6 +65,14 @@ implements Iterable<BaseEntity>, Model {
   private readonly complexEntries_?:
     Map< number, StepEntityInternalReferencePrivate< EntityTypeIDs, BaseEntity > >
 
+  // Residency provider for the raw source bytes. Defaults to a resident
+  // provider over the constructor's buffer (historical behaviour,
+  // bit-for-bit). `spillSourceToExternalStore` swaps in a windowed
+  // provider and releases the resident buffer — after that, synchronous
+  // extraction requires the range to have been paged in first (see
+  // `ensureResidentByExpressID` / `ensureResidentByLocalID`).
+  private bufferProvider_: StepBufferProvider
+
   /**
    * Will this model memoize elements, set to false to disable,
    * true to enable.
@@ -89,7 +103,9 @@ implements Iterable<BaseEntity>, Model {
    */
   constructor(
     public readonly schema: StepEntitySchema< EntityTypeIDs, BaseEntity >,
-    private readonly buffer_: Uint8Array, elementIndex: StepIndexEntry<EntityTypeIDs>[]) {
+    private buffer_: Uint8Array | undefined, elementIndex: StepIndexEntry<EntityTypeIDs>[]) {
+
+    this.bufferProvider_ = new ResidentStepBufferProvider( buffer_ as Uint8Array )
 
     const localElementIndex: StepEntityInternalReferencePrivate<EntityTypeIDs, BaseEntity>[] =
       elementIndex
@@ -268,7 +284,10 @@ implements Iterable<BaseEntity>, Model {
       this.descriptorCache_ = []
 
       // Complex (multiMapping) entries are retained objects; clear their lazy
-      // fields in place, matching the previous per-entry reset.
+      // fields in place, matching the previous per-entry reset. The mapped
+      // class references are cleared too — they capture buffer views at
+      // populate time, and a stale view would otherwise pin the released
+      // source buffer across a spill.
       if ( this.complexEntries_ !== void 0 ) {
 
         for ( const item of this.complexEntries_.values() ) {
@@ -278,6 +297,19 @@ implements Iterable<BaseEntity>, Model {
           item.vtable      = void 0
           item.vtableCount = void 0
           item.vtableIndex = void 0
+          item.multiEntity = void 0
+
+          if ( item.multiMapping !== void 0 ) {
+
+            for ( const mapped of item.multiMapping ) {
+
+              mapped.buffer      = void 0
+              mapped.entity      = void 0
+              mapped.vtable      = void 0
+              mapped.vtableCount = void 0
+              mapped.vtableIndex = void 0
+            }
+          }
         }
       }
 
@@ -306,17 +338,23 @@ implements Iterable<BaseEntity>, Model {
    * @param element The raw elment to populate the vtable entry for.
    * @return {boolean} Did the vtable entry populate correctly?
    */
-  public populateVtableEntryRaw( 
+  public populateVtableEntryRaw(
     element: StepEntityInternalReference< EntityTypeIDs > ): boolean {
     if (element.vtableIndex !== void 0 || element.typeID === 0 ) {
       return true
     }
 
+    // Acquire the record's byte range through the provider — the full
+    // resident buffer at offset 0 by default, or a window/merged view
+    // after a spill. Cursors recorded below are relative to the view.
+    const acquisition = this.bufferProvider_.acquire( element.address, element.length )
+    const viewAddress = element.address - acquisition.offset
+
     const extratedEntry =
       this.schema.parser.extractDataEntry(
-          this.buffer_,
-          element.address,
-          element.address + element.length,
+          acquisition.buffer,
+          viewAddress,
+          viewAddress + element.length,
           this.vtableBuilder_)
 
     if (extratedEntry === void 0) {
@@ -326,7 +364,7 @@ implements Iterable<BaseEntity>, Model {
     element.vtableIndex = extratedEntry[ 0 ]
     element.vtableCount = extratedEntry[ 1 ]
     element.endCursor   = extratedEntry[ 2 ]
-    element.buffer = this.buffer_
+    element.buffer = acquisition.buffer
     element.vtable = this.vtableBuilder_.buffer
 
     return true
@@ -347,28 +385,7 @@ implements Iterable<BaseEntity>, Model {
 
     const element = this.entry(localID)
 
-    if (element.vtableIndex !== void 0 || element.typeID === 0 ) {
-      return true
-    }
-
-    const extratedEntry =
-      this.schema.parser.extractDataEntry(
-          this.buffer_,
-          element.address,
-          element.address + element.length,
-          this.vtableBuilder_)
-
-    if (extratedEntry === void 0) {
-      return false
-    }
-
-    element.vtableIndex = extratedEntry[ 0 ]
-    element.vtableCount = extratedEntry[ 1 ]
-    element.endCursor   = extratedEntry[ 2 ]
-    element.buffer = this.buffer_
-    element.vtable = this.vtableBuilder_.buffer
-
-    return true
+    return this.populateVtableEntryRaw( element )
   }
 
 
@@ -385,7 +402,8 @@ implements Iterable<BaseEntity>, Model {
 
     const element = this.entry(localID)
 
-    element.buffer = this.buffer_
+    element.buffer =
+      this.bufferProvider_.acquire( element.address, element.length ).buffer
   }
 
 
@@ -395,7 +413,123 @@ implements Iterable<BaseEntity>, Model {
    * @return {number} The number of elements.
    */
   public get bufferBytesize(): number {
-    return this.buffer_.byteLength
+    return this.bufferProvider_.byteLength
+  }
+
+  /**
+   * Are the source bytes held externally (spilled), i.e. windowed in
+   * on demand rather than fully resident?
+   *
+   * @return {boolean} True after a successful `spillSourceToExternalStore`.
+   */
+  public get isSourceExternal(): boolean {
+    return this.buffer_ === void 0
+  }
+
+  /**
+   * Bytes of source currently held resident by the buffer provider
+   * (the whole buffer before a spill; the windowed working set after).
+   *
+   * @return {number} The resident byte count.
+   */
+  public get residentSourceBytes(): number {
+    return this.bufferProvider_.residentBytes
+  }
+
+  /**
+   * Release the resident source buffer and serve subsequent record
+   * reads from fixed-size windows paged in from an external store.
+   *
+   * The store must contain EXACTLY the model's source bytes (same
+   * length; byte-identical content is the caller's responsibility —
+   * typically the original file already sitting in OPFS). All cached
+   * descriptors/entities are invalidated, since they hold views over
+   * the released buffer; they rematerialise on demand through the
+   * windowed provider.
+   *
+   * After this, synchronous extraction of a record whose range isn't
+   * resident throws StepBufferNotResidentError — async API surfaces
+   * must call `ensureResidentByExpressID` / `ensureResidentByLocalID`
+   * first. Parse and geometry extraction always run before any spill,
+   * so those paths are unaffected.
+   *
+   * @param store The external store holding the source bytes.
+   * @param chunkBytes Optional window size in bytes.
+   * @param maxResidentChunks Optional residency cap in windows.
+   */
+  public spillSourceToExternalStore(
+      store: StepExternalByteStore,
+      chunkBytes?: number,
+      maxResidentChunks?: number ): void {
+
+    if ( store.byteLength !== this.bufferProvider_.byteLength ) {
+      throw new Error(
+          `External store byteLength ${store.byteLength} does not match ` +
+          `source byteLength ${this.bufferProvider_.byteLength}` )
+    }
+
+    this.bufferProvider_ = new WindowedStepBufferProvider( store, chunkBytes, maxResidentChunks )
+    this.buffer_         = void 0
+
+    this.invalidate( true )
+  }
+
+  /**
+   * Page in the byte range(s) backing a record so following
+   * synchronous extraction of it succeeds. Covers the record's own
+   * range (which contains any inline elements) and, for complex /
+   * external-mapped records, each mapped class record's range.
+   *
+   * No-op (fast resolved promise) while the source is fully resident.
+   *
+   * @param localID The local ID of the record.
+   * @return {Promise< void >} Resolves when resident.
+   */
+  public async ensureResidentByLocalID( localID: number ): Promise< void > {
+
+    if ( !this.isSourceExternal ) {
+      return
+    }
+
+    if ( localID >= this.count_ ) {
+      throw new Error(`Invalid localID ${localID}`)
+    }
+
+    await this.bufferProvider_.ensureResident(
+        this.address_[ localID ], this.length_[ localID ] )
+
+    const complex = this.complexEntries_?.get( localID )
+
+    if ( complex?.multiMapping !== void 0 ) {
+
+      for ( const mapped of complex.multiMapping ) {
+        await this.bufferProvider_.ensureResident( mapped.address, mapped.length )
+      }
+    }
+  }
+
+  /**
+   * Page in the byte range(s) backing a record by express ID — see
+   * `ensureResidentByLocalID`. Unknown express IDs resolve silently
+   * (the following read will surface the miss the same way it does
+   * for a fully-resident model).
+   *
+   * @param expressID The express ID of the record.
+   * @return {Promise< void >} Resolves when resident.
+   */
+  public async ensureResidentByExpressID( expressID: number ): Promise< void > {
+
+    if ( !this.isSourceExternal ) {
+      return
+    }
+
+    const localID = this.expressIDMap_.get( expressID )
+
+    if ( localID === void 0 ) {
+      return
+    }
+
+    await this.ensureResidentByLocalID( localID )
   }
 
 


### PR DESCRIPTION
## What

Step 3 of the lazy/incremental properties track (follows #372 SoA descriptors and #373 'names' mode; companion Share PRs: bldrs-ai/Share#1588, bldrs-ai/Share#1589).

A parsed model pinned its full raw source buffer — hundreds of MB on large models — for its whole lifetime, even though post-load property access touches a tiny fraction of it. This adds a **residency provider** seam so the source can be spilled to an external byte store (OPFS in the browser; memory/file in node) and served through **fixed-size windows** paged in on demand. The SoA `address_`/`length_` columns are the window index — no new index needed.

### Design

- **`StepBufferProvider`** (`src/step/step_buffer_provider.ts`): sync `acquire(address, length) → {buffer, offset}` + async `ensureResident(address, length)`.
  - `ResidentStepBufferProvider` wraps the full buffer at offset 0 — the default, bit-for-bit the historical behaviour.
  - `WindowedStepBufferProvider` pages chunks (default 4MiB, cap 16) from a `StepExternalByteStore` with LRU residency, in-flight load de-dup, and per-record merged copies for chunk-straddling records. Views carry their absolute base via a non-enumerable symbol (`stepBufferBase`), so view-relative vtable cursors translate back to absolute addresses where needed.
  - **Eviction is advisory**: a descriptor that captured a chunk keeps it alive via its own reference, so correctness never depends on the residency set — only memory does. `ReleaseEntityCache` (from #373) drops those pins.
- **Model** (`step_model_base.ts`): populate paths acquire record ranges through the provider. `spillSourceToExternalStore(store)` swaps providers, releases the resident buffer, and invalidates all cached descriptors — including complex/multi mapped class references, which would otherwise pin the released buffer. `ensureResidentByExpressID/LocalID` page in a record's range(s), covering inline elements (textually contained in the record) and complex entities' mapped class records.
- **Sync/async boundary**: the already-async shim property APIs (`getItemProperties`, `getPropertySets`, spatial-tree walks, `getAllItemsOfType` verbose) `ensureLine` each record before the sync read — a no-branch fast path while fully resident. A sync read of a non-resident range throws `StepBufferNotResidentError` rather than returning wrong bytes.
- **Shim surface**: `IfcAPI.SpillModelSource(modelID, store, chunkBytes?, maxResidentChunks?)`; proxy `sourceIsExternal` / `spillSourceToExternalStore` / `ensureLineResident` on both IFC and AP214 passthroughs.

### Correctness notes

Three latent mixed-space reads (one reference's vtable cursors read through another reference's buffer — harmless when both were the whole file, wrong across windows) now read through the matching reference, and the multi-class buffer sync in `guaranteeVTable` happens on every access so generated getters' `this.buffer` always matches the depth they just resolved. Pre-spill these are behaviour-preserving.

**Nothing spills unless the embedder opts in**, and parse + geometry extraction always run pre-spill — default behaviour and geometry output are unchanged (byte-identity expected to hold in the geometry regression; the default provider hands back the same buffer at offset 0).

### Known limitation (documented in code)

`getLine(id, recursive=true)` on a spilled model follows references synchronously and only the root record is ensured — recursive flattening needs the closure resident. No lazy-load consumer uses recursive reads; an async closure-ensure can follow if one appears.

## Testing

- Provider unit suite: chunk views, straddle merge based at the record, final-chunk clamp, LRU eviction sparing the active range, in-flight de-dup, cold-acquire throw, resident accounting.
- IfcAPI integration suite on `data/index.ifc` with **512-byte windows and a 3-chunk cap** (forces continuous paging + straddles): full per-record parity before/after spill, names-mode spatial tree + pset parity, sync-throw guard, store-size-mismatch rejection, `ReleaseEntityCache` interop.
- Full suite green: 35 suites, 160 tests.

## Share integration (next)

Share backs the store with the original file already sitting in OPFS and calls `SpillModelSource` after load-time sweeps (geometry, spatial tree, GLB property capture) complete — a small follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_