### PR TITLE
Add concurrency control to CI workflow to cancel superseded runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,18 @@ on:
   # on a branch without merging. auto-publish stays push:main-only.
   workflow_dispatch:
 
+# Cancel superseded runs so a rapid series of pushes to the same PR doesn't
+# leave N full build+regression(+visual-diff) pipelines running to completion
+# in parallel on the 8-vcpu runners — only the newest commit's result matters.
+# Grouped by ref (refs/pull/<n>/merge is unique per PR) so PRs never cancel
+# each other. cancel-in-progress is scoped to pull_request ONLY: push-to-main
+# runs must run to completion — auto-publish tags + publishes to npm, and each
+# main commit ships its own version, so cancelling a main run mid-publish (or
+# skipping a commit's release) is not acceptable.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   EMSDK_VERSION: '6.0.2'
   EMSDK_CACHE_FOLDER: 'cache/emsdk'


### PR DESCRIPTION
## Summary
Added concurrency configuration to the GitHub Actions build workflow to automatically cancel in-progress builds when new commits are pushed to the same pull request, while preserving all main branch builds to ensure releases complete successfully.

## Key Changes
- Added `concurrency` group scoped by workflow and git ref to prevent parallel builds of the same PR
- Configured `cancel-in-progress` to only apply to pull request events, ensuring main branch builds always run to completion
- This prevents resource waste on 8-vcpu runners when rapid successive pushes occur to the same PR, since only the newest commit's result matters

## Implementation Details
- Concurrency group uses `${{ github.workflow }}-${{ github.ref }}` to ensure PRs don't cancel each other's builds
- `cancel-in-progress` is conditionally set based on event type: `${{ github.event_name == 'pull_request' }}`
- Main branch builds are excluded from cancellation to preserve the integrity of auto-publish versioning and npm releases, where each commit must complete its full pipeline

https://claude.ai/code/session_01SyCxwn1wc35pkBiM9VC64V