### PR TITLE
M3: demand-driven geometry work queue (budget + eviction scheduler)

### DIFF
--- a/src/core/demand_geometry_queue.test.ts
+++ b/src/core/demand_geometry_queue.test.ts
@@ -1,0 +1,159 @@
+/* eslint-disable no-magic-numbers */
+// M3: the demand-geometry scheduler — priority ordering, byte budget, and
+// eviction — tested against a mock tiles backend so the policy is settled
+// independently of the wasm extract/reclaim work.
+import { describe, expect, test } from '@jest/globals'
+
+import { DemandGeometryQueue, GeometryTiles } from './demand_geometry_queue'
+
+/**
+ * A mock tiles backend: every product costs a fixed number of bytes and
+ * records the extract/release calls so tests can assert on them.
+ *
+ * @param costBytes Per-tile resident cost.
+ * @return {object} `{ tiles, extracted, released }`.
+ */
+function mockTiles( costBytes: number ) {
+  const extracted: number[] = []
+  const released: number[] = []
+  const tiles: GeometryTiles = {
+    extract( id ) {
+      extracted.push( id )
+      return costBytes
+    },
+    release( id ) {
+      released.push( id )
+    },
+  }
+  return { tiles, extracted, released }
+}
+
+describe( 'DemandGeometryQueue', () => {
+
+  test( 'materialises highest-priority requests first', () => {
+    const { tiles, extracted } = mockTiles( 10 )
+    const q = new DemandGeometryQueue( tiles, 1000 )
+
+    q.request( 1, 5 )
+    q.request( 2, 50 )
+    q.request( 3, 20 )
+    q.pump()
+
+    // Extracted in descending priority: 2 (50), 3 (20), 1 (5).
+    expect( extracted ).toEqual( [ 2, 3, 1 ] )
+    expect( q.stats.residentCount ).toBe( 3 )
+    expect( q.stats.residentBytes ).toBe( 30 )
+  } )
+
+  test( 'evicts the lowest-priority tile when the budget is exceeded', () => {
+    const { tiles, released } = mockTiles( 100 )
+    // Budget holds 3 tiles (300).
+    const q = new DemandGeometryQueue( tiles, 300 )
+
+    for ( const [ id, pri ] of [ [ 1, 10 ], [ 2, 20 ], [ 3, 30 ] ] ) {
+      q.request( id, pri )
+    }
+    q.pump()
+    expect( q.stats.residentCount ).toBe( 3 )
+
+    // A 4th, higher-priority request must evict the lowest (id 1, pri 10).
+    q.request( 4, 40 )
+    q.pump()
+
+    expect( q.isResident( 4 ) ).toBe( true )
+    expect( q.isResident( 1 ) ).toBe( false )
+    expect( released ).toContain( 1 )
+    expect( q.stats.residentBytes ).toBeLessThanOrEqual( 300 )
+  } )
+
+  test( 'a request below every resident tile does not displace them', () => {
+    const { tiles, extracted } = mockTiles( 100 )
+    const q = new DemandGeometryQueue( tiles, 200 ) // holds 2
+
+    q.request( 1, 50 )
+    q.request( 2, 40 )
+    q.pump()
+    expect( q.stats.residentCount ).toBe( 2 )
+
+    // Low-priority newcomer can't beat either resident tile → stays pending.
+    q.request( 3, 5 )
+    const n = q.pump()
+    expect( n ).toBe( 0 )
+    expect( q.isResident( 3 ) ).toBe( false )
+    expect( extracted ).toEqual( [ 1, 2 ] )
+    expect( q.stats.pendingCount ).toBe( 1 )
+  } )
+
+  test( 're-requesting an evicted product re-extracts it', () => {
+    const { tiles, extracted } = mockTiles( 100 )
+    const q = new DemandGeometryQueue( tiles, 100 ) // holds 1
+
+    q.request( 1, 10 )
+    q.pump()
+    q.request( 2, 20 ) // evicts 1
+    q.pump()
+    expect( q.isResident( 1 ) ).toBe( false )
+
+    q.request( 1, 30 ) // evicts 2, re-extracts 1
+    q.pump()
+    expect( q.isResident( 1 ) ).toBe( true )
+    // 1 extracted twice (first fill, then re-fill after eviction).
+    expect( extracted.filter( ( id ) => id === 1 ).length ).toBe( 2 )
+  } )
+
+  test( 'requesting an already-resident product does not re-extract', () => {
+    const { tiles, extracted } = mockTiles( 10 )
+    const q = new DemandGeometryQueue( tiles, 1000 )
+
+    q.request( 1, 10 )
+    q.pump()
+    q.request( 1, 99 ) // already resident — just bumps ranking
+    q.pump()
+
+    expect( extracted ).toEqual( [ 1 ] )
+  } )
+
+  test( 'a per-pump extraction cap bounds work per call', () => {
+    const { tiles } = mockTiles( 1 )
+    const q = new DemandGeometryQueue( tiles, 1_000_000 )
+
+    for ( let id = 0; id < 100; ++id ) {
+      q.request( id, id )
+    }
+    expect( q.pump( 10 ) ).toBe( 10 )
+    expect( q.stats.residentCount ).toBe( 10 )
+    expect( q.stats.pendingCount ).toBe( 90 )
+  } )
+
+  test( 'evictAll releases everything', () => {
+    const { tiles, released } = mockTiles( 10 )
+    const q = new DemandGeometryQueue( tiles, 1000 )
+
+    for ( let id = 0; id < 5; ++id ) {
+      q.request( id, id )
+    }
+    q.pump()
+    q.evictAll()
+
+    expect( q.stats.residentCount ).toBe( 0 )
+    expect( q.stats.residentBytes ).toBe( 0 )
+    expect( released.sort() ).toEqual( [ 0, 1, 2, 3, 4 ] )
+  } )
+
+  test( 'keeps the resident set bounded by the budget across a demand stream', () => {
+    const { tiles } = mockTiles( 100 )
+    const q = new DemandGeometryQueue( tiles, 500 ) // holds 5
+
+    // A moving "viewport": 200 products stream past with rising priority.
+    for ( let id = 0; id < 200; ++id ) {
+      q.request( id, id )
+      q.pump()
+      expect( q.stats.residentBytes ).toBeLessThanOrEqual( 500 )
+    }
+    // The 5 most-wanted (highest ids) remain.
+    expect( q.stats.residentCount ).toBe( 5 )
+    for ( const id of [ 195, 196, 197, 198, 199 ] ) {
+      expect( q.isResident( id ) ).toBe( true )
+    }
+  } )
+} )

