### PR TITLE
M1a: parseStreamToModel — windowed-source model off the streaming index

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -344,6 +344,25 @@ Deliberately small first step; each has a measurable exit.
   stream → OPFS write-through → windowed provider from t=0; delete the
   post-parse spill step in Share. Exit: PSB opens with no full-source
   moment (heap-snapshot verified); regression corpus byte-identical.
+
+  *Scope note (decided 2026-07): the "no full-source moment" collides
+  with the synchronous geometry-extraction pass, which needs its record
+  ranges resident and accesses records across the whole file — that
+  residency is M3's demand-driven rework. M1 is therefore split:*
+  - **M1a — engine core (in progress).** `IfcStepParser.parseStreamToModel(
+    source, store)` — stream the index (M0, bounded parse memory) and back
+    the model with a windowed provider over `store` instead of a resident
+    buffer, so the source is never held fully resident. `source` is the
+    synchronous parse feed (OPFS sync-access handle on a worker; fd/buffer
+    in node); `store` is the async model-access store (OPFS `File.slice()`).
+    Property/index access works via `ensureResident` + the async surfaces;
+    geometry still needs residency until M3. `StepModelBase`/`IfcStepModel`
+    gained an optional pre-built-provider constructor arg for this.
+    Byte-identical record decode vs the resident parse (test).
+  - **M1b — Share open path (#1602).** OPFS write-through from t=0 + the
+    parse/index worker + drop the post-parse spill. Lands the shim
+    `OpenModelStream`. Full "no full-source moment" for the geometry phase
+    waits on M3.
 - **M2 — Record events + incremental consumers.** Event bus with type-set
   subscription; type index, names skeleton, roots registry, header become
   incremental consumers; `ON_MODEL_INFO` fires from first window. Exit:

--- a/src/ifc/ifc_step_model.ts
+++ b/src/ifc/ifc_step_model.ts
@@ -10,6 +10,7 @@ import IfcStepExternalMapping from './ifc_step_external_mapping'
 import IfcModelCurves from './ifc_model_curves'
 import { CsgMemoization } from '../core/csg_operations'
 import { IfcMaterialCache } from './ifc_material_cache'
+import { StepBufferProvider } from '../step/step_buffer_provider'
 
 
 const indexerInstance = new StepTypeIndexer< EntityTypesIfc >( EntityTypesIfcCount )
@@ -34,13 +35,16 @@ export default class IfcStepModel extends StepModelBase< EntityTypesIfc > {
    * Construct this model given a buffer containing the data and the parsed data index on that,
    * adding the typeIndex on top of that.
    *
-   * @param buffer The buffer to values from.
+   * @param buffer The buffer to values from, or `undefined` with `provider`
+   * set for a windowed (streaming) source.
    * @param elementIndex The parsed index to elements in the STEP.
+   * @param provider Optional pre-built buffer provider (windowed source).
    */
   constructor(
-      buffer: Uint8Array,
-      elementIndex: StepIndexEntry< EntityTypesIfc >[] ) {
-    super( SchemaIfc, buffer, elementIndex )
+      buffer: Uint8Array | undefined,
+      elementIndex: StepIndexEntry< EntityTypesIfc >[],
+      provider?: StepBufferProvider ) {
+    super( SchemaIfc, buffer, elementIndex, provider )
 
     this.typeIndex = indexerInstance.create( elementIndex )
   }

--- a/src/ifc/ifc_step_parser.ts
+++ b/src/ifc/ifc_step_parser.ts
@@ -3,6 +3,17 @@ import StepParser, {ParseProgressCallback, ParseResult} from '../step/parsing/st
 import EntityTypesIfc from './ifc4_gen/entity_types_ifc.gen'
 import EntitTypesIfcSearch from './ifc4_gen/entity_types_search.gen'
 import IfcStepModel from './ifc_step_model'
+import { ByteSource } from '../step/parsing/byte_source'
+import { buildIndexStreaming } from '../step/parsing/streaming_index_builder'
+import {
+  StepExternalByteStore,
+  WindowedStepBufferProvider,
+} from '../step/step_buffer_provider'
+
+
+/** Default moving-window size for the streaming index build (1 MiB). */
+// eslint-disable-next-line no-magic-numbers
+const DEFAULT_STREAM_POOL_BYTES = 1024 * 1024
 
 /**
  * Parser for taking IFC file serialized in step and turning them into a lazily parsed model.
@@ -55,5 +66,52 @@ export default class IfcStepParser extends StepParser< EntityTypesIfc > {
     const [itemIndex, parseResult] = await this.parseDataBlockAsync( input, onProgress )
 
     return [parseResult, new IfcStepModel( input.buffer, itemIndex.elements )]
+  }
+
+  /**
+   * Build a model by streaming the source through a bounded moving window
+   * (see buildIndexStreaming / M0) rather than parsing one resident buffer,
+   * then backing the model with a windowed provider over `store` — so the
+   * source is never held fully resident in the JS heap.
+   *
+   * `source` serves the parse (synchronous windowed reads — on a worker this
+   * is an OPFS sync-access handle; in node/tests a file descriptor or buffer)
+   * and `store` serves the model's post-parse property access (asynchronous
+   * windowed reads paged in on demand — OPFS `File.slice()` in the browser).
+   * Both view the same file bytes, so the file-absolute addresses the index
+   * records resolve identically through either.
+   *
+   * NOTE (M1 scope): this delivers the bounded-memory *parse*. Synchronous
+   * geometry extraction still needs its record ranges resident — as after
+   * `spillSourceToExternalStore` — so a caller that extracts geometry must
+   * `ensureResident` first (demand-driven geometry is M3). Property / index
+   * access works directly via the async surfaces.
+   *
+   * @param source Synchronous byte source feeding the streaming parse.
+   * @param store Async external store backing the windowed model.
+   * @param opts Optional window sizing: `pool` (parse window),
+   * `chunkBytes` / `maxResidentChunks` (model window).
+   * @return {[ParseResult, IfcStepModel | undefined]} The parse result and
+   * the windowed model.
+   */
+  public parseStreamToModel(
+      source: ByteSource,
+      store: StepExternalByteStore,
+      opts?: { pool?: number, chunkBytes?: number, maxResidentChunks?: number } ):
+      [ParseResult, IfcStepModel | undefined] {
+
+    if ( store.byteLength !== source.byteLength ) {
+      throw new Error(
+          `Streaming store byteLength ${store.byteLength} does not match ` +
+          `source byteLength ${source.byteLength}` )
+    }
+
+    const { elements, result } =
+      buildIndexStreaming( source, this, opts?.pool ?? DEFAULT_STREAM_POOL_BYTES )
+
+    const provider =
+      new WindowedStepBufferProvider( store, opts?.chunkBytes, opts?.maxResidentChunks )
+
+    return [result, new IfcStepModel( void 0, elements, provider )]
   }
 }

--- a/src/ifc/ifc_stream_model.test.ts
+++ b/src/ifc/ifc_stream_model.test.ts
@@ -1,0 +1,92 @@
+/* eslint-disable no-magic-numbers */
+// M1 core: a model built by streaming the source through a bounded window
+// (parseStreamToModel) must decode records byte-identically to the resident
+// parse — reading them on demand through the windowed provider after
+// ensureResident, with the source never held fully resident.
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import ParsingBuffer from '../parsing/parsing_buffer'
+import IfcStepParser from './ifc_step_parser'
+import { BufferByteSource } from '../step/parsing/byte_source'
+import { InMemoryStepByteStore } from '../step/step_buffer_provider'
+import { ParseResult } from '../step/parsing/step_parser'
+import { IfcRoot } from './ifc4_gen'
+
+let bytes: Uint8Array
+
+/**
+ * Decode every IfcRoot-derived entity's GlobalId + Name from a model into a
+ * stable map — the attributes are read from the record bytes, so this
+ * exercises the actual byte path (resident buffer vs windowed provider).
+ *
+ * @param model The model to read from.
+ * @return {Map<number, string>} expressID → "GlobalId|Name".
+ */
+function rootAttributes( model: any ): Map<number, string> {
+  const out = new Map<number, string>()
+
+  for ( const expressID of model.expressIDsOfTypes( IfcRoot ) ) {
+    const entity: any = model.getElementByExpressID( expressID )
+
+    if ( entity === void 0 ) {
+      continue
+    }
+
+    const globalId = typeof entity.GlobalId === 'string' ? entity.GlobalId : ''
+    const name = typeof entity.Name === 'string' ? entity.Name : ''
+
+    out.set( expressID, `${globalId}|${name}` )
+  }
+
+  return out
+}
+
+beforeAll( () => {
+  bytes = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+} )
+
+describe( 'parseStreamToModel', () => {
+
+  test( 'streamed windowed model decodes records identically to the resident parse', async () => {
+    // Resident ground truth.
+    const residentInput = new ParsingBuffer( bytes )
+    IfcStepParser.Instance.parseHeader( residentInput )
+    const [ , residentModel ] = IfcStepParser.Instance.parseDataToModel( residentInput )
+    const expected = rootAttributes( residentModel! )
+    expect( expected.size ).toBeGreaterThan( 10 )
+
+    // Streamed: tiny parse window forces slides; tiny model chunks force
+    // paging. Same bytes behind both the sync source and the async store.
+    const [ result, streamModel ] = IfcStepParser.Instance.parseStreamToModel(
+        new BufferByteSource( bytes ),
+        new InMemoryStepByteStore( bytes ),
+        { pool: 4 * 1024, chunkBytes: 512, maxResidentChunks: 3 } )
+
+    expect( result ).toBe( ParseResult.COMPLETE )
+    expect( streamModel!.isSourceExternal ).toBe( true )
+
+    // Page each record in on demand, then decode; must match resident.
+    const actual = new Map<number, string>()
+    for ( const expressID of streamModel!.expressIDsOfTypes( IfcRoot ) ) {
+      await streamModel!.ensureResidentByExpressID( expressID )
+      const entity: any = streamModel!.getElementByExpressID( expressID )
+      if ( entity === void 0 ) {
+        continue
+      }
+      const globalId = typeof entity.GlobalId === 'string' ? entity.GlobalId : ''
+      const name = typeof entity.Name === 'string' ? entity.Name : ''
+      actual.set( expressID, `${globalId}|${name}` )
+    }
+
+    expect( actual ).toEqual( expected )
+  }, 60000 )
+
+  test( 'rejects a store whose size does not match the source', () => {
+    expect( () => IfcStepParser.Instance.parseStreamToModel(
+        new BufferByteSource( bytes ),
+        new InMemoryStepByteStore( bytes.subarray( 0, bytes.length - 1 ) ) ) )
+        .toThrow( /does not match/ )
+  } )
+} )

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -98,15 +98,22 @@ implements Iterable<BaseEntity>, Model {
    * Construct this step model with its matching schema, a buffer to read from and an element index.
    *
    * @param schema The Step schema this is based on.
-   * @param buffer_ The buffer to read this from.
+   * @param buffer_ The buffer to read this from. Pass `undefined` together
+   * with `provider` to build a model whose source is windowed from
+   * construction (e.g. a streaming open — see buildModelStreaming); the
+   * synchronous read paths (geometry extraction) then require the relevant
+   * ranges to be resident, exactly as after `spillSourceToExternalStore`.
    * @param elementIndex The element index for this, parsed or deserialized - note this takes
    * ownership of this array in the sense it will modify values/unfold inline elements etc.
+   * @param provider Optional pre-built buffer provider. When omitted, a
+   * resident provider over `buffer_` is used (the classic path).
    */
   constructor(
     public readonly schema: StepEntitySchema< EntityTypeIDs, BaseEntity >,
-    private buffer_: Uint8Array | undefined, elementIndex: StepIndexEntry<EntityTypeIDs>[]) {
+    private buffer_: Uint8Array | undefined, elementIndex: StepIndexEntry<EntityTypeIDs>[],
+    provider?: StepBufferProvider ) {
 
-    this.bufferProvider_ = new ResidentStepBufferProvider( buffer_ as Uint8Array )
+    this.bufferProvider_ = provider ?? new ResidentStepBufferProvider( buffer_ as Uint8Array )
 
     const localElementIndex: StepEntityInternalReferencePrivate<EntityTypeIDs, BaseEntity>[] =
       elementIndex


### PR DESCRIPTION
Engine core for M1 (#392) of the streaming-loader epic (#390). Builds on M0 (#398).

## Scope decision

M1's headline "windowed provider from t=0" collides with the **synchronous** geometry-extraction pass, which needs its record ranges resident and accesses records across the whole file — that residency is M3's demand-driven rework. So M1 is split, and this PR is **M1a: the engine core** (parse-time win). The Share OPFS write-through open path + parse/index worker + spill removal is **M1b (#1602)**; full "no full-source moment" for the geometry phase waits on M3.

## What

`IfcStepParser.parseStreamToModel(source, store, opts)`:
- Streams the index via `buildIndexStreaming` (M0) — bounded parse memory, no resident source buffer during the parse.
- Backs the model with a `WindowedStepBufferProvider` over `store` instead of a resident buffer, so the source is never held fully resident in the JS heap.
- `source` is the **synchronous** parse feed (an OPFS sync-access handle on a worker; a file descriptor or buffer in node/tests). `store` is the **async** model-access store (OPFS `File.slice()` in the browser). Both view the same file bytes, so the file-absolute addresses the index records resolve identically through either.

`StepModelBase` / `IfcStepModel` gained an optional pre-built-provider constructor argument (backward compatible — a resident provider is built when it's omitted, exactly as before).

Property/index access on the resulting model works via the existing async surfaces (`ensureResidentByExpressID` + windowed `getLine`). Geometry extraction still requires resident ranges, identical to the state after `spillSourceToExternalStore`.

## Tests

`ifc_stream_model.test.ts`: a streamed windowed model (tiny 4 KB parse window + 512 B model chunks / 3-chunk cap to force slides *and* paging) decodes every IfcRoot entity's GlobalId + Name **byte-identically** to the resident parse, reading each record on demand via `ensureResident`; plus store/source size-mismatch rejection. 53 existing step/spill/roots tests stay green (the constructor change is a no-op on the resident path).

Design doc updated with the M1a/M1b split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_