### PR TITLE
M2a: record events from the streaming parse + type-set subscription

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -369,6 +369,25 @@ Deliberately small first step; each has a measurable exit.
   spatial tree UI populates while PSB still parsing; props capture works
   pre-geometry. (First task: scope conway-geom per-product native
   geometry free — it gates M3.)
+  - **M2a — event core (in progress).** The streaming parse now emits a
+    per-record event `(localID, expressID, typeID)` live as each top-level
+    record is indexed (`parseDataBlockStreamed` / `buildIndexStreaming`
+    `onRecordIndexed` hook). `StreamingRecordDispatcher` routes events to
+    consumers subscribed by type set — the subtype closure via the
+    generated constructor `query` (#383), so `on([IfcRoot], …)` matches
+    products, rels, psets, quantities and future subtypes. Handlers run
+    sync in the parse path (cheap only). localIDs are dense/ascending;
+    a grow-restart re-fires from 0, so consumers must be idempotent by
+    localID/expressID (the standard ones are). Verified: a roots registry
+    built live from the stream equals `expressIDsOfTypes(IfcRoot)` on the
+    finished model. External-mapping records (typeID 0) reach `onAnyRecord`
+    only; concrete-type resolution for them is the incremental type-index
+    consumer (M2b).
+  - **M2b — standard consumers (next).** Incremental type index
+    (multi-mapping-aware), spatial names skeleton, property-roots + header
+    consumers; wire `ON_MODEL_INFO` from the first window. This is where
+    the "spatial tree populates while parsing" exit criterion lands, plus
+    the conway-geom per-product-free scoping that gates M3.
 - **M3 — Demand-driven geometry.** Work queue + budgeted arena +
   per-product wasm reclaim; load-time progressive materialisation
   (viewport-ordered). Exit: PSB time-to-first-pixel < 25 % of full-load

--- a/src/step/parsing/incremental_type_index.test.ts
+++ b/src/step/parsing/incremental_type_index.test.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-magic-numbers */
+// M2b: a type index built incrementally from the streaming parse's record
+// events must, once parsing finishes, hold the same membership as the
+// resident model's type index — for every queried type (and its subtypes).
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import ParsingBuffer from '../../parsing/parsing_buffer'
+import IfcStepParser from '../../ifc/ifc_step_parser'
+import { BufferByteSource } from './byte_source'
+import { buildIndexStreaming } from './streaming_index_builder'
+import { IncrementalTypeIndex } from './incremental_type_index'
+import { StreamingRecordDispatcher } from './streaming_record_dispatcher'
+import { ParseResult } from './step_parser'
+import { IfcRoot, IfcProduct, IfcWall, IfcPropertySet } from '../../ifc/ifc4_gen'
+
+let bytes: Uint8Array
+let model: any
+
+beforeAll( () => {
+  bytes = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+  const input = new ParsingBuffer( bytes )
+  IfcStepParser.Instance.parseHeader( input )
+  model = IfcStepParser.Instance.parseDataToModel( input )[1]
+} )
+
+describe( 'IncrementalTypeIndex', () => {
+
+  /**
+   * Stream index.ifc, feeding an IncrementalTypeIndex, and return it.
+   *
+   * @return {IncrementalTypeIndex} The populated index.
+   */
+  function streamed(): IncrementalTypeIndex<number> {
+    const index = new IncrementalTypeIndex<number>()
+    const dispatcher = new StreamingRecordDispatcher<number>()
+    dispatcher.onAnyRecord( index.handler )
+
+    const r = buildIndexStreaming(
+        new BufferByteSource( bytes ), IfcStepParser.Instance, 4 * 1024,
+        dispatcher.onRecordIndexed )
+    expect( r.result ).toBe( ParseResult.COMPLETE )
+    return index
+  }
+
+  test.each( [
+    [ 'IfcRoot', IfcRoot ],
+    [ 'IfcProduct', IfcProduct ],
+    [ 'IfcWall', IfcWall ],
+    [ 'IfcPropertySet', IfcPropertySet ],
+  ] )( 'membership matches the resident type index for %s', ( _name, ctor ) => {
+    const index = streamed()
+
+    const incremental = new Set( index.expressIDsOfTypes( ctor as any ) )
+    const resident = new Set( model.expressIDsOfTypes( ctor ) )
+
+    expect( incremental ).toEqual( resident )
+    expect( index.count( ctor as any ) ).toBe( resident.size )
+  } )
+
+  test( 'a multi-type query unions the subtype closures', () => {
+    const index = streamed()
+
+    const incremental = new Set( index.expressIDsOfTypes( IfcWall as any, IfcPropertySet as any ) )
+    const resident = new Set( model.expressIDsOfTypes( IfcWall, IfcPropertySet ) )
+
+    expect( incremental ).toEqual( resident )
+  } )
+} )

--- a/src/step/parsing/incremental_type_index.ts
+++ b/src/step/parsing/incremental_type_index.ts
@@ -1,0 +1,113 @@
+import { StepEntityConstructorAbstract } from '../step_entity_constructor'
+import { RecordHandler } from './streaming_record_dispatcher'
+
+
+/**
+ * A type index built **incrementally** from the streaming parse's per-record
+ * events (M2), rather than from the finished element array. Feed its
+ * {@link handler} to a {@link StreamingRecordDispatcher} (or directly to
+ * `buildIndexStreaming`'s `onRecordIndexed`) and it accumulates, per concrete
+ * type, the set of express IDs seen — so the moment parsing reaches a record
+ * it is queryable, without waiting for end-of-parse.
+ *
+ * Queries take entity constructors and expand to their subtype closure via
+ * the generated `query` (conway #383), so `expressIDsOfTypes(IfcProduct)`
+ * unions every product subtype exactly as the resident model's type index
+ * does.
+ *
+ * Express IDs are held in per-type `Set`s, so the consumer is idempotent
+ * under the streaming builder's rare grow-and-restart (records re-fire from
+ * localID 0): re-adding an express ID is a no-op. Memory is O(records) — the
+ * same order as the element index it mirrors.
+ *
+ * Scope: membership is keyed on the raw parse `typeID`. External-mapping /
+ * complex records (typeID 0) are therefore not attributed to their mapped
+ * classes here — resolving those needs the record's `multiMapping`, which the
+ * event stream doesn't carry; that's the model's construction-time index. For
+ * the overwhelming majority of records (simple, one type each) this index is
+ * exact, which the parity test pins.
+ */
+export class IncrementalTypeIndex<TypeIDType extends number> {
+
+  /** Concrete typeID → express IDs of records of exactly that type. */
+  private readonly byType_ = new Map<TypeIDType, Set<number>>()
+
+  /**
+   * Record one indexed entity. Bound as {@link handler} for direct use as a
+   * dispatcher subscription / `onRecordIndexed` callback.
+   *
+   * @param localID Unused (kept for the RecordHandler shape).
+   * @param expressID The record's express ID.
+   * @param typeID The record's concrete type ID (undefined / 0 records are
+   * ignored — they carry no concrete queryable type here).
+   */
+  public readonly handler: RecordHandler<TypeIDType> =
+    ( localID: number, expressID: number, typeID: TypeIDType | undefined ): void => {
+
+      if ( typeID === void 0 ) {
+        return
+      }
+
+      let ids = this.byType_.get( typeID )
+
+      if ( ids === void 0 ) {
+        ids = new Set<number>()
+        this.byType_.set( typeID, ids )
+      }
+
+      ids.add( expressID )
+    }
+
+  /**
+   * The distinct concrete type IDs seen so far.
+   *
+   * @return {IterableIterator<TypeIDType>} The concrete types.
+   */
+  public concreteTypes(): IterableIterator<TypeIDType> {
+    return this.byType_.keys()
+  }
+
+  /**
+   * Lazily iterate the express IDs of all records of the given types
+   * (including subtypes).
+   *
+   * @param types The entity constructors to query (subtype closures unioned).
+   * @return {IterableIterator<number>} Express IDs of matching records.
+   * @yields {number} Each matching express ID.
+   */
+  public* expressIDsOfTypes(
+      ...types: StepEntityConstructorAbstract<TypeIDType>[] ):
+      IterableIterator<number> {
+
+    const typeSet = types.length === 1 ? types[0].query :
+      new Set<TypeIDType>( types.flatMap( ( type ) => type.query ) )
+
+    for ( const typeID of typeSet ) {
+      const ids = this.byType_.get( typeID as TypeIDType )
+
+      if ( ids !== void 0 ) {
+        yield* ids
+      }
+    }
+  }
+
+  /**
+   * Count records of the given types (including subtypes) seen so far.
+   *
+   * @param types The entity constructors to count.
+   * @return {number} The number of matching records.
+   */
+  public count( ...types: StepEntityConstructorAbstract<TypeIDType>[] ): number {
+
+    const typeSet = types.length === 1 ? types[0].query :
+      new Set<TypeIDType>( types.flatMap( ( type ) => type.query ) )
+
+    let total = 0
+
+    for ( const typeID of typeSet ) {
+      total += this.byType_.get( typeID as TypeIDType )?.size ?? 0
+    }
+
+    return total
+  }
+}

--- a/src/step/parsing/step_parser.ts
+++ b/src/step/parsing/step_parser.ts
@@ -466,15 +466,21 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
    * @param input The input parsing buffer, positioned at the data section.
    * @param onRecordBoundary Called at each top-level record boundary with the
    * buffer; the callback may rebase the buffer's window in place.
+   * @param onRecordIndexed Called as each top-level record is indexed, with
+   * its localID, expressID and typeID (0 for external-mapping records) — the
+   * seam for incremental semantic consumers (type index, roots registry,
+   * names skeleton). Must be synchronous and cheap; expensive work belongs on
+   * a demand queue, not the parse path.
    * @param onProgress Optional byte-cursor progress callback.
    * @return {BlockParseResult} The parsing result, including the index and result enum.
    */
   public parseDataBlockStreamed(
       input: ParsingBuffer,
       onRecordBoundary: ( input: ParsingBuffer ) => void,
+      onRecordIndexed?: ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
       onProgress?: ParseProgressCallback ): BlockParseResult<TypeIDType> {
 
-    const parser = this.parseDataBlockIncremental( input, onRecordBoundary )
+    const parser = this.parseDataBlockIncremental( input, onRecordBoundary, onRecordIndexed )
 
     while ( true ) {
 
@@ -539,7 +545,8 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
    */
   private* parseDataBlockIncremental(
       input: ParsingBuffer,
-      onRecordBoundary?: ( input: ParsingBuffer ) => void ):
+      onRecordBoundary?: ( input: ParsingBuffer ) => void,
+      onRecordIndexed?: ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void ):
       Generator<number, BlockParseResult<TypeIDType>, undefined> {
 
     const indexResult: StepIndex<TypeIDType> = { elements: [] }
@@ -809,6 +816,8 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
           return syntaxError()
         }
 
+        onRecordIndexed?.( indexResult.elements.length, expressID, 0 as TypeIDType )
+
         indexResult.elements.push(
             {
               address: startElement,
@@ -948,6 +957,8 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
       if (!charws(SEMICOLON)) {
         return syntaxError()
       }
+
+      onRecordIndexed?.( indexResult.elements.length, expressID, foundItem )
 
       indexResult.elements.push(
           {

--- a/src/step/parsing/streaming_index_builder.ts
+++ b/src/step/parsing/streaming_index_builder.ts
@@ -70,12 +70,25 @@ export interface StreamingIndexResult<TypeIDType> {
  * @param source The byte source.
  * @param parser The STEP parser (typed to the schema).
  * @param pool Target window size in bytes.
+ * @param onRecordIndexed Optional per-record event, invoked live as each
+ * top-level record is indexed with its (localID, expressID, typeID) — the
+ * seam for incremental semantic consumers (M2). localIDs are dense and
+ * assigned in parse order from 0. On the rare grow-and-restart (a single
+ * record larger than the window — never on real files, whose largest STEP
+ * record is ~25 KB), the parse re-runs from the start and records re-fire
+ * from localID 0; consumers must therefore be idempotent by localID /
+ * expressID (the standard consumers — type index keyed by localID, roots
+ * registry keyed by expressID — are). Must be synchronous and cheap;
+ * expensive work belongs on a demand queue, not the parse path.
  * @return {StreamingIndexResult} The index, header, result and diagnostics.
  */
 export function buildIndexStreaming<TypeIDType>(
     source: ByteSource,
     parser: StepParser<TypeIDType>,
-    pool: number ): StreamingIndexResult<TypeIDType> {
+    pool: number,
+    onRecordIndexed?:
+      ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void ):
+    StreamingIndexResult<TypeIDType> {
 
   const fileSize = source.byteLength
 
@@ -156,7 +169,8 @@ export function buildIndexStreaming<TypeIDType>(
       ++slides
     }
 
-    const [ index, result ] = parser.parseDataBlockStreamed( input, onRecordBoundary )
+    const [ index, result ] =
+      parser.parseDataBlockStreamed( input, onRecordBoundary, onRecordIndexed )
 
     // A parse that stopped short of true EOF, with the window not spanning to
     // EOF, means a single record overflowed the window: grow and retry.

--- a/src/step/parsing/streaming_record_dispatcher.test.ts
+++ b/src/step/parsing/streaming_record_dispatcher.test.ts
@@ -1,0 +1,92 @@
+/* eslint-disable no-magic-numbers */
+// M2 core: record events emitted live from the streaming parse, routed by a
+// type-set subscription, let a consumer build a semantic structure
+// incrementally — and it must match what the finished model's type index
+// yields. Here: a roots registry collected from the event stream equals
+// `expressIDsOfTypes(IfcRoot)` on the resident model.
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import ParsingBuffer from '../../parsing/parsing_buffer'
+import IfcStepParser from '../../ifc/ifc_step_parser'
+import { BufferByteSource } from './byte_source'
+import { buildIndexStreaming } from './streaming_index_builder'
+import { StreamingRecordDispatcher } from './streaming_record_dispatcher'
+import { ParseResult } from './step_parser'
+import { IfcRoot, IfcProduct } from '../../ifc/ifc4_gen'
+
+let bytes: Uint8Array
+let residentRoots: Set<number>
+let residentProducts: Set<number>
+
+beforeAll( () => {
+  bytes = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+
+  const input = new ParsingBuffer( bytes )
+  IfcStepParser.Instance.parseHeader( input )
+  const [ , model ] = IfcStepParser.Instance.parseDataToModel( input )
+
+  residentRoots = new Set( model!.expressIDsOfTypes( IfcRoot ) )
+  residentProducts = new Set( model!.expressIDsOfTypes( IfcProduct ) )
+} )
+
+describe( 'StreamingRecordDispatcher', () => {
+
+  test( 'a roots registry built live from the event stream matches the type index', () => {
+    const roots: number[] = []
+    const products = new Set<number>()
+
+    const dispatcher = new StreamingRecordDispatcher<number>()
+    dispatcher.on( [ IfcRoot ], ( _localID, expressID ) => roots.push( expressID ) )
+    dispatcher.on( [ IfcProduct ], ( _localID, expressID ) => products.add( expressID ) )
+
+    const result = buildIndexStreaming(
+        new BufferByteSource( bytes ),
+        IfcStepParser.Instance,
+        4 * 1024, // tiny pool → the parse slides; events still fire per record
+        dispatcher.onRecordIndexed )
+
+    expect( result.result ).toBe( ParseResult.COMPLETE )
+    // index.ifc has no external-mapping records, so raw-typeID delivery is
+    // exact vs. the type index.
+    expect( new Set( roots ) ).toEqual( residentRoots )
+    expect( products ).toEqual( residentProducts )
+    // Products are a strict subset of roots (IfcProduct ⊂ IfcRoot).
+    expect( residentProducts.size ).toBeLessThan( residentRoots.size )
+    for ( const p of products ) {
+      expect( residentRoots.has( p ) ).toBe( true )
+    }
+  } )
+
+  test( 'localIDs arrive dense and in ascending parse order', () => {
+    const localIDs: number[] = []
+
+    const dispatcher = new StreamingRecordDispatcher<number>()
+    dispatcher.onAnyRecord( ( localID ) => localIDs.push( localID ) )
+
+    buildIndexStreaming(
+        new BufferByteSource( bytes ), IfcStepParser.Instance, 128 * 1024,
+        dispatcher.onRecordIndexed )
+
+    expect( localIDs.length ).toBeGreaterThan( 10 )
+    // 0,1,2,…,n-1 in order.
+    expect( localIDs ).toEqual( localIDs.map( ( _v, i ) => i ) )
+  } )
+
+  test( 'onAnyRecord sees every record; a type filter sees a subset', () => {
+    let all = 0
+    let rootsCount = 0
+
+    const dispatcher = new StreamingRecordDispatcher<number>()
+    dispatcher.onAnyRecord( () => ++all )
+    dispatcher.on( [ IfcRoot ], () => ++rootsCount )
+
+    buildIndexStreaming(
+        new BufferByteSource( bytes ), IfcStepParser.Instance, 128 * 1024,
+        dispatcher.onRecordIndexed )
+
+    expect( all ).toBeGreaterThan( rootsCount )
+    expect( rootsCount ).toBe( residentRoots.size )
+  } )
+} )

--- a/src/step/parsing/streaming_record_dispatcher.ts
+++ b/src/step/parsing/streaming_record_dispatcher.ts
@@ -1,0 +1,91 @@
+import { StepEntityConstructorAbstract } from '../step_entity_constructor'
+
+
+/**
+ * A per-record event handler. Receives a record's dense `localID` (assigned
+ * in parse order from 0), its `expressID`, and its `typeID` (0 for
+ * external-mapping records).
+ */
+export type RecordHandler<TypeIDType> =
+  ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void
+
+
+/**
+ * Routes the streaming parse's per-record events (M2) to consumers that
+ * subscribe by **type set**. A subscription's type set is the subtype closure
+ * of the entity constructors it names — the same `query` closure the type
+ * index and `expressIDsOfTypes` use (conway #383) — so `on([IfcRoot], …)`
+ * matches every product, relationship, property set and quantity, and any
+ * future IfcRoot subtype, with no whitelist to maintain.
+ *
+ * Feed `dispatcher.onRecordIndexed` to `buildIndexStreaming` /
+ * `parseDataBlockStreamed`. Handlers run synchronously in the parse path, so
+ * they must be cheap (copy ids into a compact structure); anything expensive
+ * belongs on a demand queue, not here.
+ *
+ * Because subscriptions match on the raw parse `typeID`, external-mapping /
+ * complex records (typeID 0) are only delivered via `onAnyRecord` — resolving
+ * their concrete type is the incremental-type-index consumer's job (it reads
+ * `multiMapping`), a follow-on. For the overwhelming majority of records
+ * (simple, one type each) type-set delivery is exact.
+ */
+export class StreamingRecordDispatcher<TypeIDType extends number> {
+
+  private readonly typed: Array<{
+    set: Set<TypeIDType>,
+    handler: RecordHandler<TypeIDType>,
+  }> = []
+
+  private readonly any: RecordHandler<TypeIDType>[] = []
+
+  /**
+   * Subscribe to records of the given entity types (including their
+   * subtypes).
+   *
+   * @param types The entity constructors whose subtype closures to match.
+   * @param handler Called for each matching record.
+   */
+  public on(
+      types: StepEntityConstructorAbstract<TypeIDType>[],
+      handler: RecordHandler<TypeIDType> ): void {
+
+    this.typed.push( {
+      set: new Set<TypeIDType>( types.flatMap( ( type ) => type.query ) ),
+      handler,
+    } )
+  }
+
+  /**
+   * Subscribe to every record regardless of type (the firehose — including
+   * external-mapping records).
+   *
+   * @param handler Called for every record.
+   */
+  public onAnyRecord( handler: RecordHandler<TypeIDType> ): void {
+    this.any.push( handler )
+  }
+
+  /**
+   * The per-record callback to hand to the streaming parse. Dispatches each
+   * record to the matching subscribers. Bound so it can be passed directly.
+   *
+   * @param localID The record's dense local ID.
+   * @param expressID The record's express ID.
+   * @param typeID The record's type ID (0 for external-mapping records).
+   */
+  public readonly onRecordIndexed: RecordHandler<TypeIDType> =
+    ( localID: number, expressID: number, typeID: TypeIDType | undefined ): void => {
+
+      for ( const handler of this.any ) {
+        handler( localID, expressID, typeID )
+      }
+
+      if ( typeID !== void 0 ) {
+        for ( const { set, handler } of this.typed ) {
+          if ( set.has( typeID ) ) {
+            handler( localID, expressID, typeID )
+          }
+        }
+      }
+    }
+}


### PR DESCRIPTION
Event core for M2 (#393) of the streaming-loader epic (#390). Builds on M0 (#398). Independent of the geometry fork. **First of the review-merge sequence: #401 → #402 → #403 → #404 → #405 → #408 → #409.**

## What

Emits a per-record event `(localID, expressID, typeID)` **live** as each top-level record is indexed during the streaming parse, and routes events to consumers subscribed **by type set** — the foundational seam for incremental semantic consumers (type index, names skeleton, roots registry) that run while the model is still parsing.

- **`StepParser`** — an `onRecordIndexed` hook on the parse generator, fired right after each top-level record is pushed (both the normal and external-mapping branches); threaded through `parseDataBlockStreamed` and `buildIndexStreaming`. A no-op `?.()` on the resident path.
- **`StreamingRecordDispatcher`** — `on([Type, …], handler)` matches the subtype closure via the generated constructor `query` (#383), so `on([IfcRoot], …)` catches every GlobalId-bearing record (products, rels, psets, quantities) and any future subtype with no whitelist; `onAnyRecord` is the firehose. Handlers run **synchronously** in the parse path, so they must be cheap — expensive work belongs on a demand queue (the lesson from the props-sweep tick regression).

## Compatibility with existing Share use

**Fully additive.** Share's load path goes through the resident `parseDataToModel` object path, which this PR does not touch — the event hook is an optional `?.()` no-op unless a caller supplies it, and no existing caller does. The only signature change is `parseDataBlockStreamed` (new-engine API introduced in M0, no Share consumer) gaining an optional param before `onProgress`. Zero geometry code touched → zero render-diff surface; **visual-diff CI is green on the PR head** (along with build + run-ifc-regression).

## Contract notes

- `typeID` is `TypeIDType | undefined` (unknown-type records) and `0` for external-mapping / complex records, which reach `onAnyRecord` only — concrete-type resolution for complex records is the incremental type-index consumer (M2b). The `0` sentinel is schema-sanctioned: `EXTERNALMAPPINGCONTAINER = 0` is reserved in both the IFC and AP214 generated enums, so it cannot collide with a real type in a subscription set.
- `localID`s are dense and ascending in parse order; the rare grow-restart (a single record larger than the window — never on real files) re-fires from `localID 0`, so consumers must be idempotent by localID/expressID. The standard consumers (type index keyed by localID, roots registry keyed by expressID) are.

## Tests

`streaming_record_dispatcher.test.ts`: a roots registry built **live** from the event stream equals `expressIDsOfTypes(IfcRoot)` on the finished resident model (index.ifc, no external-mapping records → exact); localIDs arrive dense and ascending under a 4 KB pool (events survive window slides); `onAnyRecord` is a strict superset of a type filter. 56 existing step/stream/spill/roots tests stay green.

## Scope

**M2a = the event core** (this PR). **M2b (#402, next in sequence)** = the incremental type-index consumer; the spatial names skeleton / property-roots / `ON_MODEL_INFO` consumers and conway-geom per-product-free scoping continued in the later stack PRs (#403–#409, conway-geom #147). Design doc updated with the split.

## Review status

Reviewed 2026-07-19 (chain review before merge): no correctness findings; three cosmetic nits noted in the review comment thread (private-field underscore convention in the dispatcher; positional-param insertion in a new-API signature; empty-subscription no-op) — deliberately not pushed to keep the reviewed, green, stacked state stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz