### PR TITLE
Resolve arbitrary express ids to STEP type + name in getItemProperties

### DIFF
--- a/src/compat/web-ifc/ap214_properties.test.ts
+++ b/src/compat/web-ifc/ap214_properties.test.ts
@@ -182,3 +182,47 @@ describe( 'compat/web-ifc/AP214Properties', () => {
     expect( await surface.getPropertySets( root.expressID ) ).toEqual( [] )
   } )
 } )
+
+
+describe( 'getItemProperties arbitrary-entity fallback (anonymous geometry)', () => {
+
+  test( 'resolves a non-tree solid id to its STEP type and body name', async () => {
+
+    // Body1 (#431) is a solid inside the widget product's representation —
+    // never a tree node unless the ephemeral solid layer is requested, so it
+    // exercises the express-id-index fallback a picked anonymous piece takes.
+    const surface = compatSurfaceFor( 'data/ap214-multibody-part.step' )
+    const solidExpressId = 431
+
+    const item: any = await surface.getItemProperties( solidExpressId )
+
+    expect( item.expressID ).toBe( solidExpressId )
+    expect( item.type ).toBe( 'MANIFOLD_SOLID_BREP' )
+    expect( item.Name.value ).toBe( 'Body1' )
+  } )
+
+  test( 'resolves an anonymous face id to its STEP type (label seed for #387)', async () => {
+
+    // NEMA face #29 has the placeholder name 'NONE' in-file; the type name is
+    // what lets a consumer synthesize "Face #29" for a picked face with no
+    // tree identity.
+    const surface = compatSurfaceFor( 'data/nema-23-76mm.step' )
+    const faceExpressId = 29
+
+    const item: any = await surface.getItemProperties( faceExpressId )
+
+    expect( item.expressID ).toBe( faceExpressId )
+    expect( item.type ).toBe( 'ADVANCED_FACE' )
+  } )
+
+  test( 'an unknown id still returns the bare identity shape', async () => {
+
+    const surface = compatSurfaceFor( 'data/ap214-multibody-part.step' )
+
+    const item: any = await surface.getItemProperties( 999999 )
+
+    expect( item.expressID ).toBe( 999999 )
+    expect( item.type ).toBe( void 0 )
+    expect( item.Name.value ).toBe( '' )
+  } )
+} )

--- a/src/compat/web-ifc/ap214_properties.ts
+++ b/src/compat/web-ifc/ap214_properties.ts
@@ -198,9 +198,48 @@ export class AP214Properties {
       }
     }
 
+    const nodeName = this.nodeNameByExpressID_!.get( id )
+
+    if ( nodeName !== void 0 ) {
+      return {
+        expressID: id,
+        Name: valueHandle( nodeName ),
+      }
+    }
+
+    // Arbitrary-entity fallback: an id that is neither a property single nor
+    // a tree node — e.g. an *anonymous* solid or face a viewer picked
+    // (geometry below the ephemeral solid layer, issue #387). Resolve it
+    // through the model's O(1) express-id index and surface the STEP entity
+    // type name plus the item's own name (usually empty for anonymous
+    // geometry), so a consumer can synthesize a label like "Face #6321"
+    // without any tree or persisted state.
+    const element = this.api.StepModel.getElementByExpressID( id )
+
+    if ( element !== void 0 ) {
+
+      let itemName = ''
+
+      try {
+        const candidate = ( element as { name?: unknown } ).name
+
+        if ( typeof candidate === 'string' ) {
+          itemName = candidate
+        }
+      } catch {
+        // Malformed name attribute — the type name still identifies the item.
+      }
+
+      return {
+        expressID: id,
+        type: EntityTypesAP214[ element.type ],
+        Name: valueHandle( itemName ),
+      }
+    }
+
     return {
       expressID: id,
-      Name: valueHandle( this.nodeNameByExpressID_!.get( id ) ?? '' ),
+      Name: valueHandle( '' ),
     }
   }
 


### PR DESCRIPTION
## Summary

First (small) piece of #387 — the label seed for anonymous below-product geometry.

`AP214Properties.getItemProperties(id)` gains a third resolution tier: an id that is neither a property single nor a tree node — i.e. an **anonymous solid or face a viewer picked**, below the ephemeral solid layer — now resolves through the model's O(1) express-id index and returns the **STEP entity type name** plus the item's own name:

```js
await properties.getItemProperties(29)
// → {expressID: 29, type: 'ADVANCED_FACE', Name: {type: 1, value: 'NONE'}}
```

This is what lets Share synthesize `Face #6321` / `Solid #250` labels for transient NavTree rows (per pablo's answers on #387: synthetic labels in NavTree, no persisted state) without special-casing entity kinds client-side. Unknown ids keep the existing bare identity shape, and the two existing tiers (property singles, tree nodes) are untouched.

## Tests

Three new cases in `ap214_properties.test.ts`: a non-tree solid resolves to `MANIFOLD_SOLID_BREP` + its body name (multibody fixture), an anonymous NEMA face resolves to `ADVANCED_FACE` (the #387 label case), and an unknown id keeps the bare shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtCiSyHzGiehkDEM7y4GbF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtCiSyHzGiehkDEM7y4GbF)_