### PR TITLE
Release the scratch parsing buffer's source pin on cache release / spill

### DIFF
--- a/src/step/parsing/step_deserialization_functions.test.ts
+++ b/src/step/parsing/step_deserialization_functions.test.ts
@@ -1,0 +1,43 @@
+// Pins for the module-level scratch parsing buffer used by numeric
+// extraction. The scratch is reinit-pointed at the caller's buffer on
+// every read and, without an explicit release, silently pins the LAST
+// buffer it saw — after a parse, the model's entire source. The
+// model's cache-release/spill path calls releaseScratchParsingBuffer()
+// to drop that pin (heap-snapshot verified: the source ArrayBuffer is
+// unreachable after spill + release, where before it was retained via
+// Context[parsingBufferReusable] → ParsingBuffer.buffer).
+import { describe, expect, test } from '@jest/globals'
+
+import {
+  releaseScratchParsingBuffer,
+  stepExtractNumber,
+} from './step_deserialization_functions'
+
+
+const REAL_VALUE = 42.5
+const INT_VALUE = 7
+
+
+describe( 'releaseScratchParsingBuffer', () => {
+
+  test( 'extraction works again after a release (scratch reinits on use)', () => {
+
+    const bytes = new TextEncoder().encode( '42.5,' )
+
+    expect( stepExtractNumber( bytes, 0, bytes.length ) ).toBe( REAL_VALUE )
+
+    releaseScratchParsingBuffer()
+
+    // The release must not break subsequent extraction — every use
+    // reinits the scratch with the caller's buffer.
+    const more = new TextEncoder().encode( '7,' )
+
+    expect( stepExtractNumber( more, 0, more.length ) ).toBe( INT_VALUE )
+
+    // And releasing twice is harmless.
+    releaseScratchParsingBuffer()
+    releaseScratchParsingBuffer()
+
+    expect( stepExtractNumber( bytes, 0, bytes.length ) ).toBe( REAL_VALUE )
+  })
+})

--- a/src/step/parsing/step_deserialization_functions.ts
+++ b/src/step/parsing/step_deserialization_functions.ts
@@ -28,7 +28,28 @@ const HASH         = ParsingConstants.HASH
 const ZERO         = ParsingConstants.ZERO
 const SLASH        = ParsingConstants.SLASH
 
-const parsingBufferReusable = new ParsingBuffer( new Uint8Array( 1 ), 0, 1 )
+const EMPTY_PARSING_BYTES = new Uint8Array( 1 )
+
+const parsingBufferReusable = new ParsingBuffer( EMPTY_PARSING_BYTES, 0, 1 )
+
+/**
+ * Drop the module-level scratch parsing buffer's reference to the last
+ * buffer it read from.
+ *
+ * The scratch is `reinit`-pointed at a caller's buffer on every numeric
+ * extraction and never cleared, so after a parse it silently pins the
+ * ENTIRE source buffer (hundreds of MB on large models) until the next
+ * extraction repoints it. That was invisible while the model itself
+ * held the source, but once `spillSourceToExternalStore` releases the
+ * model's copy this scratch became the last thing keeping it alive
+ * (found via heap-snapshot retainer chain:
+ * `Context[parsingBufferReusable] → ParsingBuffer.buffer → source`).
+ * Called from the model's spill and cache-release paths; safe at any
+ * time because every use reinits the scratch first.
+ */
+export function releaseScratchParsingBuffer(): void {
+  parsingBufferReusable.reinit( EMPTY_PARSING_BYTES, 0, 1 )
+}
 
 
 /**

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -1,4 +1,5 @@
 import { StepIndexEntry } from './parsing/step_parser'
+import { releaseScratchParsingBuffer } from './parsing/step_deserialization_functions'
 import {
   ResidentStepBufferProvider,
   StepBufferProvider,
@@ -277,6 +278,16 @@ implements Iterable<BaseEntity>, Model {
     if ( dropVtable ) {
 
       this.vtableBuilder_.clear( true )
+
+      // The module-level scratch parsing buffer stays pointed at the
+      // last buffer a numeric extraction read from — after a parse,
+      // that's this model's FULL source. Releasing caches (and
+      // especially spilling the source, which routes through here)
+      // must drop that pin too, or the released source stays alive
+      // via the scratch (heap-snapshot verified). Safe globally: every
+      // use reinits the scratch first, and any other live model just
+      // repoints it on its next read.
+      releaseScratchParsingBuffer()
 
       // Common entries: drop their materialised descriptors outright — this is
       // the memory the old retained object array could never release. They


### PR DESCRIPTION
## What

Fixes a long-standing latent retention that #374's source spill exposed: the module-level scratch `ParsingBuffer` in `step_deserialization_functions.ts` (`parsingBufferReusable`) is `reinit`-pointed at the caller's buffer on every numeric extraction and never cleared — so after a parse it silently **pins the model's entire source buffer**. That was invisible while the model held the source anyway, but once `spillSourceToExternalStore` releases the model's copy, the scratch becomes the last retainer.

**Evidence:** on Pablo's PSB smoke test of bldrs-ai/Share#1591, the spill logged `released resident source buffer (902472037B)` but a DevTools heap snapshot still showed the 902 MB `JSArrayBufferData` alive, retained via `Context[parsingBufferReusable] → ParsingBuffer.buffer → source`. A node `FinalizationRegistry` repro confirmed: the source ArrayBuffer **never collects** after spill+GC on 1.374.

## Fix

- Export `releaseScratchParsingBuffer()` — reinits the scratch to a module-owned 1-byte array.
- Call it from `StepModelBase.invalidate(true)`, which covers both `ReleaseEntityCache` and the spill (the spill routes through it). Safe at any time: every use reinits the scratch with the caller's buffer first, and any other live model repoints it on its next read.

**Verified** with the FinalizationRegistry repro against this build: `source ArrayBuffer collected after spill+gc: true` (was `false` on 1.374.1181).

## Testing

- New unit test pins that extraction still works after (repeated) releases.
- Existing spill parity suites unaffected (they read after spill; the scratch reinits on use).
- Full suite green via the pre-commit hook.

Related: #374 (windowed spill), bldrs-ai/Share#1591 (Share wiring — will bump to the release carrying this so the spill actually frees the ~900 MB), `design/new/memory-residency.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_