### PR TITLE
Fix NURBS weight handling in rational surface tessellation

### DIFF
--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -2835,11 +2835,20 @@ export class AP214GeometryExtraction {
       from: Array< Array < number > >,
       to: StdVector< StdVector< number > >): void {
 
-    to.resize( from.length, this.conwayModel.nativeVectorDouble() )
+    // Build each row and push_back (which copies) — embind's vector get()
+    // returns a COPY of the inner vector, so the previous resize + write
+    // into get(where) mutated temporaries and left the outer vector's rows
+    // empty. That silently dropped NURBS weights, so rational surfaces
+    // (STEP cylinders written as weighted Bezier patches) tessellated as
+    // plain polynomials and bulged — part of conway#350.
+    for ( const row of from ) {
 
-    for (let where = 0, end = from.length; where < end; ++where) {
+      const nativeRow = this.conwayModel.nativeVectorDouble()
 
-      this.extractToDoubleVector( from[ where ], to.get( where ) )
+      this.extractToDoubleVector( row, nativeRow )
+
+      to.push_back( nativeRow )
+      nativeRow.delete()
     }
   }
 

--- a/src/AP214E3_2010/ap214_occurrence_geometry.test.ts
+++ b/src/AP214E3_2010/ap214_occurrence_geometry.test.ts
@@ -24,6 +24,7 @@ const FIXTURE = 'data/as1-oc-214.stp'
 
 let model: ReturnType<AP214StepParser['parseDataToModel']>[1]
 let scene: AP214SceneBuilder
+let conwayGeometry: ConwayGeometry
 
 beforeAll( async () => {
 
@@ -37,7 +38,7 @@ beforeAll( async () => {
   expect( parsed ).not.toBe( void 0 )
   model = parsed
 
-  const conwayGeometry = new ConwayGeometry()
+  conwayGeometry = new ConwayGeometry()
 
   expect( await conwayGeometry.initialize() ).toBe( true )
 
@@ -121,6 +122,93 @@ describe( 'AP214 as1-oc-214 occurrence geometry', () => {
     expect( colliding.length ).toBeGreaterThan( 1 )
     const paths = colliding.map( ( n ) => JSON.stringify( n.occurrencePath ) )
     expect( new Set( paths ).size ).toBe( colliding.length )
+  } )
+
+  test( 'the rod\'s lateral b-spline surface tessellates (issue #350)', () => {
+
+    // The rod (occurrence rod-assembly_1 #1137 -> rod_1 #1131) is the one AS1
+    // part whose entire lateral surface is rational b-spline geometry (two
+    // weighted Bezier half-cylinders); its planar end caps tessellate
+    // regardless. When rational surface tessellation regresses, the rod
+    // degenerates to two thin discs — present in the scene walk and the
+    // NavTree, but invisible in the render (issue #350). Comparing the mesh's
+    // measured area against the analytic closed-cylinder area (from its own
+    // bounding box, so it is unit-agnostic) catches exactly that: caps-only
+    // is ~2.4% of the expected area, a real cylinder is ~100%.
+    const rodAssemblyNauo = 1137
+    const rodNauo = 1131
+
+    let rodGeometry: any
+
+    for ( const [ , , mesh, , , occ ] of scene.walkWithOccurrence() ) {
+      if ( occ.length === 2 && occ[ 0 ] === rodAssemblyNauo && occ[ 1 ] === rodNauo ) {
+        rodGeometry = ( mesh as any ).geometry
+        break
+      }
+    }
+
+    expect( rodGeometry ).toBeDefined()
+
+    const wasm = ( conwayGeometry as any ).wasmModule
+
+    // Reified layout: 6 floats per vertex (position xyz + normal xyz),
+    // uint32 indices, 3 per triangle.
+    const vertexFloatCount = rodGeometry.GetVertexDataSize()
+    const indexCount = rodGeometry.GetIndexDataSize()
+    /* eslint-disable no-magic-numbers */
+    const vertexData = wasm.HEAPF32.subarray(
+        rodGeometry.GetVertexData() / 4,
+        rodGeometry.GetVertexData() / 4 + vertexFloatCount )
+    const indexData = wasm.HEAPU32.subarray(
+        rodGeometry.GetIndexData() / 4,
+        rodGeometry.GetIndexData() / 4 + indexCount )
+
+    const mins = [ Infinity, Infinity, Infinity ]
+    const maxs = [ -Infinity, -Infinity, -Infinity ]
+
+    for ( let where = 0; where < vertexFloatCount; where += 6 ) {
+      for ( let axis = 0; axis < 3; ++axis ) {
+        mins[ axis ] = Math.min( mins[ axis ], vertexData[ where + axis ] )
+        maxs[ axis ] = Math.max( maxs[ axis ], vertexData[ where + axis ] )
+      }
+    }
+
+    const extents = [ 0, 1, 2 ].map( ( axis ) => maxs[ axis ] - mins[ axis ] ).sort( ( a, b ) => a - b )
+    // Cylinder aligned to one axis: two equal cross extents (diameter) and
+    // the length along the third.
+    const radius = extents[ 0 ] / 2
+    const length = extents[ 2 ]
+    const expectedArea = 2 * Math.PI * radius * ( length + radius )
+
+    let area = 0
+
+    for ( let where = 0; where < indexCount; where += 3 ) {
+      const a = indexData[ where ] * 6
+      const b = indexData[ where + 1 ] * 6
+      const c = indexData[ where + 2 ] * 6
+      const ux = vertexData[ b ] - vertexData[ a ]
+      const uy = vertexData[ b + 1 ] - vertexData[ a + 1 ]
+      const uz = vertexData[ b + 2 ] - vertexData[ a + 2 ]
+      const vx = vertexData[ c ] - vertexData[ a ]
+      const vy = vertexData[ c + 1 ] - vertexData[ a + 1 ]
+      const vz = vertexData[ c + 2 ] - vertexData[ a + 2 ]
+      const cx = uy * vz - uz * vy
+      const cy = uz * vx - ux * vz
+      const cz = ux * vy - uy * vx
+
+      area += 0.5 * Math.sqrt( ( cx * cx ) + ( cy * cy ) + ( cz * cz ) )
+    }
+
+    // Caps-only (the regression) measures ~0.024x; a correctly tessellated
+    // cylinder converges on 1x from below. 0.5 leaves generous headroom for
+    // coarser tessellation settings without ever passing a rod with no side.
+    expect( area ).toBeGreaterThan( expectedArea * 0.5 )
+
+    // ...and a sane upper bound: dropped rational weights bulged the profile
+    // ~37% over the analytic area, so also require we are close from either
+    // side.
+    expect( area ).toBeLessThan( expectedArea * 1.1 )
+    /* eslint-enable no-magic-numbers */
   } )
 
   test( 'every geometry instance carries the occurrence path of its tree leaf', async () => {

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -4477,13 +4477,19 @@ export class IfcGeometryExtraction {
       from: Array<Array<number>>,
       to: StdVector<StdVector<number>>): void {
 
-    this.wasmModule.resizeVectorVectorDouble(to, from.length)
+    // Build each row and push_back (which copies) — embind's vector get()
+    // returns a COPY of the inner vector, so the previous resize + write
+    // into get(where) mutated temporaries and left the outer vector's rows
+    // empty, silently dropping NURBS weights (see the AP214 twin of this
+    // helper and conway#350).
+    for (const row of from) {
 
-    // to.resize(from.length)
+      const nativeRow = this.conwayModel.nativeVectorDouble()
 
-    for (let where = 0, end = from.length; where < end; ++where) {
+      this.extractToDoubleVector(row, nativeRow)
 
-      this.extractToDoubleVector(from[where], to.get(where))
+      to.push_back(nativeRow)
+      nativeRow.delete()
     }
   }
 


### PR DESCRIPTION
## Summary
Fixed a critical bug in NURBS weight handling that caused rational B-spline surfaces (such as weighted Bezier patches) to tessellate incorrectly as plain polynomials, resulting in distorted geometry. This issue particularly affected STEP cylinders and other rational surfaces defined with weights.

## Key Changes
- **AP214 geometry extraction** (`ap214_geometry_extraction.ts`): Refactored `extractToDoubleVectorVector()` to use `push_back()` instead of `resize()` + `get()`. The previous approach mutated temporary copies returned by embind's `vector.get()`, leaving the outer vector's rows empty and silently dropping NURBS weights.

- **IFC geometry extraction** (`ifc_geometry_extraction.ts`): Applied the same fix to the IFC twin helper method to ensure consistent behavior across both geometry extraction paths.

- **Test coverage** (`ap214_occurrence_geometry.test.ts`): Added comprehensive regression test for issue #350 that validates rational surface tessellation by:
  - Locating the rod assembly (a part with rational B-spline lateral surfaces)
  - Computing the tessellated mesh's surface area
  - Verifying it matches the expected analytical cylinder area (within 50%-110% bounds)
  - This catches the regression where caps-only tessellation would measure ~2.4% of expected area

## Implementation Details
The fix changes from:
```typescript
to.resize(from.length, ...)
for (let where = 0; where < from.length; ++where) {
  this.extractToDoubleVector(from[where], to.get(where))  // mutates temporary
}
```

To:
```typescript
for (const row of from) {
  const nativeRow = this.conwayModel.nativeVectorDouble()
  this.extractToDoubleVector(row, nativeRow)
  to.push_back(nativeRow)  // copies the complete row with weights
  nativeRow.delete()
}
```

This ensures NURBS weights are properly preserved during the conversion from JavaScript arrays to native vectors, allowing the Conway geometry engine to correctly tessellate rational surfaces.

https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7