--- a/src/core/demand_geometry_queue.ts
+++ b/src/core/demand_geometry_queue.ts
@@ -1,0 +1,335 @@
+/**
+ * Demand-driven, budgeted geometry materialisation (M3).
+ *
+ * The streaming loader inverts geometry: instead of extracting every product
+ * up front, extraction becomes a **cache fill keyed by product**, ordered by
+ * demand (viewport frustum + distance, explicit selection, prefetch hints)
+ * and bounded by an explicit byte budget. This module is the scheduler: a
+ * priority queue over product local IDs plus an evictable resident set, with
+ * the actual extract / release delegated to a pluggable {@link GeometryTiles}.
+ *
+ * The heavy half — the wasm-side extract → tessellate → upload and the
+ * per-product native reclaim — lives behind {@link GeometryTiles}. Its
+ * production implementation needs a **conway-geom API to free one product's
+ * native geometry** (today the wasm heap has no per-product reclaim); scoping
+ * that C++ surface is the M3 blocker tracked in the design doc. This scheduler
+ * is engine-side, fully deterministic, and tested against a mock tiles impl,
+ * so the queue/budget/eviction policy is settled independently of the wasm
+ * work.
+ */
+
+/**
+ * The per-product geometry work behind the queue. Implementations do the
+ * expensive materialisation; the queue owns only ordering and the budget.
+ */
+export interface GeometryTiles {
+
+  /**
+   * Materialise a product's geometry tile and return its resident cost in
+   * bytes (GPU/scene + any retained wasm working set the budget should count).
+   * Called at most once per product between evictions.
+   *
+   * @param productLocalID The product's local ID.
+   * @return {number} The tile's resident byte cost (≥ 0).
+   */
+  extract( productLocalID: number ): number
+
+  /**
+   * Release a product's materialised tile, freeing its resident bytes — the
+   * scene mesh and, crucially, the product's native (wasm) geometry. This is
+   * the per-product reclaim the production conway-geom surface must provide.
+   *
+   * @param productLocalID The product's local ID.
+   */
+  release( productLocalID: number ): void
+}
+
+
+/** A pending request: a product and its current demand priority. */
+interface PendingRequest {
+  productLocalID: number
+  priority: number
+}
+
+
+/** A resident tile: its byte cost and the priority it was filled at. */
+interface ResidentTile {
+  bytes: number
+  priority: number
+}
+
+
+/**
+ * Runtime counters for a queue, for tests and telemetry.
+ */
+export interface DemandQueueStats {
+  extractions: number
+  evictions: number
+  residentBytes: number
+  residentCount: number
+  pendingCount: number
+}
+
+
+/**
+ * A budgeted, demand-ordered geometry materialisation queue.
+ *
+ * Usage: `request(productLocalID, priority)` as demand changes (higher
+ * priority = more wanted); `pump()` to materialise the most-wanted pending
+ * products until the queue drains or the byte budget forces eviction of
+ * lower-priority resident tiles. Re-requesting an evicted product re-fills it.
+ * A steady stream of `request` + `pump` keeps a bounded working set of the
+ * highest-priority products resident — the "full model navigable under a
+ * fixed budget" behaviour.
+ */
+export class DemandGeometryQueue {
+
+  private readonly tiles_: GeometryTiles
+
+  private readonly budgetBytes_: number
+
+  /** Highest priority a product currently wants materialising at. */
+  private readonly pending_ = new Map<number, number>()
+
+  /** Resident tiles by product local ID. */
+  private readonly resident_ = new Map<number, ResidentTile>()
+
+  private residentBytes_ = 0
+
+  private extractions_ = 0
+
+  private evictions_ = 0
+
+  /**
+   * @param tiles The extract/release backend.
+   * @param budgetBytes Maximum resident tile bytes before eviction kicks in.
+   */
+  constructor( tiles: GeometryTiles, budgetBytes: number ) {
+
+    if ( budgetBytes <= 0 ) {
+      throw new Error( `Invalid budgetBytes ${budgetBytes}` )
+    }
+
+    this.tiles_ = tiles
+    this.budgetBytes_ = budgetBytes
+  }
+
+  /**
+   * Request a product be materialised at the given demand priority. Updates
+   * the priority if already pending (keeping the higher of the two) or already
+   * resident (so eviction ranks it correctly). Requesting a resident product
+   * does not re-extract it.
+   *
+   * @param productLocalID The product to materialise.
+   * @param priority The demand priority (higher = more wanted).
+   */
+  public request( productLocalID: number, priority: number ): void {
+
+    const tile = this.resident_.get( productLocalID )
+
+    if ( tile !== void 0 ) {
+      // Already resident — just refresh its eviction ranking.
+      tile.priority = Math.max( tile.priority, priority )
+      return
+    }
+
+    const existing = this.pending_.get( productLocalID )
+
+    this.pending_.set(
+        productLocalID,
+        existing === void 0 ? priority : Math.max( existing, priority ) )
+  }
+
+  /**
+   * Materialise pending products in descending priority order, evicting the
+   * lowest-priority resident tiles whenever the budget is exceeded. A pending
+   * product whose priority is below every resident tile AND that can't fit is
+   * left pending (it will fill once demand raises it or resident tiles drop).
+   *
+   * @param maxExtractions Optional cap on how many tiles to extract this pump
+   * (e.g. a per-frame budget); unbounded when omitted.
+   * @return {number} The number of tiles extracted this pump.
+   */
+  public pump( maxExtractions: number = Number.POSITIVE_INFINITY ): number {
+
+    let extractedThisPump = 0
+
+    while ( extractedThisPump < maxExtractions && this.pending_.size > 0 ) {
+
+      const next = this.popHighestPending_()
+
+      if ( next === void 0 ) {
+        break
+      }
+
+      // If the working set is full and this request can't beat the cheapest
+      // evictable (lower-priority) resident tile, stop — nothing more fits.
+      if ( !this.ensureRoomFor_( next.priority ) ) {
+        // Put it back; it stays pending for a future pump.
+        this.pending_.set( next.productLocalID, next.priority )
+        break
+      }
+
+      const bytes = this.tiles_.extract( next.productLocalID )
+
+      this.resident_.set(
+          next.productLocalID, { bytes, priority: next.priority } )
+
+      this.residentBytes_ += bytes
+      ++this.extractions_
+      ++extractedThisPump
+
+      // A single oversized tile can still exceed budget; evict what we can.
+      this.evictToBudget_()
+    }
+
+    return extractedThisPump
+  }
+
+  /**
+   * Evict every resident tile (e.g. on model close), releasing all bytes.
+   */
+  public evictAll(): void {
+    for ( const productLocalID of this.resident_.keys() ) {
+      this.tiles_.release( productLocalID )
+      ++this.evictions_
+    }
+    this.resident_.clear()
+    this.residentBytes_ = 0
+  }
+
+  /**
+   * @return {boolean} True if the product's tile is resident.
+   * @param productLocalID The product to check.
+   */
+  public isResident( productLocalID: number ): boolean {
+    return this.resident_.has( productLocalID )
+  }
+
+  /**
+   * @return {DemandQueueStats} A snapshot of runtime counters.
+   */
+  public get stats(): DemandQueueStats {
+    return {
+      extractions: this.extractions_,
+      evictions: this.evictions_,
+      residentBytes: this.residentBytes_,
+      residentCount: this.resident_.size,
+      pendingCount: this.pending_.size,
+    }
+  }
+
+  /**
+   * Pop the highest-priority pending request. Linear scan — swap for a heap
+   * if a real workload shows the pending set growing large per pump.
+   *
+   * @return {PendingRequest | undefined} The request, or undefined if none.
+   */
+  private popHighestPending_(): PendingRequest | undefined {
+
+    let bestID: number | undefined
+    let bestPriority = Number.NEGATIVE_INFINITY
+
+    for ( const [ productLocalID, priority ] of this.pending_ ) {
+      if ( priority > bestPriority ) {
+        bestPriority = priority
+        bestID = productLocalID
+      }
+    }
+
+    if ( bestID === void 0 ) {
+      return void 0
+    }
+
+    this.pending_.delete( bestID )
+
+    return { productLocalID: bestID, priority: bestPriority }
+  }
+
+  /**
+   * Ensure there is conceptual room for a tile requested at `priority` by
+   * evicting resident tiles strictly lower in priority while over budget.
+   * Returns false if the budget is full of tiles at least as wanted as this
+   * request (so it shouldn't displace them).
+   *
+   * @param priority The incoming request's priority.
+   * @return {boolean} True if extraction should proceed.
+   */
+  private ensureRoomFor_( priority: number ): boolean {
+
+    if ( this.residentBytes_ < this.budgetBytes_ ) {
+      return true
+    }
+
+    // Over/at budget: only proceed if there's a lower-priority tile to evict.
+    let evictedAny = false
+
+    while ( this.residentBytes_ >= this.budgetBytes_ ) {
+      const victim = this.lowestPriorityResident_()
+
+      if ( victim === void 0 || victim.priority >= priority ) {
+        break
+      }
+
+      this.evictOne_( victim.productLocalID )
+      evictedAny = true
+    }
+
+    return this.residentBytes_ < this.budgetBytes_ || evictedAny
+  }
+
+  /**
+   * Evict lowest-priority resident tiles until within budget (used after an
+   * extraction that pushed us over — e.g. a large tile).
+   */
+  private evictToBudget_(): void {
+    while ( this.residentBytes_ > this.budgetBytes_ ) {
+      const victim = this.lowestPriorityResident_()
+
+      if ( victim === void 0 ) {
+        break
+      }
+
+      this.evictOne_( victim.productLocalID )
+    }
+  }
+
+  /**
+   * @return {{ productLocalID: number, priority: number } | undefined} The
+   * lowest-priority resident tile, or undefined if none.
+   */
+  private lowestPriorityResident_():
+      { productLocalID: number, priority: number } | undefined {
+
+    let worstID: number | undefined
+    let worstPriority = Number.POSITIVE_INFINITY
+
+    for ( const [ productLocalID, tile ] of this.resident_ ) {
+      if ( tile.priority < worstPriority ) {
+        worstPriority = tile.priority
+        worstID = productLocalID
+      }
+    }
+
+    return worstID === void 0 ?
+      void 0 : { productLocalID: worstID, priority: worstPriority }
+  }
+
+  /**
+   * Release one resident tile.
+   *
+   * @param productLocalID The tile to evict.
+   */
+  private evictOne_( productLocalID: number ): void {
+    const tile = this.resident_.get( productLocalID )
+
+    if ( tile === void 0 ) {
+      return
+    }
+
+    this.tiles_.release( productLocalID )
+    this.resident_.delete( productLocalID )
+    this.residentBytes_ -= tile.bytes
+    ++this.evictions_
+  }
+}


