### PR TITLE
Normalized load log: shared text format, early model line, STEP parity, geometry breakdown

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1186,7 +1186,7 @@ jobs:
           NEW_VERSION: ${{ steps.ver.outputs.version }}
         run: |
           perl -i -pe "s/(\"version\":\s*)\"[^\"]+\"/\$1\"$NEW_VERSION\"/" package.json
-          perl -i -pe "s/Conway Web-Ifc Shim v[0-9]+\.[0-9]+\.[0-9]+/Conway Web-Ifc Shim v$NEW_VERSION/" src/version/version.ts
+          perl -i -pe "s/Conway( Web-Ifc Shim)? v[0-9]+\.[0-9]+\.[0-9]+/Conway v$NEW_VERSION/" src/version/version.ts
 
       - name: Compute conway-geom submodule SHA
         id: subsha

--- a/scripts/updateVersion.mjs
+++ b/scripts/updateVersion.mjs
@@ -44,9 +44,9 @@ rewriteVersion(
 
 // Rewrite line like:
 //
-// const versionString: string = 'Conway Web-Ifc Shim v0.1.370'"
+// const versionString: string = 'Conway v0.1.370'"
 rewriteVersion(
     'src/version/version.ts',
-    /^const versionString: string = 'Conway Web-Ifc Shim v(?<major>\d+).(?<minor>\d+).\d+'$/m,
-    `const versionString: string = 'Conway Web-Ifc Shim v$<major>.$<minor>.${newPatch}'`,
+    /^const versionString: string = 'Conway v(?<major>\d+).(?<minor>\d+).\d+'$/m,
+    `const versionString: string = 'Conway v$<major>.$<minor>.${newPatch}'`,
 )

--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -2500,16 +2500,6 @@ export class AP214GeometryExtraction {
   }
 
   /**
-   * Extract a representation item, including its geometry if necessary,
-   * adding it to the current scene walk.
-   *
-   * Note - memoized result for instancing.
-   *
-   * @param from The representation to extract from.
-   * @param owningElementLocalID
-   * @param isMappedItem Whether this is a mapped item.
-   */
-  /**
    * Count of representation items by AP214 entity type name — the geometry
    * breakdown for the load report (issue #301 follow-up). Copied into
    * Statistics by the loader/proxies after extraction.
@@ -2525,6 +2515,16 @@ export class AP214GeometryExtraction {
     this.geometryTypeCounts.set(name, (this.geometryTypeCounts.get(name) ?? 0) + 1)
   }
 
+  /**
+   * Extract a representation item, including its geometry if necessary,
+   * adding it to the current scene walk.
+   *
+   * Note - memoized result for instancing.
+   *
+   * @param from The representation to extract from.
+   * @param owningElementLocalID
+   * @param isMappedItem Whether this is a mapped item.
+   */
   extractRepresentationItem(
       from: representation_item,
       owningElementLocalID?: number,

--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -2509,6 +2509,22 @@ export class AP214GeometryExtraction {
    * @param owningElementLocalID
    * @param isMappedItem Whether this is a mapped item.
    */
+  /**
+   * Count of representation items by AP214 entity type name — the geometry
+   * breakdown for the load report (issue #301 follow-up). Copied into
+   * Statistics by the loader/proxies after extraction.
+   */
+  public readonly geometryTypeCounts = new Map<string, number>()
+
+  /**
+   * Increment the geometry-type breakdown counter for a type name.
+   *
+   * @param name The entity type name.
+   */
+  private countGeometryType(name: string): void {
+    this.geometryTypeCounts.set(name, (this.geometryTypeCounts.get(name) ?? 0) + 1)
+  }
+
   extractRepresentationItem(
       from: representation_item,
       owningElementLocalID?: number,
@@ -2551,8 +2567,14 @@ export class AP214GeometryExtraction {
     if ( from instanceof mapped_item ) {
 
       return
+    }
 
-    } else if ( from instanceof boolean_result ) {
+    // Geometry-type breakdown for the load report (issue #301 follow-up):
+    // after the memoization early-return, so each unique geometry
+    // definition counts once regardless of occurrence instancing.
+    this.countGeometryType(EntityTypesAP214[from.type])
+
+    if ( from instanceof boolean_result ) {
 
       // also handles AP214BooleanClippingResult
       this.extractBooleanResult( from )

--- a/src/cli/cli_progress_renderer.ts
+++ b/src/cli/cli_progress_renderer.ts
@@ -1,41 +1,46 @@
-import { ProgressEvent, ProgressPhase } from '../core/progress'
+import { ProgressEvent } from '../core/progress'
+import { LoadLogAccumulator, ModelInfo } from '../core/progress_log'
 
 
-const PHASE_LABELS: Record<ProgressPhase, string> = {
-  headerParse: 'Parsing header',
-  dataParse: 'Parsing model data',
-  geometry: 'Extracting geometry',
-  sceneBuild: 'Building scene',
-  serialize: 'Writing output',
-}
-
-const PERCENT = 100
 const DEFAULT_NON_TTY_INTERVAL_MS = 2000
-const MS_PER_SECOND = 1000
 
 /**
- * Renders load progress events on a terminal.
+ * Renders load progress on a terminal using the shared normalized load-log
+ * format (core/progress_log.ts) — the same text rendition Share mirrors to
+ * the browser console, so a pasted CLI run and a pasted browser log read
+ * identically. Format spec: Share design/new/load-log-format.md.
  *
- * Writes to stderr so stdout stays clean for data output (query tables,
- * piped GLB paths — issue #301). On a TTY it repaints a single status line
- * with carriage returns; when redirected (CI logs) it prints a plain line on
- * phase changes and at most once per nonTtyIntervalMs so logs stay readable.
+ * Writes to stderr so stdout stays clean for data output. On a TTY the
+ * current stage's line repaints in place and freezes (newline) when the
+ * stage completes; when redirected (CI logs) it prints the live line at
+ * most once per nonTtyIntervalMs plus every frozen stage line.
  */
 export class CliProgressRenderer {
 
+  private readonly log = new LoadLogAccumulator()
   private lastLineLength = 0
   private lastPrintTime = 0
-  private lastPhase: ProgressPhase | undefined
 
   /**
    * Construct this against an output stream.
    *
    * @param out The stream to render to (default stderr).
-   * @param nonTtyIntervalMs Minimum ms between lines when not a TTY.
+   * @param nonTtyIntervalMs Minimum ms between live lines when not a TTY.
    */
   public constructor(
     private readonly out: NodeJS.WriteStream = process.stderr,
     private readonly nonTtyIntervalMs: number = DEFAULT_NON_TTY_INTERVAL_MS ) {}
+
+  /**
+   * Print the early model line (from header info).
+   *
+   * @param info The model header info.
+   */
+  public onModelInfo( info: ModelInfo ): void {
+    const line = this.log.setModelInfo( info )
+
+    this.freezeLine( line )
+  }
 
   /**
    * Progress callback — bound as an arrow so it can be handed directly to a
@@ -45,72 +50,67 @@ export class CliProgressRenderer {
    */
   public readonly onProgress = ( event: ProgressEvent ): void => {
 
-    const now = Date.now()
-    const phaseChanged = event.phase !== this.lastPhase
+    const closedLine = this.log.onProgress( event )
 
-    if ( !this.out.isTTY &&
-      !phaseChanged &&
-      now - this.lastPrintTime < this.nonTtyIntervalMs ) {
+    if ( closedLine !== void 0 ) {
+      this.freezeLine( closedLine )
+    }
+
+    const currentLine = this.log.currentLine()
+
+    if ( currentLine === void 0 ) {
       return
     }
 
-    this.lastPhase = event.phase
-    this.lastPrintTime = now
+    const now = Date.now()
 
-    const line = this.format( event )
+    if ( !this.out.isTTY && now - this.lastPrintTime < this.nonTtyIntervalMs ) {
+      return
+    }
+
+    this.lastPrintTime = now
 
     if ( this.out.isTTY ) {
 
-      const padded = line.padEnd( this.lastLineLength )
+      const padded = currentLine.padEnd( this.lastLineLength )
 
-      this.lastLineLength = line.length
+      this.lastLineLength = currentLine.length
       this.out.write( `\r${padded}` )
     } else {
 
-      this.out.write( `${line}\n` )
+      this.out.write( `${currentLine}\n` )
     }
   }
 
   /**
-   * Finish rendering — terminates the TTY status line so subsequent output
-   * (log table, statistics) starts on a fresh line.
+   * Finish rendering: freeze any running stage's line and print the
+   * separate before/after Total line.
    */
   public done(): void {
 
-    if ( this.out.isTTY && this.lastLineLength > 0 ) {
-      this.out.write( '\n' )
+    const closedLine = this.log.closeCurrentStage()
+
+    if ( closedLine !== void 0 ) {
+      this.freezeLine( closedLine )
     }
 
-    this.lastLineLength = 0
-    this.lastPhase = void 0
+    this.freezeLine( this.log.totalLine() )
   }
 
   /**
-   * Format one event as a status line.
+   * Print a line permanently, replacing any animated line on a TTY.
    *
-   * @param event The progress event.
-   * @return {string} e.g. "Extracting geometry 42% (3800/9000 products) 12.4s 512MB"
+   * @param line The line to freeze.
    */
-  private format( event: ProgressEvent ): string {
+  private freezeLine( line: string ): void {
 
-    const label = PHASE_LABELS[ event.phase ] ?? event.phase
-    const elapsedSeconds = ( event.elapsedMs / MS_PER_SECOND ).toFixed( 1 )
-
-    let counts: string
-
-    if ( event.total !== void 0 && event.total > 0 ) {
-
-      const percent = Math.floor( ( event.completed / event.total ) * PERCENT )
-
-      counts = `${percent}% (${event.completed}/${event.total} ${event.unit})`
+    if ( this.out.isTTY && this.lastLineLength > 0 ) {
+      // Overwrite the animated line in place, then commit with a newline.
+      this.out.write( `\r${line.padEnd( this.lastLineLength )}\n` )
     } else {
-
-      counts = `${event.completed} ${event.unit}`
+      this.out.write( `${line}\n` )
     }
 
-    const memory = event.memoryMb !== void 0 ?
-      ` ${Math.round( event.memoryMb )}MB` : ''
-
-    return `${label} ${counts} ${elapsedSeconds}s${memory}`
+    this.lastLineLength = 0
   }
 }

--- a/src/cli/cli_progress_renderer.ts
+++ b/src/cli/cli_progress_renderer.ts
@@ -85,10 +85,15 @@ export class CliProgressRenderer {
   /**
    * Finish rendering: freeze any running stage's line and print the
    * separate before/after Total line.
+   *
+   * @param atElapsedMs Optional load-end elapsed ms, so the final stage's
+   * duration covers the time until the load finished (not just until its
+   * last progress event).
+   * @param atMemoryMb Optional load-end heap MB.
    */
-  public done(): void {
+  public done( atElapsedMs?: number, atMemoryMb?: number ): void {
 
-    const closedLine = this.log.closeCurrentStage()
+    const closedLine = this.log.closeCurrentStage( atElapsedMs, atMemoryMb )
 
     if ( closedLine !== void 0 ) {
       this.freezeLine( closedLine )

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -3,6 +3,7 @@ import { ConwayGeometry, FileHandlerFunction as FileHandlerCallback,
 import {versionString} from '../../version/version'
 import Logger, { LogLevel as ConwayLogLevel } from '../../logging/logger'
 import { ProgressCallback } from '../../core/progress'
+import { ModelInfo } from '../../core/progress_log'
 import Environment from '../../utilities/environment'
 import * as glmatrix from 'gl-matrix'
 import { StepExternalByteStore } from '../../step/step_buffer_provider'
@@ -40,6 +41,14 @@ export interface Loadersettings {
    * feature-detect ('ON_PROGRESS simply ignored by older engines').
    */
   ON_PROGRESS?: ProgressCallback
+
+  /**
+   * Conway extension: fired once, right after the STEP header parses —
+   * before the full file parse — with everything the header reveals
+   * (file name, schema, originating system, preprocessor, byte size), so
+   * embedders can print the model line as early as possible (issue #301).
+   */
+  ON_MODEL_INFO?: ( info: ModelInfo ) => void
 }
 
 /**

--- a/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
@@ -99,10 +99,11 @@ export class IfcApiModelPassthroughFactory {
   }
 
   /**
-   * Cooperative twin of from() (used by OpenModelAsync): IFC input is
-   * parsed/extracted with periodic event-loop yields so progress UI can
-   * repaint (issue #301 §2); AP214/AP203/AP242 currently fall back to the
-   * synchronous path (thunk-tree extraction has no flat product loop yet).
+   * Cooperative twin of from() (used by OpenModelAsync): the data parse
+   * runs with periodic event-loop yields so progress UI can repaint
+   * (issue #301 §2) for IFC and AP214/AP203/AP242 alike. IFC geometry
+   * extraction is cooperative too; AP214's stays synchronous (thunk-tree
+   * extraction has no flat product loop yet) and reports as a heartbeat.
    *
    * @param modelID
    * @param data
@@ -118,24 +119,45 @@ export class IfcApiModelPassthroughFactory {
 
     const modelFormat = ModelFormatDetector.detect( new ParsingBuffer( data ) )
 
-    if ( modelFormat !== ModelFormatType.IFC ) {
-
-      return IfcApiModelPassthroughFactory.from( modelID, data, wasmModule, settings )
-    }
-
     try {
 
-      return await IfcApiProxyIfc.createAsync(modelID, data, wasmModule, settings)
+      switch ( modelFormat ) {
 
+        case ModelFormatType.AP203:
+
+          Logger.warning( 'AP203 Step Detected, using AP214 loader' )
+
+          // falls through
+        case ModelFormatType.AP242:
+
+          if ( modelFormat === ModelFormatType.AP242 ) {
+
+            Logger.warning( 'AP242 Step Detected, using AP214 loader (interim)' )
+          }
+
+          // falls through
+        case ModelFormatType.AP214:
+
+          return await IfcApiProxyAP214.createAsync(modelID, data, wasmModule, settings)
+
+        case ModelFormatType.IFC:
+
+          return await IfcApiProxyIfc.createAsync(modelID, data, wasmModule, settings)
+
+        default:
+
+          Logger.error( 'No type detected when constructing model')
+          return void 0
+      }
     } catch ( e ) {
 
       if ( e instanceof Error ) {
 
         // eslint-disable-next-line max-len
-        Logger.error( `Error loading IFC model in passthrough factory ${modelID}:\n${e.message}\n\n${e.stack}`)
+        Logger.error( `Error loading model in passthrough factory ${modelID}:\n${e.message}\n\n${e.stack}`)
       } else {
 
-        Logger.error( `Unknown error loading IFC model in passthrough factory ${modelID}` )
+        Logger.error( `Unknown error loading model in passthrough factory ${modelID}` )
       }
 
     }

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -28,6 +28,26 @@ import { AP214GeometryExtraction } from '../../AP214E3_2010/ap214_geometry_extra
 import AP214StepParser from '../../AP214E3_2010/ap214_step_parser'
 import { AP214Properties } from './ap214_properties'
 import { EntityTypesAP214Count } from '../../AP214E3_2010/AP214E3_2010_gen/entity_types_ap214.gen'
+import { ProgressTracker } from '../../core/progress'
+import { formatModelLine } from '../../core/progress_log'
+import { extractModelInfo } from '../../loaders/loading_utilities'
+import { StepHeader } from '../../step/parsing/step_parser'
+
+/**
+ * Everything parse/extraction produces that the proxy constructor's tail
+ * (mesh vectors, statistics) consumes — precomputed by createAsync so the
+ * cooperative path can await mid-parse, or computed synchronously inside
+ * the constructor for the classic OpenModel path. Mirrors IfcApiProxyIfc.
+ */
+interface Ap214ProxyLoadState {
+  conwaywasm: ConwayGeometry
+  allTimeStart: number
+  stepHeader: StepHeader
+  model: AP214StepModel
+  scene: AP214SceneBuilder
+  conwayGeometry: AP214GeometryExtraction
+  geometryTimeInMs: number
+}
 
 /**
  */
@@ -131,79 +151,27 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
       public readonly modelID: number,
       data: Uint8Array,
       private readonly wasmModule: any,
-      private readonly settings?: Loadersettings ) {
+      private readonly settings?: Loadersettings,
+      precomputed?: Ap214ProxyLoadState ) {
 
-    this.conwaywasm = new ConwayGeometry(wasmModule)
+    // The cooperative path (createAsync) parses/extracts before construction
+    // so it can await mid-load; the classic OpenModel path does it here,
+    // synchronously. Both share the tail below (mesh vectors, statistics).
+    const loadState = precomputed ??
+      IfcApiProxyAP214.parseAndExtract(modelID, data, new ConwayGeometry(wasmModule), settings)
 
-    const allTimeStart = Date.now()
-    const parser = AP214StepParser.Instance
-    const bufferInput = new ParsingBuffer(data)
-    const [stepHeader, result0] = parser.parseHeader(bufferInput)
-
-    Logger.createStatistics(modelID)
+    this.conwaywasm = loadState.conwaywasm
 
     const statistics = Logger.getStatistics(modelID)
 
-    switch (result0) {
-      case ParseResult.COMPLETE:
-
-        break
-
-      case ParseResult.INCOMPLETE:
-
-        Logger.warning('Parse incomplete but no errors')
-        statistics?.setLoadStatus('HEADER PARSE: INCOMPLETE')
-        break
-
-      case ParseResult.INVALID_STEP:
-
-        Logger.error('Error: Invalid STEP detected in parse, but no syntax error detected')
-        statistics?.setLoadStatus('HEADER PARSE: INVALID_STEP')
-        break
-
-      case ParseResult.MISSING_TYPE:
-
-        Logger.warning('Error: missing STEP type, but no syntax error detected')
-        statistics?.setLoadStatus('HEADER PARSE: MISSING_TYPE')
-        break
-
-      case ParseResult.SYNTAX_ERROR:
-
-        Logger.error(`Error: Syntax error detected on line ${bufferInput.lineCount}`)
-        statistics?.setLoadStatus('HEADER PARSE: SYNTAX_ERROR')
-        break
-
-      default:
-    }
-
-    const parseStartTime = Date.now()
-    const model = parser.parseDataToModel(bufferInput)[1]
-    const parseEndTime = Date.now()
-
-    if (model === void 0) {
-      Logger.error('[OpenModel]: model === undefined')
-      statistics?.setLoadStatus('PARSE_FAIL')
-      throw new Error( 'Failed to load model' )
-    }
-
-    statistics?.setParseTime(parseEndTime - parseStartTime)
-
-    // TODO(nickcastel50): Doing geometry extraction in here for now...
-    // parse + extract data model + geometry data
-    const conwayGeometry = new AP214GeometryExtraction(this.conwaywasm, model)
-
-    const startTime = Date.now()
-    const [extractionResult, scene] =
-      conwayGeometry.extractAP214GeometryData()
-
-    const endTime = Date.now()
-    const executionTimeInMs = endTime - startTime
-
-    if (extractionResult !== ExtractResult.COMPLETE) {
-      Logger.error('[OpenModel]: Error extracting geometry, exiting...')
-      statistics?.setLoadStatus('FAIL')
-      throw new Error( 'Couldn\'t extract model' )
-    }
+    const {
+      allTimeStart,
+      stepHeader,
+      model,
+      scene,
+      conwayGeometry,
+      geometryTimeInMs: executionTimeInMs,
+    } = loadState
 
     // get linear scaling factor
     this.linearScalingFactor = conwayGeometry.getLinearScalingFactor()
@@ -333,6 +301,277 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
     statistics?.setGeometryTime(executionTimeInMs)
     // eslint-disable-next-line no-magic-numbers
     statistics?.setGeometryMemory(scene.model.geometry.calculateGeometrySize() / (1024 * 1024))
+  }
+
+  /**
+   * Cooperative construction (conway extension, used by OpenModelAsync):
+   * identical parse/extraction to the constructor path, but the data parse
+   * periodically yields to the event loop so progress UI can repaint —
+   * issue #301 §2. Geometry extraction stays synchronous (the AP214
+   * thunk-tree walk has no flat product loop yet) and reports as a
+   * heartbeat phase.
+   *
+   * @param modelID The model ID being opened.
+   * @param data The STEP data buffer.
+   * @param wasmModule The wasm module.
+   * @param settings Loader settings (ON_PROGRESS / ON_MODEL_INFO honored).
+   * @return {Promise<IfcApiProxyAP214>} The constructed proxy.
+   */
+  public static async createAsync(
+      modelID: number,
+      data: Uint8Array,
+      wasmModule: any,
+      settings?: Loadersettings ): Promise<IfcApiProxyAP214> {
+
+    const loadState = await IfcApiProxyAP214.parseAndExtractAsync(
+        modelID, data, new ConwayGeometry(wasmModule), settings)
+
+    return new IfcApiProxyAP214(modelID, data, wasmModule, settings, loadState)
+  }
+
+  /**
+   * Log + record the header parse result on the model statistics.
+   *
+   * @param result0 The header parse result.
+   * @param bufferInput The parsing buffer (for line numbers).
+   * @param modelID The model ID (for statistics lookup).
+   */
+  private static reportHeaderParseResult(
+      result0: ParseResult,
+      bufferInput: ParsingBuffer,
+      modelID: number ): void {
+
+    const statistics = Logger.getStatistics(modelID)
+
+    switch (result0) {
+      case ParseResult.COMPLETE:
+
+        break
+
+      case ParseResult.INCOMPLETE:
+
+        Logger.warning('Parse incomplete but no errors')
+        statistics?.setLoadStatus('HEADER PARSE: INCOMPLETE')
+        break
+
+      case ParseResult.INVALID_STEP:
+
+        Logger.error('Error: Invalid STEP detected in parse, but no syntax error detected')
+        statistics?.setLoadStatus('HEADER PARSE: INVALID_STEP')
+        break
+
+      case ParseResult.MISSING_TYPE:
+
+        Logger.warning('Error: missing STEP type, but no syntax error detected')
+        statistics?.setLoadStatus('HEADER PARSE: MISSING_TYPE')
+        break
+
+      case ParseResult.SYNTAX_ERROR:
+
+        Logger.error(`Error: Syntax error detected on line ${bufferInput.lineCount}`)
+        statistics?.setLoadStatus('HEADER PARSE: SYNTAX_ERROR')
+        break
+
+      default:
+    }
+  }
+
+  /**
+   * Build the progress tracker for a load, when the settings carry an
+   * ON_PROGRESS callback.
+   *
+   * @param settings Loader settings.
+   * @return {ProgressTracker | undefined} The tracker, if progress is wanted.
+   */
+  private static makeTracker(
+      settings: Loadersettings | undefined ): ProgressTracker | undefined {
+
+    if (settings?.ON_PROGRESS === void 0) {
+      return void 0
+    }
+
+    return new ProgressTracker(settings.ON_PROGRESS)
+  }
+
+  /**
+   * Synchronous parse + geometry extraction (the classic OpenModel path).
+   *
+   * @param modelID The model ID being opened.
+   * @param data The STEP data buffer.
+   * @param conwaywasm The conway geometry wasm wrapper.
+   * @param settings Loader settings (ON_PROGRESS / ON_MODEL_INFO honored).
+   * @return {Ap214ProxyLoadState} Everything the constructor tail needs.
+   */
+  private static parseAndExtract(
+      modelID: number,
+      data: Uint8Array,
+      conwaywasm: ConwayGeometry,
+      settings?: Loadersettings ): Ap214ProxyLoadState {
+
+    const tracker = IfcApiProxyAP214.makeTracker(settings)
+
+    const allTimeStart = Date.now()
+    const parser = AP214StepParser.Instance
+    const bufferInput = new ParsingBuffer(data)
+
+    tracker?.beginPhase('headerParse', 'bytes', data.length)
+
+    const [stepHeader, result0] = parser.parseHeader(bufferInput)
+
+    Logger.createStatistics(modelID)
+
+    const statistics = Logger.getStatistics(modelID)
+
+    IfcApiProxyAP214.reportHeaderParseResult(result0, bufferInput, modelID)
+
+    // Model line as early as possible — header-only, before the full file
+    // parse (issue #301 follow-up, log line 3).
+    const modelInfo = extractModelInfo(stepHeader, data.length)
+
+    Logger.info(formatModelLine(modelInfo))
+    settings?.ON_MODEL_INFO?.(modelInfo)
+
+    tracker?.beginPhase('dataParse', 'bytes', data.length)
+
+    const parseTick = tracker !== void 0 ?
+      (cursorBytes: number) => tracker.update(cursorBytes) : void 0
+
+    const parseStartTime = Date.now()
+    const model = parser.parseDataToModel(bufferInput, parseTick)[1]
+    const parseEndTime = Date.now()
+
+    tracker?.endPhase(data.length)
+
+    if (model === void 0) {
+      Logger.error('[OpenModel]: model === undefined')
+      statistics?.setLoadStatus('PARSE_FAIL')
+      throw new Error( 'Failed to load model' )
+    }
+
+    statistics?.setParseTime(parseEndTime - parseStartTime)
+
+    const conwayGeometry = new AP214GeometryExtraction(conwaywasm, model)
+
+    // Heartbeat only: the AP214 thunk-tree extraction has no flat product
+    // loop to tick from yet (see conway_model_loader's matching note).
+    tracker?.beginPhase('geometry', 'products')
+
+    const startTime = Date.now()
+    const [extractionResult, scene] =
+      conwayGeometry.extractAP214GeometryData()
+
+    const endTime = Date.now()
+
+    tracker?.endPhase()
+
+    if (extractionResult !== ExtractResult.COMPLETE) {
+      Logger.error('[OpenModel]: Error extracting geometry, exiting...')
+      statistics?.setLoadStatus('FAIL')
+      throw new Error( 'Couldn\'t extract model' )
+    }
+
+    statistics?.setGeometryTypeCounts(conwayGeometry.geometryTypeCounts)
+
+    return {
+      conwaywasm,
+      allTimeStart,
+      stepHeader,
+      model,
+      scene,
+      conwayGeometry,
+      geometryTimeInMs: endTime - startTime,
+    }
+  }
+
+  /**
+   * Cooperative twin of parseAndExtract: awaits the async data parse so the
+   * event loop can run between progress ticks.
+   *
+   * @param modelID The model ID being opened.
+   * @param data The STEP data buffer.
+   * @param conwaywasm The conway geometry wasm wrapper.
+   * @param settings Loader settings (ON_PROGRESS / ON_MODEL_INFO honored).
+   * @return {Promise<Ap214ProxyLoadState>} Everything the constructor tail needs.
+   */
+  private static async parseAndExtractAsync(
+      modelID: number,
+      data: Uint8Array,
+      conwaywasm: ConwayGeometry,
+      settings?: Loadersettings ): Promise<Ap214ProxyLoadState> {
+
+    const tracker = IfcApiProxyAP214.makeTracker(settings)
+
+    const allTimeStart = Date.now()
+    const parser = AP214StepParser.Instance
+    const bufferInput = new ParsingBuffer(data)
+
+    tracker?.beginPhase('headerParse', 'bytes', data.length)
+
+    const [stepHeader, result0] = parser.parseHeader(bufferInput)
+
+    Logger.createStatistics(modelID)
+
+    const statistics = Logger.getStatistics(modelID)
+
+    IfcApiProxyAP214.reportHeaderParseResult(result0, bufferInput, modelID)
+
+    // Model line as early as possible — header-only, before the full file
+    // parse (issue #301 follow-up, log line 3).
+    const modelInfo = extractModelInfo(stepHeader, data.length)
+
+    Logger.info(formatModelLine(modelInfo))
+    settings?.ON_MODEL_INFO?.(modelInfo)
+
+    tracker?.beginPhase('dataParse', 'bytes', data.length)
+
+    const parseTick = tracker !== void 0 ?
+      (cursorBytes: number) => tracker.update(cursorBytes) : void 0
+
+    const parseStartTime = Date.now()
+    const model = (await parser.parseDataToModelAsync(bufferInput, parseTick))[1]
+    const parseEndTime = Date.now()
+
+    tracker?.endPhase(data.length)
+
+    if (model === void 0) {
+      Logger.error('[OpenModel]: model === undefined')
+      statistics?.setLoadStatus('PARSE_FAIL')
+      throw new Error( 'Failed to load model' )
+    }
+
+    statistics?.setParseTime(parseEndTime - parseStartTime)
+
+    const conwayGeometry = new AP214GeometryExtraction(conwaywasm, model)
+
+    // Heartbeat only: the AP214 thunk-tree extraction has no flat product
+    // loop to tick from yet (see conway_model_loader's matching note).
+    tracker?.beginPhase('geometry', 'products')
+
+    const startTime = Date.now()
+    const [extractionResult, scene] =
+      conwayGeometry.extractAP214GeometryData()
+
+    const endTime = Date.now()
+
+    tracker?.endPhase()
+
+    if (extractionResult !== ExtractResult.COMPLETE) {
+      Logger.error('[OpenModel]: Error extracting geometry, exiting...')
+      statistics?.setLoadStatus('FAIL')
+      throw new Error( 'Couldn\'t extract model' )
+    }
+
+    statistics?.setGeometryTypeCounts(conwayGeometry.geometryTypeCounts)
+
+    return {
+      conwaywasm,
+      allTimeStart,
+      stepHeader,
+      model,
+      scene,
+      conwayGeometry,
+      geometryTimeInMs: endTime - startTime,
+    }
   }
 
 

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -34,6 +34,7 @@ import Memory from '../../memory/memory'
 import { FromRawLineData } from './ifc2x4_helper'
 import { shimIfcEntityMap, shimIfcEntityReverseMap } from './shim_schema_mapping'
 import { EntityTypesIfcCount } from '../../ifc/ifc4_gen/entity_types_ifc.gen'
+import { IfcProduct } from '../../ifc/ifc4_gen'
 import { CanonicalMeshType } from '../../index'
 
 /**
@@ -414,6 +415,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       throw new Error( 'Couldn\'t extract model' )
     }
 
+    statistics?.setProductCount(model.typeCount(IfcProduct))
     statistics?.setGeometryTypeCounts(conwayGeometry.geometryTypeCounts)
 
     return {
@@ -509,6 +511,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       throw new Error( 'Couldn\'t extract model' )
     }
 
+    statistics?.setProductCount(model.typeCount(IfcProduct))
     statistics?.setGeometryTypeCounts(conwayGeometry.geometryTypeCounts)
 
     return {

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -22,6 +22,8 @@ import * as glmatrix from 'gl-matrix'
 import { IfcProperties } from './ifc_properties'
 import Logger from '../../logging/logger'
 import { ProgressTracker } from '../../core/progress'
+import { formatModelLine } from '../../core/progress_log'
+import { extractModelInfo } from '../../loaders/loading_utilities'
 import IfcStepParser from '../../ifc/ifc_step_parser'
 import ParsingBuffer from '../../parsing/parsing_buffer'
 import { StepHeader } from '../../step/parsing/step_parser'
@@ -362,6 +364,13 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     IfcApiProxyIfc.reportHeaderParseResult(result0, bufferInput, modelID)
 
+    // Model line as early as possible — header-only, before the full file
+    // parse (issue #301 follow-up, log line 3).
+    const modelInfo = extractModelInfo(stepHeader, data.length)
+
+    Logger.info(formatModelLine(modelInfo))
+    settings?.ON_MODEL_INFO?.(modelInfo)
+
     tracker?.beginPhase('dataParse', 'bytes', data.length)
 
     const parseTick = tracker !== void 0 ?
@@ -404,6 +413,8 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       statistics?.setLoadStatus('FAIL')
       throw new Error( 'Couldn\'t extract model' )
     }
+
+    statistics?.setGeometryTypeCounts(conwayGeometry.geometryTypeCounts)
 
     return {
       conwaywasm,
@@ -448,6 +459,13 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     IfcApiProxyIfc.reportHeaderParseResult(result0, bufferInput, modelID)
 
+    // Model line as early as possible — header-only, before the full file
+    // parse (issue #301 follow-up, log line 3).
+    const modelInfo = extractModelInfo(stepHeader, data.length)
+
+    Logger.info(formatModelLine(modelInfo))
+    settings?.ON_MODEL_INFO?.(modelInfo)
+
     tracker?.beginPhase('dataParse', 'bytes', data.length)
 
     const parseTick = tracker !== void 0 ?
@@ -490,6 +508,8 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       statistics?.setLoadStatus('FAIL')
       throw new Error( 'Couldn\'t extract model' )
     }
+
+    statistics?.setGeometryTypeCounts(conwayGeometry.geometryTypeCounts)
 
     return {
       conwaywasm,

--- a/src/compat/web-ifc/index.ts
+++ b/src/compat/web-ifc/index.ts
@@ -26,3 +26,16 @@ export {
   ProgressPhase,
   ProgressUnit,
 } from '../../core/progress'
+
+// The shared normalized load-log text rendition (stage lines + Total) used
+// by the conway CLI and Share's status-bar/console output alike — see
+// Share design/new/load-log-format.md.
+export {
+  LoadLogAccumulator,
+  ModelInfo,
+  ProgressEventLike,
+  formatBar,
+  formatModelLine,
+  formatSeconds,
+  stageLabel,
+} from '../../core/progress_log'

--- a/src/compat/web-ifc/index.ts
+++ b/src/compat/web-ifc/index.ts
@@ -35,6 +35,7 @@ export {
   ModelInfo,
   ProgressEventLike,
   formatBar,
+  formatMb,
   formatModelLine,
   formatSeconds,
   stageLabel,

--- a/src/core/progress_log.test.ts
+++ b/src/core/progress_log.test.ts
@@ -1,0 +1,114 @@
+import {describe, expect, test} from '@jest/globals'
+
+import {
+  LoadLogAccumulator,
+  formatBar,
+  formatModelLine,
+  formatSeconds,
+  stageLabel,
+} from './progress_log'
+
+
+const HALF_PERCENT = 56
+const FULL_PERCENT = 100
+const FULL_DOTS = 16
+const HALF_DOTS = 9
+const SAMPLE_MS = 3210
+
+describe( 'formatBar', () => {
+
+  test( 'grows dots with percent and completes at 100', () => {
+    expect( formatBar( 0 ) ).toBe( '[0%0%]' )
+    expect( formatBar( HALF_PERCENT ) ).toBe( `[0%${'.'.repeat( HALF_DOTS )}56%]` )
+    expect( formatBar( FULL_PERCENT ) ).toBe( `[0%${'.'.repeat( FULL_DOTS )}100%]` )
+  } )
+
+  test( 'renders indeterminate without a percent', () => {
+    expect( formatBar( void 0 ) ).toBe( '[...]' )
+  } )
+} )
+
+describe( 'formatModelLine', () => {
+
+  test( 'renders the full header info', () => {
+    const line = formatModelLine( {
+      fileName: 'Arty_Z7.stp',
+      schema: 'AP214',
+      originatingSystem: 'SolidWorks 2021',
+      preprocessorVersion: 'SwSTEP 2.0',
+      byteLength: 39_950_000,
+    } )
+
+    expect( line ).toBe( 'Model: Arty_Z7.stp — AP214, 38.1 MB, SolidWorks 2021 (SwSTEP 2.0)' )
+  } )
+
+  test( 'degrades gracefully with partial info', () => {
+    expect( formatModelLine( {} ) ).toBe( 'Model: (unnamed)' )
+    expect( formatModelLine( { fileName: 'a.ifc', schema: 'IFC4' } ) )
+        .toBe( 'Model: a.ifc — IFC4' )
+  } )
+} )
+
+describe( 'stageLabel', () => {
+
+  test( 'merges header and data parse into Parsing; title-cases unknowns', () => {
+    expect( stageLabel( 'headerParse' ) ).toBe( 'Parsing' )
+    expect( stageLabel( 'dataParse' ) ).toBe( 'Parsing' )
+    expect( stageLabel( 'geometry' ) ).toBe( 'Geometry' )
+    expect( stageLabel( 'convert' ) ).toBe( 'Convert' )
+    expect( stageLabel( 'somethingElse' ) ).toBe( 'SomethingElse' )
+  } )
+} )
+
+describe( 'LoadLogAccumulator', () => {
+
+  test( 'freezes stage lines with owned deltas and a separate Total', () => {
+
+    const log = new LoadLogAccumulator()
+
+    log.setModelInfo( { fileName: 'index.ifc', schema: 'IFC4' } )
+
+    // Parsing: 0→3200ms, heap 500→710 MB, determinate.
+    log.onProgress( { phase: 'dataParse', completed: 0, total: 100, elapsedMs: 0, memoryMb: 500 } )
+    log.onProgress(
+        { phase: 'dataParse', completed: 100, total: 100, elapsedMs: 3200, memoryMb: 710 } )
+
+    // Geometry begins: closes Parsing.
+    const closed = log.onProgress(
+        { phase: 'geometry', completed: 0, total: 200, elapsedMs: 3300, memoryMb: 712 } )
+
+    expect( closed ).toBe( `Parsing [0%${'.'.repeat( FULL_DOTS )}100%] 3.2s, +210 MB heap` )
+
+    log.onProgress(
+        { phase: 'geometry', completed: 112, total: 200, elapsedMs: 44_300, memoryMb: 1100 } )
+
+    expect( log.currentLine() ).toBe( `Geometry [0%${'.'.repeat( HALF_DOTS )}56%] 41.0s, +388 MB heap` )
+
+    log.closeCurrentStage()
+
+    expect( log.allLines() ).toEqual( [
+      'Model: index.ifc — IFC4',
+      `Parsing [0%${'.'.repeat( FULL_DOTS )}100%] 3.2s, +210 MB heap`,
+      `Geometry [0%${'.'.repeat( FULL_DOTS )}100%] 41.0s, +388 MB heap`,
+      'Total: 44.3s, 500 → 1100 MB heap',
+    ] )
+  } )
+
+  test( 'handles indeterminate stages and missing memory', () => {
+
+    const log = new LoadLogAccumulator()
+
+    log.onProgress( { phase: 'geometry', completed: 0, elapsedMs: 0 } )
+    log.onProgress( { phase: 'geometry', completed: 0, elapsedMs: 12_400 } )
+
+    expect( log.currentLine() ).toBe( 'Geometry [...] 12.4s' )
+
+    log.closeCurrentStage()
+
+    expect( log.totalLine() ).toBe( 'Total: 12.4s' )
+  } )
+
+  test( 'formatSeconds renders one decimal', () => {
+    expect( formatSeconds( SAMPLE_MS ) ).toBe( '3.2s' )
+  } )
+} )

--- a/src/core/progress_log.test.ts
+++ b/src/core/progress_log.test.ts
@@ -3,6 +3,7 @@ import {describe, expect, test} from '@jest/globals'
 import {
   LoadLogAccumulator,
   formatBar,
+  formatMb,
   formatModelLine,
   formatSeconds,
   stageLabel,
@@ -10,21 +11,32 @@ import {
 
 
 const HALF_PERCENT = 56
-const FULL_PERCENT = 100
-const FULL_DOTS = 16
 const HALF_DOTS = 9
 const SAMPLE_MS = 3210
+const SAMPLE_MB = 210
+const LOAD_END_MS = 16_600
+const LOAD_END_MB = 720
 
 describe( 'formatBar', () => {
 
   test( 'grows dots with percent and completes at 100', () => {
     expect( formatBar( 0 ) ).toBe( '[0%0%]' )
     expect( formatBar( HALF_PERCENT ) ).toBe( `[0%${'.'.repeat( HALF_DOTS )}56%]` )
-    expect( formatBar( FULL_PERCENT ) ).toBe( `[0%${'.'.repeat( FULL_DOTS )}100%]` )
   } )
 
   test( 'renders indeterminate without a percent', () => {
     expect( formatBar( void 0 ) ).toBe( '[...]' )
+  } )
+} )
+
+describe( 'formatSeconds / formatMb', () => {
+
+  test( 'seconds render to millisecond precision', () => {
+    expect( formatSeconds( SAMPLE_MS ) ).toBe( '3.210s' )
+  } )
+
+  test( 'memory renders to byte precision', () => {
+    expect( formatMb( SAMPLE_MB ) ).toBe( '210.000000' )
   } )
 } )
 
@@ -44,8 +56,6 @@ describe( 'formatModelLine', () => {
 
   test( 'degrades gracefully with partial info', () => {
     expect( formatModelLine( {} ) ).toBe( 'Model: (unnamed)' )
-    expect( formatModelLine( { fileName: 'a.ifc', schema: 'IFC4' } ) )
-        .toBe( 'Model: a.ifc — IFC4' )
   } )
 } )
 
@@ -55,43 +65,60 @@ describe( 'stageLabel', () => {
     expect( stageLabel( 'headerParse' ) ).toBe( 'Parsing' )
     expect( stageLabel( 'dataParse' ) ).toBe( 'Parsing' )
     expect( stageLabel( 'geometry' ) ).toBe( 'Geometry' )
-    expect( stageLabel( 'convert' ) ).toBe( 'Convert' )
     expect( stageLabel( 'somethingElse' ) ).toBe( 'SomethingElse' )
   } )
 } )
 
 describe( 'LoadLogAccumulator', () => {
 
-  test( 'freezes stage lines with owned deltas and a separate Total', () => {
+  test( 'a completed stage drops its bar and owns the gap until the next begins', () => {
 
     const log = new LoadLogAccumulator()
 
     log.setModelInfo( { fileName: 'index.ifc', schema: 'IFC4' } )
 
-    // Parsing: 0→3200ms, heap 500→710 MB, determinate.
+    // Parsing hits 100% at 3200ms, but the real work runs on to the
+    // geometry transition at 3300ms / 712 MB — the closing stage owns it.
     log.onProgress( { phase: 'dataParse', completed: 0, total: 100, elapsedMs: 0, memoryMb: 500 } )
     log.onProgress(
         { phase: 'dataParse', completed: 100, total: 100, elapsedMs: 3200, memoryMb: 710 } )
 
-    // Geometry begins: closes Parsing.
     const closed = log.onProgress(
         { phase: 'geometry', completed: 0, total: 200, elapsedMs: 3300, memoryMb: 712 } )
 
-    expect( closed ).toBe( `Parsing [0%${'.'.repeat( FULL_DOTS )}100%] 3.2s, +210 MB heap` )
+    // Completed (reached 100%): colon format, no bar, extended to 3300ms.
+    expect( closed ).toBe( 'Parsing: 3.300s, +212.000000 MB heap' )
+  } )
 
+  test( 'a stage frozen below 100% keeps its bar (failure reach)', () => {
+
+    const log = new LoadLogAccumulator()
+
+    log.onProgress( { phase: 'geometry', completed: 0, total: 200, elapsedMs: 0, memoryMb: 712 } )
     log.onProgress(
-        { phase: 'geometry', completed: 112, total: 200, elapsedMs: 44_300, memoryMb: 1100 } )
+        { phase: 'geometry', completed: 112, total: 200, elapsedMs: 41_000, memoryMb: 1100 } )
 
-    expect( log.currentLine() ).toBe( `Geometry [0%${'.'.repeat( HALF_DOTS )}56%] 41.0s, +388 MB heap` )
+    // Live line always shows the bar.
+    expect( log.currentLine() ).toBe(
+        `Geometry [0%${'.'.repeat( HALF_DOTS )}56%] 41.000s, +388.000000 MB heap` )
 
+    // Frozen at 56% (never reached 100%) → keep the bar.
     log.closeCurrentStage()
 
-    expect( log.allLines() ).toEqual( [
-      'Model: index.ifc — IFC4',
-      `Parsing [0%${'.'.repeat( FULL_DOTS )}100%] 3.2s, +210 MB heap`,
-      `Geometry [0%${'.'.repeat( FULL_DOTS )}100%] 41.0s, +388 MB heap`,
-      'Total: 44.3s, 500 → 1100 MB heap',
-    ] )
+    expect( log.finishedLines()[ 0 ] ).toBe(
+        `Geometry [0%${'.'.repeat( HALF_DOTS )}56%] 41.000s, +388.000000 MB heap` )
+  } )
+
+  test( 'closeCurrentStage extends the final stage to the load-end point', () => {
+
+    const log = new LoadLogAccumulator()
+
+    log.onProgress( { phase: 'geometry', completed: 0, elapsedMs: 100, memoryMb: 500 } )
+    // Indeterminate stage, load finishes at 16600ms / 720 MB.
+    log.closeCurrentStage( LOAD_END_MS, LOAD_END_MB )
+
+    expect( log.finishedLines()[ 0 ] ).toBe( 'Geometry: 16.500s, +220.000000 MB heap' )
+    expect( log.totalLine() ).toBe( 'Total: 16.500s, 500.000000 → 720.000000 MB heap' )
   } )
 
   test( 'handles indeterminate stages and missing memory', () => {
@@ -101,14 +128,12 @@ describe( 'LoadLogAccumulator', () => {
     log.onProgress( { phase: 'geometry', completed: 0, elapsedMs: 0 } )
     log.onProgress( { phase: 'geometry', completed: 0, elapsedMs: 12_400 } )
 
-    expect( log.currentLine() ).toBe( 'Geometry [...] 12.4s' )
+    expect( log.currentLine() ).toBe( 'Geometry [...] 12.400s' )
 
     log.closeCurrentStage()
 
-    expect( log.totalLine() ).toBe( 'Total: 12.4s' )
-  } )
-
-  test( 'formatSeconds renders one decimal', () => {
-    expect( formatSeconds( SAMPLE_MS ) ).toBe( '3.2s' )
+    // Indeterminate + complete → colon, no bar, no heap.
+    expect( log.finishedLines()[ 0 ] ).toBe( 'Geometry: 12.400s' )
+    expect( log.totalLine() ).toBe( 'Total: 12.400s' )
   } )
 } )

--- a/src/core/progress_log.ts
+++ b/src/core/progress_log.ts
@@ -1,0 +1,329 @@
+/**
+ * The shared, normalized text rendition of load progress — one format for
+ * the conway CLI, the browser console, and Share's status-bar expando, so a
+ * user pasting either surface produces the same report. Canonical format
+ * spec: Share design/new/load-log-format.md (conway issue #301).
+ *
+ * Deliberately dependency-free (no Logger/Memory/statistics imports):
+ * Share deep-imports this module via the package's `./src/*` export map and
+ * must not drag the engine graph in with it. Inputs are structurally typed
+ * against core/progress.ts's ProgressEvent shape.
+ *
+ * Example output:
+ *
+ *   Model: Arty_Z7.stp — AP214, 38.1 MB, SolidWorks 2021 (SwSTEP 2.0)
+ *   Parsing [0%................100%] 3.2s, +210 MB heap
+ *   Geometry [0%........56%] 41.0s, +388 MB heap
+ *   Total: 44.7s, 512 → 1110 MB heap
+ *
+ * Stage lines own only their deltas (duration, heap growth); Total is not
+ * additive — it is a separate before/after wall-clock + heap observation.
+ */
+
+/** What a header parse can tell us before the full file parse (issue #301). */
+export interface ModelInfo {
+  fileName?: string
+  /** e.g. 'IFC4', 'AP214', or a non-STEP format tag like 'GLB' / 'FBX'. */
+  schema?: string
+  preprocessorVersion?: string
+  originatingSystem?: string
+  byteLength?: number
+}
+
+/**
+ * Structural subset of core/progress.ts's ProgressEvent that the
+ * accumulator consumes — kept local so this module stays import-free.
+ */
+export interface ProgressEventLike {
+  phase: string
+  completed: number
+  total?: number
+  elapsedMs: number
+  memoryMb?: number
+}
+
+/** Display labels for the phase taxonomy; unknown phases title-case as-is. */
+const STAGE_LABELS: Record<string, string> = {
+  download: 'Download',
+  headerParse: 'Parsing',
+  dataParse: 'Parsing',
+  geometry: 'Geometry',
+  sceneBuild: 'Scene',
+  serialize: 'Writing',
+  convert: 'Convert',
+}
+
+const BAR_FULL_DOTS = 16
+const PERCENT = 100
+const MS_PER_SECOND = 1000
+
+/**
+ * Display label for a phase, merging headerParse+dataParse into 'Parsing'.
+ *
+ * @param phase The phase identifier.
+ * @return {string} The stage label.
+ */
+export function stageLabel( phase: string ): string {
+  const known = STAGE_LABELS[ phase ]
+
+  if ( known !== void 0 ) {
+    return known
+  }
+
+  return phase.charAt( 0 ).toUpperCase() + phase.slice( 1 )
+}
+
+/**
+ * Render the ASCII progress bar: dots grow with percent, e.g.
+ * "[0%........56%]", completing as "[0%................100%]".
+ * Indeterminate (no percent) renders "[...]".
+ *
+ * @param percent Percent complete 0-100, or undefined when indeterminate.
+ * @return {string} The rendered bar.
+ */
+export function formatBar( percent?: number ): string {
+  if ( percent === void 0 || !isFinite( percent ) ) {
+    return '[...]'
+  }
+
+  const clamped = Math.max( 0, Math.min( PERCENT, percent ) )
+  const dotCount = Math.round( ( clamped / PERCENT ) * BAR_FULL_DOTS )
+
+  return `[0%${'.'.repeat( dotCount )}${Math.floor( clamped )}%]`
+}
+
+/**
+ * One decimal place of seconds, e.g. "3.2s".
+ *
+ * @param milliseconds Elapsed milliseconds.
+ * @return {string} The formatted duration.
+ */
+export function formatSeconds( milliseconds: number ): string {
+  return `${( milliseconds / MS_PER_SECOND ).toFixed( 1 )}s`
+}
+
+/**
+ * The early model line from header-parse info — printable before the full
+ * file parse (issue #301 follow-up, log line 3).
+ *
+ * @param info The model header info.
+ * @return {string} e.g. "Model: Arty_Z7.stp — AP214, 38.1 MB,
+ * SolidWorks 2021 (SwSTEP 2.0)"
+ */
+export function formatModelLine( info: ModelInfo ): string {
+  const parts: string[] = []
+
+  if ( info.schema !== void 0 && info.schema !== '' ) {
+    parts.push( info.schema )
+  }
+
+  if ( info.byteLength !== void 0 ) {
+    // eslint-disable-next-line no-magic-numbers
+    parts.push( `${( info.byteLength / ( 1024 * 1024 ) ).toFixed( 1 )} MB` )
+  }
+
+  if ( info.originatingSystem !== void 0 && info.originatingSystem !== '' ) {
+    const preprocessor =
+      info.preprocessorVersion !== void 0 && info.preprocessorVersion !== '' ?
+        ` (${info.preprocessorVersion})` : ''
+
+    parts.push( `${info.originatingSystem}${preprocessor}` )
+  } else if ( info.preprocessorVersion !== void 0 && info.preprocessorVersion !== '' ) {
+    parts.push( info.preprocessorVersion )
+  }
+
+  const name = info.fileName !== void 0 && info.fileName !== '' ? info.fileName : '(unnamed)'
+  const detail = parts.length > 0 ? ` — ${parts.join( ', ' )}` : ''
+
+  return `Model: ${name}${detail}`
+}
+
+interface StageState {
+  label: string
+  startElapsedMs: number
+  lastElapsedMs: number
+  startHeapMb?: number
+  lastHeapMb?: number
+  percent?: number
+}
+
+/**
+ * Format one stage's line from its state.
+ *
+ * @param state The stage state.
+ * @param final Whether the stage is finished (renders 100% when determinate).
+ * @return {string} The stage line.
+ */
+function formatStageLine( state: StageState, final: boolean ): string {
+  const percent = final && state.percent !== void 0 ? PERCENT : state.percent
+  const duration = state.lastElapsedMs - state.startElapsedMs
+
+  let heap = ''
+
+  if ( state.startHeapMb !== void 0 && state.lastHeapMb !== void 0 ) {
+    const delta = Math.round( state.lastHeapMb - state.startHeapMb )
+    const sign = delta >= 0 ? '+' : ''
+
+    heap = `, ${sign}${delta} MB heap`
+  }
+
+  return `${state.label} ${formatBar( percent )} ${formatSeconds( duration )}${heap}`
+}
+
+/**
+ * Accumulates progress events into the normalized text report: a live
+ * current-stage line while a stage runs, a frozen line per finished stage,
+ * and a separate before/after Total line.
+ *
+ * Stage transitions are inferred from the event stream (a new label closes
+ * the previous stage), so the same accumulator works for conway's phases
+ * and Share's format-agnostic stages (download/parse/convert/...).
+ */
+export class LoadLogAccumulator {
+
+  private readonly finished_: string[] = []
+  private current_: StageState | undefined
+  private firstElapsedMs_: number | undefined
+  private lastElapsedMs_: number = 0
+  private firstHeapMb_: number | undefined
+  private lastHeapMb_: number | undefined
+  private modelLine_: string | undefined
+
+  /**
+   * Record the model line (from header info) — kept with the report.
+   *
+   * @param info The model header info.
+   * @return {string} The formatted model line.
+   */
+  public setModelInfo( info: ModelInfo ): string {
+    this.modelLine_ = formatModelLine( info )
+
+    return this.modelLine_
+  }
+
+  /**
+   * Feed one progress event; returns the finished stage's line when this
+   * event closed a stage (so callers can mirror it to a console/log once).
+   *
+   * @param event The progress event.
+   * @return {string | undefined} The line for a just-finished stage, if any.
+   */
+  public onProgress( event: ProgressEventLike ): string | undefined {
+    const label = stageLabel( event.phase )
+
+    this.firstElapsedMs_ ??= event.elapsedMs
+    this.lastElapsedMs_ = event.elapsedMs
+
+    if ( event.memoryMb !== void 0 ) {
+      this.firstHeapMb_ ??= event.memoryMb
+      this.lastHeapMb_ = event.memoryMb
+    }
+
+    let closedLine: string | undefined
+
+    if ( this.current_ === void 0 || this.current_.label !== label ) {
+
+      closedLine = this.closeCurrentStage()
+
+      this.current_ = {
+        label,
+        startElapsedMs: event.elapsedMs,
+        lastElapsedMs: event.elapsedMs,
+        startHeapMb: event.memoryMb,
+        lastHeapMb: event.memoryMb,
+      }
+    }
+
+    const current = this.current_
+
+    current.lastElapsedMs = event.elapsedMs
+
+    if ( event.memoryMb !== void 0 ) {
+      current.startHeapMb ??= event.memoryMb
+      current.lastHeapMb = event.memoryMb
+    }
+
+    if ( event.total !== void 0 && event.total > 0 ) {
+      current.percent = ( event.completed / event.total ) * PERCENT
+    }
+
+    return closedLine
+  }
+
+  /**
+   * Close any open stage (e.g. at load end) and freeze its line.
+   *
+   * @return {string | undefined} The closed stage's line, if one was open.
+   */
+  public closeCurrentStage(): string | undefined {
+    if ( this.current_ === void 0 ) {
+      return void 0
+    }
+
+    const line = formatStageLine( this.current_, true )
+
+    this.finished_.push( line )
+    this.current_ = void 0
+
+    return line
+  }
+
+  /**
+   * The live line for the running stage, if any.
+   *
+   * @return {string | undefined} The current stage's animated line.
+   */
+  public currentLine(): string | undefined {
+    if ( this.current_ === void 0 ) {
+      return void 0
+    }
+
+    return formatStageLine( this.current_, false )
+  }
+
+  /**
+   * Lines for finished stages, in completion order.
+   *
+   * @return {string[]} The frozen stage lines.
+   */
+  public finishedLines(): string[] {
+    return this.finished_.slice()
+  }
+
+  /**
+   * The separate before/after Total line: overall wall clock and heap
+   * observation, not a sum of stages.
+   *
+   * @return {string} e.g. "Total: 44.7s, 512 → 1110 MB heap"
+   */
+  public totalLine(): string {
+    const duration = this.lastElapsedMs_ - ( this.firstElapsedMs_ ?? 0 )
+
+    let heap = ''
+
+    if ( this.firstHeapMb_ !== void 0 && this.lastHeapMb_ !== void 0 ) {
+      heap = `, ${Math.round( this.firstHeapMb_ )} → ${Math.round( this.lastHeapMb_ )} MB heap`
+    }
+
+    return `Total: ${formatSeconds( duration )}${heap}`
+  }
+
+  /**
+   * The full report: model line (if known), finished stage lines, then the
+   * Total line. Call closeCurrentStage() first at load end.
+   *
+   * @return {string[]} All report lines.
+   */
+  public allLines(): string[] {
+    const lines: string[] = []
+
+    if ( this.modelLine_ !== void 0 ) {
+      lines.push( this.modelLine_ )
+    }
+
+    lines.push( ...this.finished_ )
+    lines.push( this.totalLine() )
+
+    return lines
+  }
+}

--- a/src/core/progress_log.ts
+++ b/src/core/progress_log.ts
@@ -56,6 +56,10 @@ const STAGE_LABELS: Record<string, string> = {
 const BAR_FULL_DOTS = 16
 const PERCENT = 100
 const MS_PER_SECOND = 1000
+// Seconds to millisecond precision, memory to byte precision (6 decimals of
+// MB ≡ bytes) — issue #301 preview feedback.
+const SECONDS_DECIMALS = 3
+const MB_DECIMALS = 6
 
 /**
  * Display label for a phase, merging headerParse+dataParse into 'Parsing'.
@@ -99,7 +103,17 @@ export function formatBar( percent?: number ): string {
  * @return {string} The formatted duration.
  */
 export function formatSeconds( milliseconds: number ): string {
-  return `${( milliseconds / MS_PER_SECOND ).toFixed( 1 )}s`
+  return `${( milliseconds / MS_PER_SECOND ).toFixed( SECONDS_DECIMALS )}s`
+}
+
+/**
+ * Format a memory value in MB to byte precision (6 decimals).
+ *
+ * @param megabytes The value in MB.
+ * @return {string} e.g. "720.000000"
+ */
+export function formatMb( megabytes: number ): string {
+  return megabytes.toFixed( MB_DECIMALS )
 }
 
 /**
@@ -148,26 +162,50 @@ interface StageState {
 }
 
 /**
- * Format one stage's line from its state.
+ * The signed heap-delta suffix for a stage, byte precision, e.g.
+ * ", +663.000000 MB heap" — empty when memory wasn't sampled.
  *
  * @param state The stage state.
- * @param final Whether the stage is finished (renders 100% when determinate).
+ * @return {string} The heap suffix (may be empty).
+ */
+function heapDeltaSuffix( state: StageState ): string {
+  if ( state.startHeapMb === void 0 || state.lastHeapMb === void 0 ) {
+    return ''
+  }
+
+  const delta = state.lastHeapMb - state.startHeapMb
+  const sign = delta >= 0 ? '+' : '-'
+
+  return `, ${sign}${formatMb( Math.abs( delta ) )} MB heap`
+}
+
+/**
+ * Format one stage's line from its state (issue #301 preview feedback):
+ *
+ * - a live stage shows its bar (determinate `[0%..56%]`, indeterminate
+ *   `[...]`) — it's still running;
+ * - a completed stage drops the bar entirely: `Label: 1.234s, +N MB heap`;
+ * - a stage frozen *before* reaching 100% (a failed/aborted determinate
+ *   stage) keeps its bar to show how far it got: `Label [0%..57%] …`.
+ *
+ * @param state The stage state.
+ * @param final Whether the stage is finished (frozen).
  * @return {string} The stage line.
  */
 function formatStageLine( state: StageState, final: boolean ): string {
-  const percent = final && state.percent !== void 0 ? PERCENT : state.percent
   const duration = state.lastElapsedMs - state.startElapsedMs
+  const heap = heapDeltaSuffix( state )
+  const determinate = state.percent !== void 0
 
-  let heap = ''
-
-  if ( state.startHeapMb !== void 0 && state.lastHeapMb !== void 0 ) {
-    const delta = Math.round( state.lastHeapMb - state.startHeapMb )
-    const sign = delta >= 0 ? '+' : ''
-
-    heap = `, ${sign}${delta} MB heap`
+  // Completed: no bar, colon-separated. A determinate stage that stopped
+  // short of 100% is a failure — keep its bar to show the reach.
+  if ( final && !( determinate && ( state.percent as number ) < PERCENT ) ) {
+    return `${state.label}: ${formatSeconds( duration )}${heap}`
   }
 
-  return `${state.label} ${formatBar( percent )} ${formatSeconds( duration )}${heap}`
+  const bar = formatBar( determinate ? state.percent : void 0 )
+
+  return `${state.label} ${bar} ${formatSeconds( duration )}${heap}`
 }
 
 /**
@@ -223,7 +261,10 @@ export class LoadLogAccumulator {
 
     if ( this.current_ === void 0 || this.current_.label !== label ) {
 
-      closedLine = this.closeCurrentStage()
+      // A stage ends when the next begins — extend the outgoing stage to
+      // this transition point so its duration/heap cover the real elapsed
+      // gap (a stage that got only its opening event would otherwise read 0).
+      closedLine = this.closeCurrentStage( event.elapsedMs, event.memoryMb )
 
       this.current_ = {
         label,
@@ -251,13 +292,27 @@ export class LoadLogAccumulator {
   }
 
   /**
-   * Close any open stage (e.g. at load end) and freeze its line.
+   * Close any open stage (e.g. at load end) and freeze its line. When an
+   * end point is given, the stage is extended to it first (a stage ends
+   * when the next begins, or when the load finishes).
    *
+   * @param atElapsedMs Elapsed ms to extend the stage to before freezing.
+   * @param atMemoryMb Heap MB to extend the stage to before freezing.
    * @return {string | undefined} The closed stage's line, if one was open.
    */
-  public closeCurrentStage(): string | undefined {
+  public closeCurrentStage( atElapsedMs?: number, atMemoryMb?: number ): string | undefined {
     if ( this.current_ === void 0 ) {
       return void 0
+    }
+
+    if ( atElapsedMs !== void 0 ) {
+      this.current_.lastElapsedMs = atElapsedMs
+      this.lastElapsedMs_ = atElapsedMs
+    }
+
+    if ( atMemoryMb !== void 0 ) {
+      this.current_.lastHeapMb = atMemoryMb
+      this.lastHeapMb_ = atMemoryMb
     }
 
     const line = formatStageLine( this.current_, true )
@@ -302,7 +357,7 @@ export class LoadLogAccumulator {
     let heap = ''
 
     if ( this.firstHeapMb_ !== void 0 && this.lastHeapMb_ !== void 0 ) {
-      heap = `, ${Math.round( this.firstHeapMb_ )} → ${Math.round( this.lastHeapMb_ )} MB heap`
+      heap = `, ${formatMb( this.firstHeapMb_ )} → ${formatMb( this.lastHeapMb_ )} MB heap`
     }
 
     return `Total: ${formatSeconds( duration )}${heap}`

--- a/src/ifc/ifc_command_line_main.ts
+++ b/src/ifc/ifc_command_line_main.ts
@@ -451,7 +451,8 @@ function doWork() {
             statistics.setMemoryStatistics(Memory.checkMemoryUsage())
           }
 
-          progressRenderer?.done()
+          progressRenderer?.done(
+              Date.now() - allTimeStart, Memory.usedHeapMb())
 
           Logger.displayLogs()
           Logger.printStatistics(modelID)

--- a/src/ifc/ifc_command_line_main.ts
+++ b/src/ifc/ifc_command_line_main.ts
@@ -21,7 +21,7 @@ import Environment from '../utilities/environment'
 import Memory from '../memory/memory'
 import { ExtractResult } from '../core/shared_constants'
 import path from 'path'
-import { parseFileHeader } from '../loaders/loading_utilities'
+import { extractModelInfo, parseFileHeader } from '../loaders/loading_utilities'
 
 // create a model ID
 const modelID: number = 0
@@ -221,6 +221,9 @@ function doWork() {
           const [stepHeader, result0] = parser.parseHeader(bufferInput)
 
           const headerDataTimeEnd = Date.now()
+
+          // Model line as early as possible — header-only (issue #301).
+          progressRenderer?.onModelInfo(extractModelInfo(stepHeader, indexIfcBuffer.length))
 
           switch (result0) {
             case ParseResult.COMPLETE:

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -4099,6 +4099,15 @@ export class IfcGeometryExtraction {
   }
 
   /**
+   * Increment the geometry-type breakdown counter for a type name.
+   *
+   * @param name The entity type name.
+   */
+  private countGeometryType(name: string): void {
+    this.geometryTypeCounts.set(name, (this.geometryTypeCounts.get(name) ?? 0) + 1)
+  }
+
+  /**
    * Extract a representation item, including its geometry if necessary,
    * adding it to the current scene walk.
    *
@@ -4110,15 +4119,6 @@ export class IfcGeometryExtraction {
    * @param isSpace
    * @param isMappedItem
    */
-  /**
-   * Increment the geometry-type breakdown counter for a type name.
-   *
-   * @param name The entity type name.
-   */
-  private countGeometryType(name: string): void {
-    this.geometryTypeCounts.set(name, (this.geometryTypeCounts.get(name) ?? 0) + 1)
-  }
-
   extractRepresentationItem(from: IfcRepresentationItem,
       owningElementLocalID?: number,
       isRelVoid: boolean = false,

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -371,6 +371,14 @@ export class IfcGeometryExtraction {
 
   private csgMemoization: boolean = true
 
+  /**
+   * Count of newly-extracted representation items by IFC entity type name
+   * (e.g. IFCEXTRUDEDAREASOLID, IFCFACETEDBREP, IFCBOOLEANCLIPPINGRESULT) —
+   * the geometry breakdown for the load report (issue #301 follow-up).
+   * Copied into Statistics by the loader/proxies after extraction.
+   */
+  public readonly geometryTypeCounts = new Map<string, number>()
+
   private csgDepth: number = 0
 
   /**
@@ -4102,6 +4110,15 @@ export class IfcGeometryExtraction {
    * @param isSpace
    * @param isMappedItem
    */
+  /**
+   * Increment the geometry-type breakdown counter for a type name.
+   *
+   * @param name The entity type name.
+   */
+  private countGeometryType(name: string): void {
+    this.geometryTypeCounts.set(name, (this.geometryTypeCounts.get(name) ?? 0) + 1)
+  }
+
   extractRepresentationItem(from: IfcRepresentationItem,
       owningElementLocalID?: number,
       isRelVoid: boolean = false,
@@ -4137,7 +4154,14 @@ export class IfcGeometryExtraction {
 
       // mapped items are handled separately.
       return
-    } else if (from instanceof IfcPolygonalFaceSet) {
+    }
+
+    // Geometry-type breakdown for the load report (issue #301 follow-up):
+    // counted here, after the memoization early-return, so each unique
+    // geometry definition counts once regardless of instancing.
+    this.countGeometryType(EntityTypesIfc[from.type])
+
+    if (from instanceof IfcPolygonalFaceSet) {
 
       const faceSetResult: ExtractResult =
         this.extractPolygonalFaceSet(from, false, isRelVoid)

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {
   ModelInfo,
   ProgressEventLike,
   formatBar,
+  formatMb,
   formatModelLine,
   formatSeconds,
   stageLabel,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,12 @@ export {
   yieldToEventLoop,
 } from './core/progress'
 export { ModelLoadOptions } from './loaders/conway_model_loader'
+export {
+  LoadLogAccumulator,
+  ModelInfo,
+  ProgressEventLike,
+  formatBar,
+  formatModelLine,
+  formatSeconds,
+  stageLabel,
+} from './core/progress_log'

--- a/src/loaders/conway_model_loader.ts
+++ b/src/loaders/conway_model_loader.ts
@@ -3,16 +3,18 @@ import { AP214GeometryExtraction } from '../AP214E3_2010/ap214_geometry_extracti
 import AP214StepParser from '../AP214E3_2010/ap214_step_parser'
 import { Model } from '../core/model'
 import { ProgressCallback, ProgressTracker } from '../core/progress'
+import { ModelInfo, formatModelLine } from '../core/progress_log'
 import { Scene } from '../core/scene'
 import { ExtractResult } from '../core/shared_constants'
 import ModelFormatDetector, { ModelFormatType } from '../format_detection/model_format_detector'
 import { IfcGeometryExtraction } from '../ifc/ifc_geometry_extraction'
+import { IfcProduct } from '../ifc/ifc4_gen'
 import IfcStepParser from '../ifc/ifc_step_parser'
 import Logger from '../logging/logger'
 import Memory from '../memory/memory'
 import ParsingBuffer from '../parsing/parsing_buffer'
 import { ParseResult } from '../step/parsing/step_parser'
-import { parseFileHeader } from './loading_utilities'
+import { extractModelInfo, parseFileHeader } from './loading_utilities'
 
 const ONE_KB = 1024
 const ONE_MB = ONE_KB * ONE_KB
@@ -37,6 +39,13 @@ export interface ModelLoadOptions {
 
   /** Minimum ms between progress events (default in core/progress.ts). */
   progressIntervalMs?: number
+
+  /**
+   * Fired once, right after the STEP header parses — before the full file
+   * parse — with everything the header reveals, so callers can print the
+   * model line as early as possible (issue #301 follow-up, log line 3).
+   */
+  onModelInfo?: ( info: ModelInfo ) => void
 }
 
 /**
@@ -149,6 +158,14 @@ export class ConwayModelLoader {
             default:
           }
 
+          {
+            // Model line as early as possible — header-only (issue #301).
+            const modelInfo = extractModelInfo( stepHeader, data.length )
+
+            Logger.info( formatModelLine( modelInfo ) )
+            options?.onModelInfo?.( modelInfo )
+          }
+
           tracker?.beginPhase( 'dataParse', 'bytes', data.length )
 
           const parseTick = tracker !== void 0 ?
@@ -217,6 +234,8 @@ export class ConwayModelLoader {
           statistics.setGeometryMemory(
                
               conwayModel.model.geometry.calculateGeometrySize() / (ONE_MB))
+
+          statistics.setGeometryTypeCounts(conwayModel.geometryTypeCounts)
 
           model.invalidate(true)
 
@@ -341,6 +360,14 @@ export class ConwayModelLoader {
             default:
           }
 
+          {
+            // Model line as early as possible — header-only (issue #301).
+            const modelInfo = extractModelInfo( stepHeader, data.length )
+
+            Logger.info( formatModelLine( modelInfo ) )
+            options?.onModelInfo?.( modelInfo )
+          }
+
           tracker?.beginPhase( 'dataParse', 'bytes', data.length )
 
           const parseTick = tracker !== void 0 ?
@@ -423,6 +450,9 @@ export class ConwayModelLoader {
           if (ifcProjectName !== null) {
             statistics.setProjectName(ifcProjectName)
           }
+
+          statistics.setProductCount(model.typeCount(IfcProduct))
+          statistics.setGeometryTypeCounts(conwayModel.geometryTypeCounts)
 
           model.invalidate(true)
 

--- a/src/loaders/loading_utilities.ts
+++ b/src/loaders/loading_utilities.ts
@@ -1,3 +1,6 @@
+import { ModelInfo } from '../core/progress_log'
+import { StepHeader } from '../step/parsing/step_parser'
+
 
 /**
  * Parse a FILE_HEADER header from a STEP file to extract relevant info.
@@ -31,4 +34,65 @@ export function parseFileHeader(input: string): string[] {
   }
 
   return result
+}
+
+
+// FILE_NAME field positions per ISO 10303-21:
+// (name, time_stamp, author, organization, preprocessor_version,
+//  originating_system, authorization)
+const FILE_NAME_NAME = 0
+const FILE_NAME_PREPROCESSOR = 5
+const FILE_NAME_ORIGINATING_SYSTEM = 6
+
+/**
+ * Extract the early model line's fields from a parsed STEP header — this is
+ * everything we can know before the full file parse (issue #301 follow-up:
+ * "output this as early as possible"). Values are unquoted for display.
+ *
+ * @param stepHeader The parsed STEP header.
+ * @param byteLength The source buffer size in bytes.
+ * @return {ModelInfo} The extracted info (fields undefined when absent).
+ */
+export function extractModelInfo( stepHeader: StepHeader, byteLength: number ): ModelInfo {
+
+  const info: ModelInfo = { byteLength }
+
+  const schemaRaw = stepHeader.headers.get( 'FILE_SCHEMA' )
+
+  if ( schemaRaw !== void 0 ) {
+    // Shaped like (('IFC4')) / (('AP214...')): pull the first quoted token.
+    const match = schemaRaw.match( /'([^']+)'/ )
+
+    info.schema = match !== null ? match[ 1 ] : schemaRaw
+  }
+
+  let fileNameRaw = stepHeader.headers.get( 'FILE_NAME' )
+
+  if ( fileNameRaw !== void 0 ) {
+    // strip start / end parenthesis (mirrors the statistics path)
+    fileNameRaw = fileNameRaw.substring( 1, fileNameRaw.length - 1 )
+
+    const fields = parseFileHeader( fileNameRaw )
+
+    const unquote = ( value: string | undefined ): string | undefined => {
+      if ( value === void 0 ) {
+        return void 0
+      }
+
+      const trimmed = value.trim()
+
+      return trimmed.replace( /^'/, '' ).replace( /'$/, '' )
+    }
+
+    const name = unquote( fields[ FILE_NAME_NAME ] )
+
+    if ( name !== void 0 && name !== '' ) {
+      info.fileName = name
+    }
+
+    info.preprocessorVersion = unquote( fields[ FILE_NAME_PREPROCESSOR ] )
+    info.originatingSystem = unquote( fields[ FILE_NAME_ORIGINATING_SYSTEM ] )
+  }
+
+  return info
 }

--- a/src/statistics/statistics.ts
+++ b/src/statistics/statistics.ts
@@ -15,6 +15,8 @@ export class Statistics {
   private preprocessorVersion: string | undefined
   private originatingSystem: string | undefined
   private memoryStatistics: string | undefined
+  private productCount: number | undefined
+  private geometryTypeCounts: Map<string, number> | undefined
 
   // Getters and setters
 
@@ -179,6 +181,64 @@ export class Statistics {
   }
 
   /**
+   *
+   * @return {number | undefined} - number of products extracted
+   */
+  getProductCount(): number | undefined {
+    return this.productCount
+  }
+
+  /**
+   *
+   * @param value - number of products extracted
+   */
+  setProductCount(value: number) {
+    this.productCount = value
+  }
+
+  /**
+   *
+   * @return {Map<string, number> | undefined} - geometry type breakdown
+   * (entity type name -> count of unique geometry definitions extracted)
+   */
+  getGeometryTypeCounts(): Map<string, number> | undefined {
+    return this.geometryTypeCounts
+  }
+
+  /**
+   *
+   * @param value - geometry type breakdown map
+   */
+  setGeometryTypeCounts(value: Map<string, number>) {
+    this.geometryTypeCounts = value
+  }
+
+  /**
+   * Format the geometry-type breakdown as a compact sorted list, e.g.
+   * "IFCEXTRUDEDAREASOLID×3421 IFCFACETEDBREP×212 (+3 more)".
+   *
+   * @param maxEntries - cap on listed types (rest summarized)
+   * @return {string | undefined} the formatted breakdown, if any
+   */
+  // eslint-disable-next-line no-magic-numbers
+  formatGeometryTypeCounts(maxEntries: number = 12): string | undefined {
+    if (this.geometryTypeCounts === void 0 || this.geometryTypeCounts.size === 0) {
+      return void 0
+    }
+
+    const sorted = Array.from(this.geometryTypeCounts.entries())
+        .sort((leftEntry, rightEntry) => rightEntry[1] - leftEntry[1])
+
+    const shown = sorted.slice(0, maxEntries)
+        .map(([name, count]) => `${name}×${count}`)
+        .join(' ')
+
+    const remainder = sorted.length - maxEntries
+
+    return remainder > 0 ? `${shown} (+${remainder} more)` : shown
+  }
+
+  /**
    * prints statistics
    */
   printStatistics(): void {
@@ -225,14 +285,21 @@ export class Statistics {
       versionStr = 'Version not defined'
     }
 
+    const products = this.productCount !== void 0 ?
+      `Products: ${this.productCount}, ` : ''
+    const breakdown = this.formatGeometryTypeCounts()
+    const geometryTypes = breakdown !== void 0 ? `, Geometry Types: ${breakdown}` : ''
+
     return `[${dateString}]: Load Status: ${this.loadStatus}, ` +
             `Project Name: ${this.projectName}, Version: ${versionStr}, ` +
             `Conway Version: ${conwayVersionNumber}-${wasmType}, ` +
             `Parse Time: ${this.parseTime} ms, Geometry Time: ${this.geometryTime} ms, ` +
             `Total Time: ${this.totalTime} ms, ` +
             `Geometry Memory: ${this.geometryMemory?.toFixed(3)} MB, ` +
+            products +
             `Memory Statistics: ${this.memoryStatistics}, ` +
             `Preprocessor Version: ${this.preprocessorVersion}, ` +
-            `Originating System: ${this.originatingSystem}`
+            `Originating System: ${this.originatingSystem}` +
+            geometryTypes
   }
 }

--- a/src/version/version.ts
+++ b/src/version/version.ts
@@ -5,7 +5,7 @@
 // only the first segment (major) is meaningful and is the one CI carries forward.
 // Must stay in `vN.N.N` shape: the CI stamp regex, scripts/updateVersion.mjs, and
 // statistics.ts all match `v\d+\.\d+\.\d+`.
-const versionString: string = 'Conway Web-Ifc Shim v1.0.0'
+const versionString: string = 'Conway v1.0.0'
 
 
 export {versionString}


### PR DESCRIPTION
Follow-up to #377 for issue #301, from preview feedback on Share PR bldrs-ai/Share#1593: one normalized text rendition of a load shared by the CLI and Share, an early model line, STEP progress parity, and a geometry-type breakdown in the stats.

## The shared load-log format (`core/progress_log.ts`)

```
Model: Arty_Z7.stp — AP214, 38.1 MB, SolidWorks 2021 (SwSTEP 2.0)
Parsing [0%................100%] 3.2s, +210 MB heap
Geometry [0%........56%] 41.0s, +388 MB heap        ← live/animated line
Total: 46.3s, 512 → 1110 MB heap                    ← separate before/after, not additive
```

- `LoadLogAccumulator` + formatters: stage lines own *only their deltas* (duration, signed heap growth); Total is a separate before/after wall-clock + heap observation. Determinate stages grow an ASCII bar (16 dots ≡ 100%); indeterminate render `[...]`.
- Dependency-free by design: Share deep-imports it via the `./src/*` export map so both surfaces render identical text (spec: Share `design/new/load-log-format.md`). The CLI renderer (`cli_progress_renderer.ts`) is rebuilt on it — frozen stage lines + animated current line + Total, all on stderr.

## Early model line (issue log-line 3)

`extractModelInfo` pulls file name, schema, preprocessor + originating system from the parsed STEP header and emits **right after headerParse** — not dependent on the full file parse — via `Logger.info`, the shim's new `Loadersettings.ON_MODEL_INFO`, and `ModelLoadOptions.onModelInfo`.

## STEP/AP214 progress parity

`IfcApiProxyAP214` refactored like the IFC proxy (`parseAndExtract`/`Async` + `createAsync`): ON_PROGRESS ticks for header/dataParse (determinate in bytes), heartbeat geometry phase, ON_MODEL_INFO. The factory's `fromAsync` now routes AP203/AP242/AP214 through the cooperative path — Arty_Z7-class STEP loads report like IFC.

## Geometry-type breakdown

Both extractors count newly-extracted representation items by entity type (after the memoization early-return, so unique definitions — not instances). `Statistics` carries `productCount` + `geometryTypeCounts` and formats them into the summary line: `Products: 9000, … Geometry Types: IFCEXTRUDEDAREASOLID×3421 IFCFACETEDBREP×212 (+3 more)`.

## Version string

`'Conway Web-Ifc Shim vN'` → `'Conway vN'` (the web-ifc surface is a compat layer being deprecated). `scripts/updateVersion.mjs` and the CI stamp in `build.yml` updated together; the stamp regex tolerates both prefixes for the transition.

## Tests

`progress_log` formatting vectors (bar growth, model line, stage deltas, indeterminate stages, Total) — mirrored byte-for-byte by Share's interim copy so the later import swap is safe. Full suite green: 41 suites / 192 tests.

## Follow-ups

- AP214 determinate geometry (needs a flat walk over the thunk tree).
- Per-type max mesh sizes in the breakdown.
- After merge + publish: Share pin bump + swap its interim `loadLogFormat.js` for the deep import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGQbMmcVsehX9FwCFKuYyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGQbMmcVsehX9FwCFKuYyf)_