### PR TITLE
M2b: incremental type index consumer off the record-event stream

### DIFF
--- a/src/step/parsing/incremental_type_index.test.ts
+++ b/src/step/parsing/incremental_type_index.test.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-magic-numbers */
+// M2b: a type index built incrementally from the streaming parse's record
+// events must, once parsing finishes, hold the same membership as the
+// resident model's type index — for every queried type (and its subtypes).
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import ParsingBuffer from '../../parsing/parsing_buffer'
+import IfcStepParser from '../../ifc/ifc_step_parser'
+import { BufferByteSource } from './byte_source'
+import { buildIndexStreaming } from './streaming_index_builder'
+import { IncrementalTypeIndex } from './incremental_type_index'
+import { StreamingRecordDispatcher } from './streaming_record_dispatcher'
+import { ParseResult } from './step_parser'
+import { IfcRoot, IfcProduct, IfcWall, IfcPropertySet } from '../../ifc/ifc4_gen'
+
+let bytes: Uint8Array
+let model: any
+
+beforeAll( () => {
+  bytes = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+  const input = new ParsingBuffer( bytes )
+  IfcStepParser.Instance.parseHeader( input )
+  model = IfcStepParser.Instance.parseDataToModel( input )[1]
+} )
+
+describe( 'IncrementalTypeIndex', () => {
+
+  /**
+   * Stream index.ifc, feeding an IncrementalTypeIndex, and return it.
+   *
+   * @return {IncrementalTypeIndex} The populated index.
+   */
+  function streamed(): IncrementalTypeIndex<number> {
+    const index = new IncrementalTypeIndex<number>()
+    const dispatcher = new StreamingRecordDispatcher<number>()
+    dispatcher.onAnyRecord( index.handler )
+
+    const r = buildIndexStreaming(
+        new BufferByteSource( bytes ), IfcStepParser.Instance, 4 * 1024,
+        dispatcher.onRecordIndexed )
+    expect( r.result ).toBe( ParseResult.COMPLETE )
+    return index
+  }
+
+  test.each( [
+    [ 'IfcRoot', IfcRoot ],
+    [ 'IfcProduct', IfcProduct ],
+    [ 'IfcWall', IfcWall ],
+    [ 'IfcPropertySet', IfcPropertySet ],
+  ] )( 'membership matches the resident type index for %s', ( _name, ctor ) => {
+    const index = streamed()
+
+    const incremental = new Set( index.expressIDsOfTypes( ctor as any ) )
+    const resident = new Set( model.expressIDsOfTypes( ctor ) )
+
+    expect( incremental ).toEqual( resident )
+    expect( index.count( ctor as any ) ).toBe( resident.size )
+  } )
+
+  test( 'a multi-type query unions the subtype closures', () => {
+    const index = streamed()
+
+    const incremental = new Set( index.expressIDsOfTypes( IfcWall as any, IfcPropertySet as any ) )
+    const resident = new Set( model.expressIDsOfTypes( IfcWall, IfcPropertySet ) )
+
+    expect( incremental ).toEqual( resident )
+  } )
+} )