### PR DESCRIPTION
**M3** (#394), epic #390. **Base retargeted to `main`** (M2a #401 + M2b #402 are merged); diff is now exactly the M3 increment. **Merge sequence position: #403 → #404 → #405 → #408 → #409.**

## What

Inverts geometry from a load phase into a **demand-ordered, budgeted cache fill keyed by product**. `DemandGeometryQueue` is the scheduler: a priority queue over product local IDs (viewport frustum + distance / selection / prefetch priority) plus an evictable resident set bounded by a byte budget, with the actual extract/release delegated to a pluggable `GeometryTiles` backend.

- `request(id, priority)` as demand changes; `pump()` materialises the most-wanted pending products, evicting lower-priority resident tiles when over budget; a low-priority newcomer that can't displace anyone stays pending; re-requesting an evicted product re-fills it.
- Eviction victims must be **strictly** lower priority, so equal-priority tiles never thrash each other.
- Per-pump extraction cap (a frame budget); `evictAll()` for model close.
- Deterministic, engine-side, no wasm dependency.

## Compatibility with existing Share use

**Fully additive** — two new files, nothing existing modified. No Share surface, no geometry code touched → zero render-diff exposure; **visual-diff CI green on the PR head** (with build + run-ifc-regression).

## Scope note — the blocker described below was subsequently resolved

When this PR was authored, the wasm-side per-product reclaim was the open M3 blocker. That question has since been settled and built: the *"Resident memory: two regimes"* design (chunked tile pool, not per-product `free()`) landed as the mem system in **#408** and the C++ `TilePool` + wasm bindings in **conway-geom #147** (verified end-to-end against a real wasm build). This PR's `GeometryTiles` seam is exactly what `GeometryTilePool` (#408) implements.

## Known behavior (documented, structurally prevented downstream)

A single tile whose byte cost exceeds the *entire* budget is extracted and then immediately self-evicted by the post-extract budget pass, and a persistent consumer would churn it. The production composition prevents this class structurally: #408's `ChunkedPool` refuses oversized commits all-or-nothing **before** extraction, and its conservative logical-≥-physical accounting keeps queue and pool consistent (pinned by #408's composed tests). Flagged here so the raw-queue contract is understood.

## Tests

`demand_geometry_queue.test.ts` (8): priority ordering; budget-driven eviction of the lowest-priority tile; no-displace-below-resident; re-extract after eviction; no re-extract when resident; per-pump cap; `evictAll`; and a **200-product demand stream** that stays bounded to the budget with the 5 most-wanted resident (the "full model navigable under a fixed budget" behaviour).

## Review status

Reviewed 2026-07-19 (chain review before merge): eviction edge cases hand-traced (equal-priority no-thrash, mixed-priority multi-evict, budget invariant per step); no correctness findings; the oversized-tile behavior documented above is the single noted sharp edge, no code change warranted at this layer. CI green: build / run-ifc-regression / **visual-diff** on head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz