### PR TITLE
Add cooperative progress tracking and async load support

### DIFF
--- a/src/AP214E3_2010/ap214_step_parser.ts
+++ b/src/AP214E3_2010/ap214_step_parser.ts
@@ -1,5 +1,5 @@
 import ParsingBuffer from '../parsing/parsing_buffer'
-import StepParser, {ParseResult} from '../step/parsing/step_parser'
+import StepParser, {ParseProgressCallback, ParseResult} from '../step/parsing/step_parser'
 import AP214StepModel from './ap214_step_model'
 import EntityTypesAP214 from './AP214E3_2010_gen/entity_types_ap214.gen'
 import EntitTypesIfcSearch from './AP214E3_2010_gen/entity_types_search.gen'
@@ -27,12 +27,32 @@ export default class AP214StepParser extends StepParser< EntityTypesAP214 > {
    * Parse data to the model
    *
    * @param input The parsing buffer, set to user data, to read.
+   * @param onProgress Optional byte-cursor progress callback for the data parse.
    * @return {[ParseResult, AP214StepModel | undefined]} The parse result as well as the model,
    * if it can be extracted.
    */
   public parseDataToModel(
-      input: ParsingBuffer ): [ParseResult, AP214StepModel | undefined] {
-    const [itemIndex, parseResult] = this.parseDataBlock( input )
+      input: ParsingBuffer,
+      onProgress?: ParseProgressCallback ): [ParseResult, AP214StepModel | undefined] {
+    const [itemIndex, parseResult] = this.parseDataBlock( input, onProgress )
+
+    return [parseResult, new AP214StepModel( input.buffer, itemIndex.elements )]
+  }
+
+  /**
+   * Cooperative variant of parseDataToModel — periodically yields to the
+   * event loop mid-parse (see StepParser.parseDataBlockAsync, issue #301 §2).
+   *
+   * @param input The parsing buffer, set to user data, to read.
+   * @param onProgress Optional byte-cursor progress callback for the data parse.
+   * @return {Promise<[ParseResult, AP214StepModel | undefined]>} The parse result as well
+   * as the model, if it can be extracted.
+   */
+  public async parseDataToModelAsync(
+      input: ParsingBuffer,
+      onProgress?: ParseProgressCallback ):
+      Promise<[ParseResult, AP214StepModel | undefined]> {
+    const [itemIndex, parseResult] = await this.parseDataBlockAsync( input, onProgress )
 
     return [parseResult, new AP214StepModel( input.buffer, itemIndex.elements )]
   }

--- a/src/cli/cli_progress_renderer.ts
+++ b/src/cli/cli_progress_renderer.ts
@@ -1,0 +1,116 @@
+import { ProgressEvent, ProgressPhase } from '../core/progress'
+
+
+const PHASE_LABELS: Record<ProgressPhase, string> = {
+  headerParse: 'Parsing header',
+  dataParse: 'Parsing model data',
+  geometry: 'Extracting geometry',
+  sceneBuild: 'Building scene',
+  serialize: 'Writing output',
+}
+
+const PERCENT = 100
+const DEFAULT_NON_TTY_INTERVAL_MS = 2000
+const MS_PER_SECOND = 1000
+
+/**
+ * Renders load progress events on a terminal.
+ *
+ * Writes to stderr so stdout stays clean for data output (query tables,
+ * piped GLB paths — issue #301). On a TTY it repaints a single status line
+ * with carriage returns; when redirected (CI logs) it prints a plain line on
+ * phase changes and at most once per nonTtyIntervalMs so logs stay readable.
+ */
+export class CliProgressRenderer {
+
+  private lastLineLength = 0
+  private lastPrintTime = 0
+  private lastPhase: ProgressPhase | undefined
+
+  /**
+   * Construct this against an output stream.
+   *
+   * @param out The stream to render to (default stderr).
+   * @param nonTtyIntervalMs Minimum ms between lines when not a TTY.
+   */
+  public constructor(
+    private readonly out: NodeJS.WriteStream = process.stderr,
+    private readonly nonTtyIntervalMs: number = DEFAULT_NON_TTY_INTERVAL_MS ) {}
+
+  /**
+   * Progress callback — bound as an arrow so it can be handed directly to a
+   * ProgressTracker / ModelLoadOptions.onProgress.
+   *
+   * @param event The progress event to render.
+   */
+  public readonly onProgress = ( event: ProgressEvent ): void => {
+
+    const now = Date.now()
+    const phaseChanged = event.phase !== this.lastPhase
+
+    if ( !this.out.isTTY &&
+      !phaseChanged &&
+      now - this.lastPrintTime < this.nonTtyIntervalMs ) {
+      return
+    }
+
+    this.lastPhase = event.phase
+    this.lastPrintTime = now
+
+    const line = this.format( event )
+
+    if ( this.out.isTTY ) {
+
+      const padded = line.padEnd( this.lastLineLength )
+
+      this.lastLineLength = line.length
+      this.out.write( `\r${padded}` )
+    } else {
+
+      this.out.write( `${line}\n` )
+    }
+  }
+
+  /**
+   * Finish rendering — terminates the TTY status line so subsequent output
+   * (log table, statistics) starts on a fresh line.
+   */
+  public done(): void {
+
+    if ( this.out.isTTY && this.lastLineLength > 0 ) {
+      this.out.write( '\n' )
+    }
+
+    this.lastLineLength = 0
+    this.lastPhase = void 0
+  }
+
+  /**
+   * Format one event as a status line.
+   *
+   * @param event The progress event.
+   * @return {string} e.g. "Extracting geometry 42% (3800/9000 products) 12.4s 512MB"
+   */
+  private format( event: ProgressEvent ): string {
+
+    const label = PHASE_LABELS[ event.phase ] ?? event.phase
+    const elapsedSeconds = ( event.elapsedMs / MS_PER_SECOND ).toFixed( 1 )
+
+    let counts: string
+
+    if ( event.total !== void 0 && event.total > 0 ) {
+
+      const percent = Math.floor( ( event.completed / event.total ) * PERCENT )
+
+      counts = `${percent}% (${event.completed}/${event.total} ${event.unit})`
+    } else {
+
+      counts = `${event.completed} ${event.unit}`
+    }
+
+    const memory = event.memoryMb !== void 0 ?
+      ` ${Math.round( event.memoryMb )}MB` : ''
+
+    return `${label} ${counts} ${elapsedSeconds}s${memory}`
+  }
+}

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -1,7 +1,8 @@
 import { ConwayGeometry, FileHandlerFunction as FileHandlerCallback,
  } from '../../index'
 import {versionString} from '../../version/version'
-import Logger from '../../logging/logger'
+import Logger, { LogLevel as ConwayLogLevel } from '../../logging/logger'
+import { ProgressCallback } from '../../core/progress'
 import Environment from '../../utilities/environment'
 import * as glmatrix from 'gl-matrix'
 import { StepExternalByteStore } from '../../step/step_buffer_provider'
@@ -31,6 +32,35 @@ export interface Loadersettings {
   CIRCLE_SEGMENTS_MEDIUM?: number
   CIRCLE_SEGMENTS_HIGH?: number
   BOOL_ABORT_THRESHOLD?: number
+
+  /**
+   * Conway extension (real web-ifc has no per-phase progress surface):
+   * throttled structured progress events during OpenModel/OpenModelAsync —
+   * see core/progress.ts and conway issue #301. Embedders should
+   * feature-detect ('ON_PROGRESS simply ignored by older engines').
+   */
+  ON_PROGRESS?: ProgressCallback
+}
+
+/**
+ * web-ifc compatible log levels (numeric values match web-ifc's enum so an
+ * engine swap keeps SetLogLevel calls working). Mapped onto conway's
+ * Logger threshold — see logging/logger.ts.
+ */
+export enum LogLevel {
+  LOG_LEVEL_DEBUG = 1,
+  LOG_LEVEL_INFO = 2,
+  LOG_LEVEL_WARN = 3,
+  LOG_LEVEL_ERROR = 4,
+  LOG_LEVEL_OFF = 5,
+}
+
+const CONWAY_LOG_LEVEL_BY_WEBIFC: Record<LogLevel, ConwayLogLevel> = {
+  [LogLevel.LOG_LEVEL_DEBUG]: ConwayLogLevel.DEBUG,
+  [LogLevel.LOG_LEVEL_INFO]: ConwayLogLevel.INFO,
+  [LogLevel.LOG_LEVEL_WARN]: ConwayLogLevel.WARNING,
+  [LogLevel.LOG_LEVEL_ERROR]: ConwayLogLevel.ERROR,
+  [LogLevel.LOG_LEVEL_OFF]: ConwayLogLevel.OFF,
 }
 
 export interface Vector<T> {
@@ -192,6 +222,58 @@ export class IfcAPI {
     this.models.set( modelIdResult, result )
 
     return modelIdResult
+  }
+
+  /**
+   * Cooperative variant of OpenModel (conway extension; feature-detect with
+   * typeof api.OpenModelAsync === 'function'). Identical parse/extraction,
+   * but periodically yields to the event loop so browsers can repaint
+   * progress UI (settings.ON_PROGRESS) and the tab is not flagged as
+   * stalled — conway issue #301 §2. Currently cooperative for IFC input;
+   * AP214/AP203/AP242 fall back to the synchronous path.
+   *
+   * @param data containing IFC data (bytes)
+   * @param settings settings for loading the model
+   * @return {Promise<number>} model ID
+   */
+  async OpenModelAsync(data: Uint8Array, settings?: Loadersettings): Promise<number> {
+
+    const modelIdResult = this.globalModelIDCounter
+
+    const result =
+      await IfcApiModelPassthroughFactory.fromAsync(
+          modelIdResult,
+          data,
+          this.wasmModule,
+          settings)
+
+    if ( result === void 0 ) {
+      return -1
+    }
+
+    this.globalModelIDCounter++
+
+    this.models.set( modelIdResult, result )
+
+    return modelIdResult
+  }
+
+  /**
+   * Set conway's console-echo log threshold, web-ifc compatible surface
+   * (numeric LogLevel enum). Embedders (e.g. Share) use this to quiet a
+   * clean load's console down to warnings/errors — conway issue #301.
+   *
+   * @param level the web-ifc style numeric log level
+   */
+  SetLogLevel(level: LogLevel): void {
+    const mapped = CONWAY_LOG_LEVEL_BY_WEBIFC[level]
+
+    if (mapped === void 0) {
+      Logger.warning(`[SetLogLevel]: unknown log level ${level}`)
+      return
+    }
+
+    Logger.setLogLevel(mapped)
   }
 
 

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -238,7 +238,10 @@ export class IfcAPI {
    */
   async OpenModelAsync(data: Uint8Array, settings?: Loadersettings): Promise<number> {
 
-    const modelIdResult = this.globalModelIDCounter
+    // Reserve the ID before the first await — another OpenModel(Async) call
+    // interleaving with the cooperative parse must not get the same ID. A
+    // failed open burns an ID, which is harmless (IDs are only keys).
+    const modelIdResult = this.globalModelIDCounter++
 
     const result =
       await IfcApiModelPassthroughFactory.fromAsync(
@@ -250,8 +253,6 @@ export class IfcAPI {
     if ( result === void 0 ) {
       return -1
     }
-
-    this.globalModelIDCounter++
 
     this.models.set( modelIdResult, result )
 

--- a/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
@@ -97,4 +97,47 @@ export class IfcApiModelPassthroughFactory {
         Logger.error( 'No type detected when constructing model')
     }
   }
+
+  /**
+   * Cooperative twin of from() (used by OpenModelAsync): IFC input is
+   * parsed/extracted with periodic event-loop yields so progress UI can
+   * repaint (issue #301 §2); AP214/AP203/AP242 currently fall back to the
+   * synchronous path (thunk-tree extraction has no flat product loop yet).
+   *
+   * @param modelID
+   * @param data
+   * @param wasmModule
+   * @param settings
+   * @return {Promise<IfcApiModelPassthrough | undefined>}
+   */
+  public static async fromAsync(
+      modelID: number,
+      data: Uint8Array,
+      wasmModule: any,
+      settings?: Loadersettings ): Promise<IfcApiModelPassthrough | undefined> {
+
+    const modelFormat = ModelFormatDetector.detect( new ParsingBuffer( data ) )
+
+    if ( modelFormat !== ModelFormatType.IFC ) {
+
+      return IfcApiModelPassthroughFactory.from( modelID, data, wasmModule, settings )
+    }
+
+    try {
+
+      return await IfcApiProxyIfc.createAsync(modelID, data, wasmModule, settings)
+
+    } catch ( e ) {
+
+      if ( e instanceof Error ) {
+
+        // eslint-disable-next-line max-len
+        Logger.error( `Error loading IFC model in passthrough factory ${modelID}:\n${e.message}\n\n${e.stack}`)
+      } else {
+
+        Logger.error( `Unknown error loading IFC model in passthrough factory ${modelID}` )
+      }
+
+    }
+  }
 }

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -21,8 +21,10 @@ import { NodeValueHandle } from './properties_passthrough'
 import * as glmatrix from 'gl-matrix'
 import { IfcProperties } from './ifc_properties'
 import Logger from '../../logging/logger'
+import { ProgressTracker } from '../../core/progress'
 import IfcStepParser from '../../ifc/ifc_step_parser'
 import ParsingBuffer from '../../parsing/parsing_buffer'
+import { StepHeader } from '../../step/parsing/step_parser'
 import { ExtractResult } from '../../index'
 import { IfcGeometryExtraction } from '../../ifc/ifc_geometry_extraction'
 import { ParseResult } from '../../index'
@@ -31,6 +33,22 @@ import { FromRawLineData } from './ifc2x4_helper'
 import { shimIfcEntityMap, shimIfcEntityReverseMap } from './shim_schema_mapping'
 import { EntityTypesIfcCount } from '../../ifc/ifc4_gen/entity_types_ifc.gen'
 import { CanonicalMeshType } from '../../index'
+
+/**
+ * Everything parse/extraction produces that the proxy constructor's tail
+ * (mesh vectors, statistics) consumes — precomputed by createAsync so the
+ * cooperative path can await mid-parse, or computed synchronously inside
+ * the constructor for the classic OpenModel path.
+ */
+interface IfcProxyLoadState {
+  conwaywasm: ConwayGeometry
+  allTimeStart: number
+  stepHeader: StepHeader
+  model: IfcStepModel
+  scene: IfcSceneBuilder
+  conwayGeometry: IfcGeometryExtraction
+  geometryTimeInMs: number
+}
 
 /**
  * The proxy for IFC from the shim.
@@ -74,79 +92,27 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       public readonly modelID: number,
       data: Uint8Array,
       private readonly wasmModule: any,
-      private readonly settings?: Loadersettings ) {
+      private readonly settings?: Loadersettings,
+      precomputed?: IfcProxyLoadState ) {
 
-    this.conwaywasm = new ConwayGeometry(wasmModule)
+    // The cooperative path (createAsync) parses/extracts before construction
+    // so it can await mid-load; the classic OpenModel path does it here,
+    // synchronously. Both share the tail below (mesh vectors, statistics).
+    const loadState = precomputed ??
+      IfcApiProxyIfc.parseAndExtract(modelID, data, new ConwayGeometry(wasmModule), settings)
 
-    const allTimeStart = Date.now()
-    const parser = IfcStepParser.Instance
-    const bufferInput = new ParsingBuffer(data)
-    const [stepHeader, result0] = parser.parseHeader(bufferInput)
-
-    Logger.createStatistics(modelID)
+    this.conwaywasm = loadState.conwaywasm
 
     const statistics = Logger.getStatistics(modelID)
 
-    switch (result0) {
-      case ParseResult.COMPLETE:
-
-        break
-
-      case ParseResult.INCOMPLETE:
-
-        Logger.warning('Parse incomplete but no errors')
-        statistics?.setLoadStatus('HEADER PARSE: INCOMPLETE')
-        break
-
-      case ParseResult.INVALID_STEP:
-
-        Logger.error('Error: Invalid STEP detected in parse, but no syntax error detected')
-        statistics?.setLoadStatus('HEADER PARSE: INVALID_STEP')
-        break
-
-      case ParseResult.MISSING_TYPE:
-
-        Logger.warning('Error: missing STEP type, but no syntax error detected')
-        statistics?.setLoadStatus('HEADER PARSE: MISSING_TYPE')
-        break
-
-      case ParseResult.SYNTAX_ERROR:
-
-        Logger.error(`Error: Syntax error detected on line ${bufferInput.lineCount}`)
-        statistics?.setLoadStatus('HEADER PARSE: SYNTAX_ERROR')
-        break
-
-      default:
-    }
-
-    const parseStartTime = Date.now()
-    const model = parser.parseDataToModel(bufferInput)[1]
-    const parseEndTime = Date.now()
-
-    if (model === void 0) {
-      Logger.error('[OpenModel]: model === undefined')
-      statistics?.setLoadStatus('PARSE_FAIL')
-      throw new Error( 'Failed to load model' )
-    }
-
-    statistics?.setParseTime(parseEndTime - parseStartTime)
-
-    // TODO(nickcastel50): Doing geometry extraction in here for now...
-    // parse + extract data model + geometry data
-    const conwayGeometry = new IfcGeometryExtraction(this.conwaywasm, model)
-
-    const startTime = Date.now()
-    const [extractionResult, scene] =
-      conwayGeometry.extractIFCGeometryData()
-
-    const endTime = Date.now()
-    const executionTimeInMs = endTime - startTime
-
-    if (extractionResult !== ExtractResult.COMPLETE) {
-      Logger.error('[OpenModel]: Error extracting geometry, exiting...')
-      statistics?.setLoadStatus('FAIL')
-      throw new Error( 'Couldn\'t extract model' )
-    }
+    const {
+      allTimeStart,
+      stepHeader,
+      model,
+      scene,
+      conwayGeometry,
+      geometryTimeInMs: executionTimeInMs,
+    } = loadState
 
     // get linear scaling factor
     this.linearScalingFactor = conwayGeometry.getLinearScalingFactor()
@@ -276,6 +242,264 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     statistics?.setGeometryTime(executionTimeInMs)
     // eslint-disable-next-line no-magic-numbers
     statistics?.setGeometryMemory(scene.model.geometry.calculateGeometrySize() / (1024 * 1024))
+  }
+
+  /**
+   * Cooperative construction (conway extension, used by OpenModelAsync):
+   * identical parse/extraction to the constructor path, but periodically
+   * yields to the event loop so progress UI can repaint — issue #301 §2.
+   *
+   * @param modelID The model ID being opened.
+   * @param data The IFC data buffer.
+   * @param wasmModule The wasm module.
+   * @param settings Loader settings (ON_PROGRESS is honored).
+   * @return {Promise<IfcApiProxyIfc>} The constructed proxy.
+   */
+  public static async createAsync(
+      modelID: number,
+      data: Uint8Array,
+      wasmModule: any,
+      settings?: Loadersettings ): Promise<IfcApiProxyIfc> {
+
+    const loadState = await IfcApiProxyIfc.parseAndExtractAsync(
+        modelID, data, new ConwayGeometry(wasmModule), settings)
+
+    return new IfcApiProxyIfc(modelID, data, wasmModule, settings, loadState)
+  }
+
+  /**
+   * Log + record the header parse result on the model statistics.
+   *
+   * @param result0 The header parse result.
+   * @param bufferInput The parsing buffer (for line numbers).
+   * @param modelID The model ID (for statistics lookup).
+   */
+  private static reportHeaderParseResult(
+      result0: ParseResult,
+      bufferInput: ParsingBuffer,
+      modelID: number ): void {
+
+    const statistics = Logger.getStatistics(modelID)
+
+    switch (result0) {
+      case ParseResult.COMPLETE:
+
+        break
+
+      case ParseResult.INCOMPLETE:
+
+        Logger.warning('Parse incomplete but no errors')
+        statistics?.setLoadStatus('HEADER PARSE: INCOMPLETE')
+        break
+
+      case ParseResult.INVALID_STEP:
+
+        Logger.error('Error: Invalid STEP detected in parse, but no syntax error detected')
+        statistics?.setLoadStatus('HEADER PARSE: INVALID_STEP')
+        break
+
+      case ParseResult.MISSING_TYPE:
+
+        Logger.warning('Error: missing STEP type, but no syntax error detected')
+        statistics?.setLoadStatus('HEADER PARSE: MISSING_TYPE')
+        break
+
+      case ParseResult.SYNTAX_ERROR:
+
+        Logger.error(`Error: Syntax error detected on line ${bufferInput.lineCount}`)
+        statistics?.setLoadStatus('HEADER PARSE: SYNTAX_ERROR')
+        break
+
+      default:
+    }
+  }
+
+  /**
+   * Build the progress tracker for a load, when the settings carry an
+   * ON_PROGRESS callback.
+   *
+   * @param settings Loader settings.
+   * @return {ProgressTracker | undefined} The tracker, if progress is wanted.
+   */
+  private static makeTracker(
+      settings: Loadersettings | undefined ): ProgressTracker | undefined {
+
+    if (settings?.ON_PROGRESS === void 0) {
+      return void 0
+    }
+
+    return new ProgressTracker(settings.ON_PROGRESS)
+  }
+
+  /**
+   * Synchronous parse + geometry extraction (the classic OpenModel path).
+   *
+   * @param modelID The model ID being opened.
+   * @param data The IFC data buffer.
+   * @param conwaywasm The conway geometry wasm wrapper.
+   * @param settings Loader settings (ON_PROGRESS is honored).
+   * @return {IfcProxyLoadState} Everything the constructor tail needs.
+   */
+  private static parseAndExtract(
+      modelID: number,
+      data: Uint8Array,
+      conwaywasm: ConwayGeometry,
+      settings?: Loadersettings ): IfcProxyLoadState {
+
+    const tracker = IfcApiProxyIfc.makeTracker(settings)
+
+    const allTimeStart = Date.now()
+    const parser = IfcStepParser.Instance
+    const bufferInput = new ParsingBuffer(data)
+
+    tracker?.beginPhase('headerParse', 'bytes', data.length)
+
+    const [stepHeader, result0] = parser.parseHeader(bufferInput)
+
+    Logger.createStatistics(modelID)
+
+    const statistics = Logger.getStatistics(modelID)
+
+    IfcApiProxyIfc.reportHeaderParseResult(result0, bufferInput, modelID)
+
+    tracker?.beginPhase('dataParse', 'bytes', data.length)
+
+    const parseTick = tracker !== void 0 ?
+      (cursorBytes: number) => tracker.update(cursorBytes) : void 0
+
+    const parseStartTime = Date.now()
+    const model = parser.parseDataToModel(bufferInput, parseTick)[1]
+    const parseEndTime = Date.now()
+
+    tracker?.endPhase(data.length)
+
+    if (model === void 0) {
+      Logger.error('[OpenModel]: model === undefined')
+      statistics?.setLoadStatus('PARSE_FAIL')
+      throw new Error( 'Failed to load model' )
+    }
+
+    statistics?.setParseTime(parseEndTime - parseStartTime)
+
+    const conwayGeometry = new IfcGeometryExtraction(conwaywasm, model)
+
+    tracker?.beginPhase('geometry', 'products')
+
+    const geometryTick = tracker !== void 0 ?
+      (completed: number, total: number) => {
+        tracker.setPhaseTotal(total)
+        tracker.update(completed)
+      } : void 0
+
+    const startTime = Date.now()
+    const [extractionResult, scene] =
+      conwayGeometry.extractIFCGeometryData(geometryTick)
+
+    const endTime = Date.now()
+
+    tracker?.endPhase()
+
+    if (extractionResult !== ExtractResult.COMPLETE) {
+      Logger.error('[OpenModel]: Error extracting geometry, exiting...')
+      statistics?.setLoadStatus('FAIL')
+      throw new Error( 'Couldn\'t extract model' )
+    }
+
+    return {
+      conwaywasm,
+      allTimeStart,
+      stepHeader,
+      model,
+      scene,
+      conwayGeometry,
+      geometryTimeInMs: endTime - startTime,
+    }
+  }
+
+  /**
+   * Cooperative twin of parseAndExtract: awaits the *Async parser/extraction
+   * variants so the event loop can run between progress ticks.
+   *
+   * @param modelID The model ID being opened.
+   * @param data The IFC data buffer.
+   * @param conwaywasm The conway geometry wasm wrapper.
+   * @param settings Loader settings (ON_PROGRESS is honored).
+   * @return {Promise<IfcProxyLoadState>} Everything the constructor tail needs.
+   */
+  private static async parseAndExtractAsync(
+      modelID: number,
+      data: Uint8Array,
+      conwaywasm: ConwayGeometry,
+      settings?: Loadersettings ): Promise<IfcProxyLoadState> {
+
+    const tracker = IfcApiProxyIfc.makeTracker(settings)
+
+    const allTimeStart = Date.now()
+    const parser = IfcStepParser.Instance
+    const bufferInput = new ParsingBuffer(data)
+
+    tracker?.beginPhase('headerParse', 'bytes', data.length)
+
+    const [stepHeader, result0] = parser.parseHeader(bufferInput)
+
+    Logger.createStatistics(modelID)
+
+    const statistics = Logger.getStatistics(modelID)
+
+    IfcApiProxyIfc.reportHeaderParseResult(result0, bufferInput, modelID)
+
+    tracker?.beginPhase('dataParse', 'bytes', data.length)
+
+    const parseTick = tracker !== void 0 ?
+      (cursorBytes: number) => tracker.update(cursorBytes) : void 0
+
+    const parseStartTime = Date.now()
+    const model = (await parser.parseDataToModelAsync(bufferInput, parseTick))[1]
+    const parseEndTime = Date.now()
+
+    tracker?.endPhase(data.length)
+
+    if (model === void 0) {
+      Logger.error('[OpenModel]: model === undefined')
+      statistics?.setLoadStatus('PARSE_FAIL')
+      throw new Error( 'Failed to load model' )
+    }
+
+    statistics?.setParseTime(parseEndTime - parseStartTime)
+
+    const conwayGeometry = new IfcGeometryExtraction(conwaywasm, model)
+
+    tracker?.beginPhase('geometry', 'products')
+
+    const geometryTick = tracker !== void 0 ?
+      (completed: number, total: number) => {
+        tracker.setPhaseTotal(total)
+        tracker.update(completed)
+      } : void 0
+
+    const startTime = Date.now()
+    const [extractionResult, scene] =
+      await conwayGeometry.extractIFCGeometryDataAsync(geometryTick)
+
+    const endTime = Date.now()
+
+    tracker?.endPhase()
+
+    if (extractionResult !== ExtractResult.COMPLETE) {
+      Logger.error('[OpenModel]: Error extracting geometry, exiting...')
+      statistics?.setLoadStatus('FAIL')
+      throw new Error( 'Couldn\'t extract model' )
+    }
+
+    return {
+      conwaywasm,
+      allTimeStart,
+      stepHeader,
+      model,
+      scene,
+      conwayGeometry,
+      geometryTimeInMs: endTime - startTime,
+    }
   }
 
 

--- a/src/compat/web-ifc/index.ts
+++ b/src/compat/web-ifc/index.ts
@@ -15,3 +15,14 @@
 // See design/new/web-ifc-compat-surface.md for scope + the Conway-owned
 // constants / AP203 / properties-layer decisions.
 export * from './ifc_api'
+
+// Conway extension: the structured progress contract carried by
+// `Loadersettings.ON_PROGRESS` / `OpenModelAsync` (issue #301). Exported
+// here so shim consumers (Share) can type progress handlers without
+// reaching into conway internals.
+export {
+  ProgressEvent,
+  ProgressCallback,
+  ProgressPhase,
+  ProgressUnit,
+} from '../../core/progress'

--- a/src/core/progress.test.ts
+++ b/src/core/progress.test.ts
@@ -1,0 +1,100 @@
+import {describe, expect, test} from '@jest/globals'
+
+import { ProgressEvent, ProgressTracker, yieldToEventLoop } from './progress'
+
+
+const TOTAL_BYTES = 1000
+const QUARTER = 250
+const HALF = 500
+const ONE_HOUR_MS = 3_600_000
+const TOTAL_PRODUCTS = 100
+const UPDATE_COUNT = 50
+const SMALL_TOTAL = 10
+const OVERSHOOT = 25
+
+describe( 'ProgressTracker', () => {
+
+  test( 'emits unthrottled phase boundaries and throttled updates', () => {
+
+    const events: ProgressEvent[] = []
+
+    // Interval of 0 → every update emits (deterministic in tests).
+    const tracker = new ProgressTracker( ( event ) => events.push( event ), 0 )
+
+    tracker.beginPhase( 'dataParse', 'bytes', TOTAL_BYTES )
+    tracker.update( QUARTER )
+    tracker.update( HALF )
+    tracker.endPhase( TOTAL_BYTES )
+
+    expect( events.length ).toBe( 4 )
+    expect( events[ 0 ] ).toMatchObject(
+        { phase: 'dataParse', completed: 0, total: TOTAL_BYTES, unit: 'bytes' } )
+    expect( events[ 1 ].completed ).toBe( QUARTER )
+    expect( events[ 2 ].completed ).toBe( HALF )
+    expect( events[ 3 ].completed ).toBe( TOTAL_BYTES )
+    expect( events.every( ( event ) => event.elapsedMs >= 0 ) ).toBe( true )
+  } )
+
+  test( 'throttles updates inside the minimum interval', () => {
+
+    const events: ProgressEvent[] = []
+
+    const tracker = new ProgressTracker( ( event ) => events.push( event ), ONE_HOUR_MS )
+
+    tracker.beginPhase( 'geometry', 'products', TOTAL_PRODUCTS )
+
+    for ( let where = 1; where <= UPDATE_COUNT; ++where ) {
+      tracker.update( where )
+    }
+
+    tracker.endPhase()
+
+    // begin + end only — all interior updates land inside the interval.
+    expect( events.length ).toBe( 2 )
+    expect( events[ 1 ].completed ).toBe( TOTAL_PRODUCTS )
+  } )
+
+  test( 'clamps completed to total and honors setPhaseTotal', () => {
+
+    const events: ProgressEvent[] = []
+
+    const tracker = new ProgressTracker( ( event ) => events.push( event ), 0 )
+
+    tracker.beginPhase( 'geometry', 'products' )
+
+    expect( events[ 0 ].total ).toBeUndefined()
+
+    tracker.setPhaseTotal( SMALL_TOTAL )
+    tracker.update( OVERSHOOT )
+
+    expect( events[ 1 ].total ).toBe( SMALL_TOTAL )
+    expect( events[ 1 ].completed ).toBe( SMALL_TOTAL )
+  } )
+
+  test( 'ignores updates outside any phase', () => {
+
+    const events: ProgressEvent[] = []
+
+    const tracker = new ProgressTracker( ( event ) => events.push( event ), 0 )
+
+    tracker.update( 5 )
+
+    expect( events.length ).toBe( 0 )
+  } )
+} )
+
+describe( 'yieldToEventLoop', () => {
+
+  test( 'lets queued macrotasks run', async () => {
+
+    let timerRan = false
+
+    setTimeout( () => {
+      timerRan = true
+    }, 0 )
+
+    await yieldToEventLoop()
+
+    expect( timerRan ).toBe( true )
+  } )
+} )

--- a/src/core/progress.ts
+++ b/src/core/progress.ts
@@ -1,0 +1,173 @@
+import Memory from '../memory/memory'
+
+
+/**
+ * The sequential phases of a model load, matching the phase split already
+ * measured by Statistics (parseTime / geometryTime) and the CI perf harness
+ * (perf.csv) so a progress report, a CLI run and a CI perf row are directly
+ * comparable. See conway issue #301.
+ *
+ * The heavy interiors of 'geometry' (per-face tessellation, CSG, weld) are
+ * single opaque wasm calls with no interior progress — ticks happen at the
+ * per-product TS loop, so a hang localizes to one product.
+ */
+export type ProgressPhase =
+  'headerParse' | 'dataParse' | 'geometry' | 'sceneBuild' | 'serialize'
+
+export type ProgressUnit = 'bytes' | 'elements' | 'products' | 'meshes' | 'chunks'
+
+/**
+ * A single progress report during a model load.
+ *
+ * When total is present the phase is determinate and a real progress bar can
+ * be rendered; when absent only activity (a heartbeat) is being reported.
+ */
+export interface ProgressEvent {
+  readonly phase: ProgressPhase
+  /** Units completed so far in this phase (monotonic within the phase). */
+  readonly completed: number
+  /** Units total for this phase, when cheaply knowable up front. */
+  readonly total?: number
+  readonly unit: ProgressUnit
+  /** Milliseconds since the tracker (i.e. the load) started. */
+  readonly elapsedMs: number
+  /** Coarse used-JS-heap sample in MB, when the environment exposes one. */
+  readonly memoryMb?: number
+}
+
+export type ProgressCallback = ( event: ProgressEvent ) => void
+
+/**
+ * Primitive (completed, total) progress callback used by extraction loops,
+ * keeping them decoupled from the ProgressEvent contract — a ProgressTracker
+ * maps these into events at the loader layer.
+ */
+export type CountProgressCallback = ( completed: number, total: number ) => void
+
+/** Default minimum milliseconds between emitted progress events. */
+export const DEFAULT_PROGRESS_INTERVAL_MS = 100
+
+/**
+ * Resolves in a macrotask, letting the event loop breathe so browsers can
+ * repaint progress UI and timers (e.g. stall watchdogs) can fire. Used by the
+ * *Async load variants between progress ticks.
+ *
+ * @return {Promise<void>} A promise resolved on the next timer turn.
+ */
+export function yieldToEventLoop(): Promise<void> {
+  return new Promise<void>( ( resolve ) => {
+    setTimeout( resolve, 0 )
+  } )
+}
+
+/**
+ * Throttled fan-in point for progress ticks during a load.
+ *
+ * Hot loops call update() as often as they like (it is cheap); events are
+ * only materialized and forwarded at most once per minIntervalMs, plus
+ * unthrottled events at phase begin/end so consumers always see phase
+ * boundaries. Memory is sampled only when an event is actually emitted.
+ */
+export class ProgressTracker {
+
+  private readonly startTime: number = Date.now()
+  private lastEmitTime: number = 0
+  private phase_: ProgressPhase | undefined
+  private unit_: ProgressUnit = 'elements'
+  private total_: number | undefined
+
+  /**
+   * Construct this with the callback progress events are forwarded to.
+   *
+   * @param onProgress The consumer callback.
+   * @param minIntervalMs Minimum milliseconds between throttled events.
+   */
+  public constructor(
+    private readonly onProgress: ProgressCallback,
+    private readonly minIntervalMs: number = DEFAULT_PROGRESS_INTERVAL_MS ) {}
+
+  /**
+   * The currently reporting phase, if any.
+   *
+   * @return {ProgressPhase | undefined} The current phase.
+   */
+  public get phase(): ProgressPhase | undefined {
+    return this.phase_
+  }
+
+  /**
+   * Begin a phase, emitting an unthrottled zero-progress event.
+   *
+   * @param phase The phase being entered.
+   * @param unit The unit completed/total are measured in for this phase.
+   * @param total The total units for this phase, when known up front.
+   */
+  public beginPhase( phase: ProgressPhase, unit: ProgressUnit, total?: number ): void {
+    this.phase_ = phase
+    this.unit_ = unit
+    this.total_ = total
+
+    this.emit( 0 )
+  }
+
+  /**
+   * Set/replace the current phase's total once it becomes known
+   * (e.g. product count discovered inside geometry extraction).
+   *
+   * @param total The total units for the current phase.
+   */
+  public setPhaseTotal( total: number ): void {
+    this.total_ = total
+  }
+
+  /**
+   * Report progress within the current phase; throttled.
+   *
+   * @param completed Units completed so far.
+   */
+  public update( completed: number ): void {
+    const now = Date.now()
+
+    if ( now - this.lastEmitTime < this.minIntervalMs ) {
+      return
+    }
+
+    this.emit( completed, now )
+  }
+
+  /**
+   * End the current phase, emitting an unthrottled final event with
+   * completed === total when a total is known.
+   *
+   * @param completed Final completed units (defaults to the phase total).
+   */
+  public endPhase( completed?: number ): void {
+    this.emit( completed ?? this.total_ ?? 0 )
+    this.phase_ = void 0
+  }
+
+  /**
+   * Materialize and forward an event now, bypassing the throttle.
+   *
+   * @param completed Units completed so far.
+   * @param now Current time in ms (defaults to Date.now()).
+   */
+  private emit( completed: number, now: number = Date.now() ): void {
+    if ( this.phase_ === void 0 ) {
+      return
+    }
+
+    this.lastEmitTime = now
+
+    const total = this.total_
+
+    this.onProgress( {
+      phase: this.phase_,
+      completed: total !== void 0 ? Math.min( completed, total ) : completed,
+      total: total,
+      unit: this.unit_,
+      elapsedMs: now - this.startTime,
+      memoryMb: Memory.usedHeapMb(),
+    } )
+  }
+}

--- a/src/ifc/ifc_command_line_main.ts
+++ b/src/ifc/ifc_command_line_main.ts
@@ -14,7 +14,9 @@ import { ConwayGeometry }
 import { IfcSceneBuilder } from './ifc_scene_builder'
 import GeometryConvertor from '../core/geometry_convertor'
 import GeometryAggregator from '../core/geometry_aggregator'
-import Logger from '../logging/logger'
+import Logger, { LogLevel } from '../logging/logger'
+import { CountProgressCallback, ProgressTracker } from '../core/progress'
+import { CliProgressRenderer } from '../cli/cli_progress_renderer'
 import Environment from '../utilities/environment'
 import Memory from '../memory/memory'
 import { ExtractResult } from '../core/shared_constants'
@@ -142,6 +144,16 @@ function doWork() {
             type: 'boolean',
             alias: 'r',
           })
+          yargs2.option('verbose', {
+            describe: 'Verbose logging (full deduped log table + debug lines)',
+            type: 'boolean',
+            alias: 'v',
+          })
+          yargs2.option('quiet', {
+            describe: 'Errors only; also disables the progress display',
+            type: 'boolean',
+            alias: 'q',
+          })
           yargs2.positional('filename', { describe: 'IFC File Paths', type: 'string' })
         }, (argv) => {
           const ifcFile = argv['filename'] as string
@@ -167,6 +179,20 @@ function doWork() {
           const outputGltfDraco = (argv['gltf-draco'] as boolean |
             undefined)
           const outputGlbDraco = (argv['glb-draco'] as boolean | undefined)
+          const verbose = (argv['verbose'] as boolean | undefined) ?? false
+          const quiet = (argv['quiet'] as boolean | undefined) ?? false
+
+          // Logs (and the load summary) echo on stderr so stdout carries
+          // only data output (query table / serialized paths) — issue #301.
+          Logger.setSink((_level, message) => process.stderr.write(`${message}\n`))
+          Logger.setLogLevel(
+              quiet ? LogLevel.ERROR : (verbose ? LogLevel.DEBUG : LogLevel.INFO))
+
+          // Live progress: single repainting status line on a TTY, sparse
+          // plain lines when redirected. Rendering on stderr, like the logs.
+          const progressRenderer = quiet ? void 0 : new CliProgressRenderer()
+          const tracker = progressRenderer !== void 0 ?
+            new ProgressTracker(progressRenderer.onProgress) : void 0
 
           try {
             indexIfcBuffer = fs.readFileSync(ifcFile)
@@ -189,6 +215,8 @@ function doWork() {
           const bufferInput = new ParsingBuffer(indexIfcBuffer)
 
           const headerDataTimeStart = Date.now()
+
+          tracker?.beginPhase('headerParse', 'bytes', indexIfcBuffer.length)
 
           const [stepHeader, result0] = parser.parseHeader(bufferInput)
 
@@ -222,9 +250,16 @@ function doWork() {
             default:
           }
 
+          tracker?.beginPhase('dataParse', 'bytes', indexIfcBuffer.length)
+
+          const parseTick = tracker !== void 0 ?
+            (cursorBytes: number) => tracker.update(cursorBytes) : void 0
+
           const parseDataTimeStart = Date.now()
-          const [result1, model] = parser.parseDataToModel(bufferInput)
+          const [result1, model] = parser.parseDataToModel(bufferInput, parseTick)
           const parseDataTimeEnd = Date.now()
+
+          tracker?.endPhase(indexIfcBuffer.length)
 
           switch (result1) {
             case ParseResult.COMPLETE:
@@ -269,7 +304,17 @@ function doWork() {
                   path.dirname( ifcFile ),
                   path.basename( ifcFile, path.extname( ifcFile) ) )
 
-            const result = geometryExtraction(model, limitCSG, maxCSGDepth)
+            tracker?.beginPhase('geometry', 'products')
+
+            const geometryTick: CountProgressCallback | undefined = tracker !== void 0 ?
+              (completed: number, total: number) => {
+                tracker.setPhaseTotal(total)
+                tracker.update(completed)
+              } : void 0
+
+            const result = geometryExtraction(model, limitCSG, maxCSGDepth, geometryTick)
+
+            tracker?.endPhase()
 
             if (result !== void 0) {
               const scene = result
@@ -284,12 +329,18 @@ function doWork() {
               const maxGeometrySize = maxChunk << MEGABYTE_SHIFT
 
               if (noOutput === undefined || !noOutput) {
+                // Heartbeat only: chunk counts aren't known until the
+                // aggregator runs inside serializeGeometry.
+                tracker?.beginPhase('serialize', 'chunks')
+
                 if (outputGltf === undefined && outputGlb === undefined &&
-                    outputGltfDraco === undefined && outputGlbDraco === undefined) { 
+                    outputGltfDraco === undefined && outputGlbDraco === undefined) {
                     serializeGeometry(scene, fileName, maxGeometrySize, true, true, true, true, includeSpace)
                   } else {
-                  serializeGeometry(scene, fileName, maxGeometrySize, outputGltf, outputGlb, outputGltfDraco, outputGlbDraco, includeSpace) 
+                  serializeGeometry(scene, fileName, maxGeometrySize, outputGltf, outputGlb, outputGltfDraco, outputGlbDraco, includeSpace)
                 }
+
+                tracker?.endPhase()
               }
             }
           } else {
@@ -397,6 +448,7 @@ function doWork() {
             statistics.setMemoryStatistics(Memory.checkMemoryUsage())
           }
 
+          progressRenderer?.done()
 
           Logger.displayLogs()
           Logger.printStatistics(modelID)
@@ -656,12 +708,14 @@ function propertyExtraction(model: IfcStepModel) {
  * @param model
  * @param limitCSGDepth
  * @param maxCSGDepth
+ * @param onProgress Optional per-product progress callback (completed, total).
  * @return {IfcSceneBuilder | undefined} The scene or undefined on error.
  */
 function geometryExtraction(
   model: IfcStepModel,
   limitCSGDepth: boolean = true,
-  maxCSGDepth: number = 20):
+  maxCSGDepth: number = 20,
+  onProgress?: CountProgressCallback):
   IfcSceneBuilder | undefined {
 
   const conwayModel =
@@ -674,7 +728,7 @@ function geometryExtraction(
   // parse + extract data model + geometry data
   const startTime = Date.now()
   const [extractionResult, scene] =
-    conwayModel.extractIFCGeometryData()
+    conwayModel.extractIFCGeometryData(onProgress)
   const endTime = Date.now()
   const executionTimeInMs = endTime - startTime
 

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -5896,15 +5896,21 @@ export class IfcGeometryExtraction {
 
     const stepper = this.extractIFCGeometryDataIncremental()
 
-    while ( true ) {
+    try {
+      while ( true ) {
 
-      const next = stepper.next()
+        const next = stepper.next()
 
-      if ( next.done === true ) {
-        return next.value
+        if ( next.done === true ) {
+          return next.value
+        }
+
+        onProgress?.( next.value[ 0 ], next.value[ 1 ] )
       }
-
-      onProgress?.( next.value[ 0 ], next.value[ 1 ] )
+    } finally {
+      // If onProgress threw while the generator was suspended, this runs its
+      // finally (memoization-state restore); no-op on a finished generator.
+      stepper.return( void 0 as never )
     }
   }
 
@@ -5928,20 +5934,26 @@ export class IfcGeometryExtraction {
 
     let lastYield = Date.now()
 
-    while ( true ) {
+    try {
+      while ( true ) {
 
-      const next = stepper.next()
+        const next = stepper.next()
 
-      if ( next.done === true ) {
-        return next.value
+        if ( next.done === true ) {
+          return next.value
+        }
+
+        onProgress?.( next.value[ 0 ], next.value[ 1 ] )
+
+        if ( Date.now() - lastYield >= yieldIntervalMs ) {
+          await yieldToEventLoop()
+          lastYield = Date.now()
+        }
       }
-
-      onProgress?.( next.value[ 0 ], next.value[ 1 ] )
-
-      if ( Date.now() - lastYield >= yieldIntervalMs ) {
-        await yieldToEventLoop()
-        lastYield = Date.now()
-      }
+    } finally {
+      // If onProgress threw while the generator was suspended, this runs its
+      // finally (memoization-state restore); no-op on a finished generator.
+      stepper.return( void 0 as never )
     }
   }
 

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -54,6 +54,7 @@ import {
 import { CanonicalMaterial, ColorRGBA, exponentToRoughness } from '../core/canonical_material'
 import { CanonicalMesh, CanonicalMeshType } from '../core/canonical_mesh'
 import { CanonicalProfile } from '../core/canonical_profile'
+import { CountProgressCallback, yieldToEventLoop } from '../core/progress'
 import { ObjectPool } from '../core/native_pool'
 import {
   NativeULongVector,
@@ -207,6 +208,10 @@ import { ParamsGetBlock } from '../../dependencies/conway-geom/interface/paramet
 
 
 type Mutable<T> = { -readonly [P in keyof T]: T[P] }
+
+// Await cadence for extractIFCGeometryDataAsync: long enough that yielding
+// doesn't dominate, short enough that browser paint + watchdogs stay live.
+const DEFAULT_GEOMETRY_YIELD_INTERVAL_MS = 50
 
 
 /**
@@ -5875,11 +5880,87 @@ export class IfcGeometryExtraction {
   /**
    * Extract the geometry data from the IFC
    *
+   * Synchronous driver over extractIFCGeometryDataIncremental — see
+   * extractIFCGeometryDataAsync for the cooperative (repaint-friendly)
+   * variant.
+   *
+   * @param onProgress Optional per-product progress callback
+   * (completed, total). The heavy per-product work (tessellation, CSG,
+   * weld) happens inside single wasm calls, so ticks land between
+   * products — a hang localizes to one product. Issue #301.
    * @return {[ExtractResult, IfcSceneBuilder]} - Enum indicating extraction result
    * + Geometry array
    */
-  extractIFCGeometryData():
+  extractIFCGeometryData( onProgress?: CountProgressCallback ):
     [ExtractResult, IfcSceneBuilder] {
+
+    const stepper = this.extractIFCGeometryDataIncremental()
+
+    while ( true ) {
+
+      const next = stepper.next()
+
+      if ( next.done === true ) {
+        return next.value
+      }
+
+      onProgress?.( next.value[ 0 ], next.value[ 1 ] )
+    }
+  }
+
+  /**
+   * Cooperative variant of extractIFCGeometryData: identical extraction
+   * (same generator body), but periodically awaits a macrotask between
+   * products so the event loop can run — browsers repaint progress UI and
+   * watchdog timers fire during a large extraction. Issue #301 §2.
+   *
+   * @param onProgress Optional per-product progress callback (completed, total).
+   * @param yieldIntervalMs Minimum ms between event-loop yields.
+   * @return {Promise<[ExtractResult, IfcSceneBuilder]>} - Enum indicating
+   * extraction result + Geometry array
+   */
+  async extractIFCGeometryDataAsync(
+      onProgress?: CountProgressCallback,
+      yieldIntervalMs: number = DEFAULT_GEOMETRY_YIELD_INTERVAL_MS ):
+    Promise<[ExtractResult, IfcSceneBuilder]> {
+
+    const stepper = this.extractIFCGeometryDataIncremental()
+
+    let lastYield = Date.now()
+
+    while ( true ) {
+
+      const next = stepper.next()
+
+      if ( next.done === true ) {
+        return next.value
+      }
+
+      onProgress?.( next.value[ 0 ], next.value[ 1 ] )
+
+      if ( Date.now() - lastYield >= yieldIntervalMs ) {
+        await yieldToEventLoop()
+        lastYield = Date.now()
+      }
+    }
+  }
+
+  /**
+   * Extract the geometry data from the IFC, suspending with
+   * [completed, total] between products so drivers can report progress (and
+   * optionally yield to the event loop) without the extraction body
+   * diverging between sync and async paths.
+   *
+   * The total counts IfcProducts plus IfcRelAggregates (the second
+   * extraction pass) straight off the type index's prefix sums; completed is
+   * monotonic across both loops.
+   *
+   * @yields {[number, number]} [completed, total] extraction progress.
+   * @return {[ExtractResult, IfcSceneBuilder]} - Enum indicating extraction result
+   * + Geometry array
+   */
+  private* extractIFCGeometryDataIncremental():
+    Generator<[number, number], [ExtractResult, IfcSceneBuilder], undefined> {
 
     let result: ExtractResult = ExtractResult.INCOMPLETE
 
@@ -5947,7 +6028,16 @@ export class IfcGeometryExtraction {
 
       const products = this.model.types(IfcProduct)
 
+      // Prefix-sum counts (no iteration/materialization) — see typeCount.
+      // Slight over-count from multi-mapped elements just leaves the bar
+      // shy of 100% until endPhase; fine for progress.
+      const totalItems =
+        this.model.typeCount(IfcProduct) + this.model.typeCount(IfcRelAggregates)
+      let completedItems = 0
+
       for (const product of products) {
+
+        yield [++completedItems, totalItems]
 
         this.scene.clearParentStack()
 
@@ -6116,6 +6206,8 @@ export class IfcGeometryExtraction {
       const relAggregates = this.model.types(IfcRelAggregates)
 
       for ( const relAggregate of relAggregates ) {
+
+        yield [++completedItems, totalItems]
 
         try {
 

--- a/src/ifc/ifc_geometry_extraction_progress.test.ts
+++ b/src/ifc/ifc_geometry_extraction_progress.test.ts
@@ -1,0 +1,83 @@
+import fs from 'fs'
+import { beforeAll, describe, expect, test } from '@jest/globals'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { IfcGeometryExtraction } from './ifc_geometry_extraction'
+import IfcStepModel from './ifc_step_model'
+import IfcStepParser from './ifc_step_parser'
+
+
+const conwayGeometry = new ConwayGeometry()
+
+/**
+ * Parse the shared index.ifc fixture into a fresh model.
+ *
+ * @return {IfcStepModel} The parsed model.
+ */
+function parseFixtureModel(): IfcStepModel {
+  const parser = IfcStepParser.Instance
+  const indexIfcBuffer: Buffer = fs.readFileSync('data/index.ifc')
+  const bufferInput = new ParsingBuffer(indexIfcBuffer)
+
+  parser.parseHeader(bufferInput)
+
+  const model = parser.parseDataToModel(bufferInput)[1]
+
+  expect(model).toBeDefined()
+
+  return model!
+}
+
+beforeAll(async () => {
+  await conwayGeometry.initialize()
+})
+
+describe('geometry extraction progress', () => {
+
+  test('progress ticks are monotonic with a stable total', () => {
+
+    const model = parseFixtureModel()
+    const extraction = new IfcGeometryExtraction(conwayGeometry, model)
+
+    const ticks: [number, number][] = []
+
+    const [result] = extraction.extractIFCGeometryData(
+        (completed, total) => ticks.push([completed, total]))
+
+    expect(result).toBeDefined()
+    expect(ticks.length).toBeGreaterThan(0)
+
+    const total = ticks[0][1]
+
+    for (let where = 0; where < ticks.length; ++where) {
+      expect(ticks[where][1]).toBe(total)
+
+      if (where > 0) {
+        expect(ticks[where][0]).toBe(ticks[where - 1][0] + 1)
+      }
+    }
+
+    expect(ticks[ticks.length - 1][0]).toBeLessThanOrEqual(total)
+  })
+
+  test('restores memoization state when the progress consumer throws', () => {
+
+    const model = parseFixtureModel()
+
+    const defaultCsgDepth = 20
+
+    // lowMemoryMode makes the extraction flip elementMemoization off inside
+    // its try block — the generator's finally must restore it even when the
+    // driver loop is exited by a consumer exception mid-extraction.
+    const extraction =
+      new IfcGeometryExtraction(conwayGeometry, model, true, defaultCsgDepth, true)
+
+    expect(model.elementMemoization).toBe(true)
+
+    expect(() => extraction.extractIFCGeometryData(() => {
+      throw new Error('progress consumer failure')
+    })).toThrow('progress consumer failure')
+
+    expect(model.elementMemoization).toBe(true)
+  })
+})

--- a/src/ifc/ifc_step_parser.ts
+++ b/src/ifc/ifc_step_parser.ts
@@ -1,5 +1,5 @@
 import ParsingBuffer from '../parsing/parsing_buffer'
-import StepParser, {ParseResult} from '../step/parsing/step_parser'
+import StepParser, {ParseProgressCallback, ParseResult} from '../step/parsing/step_parser'
 import EntityTypesIfc from './ifc4_gen/entity_types_ifc.gen'
 import EntitTypesIfcSearch from './ifc4_gen/entity_types_search.gen'
 import IfcStepModel from './ifc_step_model'
@@ -27,12 +27,32 @@ export default class IfcStepParser extends StepParser< EntityTypesIfc > {
    * Parse data to the model
    *
    * @param input The parsing buffer, set to user data, to read.
+   * @param onProgress Optional byte-cursor progress callback for the data parse.
    * @return {[ParseResult, IfcStepModel | undefined]} The parse result as well as the model,
    * if it can be extracted.
    */
   public parseDataToModel(
-      input: ParsingBuffer ): [ParseResult, IfcStepModel | undefined] {
-    const [itemIndex, parseResult] = this.parseDataBlock( input )
+      input: ParsingBuffer,
+      onProgress?: ParseProgressCallback ): [ParseResult, IfcStepModel | undefined] {
+    const [itemIndex, parseResult] = this.parseDataBlock( input, onProgress )
+
+    return [parseResult, new IfcStepModel( input.buffer, itemIndex.elements )]
+  }
+
+  /**
+   * Cooperative variant of parseDataToModel — periodically yields to the
+   * event loop mid-parse (see StepParser.parseDataBlockAsync, issue #301 §2).
+   *
+   * @param input The parsing buffer, set to user data, to read.
+   * @param onProgress Optional byte-cursor progress callback for the data parse.
+   * @return {Promise<[ParseResult, IfcStepModel | undefined]>} The parse result as well
+   * as the model, if it can be extracted.
+   */
+  public async parseDataToModelAsync(
+      input: ParsingBuffer,
+      onProgress?: ParseProgressCallback ):
+      Promise<[ParseResult, IfcStepModel | undefined]> {
+    const [itemIndex, parseResult] = await this.parseDataBlockAsync( input, onProgress )
 
     return [parseResult, new IfcStepModel( input.buffer, itemIndex.elements )]
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,19 @@ export { IfcPropertyExtraction } from './ifc/ifc_property_extraction'
 export { ConwayGeometry, GeometryObject, FileHandlerFunction} from '../dependencies/conway-geom'
 export { versionString } from './version/version'
 // Replace your current Logger export with this
-export { default as Logger } from './logging/logger'
- 
+export { default as Logger, LogLevel, LogEntry, LoggingProxy, LogSink } from './logging/logger'
+
 export { product, shape_definition_representation } from './AP214E3_2010/AP214E3_2010_gen'
 export { CanonicalMeshType } from './core/canonical_mesh'
 export { CanonicalMaterial } from './core/canonical_material'
 export { ExtractResult } from './core/shared_constants'
+export {
+  ProgressEvent,
+  ProgressCallback,
+  ProgressPhase,
+  ProgressUnit,
+  ProgressTracker,
+  CountProgressCallback,
+  yieldToEventLoop,
+} from './core/progress'
+export { ModelLoadOptions } from './loaders/conway_model_loader'

--- a/src/indexing/multi_index_set.ts
+++ b/src/indexing/multi_index_set.ts
@@ -3,6 +3,23 @@ import { MultiIndexSetCursorOr } from './multi_index_set_cursor_or'
 import { indexSetPointQuery32 } from './search_operations'
 import { SingleIndexSetCursor } from './single_index_set_cursor'
 
+/* eslint-disable no-magic-numbers -- SWAR popcount constants */
+/**
+ * Standard SWAR population count for a 32 bit integer.
+ *
+ * @param value The value to count set bits in.
+ * @return {number} The number of set bits.
+ */
+function popCount32( value: number ): number {
+  let result = value - ( ( value >> 1 ) & 0x55555555 )
+
+  result = ( result & 0x33333333 ) + ( ( result >> 2 ) & 0x33333333 )
+  result = ( result + ( result >> 4 ) ) & 0x0F0F0F0F
+
+  return ( result * 0x01010101 ) >> 24
+}
+/* eslint-enable no-magic-numbers */
+
 /**
  * A set of indices each associated with a number identifier.
  */
@@ -64,6 +81,43 @@ export class MultiIndexSet< IndexType extends number > {
     const indexEnd    = prefixSum[ indexType + 1 ] * 2
 
     return indexSetPointQuery32( localID, this.elements_, indexOffset, indexEnd )
+  }
+
+  /**
+   * Count of items for a set of types without materializing entities —
+   * popcounts the packed one-hot blocks per type (the prefix sums index
+   * 32-element blocks, not items), so it's O(blocks), thousands of times
+   * cheaper than iterating a cursor. Per-type ranges are disjoint, but an
+   * element multi-mapped under several of the queried types counts once per
+   * mapping (matching what a cursor union would visit), so treat multi-type
+   * counts as an upper bound (fine for progress totals, its motivating use).
+   *
+   * @param indexTypes The list of types to count.
+   * @return {number} The summed count for the given types.
+   */
+  public count( ...indexTypes: IndexType[] ): number {
+    const prefixSum = this.prefixSumTable_
+    const elements = this.elements_
+
+    let result = 0
+
+    for ( const indexType of indexTypes ) {
+
+      if ( indexType >= prefixSum.length - 1 ) {
+        continue
+      }
+
+      const blockStart = prefixSum[ indexType ] * 2
+      const blockEnd = prefixSum[ indexType + 1 ] * 2
+
+      // Each packed block is [maskedTopBits, oneHotBitfield] — the bitfield's
+      // set bits are the block's members.
+      for ( let where = blockStart; where < blockEnd; where += 2 ) {
+        result += popCount32( elements[ where + 1 ] )
+      }
+    }
+
+    return result
   }
 
   /**

--- a/src/loaders/conway_model_loader.ts
+++ b/src/loaders/conway_model_loader.ts
@@ -2,6 +2,7 @@ import { ConwayGeometry } from '../../dependencies/conway-geom'
 import { AP214GeometryExtraction } from '../AP214E3_2010/ap214_geometry_extraction'
 import AP214StepParser from '../AP214E3_2010/ap214_step_parser'
 import { Model } from '../core/model'
+import { ProgressCallback, ProgressTracker } from '../core/progress'
 import { Scene } from '../core/scene'
 import { ExtractResult } from '../core/shared_constants'
 import ModelFormatDetector, { ModelFormatType } from '../format_detection/model_format_detector'
@@ -17,6 +18,28 @@ const ONE_KB = 1024
 const ONE_MB = ONE_KB * ONE_KB
 
 /**
+ * Options threading the progress/yield contract (issue #301) through a load.
+ */
+export interface ModelLoadOptions {
+
+  /**
+   * Structured, throttled progress events across the load phases
+   * (headerParse / dataParse / geometry) — see core/progress.ts.
+   */
+  onProgress?: ProgressCallback
+
+  /**
+   * When true, the parse and geometry loops periodically await a macrotask
+   * so browsers can repaint between progress events and the tab is not
+   * flagged as stalled. Costs a few % wall clock; off by default.
+   */
+  yieldToEventLoop?: boolean
+
+  /** Minimum ms between progress events (default in core/progress.ts). */
+  progressIntervalMs?: number
+}
+
+/**
  * Static class for loading a model from a Uint 8 array...
  *
  * note this is only the initial model parse, no geometry extraction has been performed.
@@ -30,15 +53,22 @@ export class ConwayModelLoader {
    * @param limitCSGDepth Whether to limit CSG depth during geometry extraction.
    * @param maximumCSGDepth The maximum CSG depth allowed during geometry extraction.
    * @param modelID The model id to use for statistics (or 0 if none is provided)
+   * @param options Optional progress/yield options for the load.
    * @return {Promise<[Model, Scene]>} A promise to return the loaded model and scene.
    */
   public static async loadModelWithScene(
       data: Uint8Array,
       limitCSGDepth: boolean = true,
       maximumCSGDepth: number = 20,
-      modelID: number = 0 ): Promise<[Model, Scene]> {
+      modelID: number = 0,
+      options?: ModelLoadOptions ): Promise<[Model, Scene]> {
 
     const allTimeStart = Date.now()
+
+    const onProgress = options?.onProgress
+    const tracker = onProgress !== void 0 ?
+      new ProgressTracker( onProgress, options?.progressIntervalMs ) : void 0
+    const cooperative = options?.yieldToEventLoop === true
 
     const modelFormat = ModelFormatDetector.detect( new ParsingBuffer( data ) )
 
@@ -48,7 +78,7 @@ export class ConwayModelLoader {
 
       case ModelFormatType.AP203:
 
-        console.log( 'AP203 Step Detected, using AP214 loader' )
+        Logger.info( 'AP203 Step Detected, using AP214 loader' )
         is203 = true
         // falls through
 
@@ -58,14 +88,14 @@ export class ConwayModelLoader {
         // product-structure/property subset. See
         // design/new/step-metadata-nist.md §"The AP242 wrinkle".
         if ( modelFormat === ModelFormatType.AP242 ) {
-          console.log( 'AP242 Step Detected, using AP214 loader (interim)' )
+          Logger.info( 'AP242 Step Detected, using AP214 loader (interim)' )
         }
         // falls through
 
       case ModelFormatType.AP214:
 
         if (!is203 && modelFormat !== ModelFormatType.AP242) {
-          console.log( 'AP214 Step Detected' )
+          Logger.info( 'AP214 Step Detected' )
         }
 
         try {
@@ -83,11 +113,13 @@ export class ConwayModelLoader {
 
           const headerDataTimeStart = Date.now()
 
+          tracker?.beginPhase( 'headerParse', 'bytes', data.length )
+
           const [stepHeader, result0] = parser.parseHeader(bufferInput)
 
           const headerDataTimeEnd = Date.now()
 
-          Logger.info( `Header parse time ${headerDataTimeEnd - headerDataTimeStart} ms` )
+          Logger.debug( `Header parse time ${headerDataTimeEnd - headerDataTimeStart} ms` )
 
           switch (result0) {
             case ParseResult.COMPLETE:
@@ -117,9 +149,18 @@ export class ConwayModelLoader {
             default:
           }
 
+          tracker?.beginPhase( 'dataParse', 'bytes', data.length )
+
+          const parseTick = tracker !== void 0 ?
+            ( cursorBytes: number ) => tracker.update( cursorBytes ) : void 0
+
           const parseDataTimeStart = Date.now()
-          const [result1, model]   = parser.parseDataToModel( bufferInput )
+          const [result1, model]   = cooperative ?
+            await parser.parseDataToModelAsync( bufferInput, parseTick ) :
+            parser.parseDataToModel( bufferInput, parseTick )
           const parseDataTimeEnd   = Date.now()
+
+          tracker?.endPhase( data.length )
 
           switch (result1) {
             case ParseResult.COMPLETE:
@@ -156,6 +197,11 @@ export class ConwayModelLoader {
 
           const conwayModel = new AP214GeometryExtraction(conwayWasm, model)
 
+          // AP214 extraction is thunk-tree structured (no flat product loop),
+          // so it reports as an indeterminate heartbeat phase for now — the
+          // per-item ticks + cooperative yielding exist only on the IFC path.
+          tracker?.beginPhase( 'geometry', 'products' )
+
           // parse + extract data model + geometry data
           const startTime = Date.now()
           const [extractionResult, scene] =
@@ -163,6 +209,8 @@ export class ConwayModelLoader {
 
           const endTime = Date.now()
           const executionTimeInMs = endTime - startTime
+
+          tracker?.endPhase()
 
           statistics.setGeometryTime(executionTimeInMs)
 
@@ -220,7 +268,7 @@ export class ConwayModelLoader {
           Logger.displayLogs()
           Logger.printStatistics(modelID)
 
-          console.log( 'Loader returning' )
+          Logger.debug( 'Loader returning' )
 
           return [model, scene]
 
@@ -241,7 +289,7 @@ export class ConwayModelLoader {
 
         try {
 
-          console.log( 'IFC Detected' )
+          Logger.info( 'IFC Detected' )
 
           const conwayWasm = new ConwayGeometry()
 
@@ -257,11 +305,13 @@ export class ConwayModelLoader {
 
           const headerDataTimeStart = Date.now()
 
+          tracker?.beginPhase( 'headerParse', 'bytes', data.length )
+
           const [stepHeader, result0] = parser.parseHeader(bufferInput)
 
           const headerDataTimeEnd = Date.now()
 
-          Logger.info(`Header parse time ${headerDataTimeEnd - headerDataTimeStart} ms`)
+          Logger.debug(`Header parse time ${headerDataTimeEnd - headerDataTimeStart} ms`)
 
           switch (result0) {
             case ParseResult.COMPLETE:
@@ -291,9 +341,18 @@ export class ConwayModelLoader {
             default:
           }
 
+          tracker?.beginPhase( 'dataParse', 'bytes', data.length )
+
+          const parseTick = tracker !== void 0 ?
+            ( cursorBytes: number ) => tracker.update( cursorBytes ) : void 0
+
           const parseDataTimeStart = Date.now()
-          const [result1, model] = parser.parseDataToModel(bufferInput)
+          const [result1, model] = cooperative ?
+            await parser.parseDataToModelAsync(bufferInput, parseTick) :
+            parser.parseDataToModel(bufferInput, parseTick)
           const parseDataTimeEnd = Date.now()
+
+          tracker?.endPhase( data.length )
 
           switch (result1) {
             case ParseResult.COMPLETE:
@@ -334,13 +393,24 @@ export class ConwayModelLoader {
             limitCSGDepth,
             maximumCSGDepth)
 
+          tracker?.beginPhase( 'geometry', 'products' )
+
+          const geometryTick = tracker !== void 0 ?
+            ( completed: number, total: number ) => {
+              tracker.setPhaseTotal( total )
+              tracker.update( completed )
+            } : void 0
+
           // parse + extract data model + geometry data
           const startTime = Date.now()
-          const [extractionResult, scene] =
-            conwayModel.extractIFCGeometryData()
+          const [extractionResult, scene] = cooperative ?
+            await conwayModel.extractIFCGeometryDataAsync(geometryTick) :
+            conwayModel.extractIFCGeometryData(geometryTick)
 
           const endTime = Date.now()
           const executionTimeInMs = endTime - startTime
+
+          tracker?.endPhase()
 
           statistics.setGeometryTime(executionTimeInMs)
 
@@ -404,7 +474,7 @@ export class ConwayModelLoader {
           Logger.displayLogs()
           Logger.printStatistics(modelID)
 
-          console.log( 'Loader returning' )
+          Logger.debug( 'Loader returning' )
 
           return [model, scene]
 

--- a/src/logging/logger.test.ts
+++ b/src/logging/logger.test.ts
@@ -1,0 +1,90 @@
+import {afterEach, beforeEach, describe, expect, test} from '@jest/globals'
+
+import Logger, { LogLevel, LogLevelName } from './logger'
+
+
+type Echoed = [LogLevelName, string]
+
+describe( 'Logger levels + sink', () => {
+
+  let echoed: Echoed[] = []
+
+  beforeEach( () => {
+    echoed = []
+    Logger.clearLogs()
+    Logger.setSink( ( level, message ) => echoed.push( [level, message] ) )
+    Logger.setLogLevel( LogLevel.INFO )
+  } )
+
+  afterEach( () => {
+    Logger.clearLogs()
+    Logger.setSink()
+    Logger.setLogLevel( LogLevel.INFO )
+  } )
+
+  test( 'echoes at or above the threshold only', () => {
+
+    Logger.setLogLevel( LogLevel.WARNING )
+
+    Logger.debug( 'debug line' )
+    Logger.info( 'info line' )
+    Logger.warning( 'warning line' )
+    Logger.error( 'error line' )
+
+    expect( echoed ).toEqual( [
+      ['warning', 'warning line'],
+      ['error', 'error line'],
+    ] )
+  } )
+
+  test( 'OFF silences everything, buffer still collects', () => {
+
+    Logger.setLogLevel( LogLevel.OFF )
+
+    Logger.error( 'not echoed' )
+
+    expect( echoed.length ).toBe( 0 )
+    expect( Logger.getLogs().length ).toBe( 1 )
+  } )
+
+  test( 'echoes the first occurrence only, dedups repeats into the buffer', () => {
+
+    Logger.warning( 'repeated expressID: 1' )
+    Logger.warning( 'repeated expressID: 2' )
+    Logger.warning( 'repeated expressID: 3' )
+
+    expect( echoed.length ).toBe( 1 )
+
+    const entry = Logger.getLogs().find( ( log ) => log.message === 'repeated' )
+
+    expect( entry?.count ).toBe( 3 )
+    expect( entry?.expressIDs.size ).toBe( 3 )
+  } )
+
+  test( 'isLevelEnabled matches the threshold ordering', () => {
+
+    Logger.setLogLevel( LogLevel.WARNING )
+
+    expect( Logger.isLevelEnabled( LogLevel.DEBUG ) ).toBe( false )
+    expect( Logger.isLevelEnabled( LogLevel.INFO ) ).toBe( false )
+    expect( Logger.isLevelEnabled( LogLevel.WARNING ) ).toBe( true )
+    expect( Logger.isLevelEnabled( LogLevel.ERROR ) ).toBe( true )
+  } )
+
+  test( 'proxies receive entries regardless of the threshold', () => {
+
+    const proxied: string[] = []
+    const proxy = { log: ( entry: { message: string } ) => proxied.push( entry.message ) }
+
+    Logger.addProxy( proxy )
+
+    try {
+      Logger.setLogLevel( LogLevel.OFF )
+      Logger.info( 'proxied line' )
+
+      expect( proxied ).toEqual( ['proxied line'] )
+    } finally {
+      Logger.removeProxy( proxy )
+    }
+  } )
+} )

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -2,10 +2,32 @@ import { Statistics } from '../statistics/statistics'
 import Environment, { EnvironmentType } from '../utilities/environment'
 
 
-type LogLevel = 'info' | 'warning' | 'error'
+export type LogLevelName = 'debug' | 'info' | 'warning' | 'error'
+
+/**
+ * Numeric log threshold, ordered so that a message is emitted to the console
+ * sink when its level is >= the current threshold. OFF silences everything.
+ * Buffered entries (for displayLogs/proxies) are collected regardless of the
+ * threshold — the threshold only controls what echoes to the console as it
+ * happens.
+ */
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARNING = 2,
+  ERROR = 3,
+  OFF = 4,
+}
+
+const LOG_LEVEL_BY_NAME: Record<LogLevelName, LogLevel> = {
+  'debug': LogLevel.DEBUG,
+  'info': LogLevel.INFO,
+  'warning': LogLevel.WARNING,
+  'error': LogLevel.ERROR,
+}
 
 export interface LogEntry {
-    level: LogLevel
+    level: LogLevelName
     message: string
     count: number
     expressIDs:Set<string>
@@ -17,13 +39,41 @@ export interface LoggingProxy {
 }
 
 /**
+ * Where echoed log lines go. The default writes through the matching console
+ * method; the CLI swaps in a sink that writes everything to stderr so stdout
+ * stays clean for data output.
+ */
+export type LogSink = ( level: LogLevelName, message: string ) => void
+
+const defaultSink: LogSink = ( level, message ) => {
+  switch ( level ) {
+    case 'error':
+      console.error( message )
+      break
+    case 'warning':
+      console.warn( message )
+      break
+    default:
+      console.log( message )
+  }
+}
+
+/**
  * Logger class which supports logging statistics, as well as proxy logging interfaces
  * for extended logging.
+ *
+ * Entries are deduplicated (repeat messages increment a count and accumulate
+ * express IDs) and buffered for displayLogs()/proxies. Additionally, the
+ * first occurrence of each distinct entry at or above the current threshold
+ * is echoed to the console sink immediately, so warnings/errors are visible
+ * live without waiting for a displayLogs() dump.
  */
 export default class Logger {
   private static logs: LogEntry[] = []
   private static proxies: LoggingProxy[] = []
   private static statistics: Map<number, Statistics> = new Map<number, Statistics>()
+  private static threshold: LogLevel = LogLevel.INFO
+  private static sink: LogSink = defaultSink
 
 
   /**
@@ -47,12 +97,50 @@ export default class Logger {
   }
 
   /**
+   * Set the console-echo threshold. Embedders (e.g. Share) call this to
+   * quiet or expand conway's console output; the CLI maps -q/-v/-vv here.
+   *
+   * @param level - new threshold
+   */
+  public static setLogLevel(level: LogLevel): void {
+    Logger.threshold = level
+  }
+
+  /**
+   *
+   * @return {LogLevel} the current console-echo threshold
+   */
+  public static getLogLevel(): LogLevel {
+    return Logger.threshold
+  }
+
+  /**
+   * Is a given level at or above the current threshold?
+   *
+   * @param level - level to test
+   * @return {boolean} true when messages at this level echo to the console
+   */
+  public static isLevelEnabled(level: LogLevel): boolean {
+    return level >= Logger.threshold && Logger.threshold !== LogLevel.OFF
+  }
+
+  /**
+   * Replace the console sink (e.g. the CLI routes all echoes to stderr so
+   * stdout stays parseable). Pass undefined to restore the default.
+   *
+   * @param sink - replacement sink or undefined
+   */
+  public static setSink(sink?: LogSink): void {
+    Logger.sink = sink ?? defaultSink
+  }
+
+  /**
    *
    * @param message - log message
    * @param level - log level
    * @return {number} log index
    */
-  private static findLogIndex(message: string, level: LogLevel): number {
+  private static findLogIndex(message: string, level: LogLevelName): number {
     return Logger.logs.findIndex((log) => log.message === message && log.level === level)
   }
 
@@ -61,12 +149,13 @@ export default class Logger {
    * @param level - log level
    * @param message - log message
    */
-  private static log(level: LogLevel, message: string): void {
+  private static log(level: LogLevelName, message: string): void {
     const baseMessage = message.split(' expressID: ')[0] // Extract the base message
     const data = message.split(' expressID: ')[1] // Extract the expressID
 
     const index = Logger.findLogIndex(baseMessage, level)
     let logEntry: LogEntry
+    let firstOccurrence = false
 
     if (index >= 0) {
       Logger.logs[index].count += 1
@@ -76,6 +165,7 @@ export default class Logger {
       }
       logEntry = Logger.logs[index]
     } else {
+      firstOccurrence = true
       logEntry = {
         level,
         message: baseMessage,
@@ -83,6 +173,12 @@ export default class Logger {
         expressIDs: data ? new Set([data]) : new Set(),
       }
       Logger.logs.push(logEntry)
+    }
+
+    // Echo only the first occurrence of each distinct entry — repeats keep
+    // deduplicating silently into the buffer (visible via displayLogs()).
+    if (firstOccurrence && Logger.isLevelEnabled(LOG_LEVEL_BY_NAME[level])) {
+      Logger.sink(level, baseMessage)
     }
 
     Logger.proxies.forEach((proxy) => proxy.log(logEntry))
@@ -124,6 +220,27 @@ export default class Logger {
   }
 
   /**
+   * Remove a previously added proxy (no-op if absent).
+   *
+   * @param proxy - the proxy to remove
+   */
+  public static removeProxy(proxy: LoggingProxy): void {
+    const index = Logger.proxies.indexOf(proxy)
+
+    if (index >= 0) {
+      Logger.proxies.splice(index, 1)
+    }
+  }
+
+  /**
+   *
+   * @param message - log message
+   */
+  public static debug(message: string): void {
+    Logger.log('debug', message)
+  }
+
+  /**
    *
    * @param message - log message
    */
@@ -144,7 +261,7 @@ export default class Logger {
    * Create the statistics for a model ID.
    *
    * @param modelID The model ID to create statistics for
-   * 
+   *
    * @return {Statistics} The created statistics object.
    */
   public static createStatistics(modelID: number): Statistics {
@@ -160,10 +277,16 @@ export default class Logger {
    * @param modelID
    */
   public static printStatistics(modelID: number) {
+    if (!Logger.isLevelEnabled(LogLevel.INFO)) {
+      return
+    }
+
     const statistics_ = this.statistics.get(modelID)
 
     if (statistics_ !== void 0) {
-      statistics_.printStatistics()
+      // Through the sink (not printStatistics' console.log) so the CLI's
+      // stderr sink keeps stdout clean for data output.
+      Logger.sink('info', statistics_.format())
     } else {
       Logger.error(`No statistics for modelID: ${modelID}`)
     }
@@ -207,9 +330,18 @@ export default class Logger {
   }
 
   /**
-   * display logs in a table
+   * Display the deduplicated log buffer in a table.
+   *
+   * Gated behind the DEBUG threshold by default — a clean load should leave
+   * a quiet console (issue #301); pass force for explicit dumps (CLI -v).
+   *
+   * @param force - dump regardless of the current threshold
    */
-  public static displayLogs(): void {
+  public static displayLogs(force: boolean = false): void {
+    if (!force && !Logger.isLevelEnabled(LogLevel.DEBUG)) {
+      return
+    }
+
     Logger.compressLogs()
     console.table(Logger.logs)
   }

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -38,6 +38,30 @@ export default class Memory {
   }
 
   /**
+   * Numeric used-heap sample for progress/telemetry events, unlike the
+   * human-formatted strings above. Chrome-only in browsers
+   * (performance.memory); undefined where the environment exposes nothing.
+   *
+   * @return {number | undefined} - used JS heap in MB, if available
+   */
+  static usedHeapMb(): number | undefined {
+    /* eslint-disable no-magic-numbers */
+    switch (Environment.environmentType) {
+      case EnvironmentType.BROWSER:
+        if (typeof window !== 'undefined' && window.performance?.memory) {
+          return window.performance.memory.usedJSHeapSize / 1024 / 1024
+        }
+        return void 0
+      case EnvironmentType.NODE:
+      case EnvironmentType.BOTH_FEATURES:
+        return process.memoryUsage().heapUsed / 1024 / 1024
+      default:
+        return void 0
+    }
+    /* eslint-enable no-magic-numbers */
+  }
+
+  /**
    *
    * @return {string} - memory usage result for browser systems
    */

--- a/src/statistics/statistics.ts
+++ b/src/statistics/statistics.ts
@@ -182,6 +182,16 @@ export class Statistics {
    * prints statistics
    */
   printStatistics(): void {
+    console.log(this.format())
+  }
+
+  /**
+   * Format the load-summary line (Logger routes this through its sink so
+   * the CLI can keep stdout clean — issue #301).
+   *
+   * @return {string} the single-line load summary
+   */
+  format(): string {
     const date = new Date()
     const options: Intl.DateTimeFormatOptions = {
       year: 'numeric',
@@ -215,9 +225,7 @@ export class Statistics {
       versionStr = 'Version not defined'
     }
 
-     
-    console.log(
-        `[${dateString}]: Load Status: ${this.loadStatus}, ` +
+    return `[${dateString}]: Load Status: ${this.loadStatus}, ` +
             `Project Name: ${this.projectName}, Version: ${versionStr}, ` +
             `Conway Version: ${conwayVersionNumber}-${wasmType}, ` +
             `Parse Time: ${this.parseTime} ms, Geometry Time: ${this.geometryTime} ms, ` +
@@ -225,8 +233,6 @@ export class Statistics {
             `Geometry Memory: ${this.geometryMemory?.toFixed(3)} MB, ` +
             `Memory Statistics: ${this.memoryStatistics}, ` +
             `Preprocessor Version: ${this.preprocessorVersion}, ` +
-            `Originating System: ${this.originatingSystem}`,
-    )
-     
+            `Originating System: ${this.originatingSystem}`
   }
 }

--- a/src/step/parsing/step_parser.ts
+++ b/src/step/parsing/step_parser.ts
@@ -1,3 +1,4 @@
+import { yieldToEventLoop } from '../../core/progress'
 import TypeIndex from '../../indexing/type_index'
 import HexParser from '../../parsing/hex_parser'
 import ParsingBuffer from '../../parsing/parsing_buffer'
@@ -89,6 +90,23 @@ const stringParser = StepStringParser.Instance.match
 
 export type BlockParseResult<TypeIDType> = [StepIndex<TypeIDType>, ParseResult]
 export type LineArgumentParseResult<TypeIDType> = [StepIndex<TypeIDType>, ParseResult]
+
+/**
+ * Byte-cursor progress callback for the data-parse loop — the parse phase is
+ * determinate in bytes (cursor position / buffer size). Kept primitive so the
+ * parser stays decoupled from the higher-level progress event contract in
+ * core/progress.ts (ProgressTracker maps this into a ProgressEvent).
+ */
+export type ParseProgressCallback = ( cursorBytes: number ) => void
+
+// One generator suspension per (mask + 1) parsed elements keeps progress
+// overhead unmeasurable in the hot data-parse loop (a 9M-entity model yields
+// ~2200 times) while still ticking several times a second on large models.
+const PARSE_PROGRESS_ELEMENT_MASK = 4095
+
+// Await cadence for the *Async drivers: long enough that yielding doesn't
+// dominate, short enough that browser paint + watchdog timers stay live.
+const DEFAULT_PARSE_YIELD_INTERVAL_MS = 50
 
 export interface StepHeader {
   headers: Map<string, string>
@@ -410,12 +428,85 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
   }
 
   /**
-   * Parse the data block of a step file, indexing it.,
+   * Parse the data block of a step file, indexing it.
+   *
+   * Synchronous driver over parseDataBlockIncremental — see
+   * parseDataBlockAsync for the cooperative (repaint-friendly) variant.
    *
    * @param input The input parsing buffer, in the data section.
+   * @param onProgress Optional byte-cursor progress callback, invoked
+   * roughly every PARSE_PROGRESS_ELEMENT_MASK + 1 elements.
    * @return {BlockParseResult} The parsing result, including the index and result enum.
    */
-  public parseDataBlock(input: ParsingBuffer): BlockParseResult<TypeIDType> {
+  public parseDataBlock(
+      input: ParsingBuffer,
+      onProgress?: ParseProgressCallback ): BlockParseResult<TypeIDType> {
+
+    const parser = this.parseDataBlockIncremental( input )
+
+    while ( true ) {
+
+      const next = parser.next()
+
+      if ( next.done === true ) {
+        return next.value
+      }
+
+      onProgress?.( next.value )
+    }
+  }
+
+  /**
+   * Cooperative variant of parseDataBlock: identical parse (same generator
+   * body), but periodically awaits a macrotask so the event loop can run —
+   * browsers repaint progress UI, watchdog timers fire, and the tab is not
+   * flagged as stalled during a large parse. Issue #301 §2.
+   *
+   * @param input The input parsing buffer, in the data section.
+   * @param onProgress Optional byte-cursor progress callback.
+   * @param yieldIntervalMs Minimum ms between event-loop yields.
+   * @return {Promise<BlockParseResult>} The parsing result, including the
+   * index and result enum.
+   */
+  public async parseDataBlockAsync(
+      input: ParsingBuffer,
+      onProgress?: ParseProgressCallback,
+      yieldIntervalMs: number = DEFAULT_PARSE_YIELD_INTERVAL_MS ):
+      Promise<BlockParseResult<TypeIDType>> {
+
+    const parser = this.parseDataBlockIncremental( input )
+
+    let lastYield = Date.now()
+
+    while ( true ) {
+
+      const next = parser.next()
+
+      if ( next.done === true ) {
+        return next.value
+      }
+
+      onProgress?.( next.value )
+
+      if ( Date.now() - lastYield >= yieldIntervalMs ) {
+        await yieldToEventLoop()
+        lastYield = Date.now()
+      }
+    }
+  }
+
+  /**
+   * Parse the data block of a step file, indexing it, suspending with the
+   * current byte cursor every PARSE_PROGRESS_ELEMENT_MASK + 1 elements so
+   * drivers can report progress (and optionally yield to the event loop)
+   * without the loop body diverging between sync and async paths.
+   *
+   * @param input The input parsing buffer, in the data section.
+   * @yields {number} The current byte cursor within the input buffer.
+   * @return {BlockParseResult} The parsing result, including the index and result enum.
+   */
+  private* parseDataBlockIncremental(input: ParsingBuffer):
+      Generator<number, BlockParseResult<TypeIDType>, undefined> {
 
     const indexResult: StepIndex<TypeIDType> = { elements: [] }
 
@@ -606,7 +697,14 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
       }
     }
 
+    let parsedElementCount = 0
+
     while (input.unfinished) {
+
+      // Cheap power-of-two cadence check for the progress yield.
+      if ( ( ++parsedElementCount & PARSE_PROGRESS_ELEMENT_MASK ) === 0 ) {
+        yield input.cursor
+      }
 
       if (!charws(HASH)) {
         if (tokenws(END_SECTION)) {

--- a/src/step/parsing/step_parser_progress.test.ts
+++ b/src/step/parsing/step_parser_progress.test.ts
@@ -1,0 +1,108 @@
+import {describe, expect, test} from '@jest/globals'
+
+import ParsingBuffer from '../../parsing/parsing_buffer'
+import IfcStepParser from '../../ifc/ifc_step_parser'
+import { IfcCartesianPoint } from '../../ifc/ifc4_gen'
+import { ParseResult } from './step_parser'
+
+
+// Enough entities to cross the parser's progress cadence (one tick per 4096
+// elements) several times.
+const ENTITY_COUNT = 10_000
+
+/**
+ * Build a synthetic IFC buffer with ENTITY_COUNT cartesian points.
+ *
+ * @return {Uint8Array} The encoded synthetic file.
+ */
+function makeSyntheticIfc(): Uint8Array {
+
+  const lines: string[] = [
+    'ISO-10303-21;',
+    'HEADER;',
+    'FILE_DESCRIPTION((\'\'),\'2;1\');',
+    'FILE_NAME(\'synthetic\',\'\',(\'\'),(\'\'),\'\',\'\',\'\');',
+    'FILE_SCHEMA((\'IFC4\'));',
+    'ENDSEC;',
+    'DATA;',
+  ]
+
+  for ( let where = 1; where <= ENTITY_COUNT; ++where ) {
+    lines.push( `#${where}=IFCCARTESIANPOINT((0.,0.,0.));` )
+  }
+
+  lines.push( 'ENDSEC;', 'END-ISO-10303-21;' )
+
+  return new TextEncoder().encode( lines.join( '\n' ) )
+}
+
+const parser = IfcStepParser.Instance
+
+describe( 'parse progress', () => {
+
+  test( 'sync parse ticks a monotonic byte cursor and parses everything', () => {
+
+    const data = makeSyntheticIfc()
+    const bufferInput = new ParsingBuffer( data )
+
+    parser.parseHeader( bufferInput )
+
+    const cursors: number[] = []
+
+    const [result, model] =
+      parser.parseDataToModel( bufferInput, ( cursor ) => cursors.push( cursor ) )
+
+    expect( result ).toBe( ParseResult.COMPLETE )
+    expect( model?.size ).toBe( ENTITY_COUNT )
+
+    expect( cursors.length ).toBeGreaterThanOrEqual( 2 )
+
+    for ( let where = 1; where < cursors.length; ++where ) {
+      expect( cursors[ where ] ).toBeGreaterThan( cursors[ where - 1 ] )
+    }
+
+    expect( cursors[ cursors.length - 1 ] ).toBeLessThanOrEqual( data.length )
+  } )
+
+  test( 'async parse produces the same model as sync', async () => {
+
+    const data = makeSyntheticIfc()
+
+    const syncInput = new ParsingBuffer( data )
+
+    parser.parseHeader( syncInput )
+
+    const [syncResult, syncModel] = parser.parseDataToModel( syncInput )
+
+    const asyncInput = new ParsingBuffer( data )
+
+    parser.parseHeader( asyncInput )
+
+    let ticks = 0
+
+    const [asyncResult, asyncModel] =
+      await parser.parseDataToModelAsync( asyncInput, () => ++ticks )
+
+    expect( asyncResult ).toBe( syncResult )
+    expect( asyncModel?.size ).toBe( syncModel?.size )
+    expect( ticks ).toBeGreaterThanOrEqual( 2 )
+  } )
+
+  test( 'typeCount matches lazy iteration without materializing first', () => {
+
+    const data = makeSyntheticIfc()
+    const bufferInput = new ParsingBuffer( data )
+
+    parser.parseHeader( bufferInput )
+
+    const model = parser.parseDataToModel( bufferInput )[ 1 ]
+
+    expect( model ).toBeDefined()
+
+    const counted = model!.typeCount( IfcCartesianPoint )
+    const iterated = Array.from( model!.types( IfcCartesianPoint ) ).length
+
+    expect( counted ).toBe( iterated )
+    expect( counted ).toBe( ENTITY_COUNT )
+  } )
+} )

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -863,6 +863,24 @@ implements Iterable<BaseEntity>, Model {
   }
 
   /**
+   * Count entities of a set of types (including sub-types) without iterating
+   * or materializing them — reads the type index's prefix sums, so it's cheap
+   * enough to call up front for progress totals (see core/progress.ts).
+   * Multi-mapped elements can be counted once per matching mapping, so treat
+   * this as an upper bound; see MultiIndexSet.count.
+   *
+   * @param types The list of types to count.
+   * @return {number} The number of matching entities.
+   */
+  public typeCount<T extends StepEntityConstructorAbstract<EntityTypeIDs>[]>(
+      ...types: T ): number {
+    const distinctTypes = types.length === 1 ? (types[0].query) :
+      (new Set(types.flatMap((type) => type.query)))
+
+    return this.typeIndex.count(...distinctTypes)
+  }
+
+  /**
    * Get the non empty type IDs for this.
    *
    * @return {Set} The unique set of non empty type IDs for this model.


### PR DESCRIPTION
## Summary

This PR implements structured progress tracking and cooperative (event-loop-yielding) model loading to address issue #301. It enables progress UI updates during large model loads without blocking the browser, and provides a unified progress reporting contract across the codebase.

## Key Changes

- **Progress Tracking Infrastructure** (`src/core/progress.ts`):
  - New `ProgressTracker` class that throttles progress events and tracks load phases (headerParse, dataParse, geometry, sceneBuild, serialize)
  - `ProgressEvent` interface for structured progress reporting with phase, completed/total counts, elapsed time, and memory usage
  - `yieldToEventLoop()` utility for cooperative async patterns
  - Support for both determinate (with total) and indeterminate progress reporting

- **Async Load Paths**:
  - `IfcApiProxyIfc.createAsync()` for cooperative IFC parsing/extraction with event-loop yields
  - `StepParser.parseDataBlockAsync()` for cooperative data parsing
  - `IfcGeometryExtraction.extractIFCGeometryDataAsync()` for cooperative geometry extraction
  - `ConwayModelLoader.loadModelWithScene()` extended with `ModelLoadOptions` for progress/yield control
  - `IfcAPI.OpenModelAsync()` as the public async entry point

- **Progress Integration**:
  - Parse and geometry loops now accept optional progress callbacks
  - Progress ticks at ~4096 element intervals during parsing (cheap, frequent enough)
  - Per-product ticks during geometry extraction (heavy work is opaque wasm calls)
  - Cooperative yields every 50ms by default to keep UI responsive

- **Logger Enhancements** (`src/logging/logger.ts`):
  - Numeric `LogLevel` enum (DEBUG, INFO, WARNING, ERROR, OFF) with threshold-based console echoing
  - `LogSink` abstraction for routing output (CLI uses stderr to keep stdout clean)
  - `setLogLevel()`, `getLogLevel()`, `isLevelEnabled()` for runtime log control
  - Entries still buffered regardless of threshold; only console echo is filtered

- **CLI Progress Rendering** (`src/cli/cli_progress_renderer.ts`):
  - `CliProgressRenderer` for terminal progress display
  - TTY-aware: repaints single status line on TTY, prints plain lines when redirected
  - Throttled output in non-TTY mode to keep CI logs readable
  - Formats as: "Extracting geometry 42% (3800/9000 products) 12.4s 512MB"

- **Web-IFC Compatibility**:
  - `Loadersettings.ON_PROGRESS` callback for progress events
  - `LogLevel` enum matching web-ifc's numeric values for drop-in compatibility
  - `OpenModelAsync()` method (feature-detectable with `typeof`)

- **Supporting Changes**:
  - `IfcProxyLoadState` interface to share parse/extract results between sync and async paths
  - `parseAndExtract()` / `parseAndExtractAsync()` static methods factoring out common logic
  - `MultiIndexSet.typeCount()` for cheap per-type entity counting (used for progress totals)
  - `Statistics.format()` for single-line load summary (routed through Logger sink)
  - Memory sampling via `Memory.usedHeapMb()` for progress events

## Implementation Details

- **Cooperative Pattern**: Uses generators (`*Incremental()` methods) driven by both sync loops and async/await, allowing the same parse/extract logic to work in both paths
- **Progress Cadence**: Balances overhead vs responsiveness—parse ticks every ~4K elements, geometry ticks per-product, both with configurable throttling
- **Backward Compatibility**: Sync paths unchanged; async is opt-in via `OpenModelAsync()` or `ModelLoadOptions.yieldToEventLoop`
- **Deduplication**: Logger dedupes repeated messages and accumulates express IDs, with first occurrence echoed immediately (if above threshold) and full table available via `displayLogs()`
- **CLI Integration**: Logs and statistics route through stderr; stdout reserved for data output (query

https://claude.ai/code/session_01FGQbMmcVsehX9FwCFKuYyf