--- a/src/step/parsing/incremental_type_index.ts
+++ b/src/step/parsing/incremental_type_index.ts
@@ -1,0 +1,113 @@
+import { StepEntityConstructorAbstract } from '../step_entity_constructor'
+import { RecordHandler } from './streaming_record_dispatcher'
+
+
+/**
+ * A type index built **incrementally** from the streaming parse's per-record
+ * events (M2), rather than from the finished element array. Feed its
+ * {@link handler} to a {@link StreamingRecordDispatcher} (or directly to
+ * `buildIndexStreaming`'s `onRecordIndexed`) and it accumulates, per concrete
+ * type, the set of express IDs seen — so the moment parsing reaches a record
+ * it is queryable, without waiting for end-of-parse.
+ *
+ * Queries take entity constructors and expand to their subtype closure via
+ * the generated `query` (conway #383), so `expressIDsOfTypes(IfcProduct)`
+ * unions every product subtype exactly as the resident model's type index
+ * does.
+ *
+ * Express IDs are held in per-type `Set`s, so the consumer is idempotent
+ * under the streaming builder's rare grow-and-restart (records re-fire from
+ * localID 0): re-adding an express ID is a no-op. Memory is O(records) — the
+ * same order as the element index it mirrors.
+ *
+ * Scope: membership is keyed on the raw parse `typeID`. External-mapping /
+ * complex records (typeID 0) are therefore not attributed to their mapped
+ * classes here — resolving those needs the record's `multiMapping`, which the
+ * event stream doesn't carry; that's the model's construction-time index. For
+ * the overwhelming majority of records (simple, one type each) this index is
+ * exact, which the parity test pins.
+ */
+export class IncrementalTypeIndex<TypeIDType extends number> {
+
+  /** Concrete typeID → express IDs of records of exactly that type. */
+  private readonly byType_ = new Map<TypeIDType, Set<number>>()
+
+  /**
+   * Record one indexed entity. Bound as {@link handler} for direct use as a
+   * dispatcher subscription / `onRecordIndexed` callback.
+   *
+   * @param localID Unused (kept for the RecordHandler shape).
+   * @param expressID The record's express ID.
+   * @param typeID The record's concrete type ID (undefined / 0 records are
+   * ignored — they carry no concrete queryable type here).
+   */
+  public readonly handler: RecordHandler<TypeIDType> =
+    ( localID: number, expressID: number, typeID: TypeIDType | undefined ): void => {
+
+      if ( typeID === void 0 ) {
+        return
+      }
+
+      let ids = this.byType_.get( typeID )
+
+      if ( ids === void 0 ) {
+        ids = new Set<number>()
+        this.byType_.set( typeID, ids )
+      }
+
+      ids.add( expressID )
+    }
+
+  /**
+   * The distinct concrete type IDs seen so far.
+   *
+   * @return {IterableIterator<TypeIDType>} The concrete types.
+   */
+  public concreteTypes(): IterableIterator<TypeIDType> {
+    return this.byType_.keys()
+  }
+
+  /**
+   * Lazily iterate the express IDs of all records of the given types
+   * (including subtypes).
+   *
+   * @param types The entity constructors to query (subtype closures unioned).
+   * @return {IterableIterator<number>} Express IDs of matching records.
+   * @yields {number} Each matching express ID.
+   */
+  public* expressIDsOfTypes(
+      ...types: StepEntityConstructorAbstract<TypeIDType>[] ):
+      IterableIterator<number> {
+
+    const typeSet = types.length === 1 ? types[0].query :
+      new Set<TypeIDType>( types.flatMap( ( type ) => type.query ) )
+
+    for ( const typeID of typeSet ) {
+      const ids = this.byType_.get( typeID as TypeIDType )
+
+      if ( ids !== void 0 ) {
+        yield* ids
+      }
+    }
+  }
+
+  /**
+   * Count records of the given types (including subtypes) seen so far.
+   *
+   * @param types The entity constructors to count.
+   * @return {number} The number of matching records.
+   */
+  public count( ...types: StepEntityConstructorAbstract<TypeIDType>[] ): number {
+
+    const typeSet = types.length === 1 ? types[0].query :
+      new Set<TypeIDType>( types.flatMap( ( type ) => type.query ) )
+
+    let total = 0
+
+    for ( const typeID of typeSet ) {
+      total += this.byType_.get( typeID as TypeIDType )?.size ?? 0
+    }
+
+    return total
+  }
+}


### PR DESCRIPTION
**Stacked on M2a (#401)** — part of M2 (#393), epic #390. Base is the M2a branch; retarget to `main` once #401 merges.

## What

`IncrementalTypeIndex` — a type index built **incrementally** from M2a's per-record events, so a type query is answerable the moment parsing reaches the records, without waiting for end-of-parse. Feed its `handler` to a `StreamingRecordDispatcher` (or `buildIndexStreaming`'s `onRecordIndexed`); it accumulates per-concrete-type express-ID sets. Queries take entity constructors and expand to the subtype closure via the generated `query` (#383), so `expressIDsOfTypes(IfcProduct)` unions every product subtype exactly as the resident model's type index does.

- Express IDs held in per-type `Set`s → idempotent under the streaming builder's rare grow-restart (records re-fire from localID 0).
- Memory O(records), the same order as the element index it mirrors.

## Scope

Membership is keyed on the raw parse `typeID`. External-mapping / complex records (typeID 0) aren't attributed to their mapped classes here — resolving those needs the record's `multiMapping`, which the event stream doesn't carry (that's the model's construction-time index). Exact for the simple-record majority, which the test pins.

## Tests

`incremental_type_index.test.ts`: membership + count match the resident model's type index for `IfcRoot` / `IfcProduct` / `IfcWall` / `IfcPropertySet`, and a multi-type union.

Part of the streaming-loader stack (M2a→M2b→M3→M4→M5) laid out for sequential review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_