### PR TITLE
Roots-only express ID iteration (type-index only, spill-safe)

### DIFF
--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -421,6 +421,35 @@ export class IfcAPI {
   }
 
   /**
+   * Conway extension: lazily iterate the express IDs of all root-derived
+   * (GlobalId-bearing) entities — products, relationships, property sets,
+   * quantities — straight from the type index. No entity descriptors are
+   * materialised and the source buffer is never touched, so this is safe
+   * and cheap even after SpillModelSource, and lets property sweeps skip
+   * the geometric-resource records that dominate large models.
+   *
+   * Multi-mapped entities may be yielded once per mapping; callers that
+   * need distinct IDs should dedupe. Returns undefined when the model
+   * doesn't exist or its schema has no root-type notion (e.g. AP214).
+   *
+   * @param modelID The model to iterate.
+   * @return {IterableIterator<number> | undefined} Lazy express ID
+   * iterator, or undefined when unsupported.
+   */
+  RootExpressIDs(modelID: number): IterableIterator<number> | undefined {
+
+    const result = this.models.get(modelID)
+
+    if (result === void 0) {
+
+      Logger.error('[RootExpressIDs]: model === undefined')
+      return void 0
+    }
+
+    return result.rootExpressIDs?.()
+  }
+
+  /**
    *
    * @param modelID
    * @return {Vector<LoaderError>}

--- a/src/compat/web-ifc/ifc_api_model_passthrough.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough.ts
@@ -45,4 +45,12 @@ export interface IfcApiModelPassthrough {
    * synchronous read succeeds. Fast no-op while fully resident.
    */
   ensureLineResident?( expressID: number ): Promise< void >
+
+  /**
+   * Optional: lazily iterate the express IDs of all root-derived
+   * (GlobalId-bearing) entities via the type index, without
+   * materialising entities or touching the source buffer.
+   * Multi-mapped entities may repeat; callers should dedupe.
+   */
+  rootExpressIDs?(): IterableIterator< number >
 }

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -34,7 +34,7 @@ import Memory from '../../memory/memory'
 import { FromRawLineData } from './ifc2x4_helper'
 import { shimIfcEntityMap, shimIfcEntityReverseMap } from './shim_schema_mapping'
 import { EntityTypesIfcCount } from '../../ifc/ifc4_gen/entity_types_ifc.gen'
-import { IfcProduct } from '../../ifc/ifc4_gen'
+import { IfcProduct, IfcRoot } from '../../ifc/ifc4_gen'
 import { CanonicalMeshType } from '../../index'
 
 /**
@@ -758,6 +758,22 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    */
   async ensureLineResident(expressID: number): Promise<void> {
     await this.model[0].ensureResidentByExpressID(expressID)
+  }
+
+  /**
+   * Lazily iterate the express IDs of all IfcRoot-derived entities
+   * (products, relationships, property sets, quantities — everything
+   * carrying a GlobalId) straight from the type index, without
+   * materialising entity descriptors or touching the source buffer.
+   *
+   * This lets property sweeps skip the ~96% of records in large models
+   * that are geometric resources, and stays safe on a spilled source.
+   * Multi-mapped entities may repeat, so callers should dedupe.
+   *
+   * @return {IterableIterator<number>} Express IDs of IfcRoot subtypes.
+   */
+  rootExpressIDs(): IterableIterator<number> {
+    return this.model[0].expressIDsOfTypes(IfcRoot)
   }
 
   /**

--- a/src/compat/web-ifc/ifc_root_express_ids.test.ts
+++ b/src/compat/web-ifc/ifc_root_express_ids.test.ts
@@ -1,0 +1,106 @@
+/* eslint-disable no-magic-numbers */
+// Tests for the roots-only express ID iterator (RootExpressIDs).
+//
+// Parity requirement: the iterator yields exactly the GlobalId-bearing
+// (IfcRoot-derived) records — no geometric resources — and it must do so
+// straight from the type index: no descriptor materialisation and no
+// source-buffer reads, so it keeps working on a spilled model with
+// nothing resident (where sync getLine throws).
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { InMemoryStepByteStore } from '../../step/step_buffer_provider'
+import { IfcAPI } from './ifc_api'
+
+const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
+
+// Tiny windows force the spilled model to have ~nothing resident.
+const CHUNK_BYTES = 512
+const MAX_RESIDENT_CHUNKS = 3
+
+let api: IfcAPI
+let buffer: Uint8Array
+
+/** Open a fresh model from the shared fixture bytes. */
+function openModel(): number {
+  return api.OpenModel(buffer, SETTINGS)
+}
+
+/**
+ * Collect the distinct express IDs of records whose decoded properties
+ * carry a GlobalId — the ground truth the type-index iterator must match.
+ *
+ * @param modelID The model to sweep.
+ * @return {Promise<Set<number>>} Express IDs of GlobalId-bearing records.
+ */
+async function globalIdBearingIDs(modelID: number): Promise<Set<number>> {
+  const lineIDs = api.getPassthrough(modelID)!.getAllLines()
+  const result = new Set<number>()
+
+  for (let i = 0; i < lineIDs.size(); i++) {
+    const expressID = lineIDs.get(i)
+    const properties = await api.properties.getItemProperties(modelID, expressID)
+
+    if (properties?.GlobalId !== void 0 && properties?.GlobalId !== null) {
+      result.add(expressID)
+    }
+  }
+
+  return result
+}
+
+beforeAll(async () => {
+  api = new IfcAPI()
+  await api.Init()
+
+  buffer = new Uint8Array(fs.readFileSync('data/index.ifc'))
+}, 120000)
+
+describe('RootExpressIDs', () => {
+
+  test('yields exactly the GlobalId-bearing records', async () => {
+    const modelID = openModel()
+
+    const expected = await globalIdBearingIDs(modelID)
+
+    // Multi-mapped entities may repeat, so dedupe through a Set.
+    const roots = new Set(api.RootExpressIDs(modelID)!)
+
+    expect(roots.size).toBeGreaterThan(10)
+    expect(roots).toEqual(expected)
+
+    // And strictly fewer records than the whole model — the point is
+    // skipping the geometric resources.
+    const totalLines = api.getPassthrough(modelID)!.getAllLines().size()
+
+    expect(roots.size).toBeLessThan(totalLines)
+
+    api.CloseModel(modelID)
+  }, 120000)
+
+  test('works on a spilled model with nothing resident', async () => {
+    const modelID = openModel()
+    const passthrough = api.getPassthrough(modelID)! as any
+
+    const before = new Set(api.RootExpressIDs(modelID)!)
+    const firstID = passthrough.getAllLines().get(0)
+
+    api.SpillModelSource(
+        modelID, new InMemoryStepByteStore(buffer), CHUNK_BYTES, MAX_RESIDENT_CHUNKS)
+    api.ReleaseEntityCache(modelID)
+
+    // Sanity: the sync record path really is non-resident here...
+    expect(() => passthrough.getLine(firstID)).toThrow(/not resident/)
+
+    // ...yet the iterator never touches the source buffer, so it still
+    // yields the identical set.
+    expect(new Set(api.RootExpressIDs(modelID)!)).toEqual(before)
+
+    api.CloseModel(modelID)
+  }, 120000)
+
+  test('returns undefined for a missing model', () => {
+    expect(api.RootExpressIDs(999999)).toBeUndefined()
+  })
+})

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -892,6 +892,50 @@ implements Iterable<BaseEntity>, Model {
   }
 
   /**
+   * Iterate the express IDs of entities of a set of types (including sub-types)
+   * without materializing entity descriptors or touching the source buffer —
+   * only the type index and the express ID column are read, so this stays cheap
+   * and safe even when the model source has been spilled to an external store.
+   *
+   * Multi-mapped elements (e.g. complex/multi-entity mappings) may be yielded
+   * once per matching mapping, so callers that need distinct IDs should dedupe.
+   *
+   * @param types The list of types to iterate.
+   * @return {IterableIterator} A lazy iterator of express IDs for matching entities.
+   * @yields {number} The express ID of each matching entity.
+   */
+  public* expressIDsOfTypes<T extends StepEntityConstructorAbstract<EntityTypeIDs>[]>(
+      ...types: T ): IterableIterator<number> {
+    const distinctTypes = types.length === 1 ? (types[0].query) :
+      (new Set(types.flatMap((type) => type.query)))
+
+    const cursor             = this.typeIndex.cursor(...distinctTypes)
+    const expressIDs         = this.expressID_
+    const firstInlineElement = this.firstInlineElement_
+
+    try {
+      while (cursor.step()) {
+        const high = cursor.high
+        let low = cursor.low
+
+        while (low !== 0) {
+          const lowestOneHot = extractOneHotLow(low)
+
+          low ^= (1 << lowestOneHot)
+
+          const localID = (high | lowestOneHot)
+
+          if (localID < firstInlineElement) {
+            yield expressIDs[ localID ]
+          }
+        }
+      }
+    } finally {
+      cursor.free()
+    }
+  }
+
+  /**
    * Get the non empty type IDs for this.
    *
    * @return {Set} The unique set of non empty type IDs for this model.


### PR DESCRIPTION
## What

Adds a type-filtered iteration path so property sweeps can enumerate the IfcRoot-derived records (products, relationships, psets, quantities — everything GlobalId-bearing) straight from the type index, instead of walking every line in the model:

- `StepModelBase.expressIDsOfTypes(...types)` — lazy generator mirroring `from()`'s cursor decode, but yielding express IDs directly. No entity descriptors are materialised and the source buffer is never touched, so it's cheap and stays safe on a spilled (windowed) source.
- `IfcApiProxyIfc.rootExpressIDs()` + optional `IfcApiModelPassthrough` member — the IfcRoot subtype closure via the generated constructor `query`.
- `IfcAPI.RootExpressIDs(modelID)` — shim surface for consumers (Share). Returns `undefined` for missing models or schemas without a root notion (AP214), so callers can fall back to the full walk.

## Why

Share's property sweeps currently iterate `GetAllLines()` and probe each record, materialising millions of entity descriptors on large models just to find the small GlobalId-bearing subset (PSB: ~341k roots out of ~9.7M entities). This is the dominant cost and transient-heap driver of the props capture pass, and it's the natural complement to the source spill: the roots enumeration itself now needs no source bytes at all.

Design doc: `design/new/memory-residency.md` (follow-up consumption step lands in Share, tracked in `bldrs-ai/Share design/new/lazy-properties-memory.md`).

## Measurements (SKYLARK, 7.8M entities)

| | ids | time | heap delta |
|---|---|---|---|
| `GetAllLines()` vector | 29,246,847 | 11,574 ms | (vector alloc) |
| `RootExpressIDs()` (deduped) | 3,647 | 4 ms | 0.0 MB |

Iteration after `ReleaseEntityCache` shows zero heap growth — confirming no descriptor rematerialisation.

## Tests

`src/compat/web-ifc/ifc_root_express_ids.test.ts`:
- Parity: deduped iterator output equals the ground-truth set of records whose decoded properties carry a `GlobalId` (full `getItemProperties` sweep of `data/index.ifc`), and is strictly smaller than the line count.
- Spill safety: after `SpillModelSource` with tiny windows + `ReleaseEntityCache`, sync `getLine` throws not-resident, yet the iterator still yields the identical set.
- Missing model returns `undefined`.

Existing spill suite (`ifc_spill_source.test.ts`) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_