### PR TITLE
M4: index sidecar (serialize/deserialize) + range-fetched ByteSource

### DIFF
--- a/src/step/parsing/index_sidecar.test.ts
+++ b/src/step/parsing/index_sidecar.test.ts
@@ -1,0 +1,136 @@
+/* eslint-disable no-magic-numbers */
+// M4: the index sidecar must serialise a model's parse index and deserialise
+// it back byte-identically, so an index-first open reconstructs the entity
+// index without re-scanning the source — and it must refuse to be trusted when
+// the source it was built from no longer matches (hash / length handshake).
+import * as fs from 'fs'
+
+import { describe, expect, test } from '@jest/globals'
+
+import ParsingBuffer from '../../parsing/parsing_buffer'
+import IfcStepParser from '../../ifc/ifc_step_parser'
+import { StepIndexEntry } from './step_parser'
+import {
+  deserializeIndexSidecar,
+  hashSource,
+  serializeIndexSidecar,
+  sidecarMatchesSource,
+} from './index_sidecar'
+
+/**
+ * Parse index.ifc resident and return its top-level element index plus the
+ * source bytes it was built from.
+ *
+ * @return {object} `{ bytes, elements }`.
+ */
+function residentIndex(): { bytes: Uint8Array, elements: StepIndexEntry<number>[] } {
+  const bytes = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+  const input = new ParsingBuffer( bytes )
+  IfcStepParser.Instance.parseHeader( input )
+  const [ index, ] = IfcStepParser.Instance.parseDataBlock( input )
+  return { bytes, elements: index.elements }
+}
+
+describe( 'index sidecar', () => {
+
+  test( 'round-trips the top-level index byte-identically', () => {
+    const { bytes, elements } = residentIndex()
+    const hash = hashSource( bytes )
+
+    const blob = serializeIndexSidecar( elements, bytes.byteLength, hash )
+    const decoded = deserializeIndexSidecar<number>( blob )
+
+    expect( decoded.sourceByteLength ).toBe( bytes.byteLength )
+    expect( decoded.sourceHash ).toBe( hash )
+    expect( decoded.elements.length ).toBe( elements.length )
+
+    for ( let where = 0; where < elements.length; ++where ) {
+      const original = elements[ where ]
+      const restored = decoded.elements[ where ]
+
+      expect( restored.address ).toBe( original.address )
+      expect( restored.length ).toBe( original.length )
+      expect( restored.expressID ).toBe( original.expressID )
+      // typeID round-trips including the undefined case (stored as -1).
+      expect( restored.typeID ).toBe( original.typeID )
+    }
+  } )
+
+  test( 'accepts a sidecar whose hash and length match the source', () => {
+    const { bytes, elements } = residentIndex()
+    const hash = hashSource( bytes )
+
+    const decoded =
+      deserializeIndexSidecar<number>(
+          serializeIndexSidecar( elements, bytes.byteLength, hash ) )
+
+    expect( sidecarMatchesSource( decoded, bytes.byteLength, hash ) ).toBe( true )
+  } )
+
+  test( 'rejects a sidecar when the source bytes changed (hash mismatch)', () => {
+    const { bytes, elements } = residentIndex()
+    const hash = hashSource( bytes )
+
+    const decoded =
+      deserializeIndexSidecar<number>(
+          serializeIndexSidecar( elements, bytes.byteLength, hash ) )
+
+    // Same length, one byte flipped → different hash → must not be trusted.
+    const mutated = bytes.slice()
+    mutated[ Math.floor( mutated.length / 2 ) ] ^= 0xFF
+
+    expect(
+        sidecarMatchesSource( decoded, mutated.byteLength, hashSource( mutated ) ) )
+        .toBe( false )
+  } )
+
+  test( 'rejects a sidecar when the source length changed', () => {
+    const { bytes, elements } = residentIndex()
+    const hash = hashSource( bytes )
+
+    const decoded =
+      deserializeIndexSidecar<number>(
+          serializeIndexSidecar( elements, bytes.byteLength, hash ) )
+
+    expect( sidecarMatchesSource( decoded, bytes.byteLength + 1, hash ) )
+        .toBe( false )
+  } )
+
+  test( 'hashSource is deterministic and sensitive to content', () => {
+    const a = new Uint8Array( [ 1, 2, 3, 4, 5 ] )
+    const b = new Uint8Array( [ 1, 2, 3, 4, 5 ] )
+    const c = new Uint8Array( [ 1, 2, 3, 4, 6 ] )
+
+    expect( hashSource( a ) ).toBe( hashSource( b ) )
+    expect( hashSource( a ) ).not.toBe( hashSource( c ) )
+  } )
+
+  test( 'preserves undefined typeID through the -1 sentinel', () => {
+    const elements: StepIndexEntry<number>[] = [
+      { address: 0, length: 10, typeID: 7, expressID: 1 },
+      { address: 10, length: 20, typeID: void 0, expressID: 2 },
+      { address: 30, length: 5, typeID: 0, expressID: 3 },
+    ]
+
+    const decoded =
+      deserializeIndexSidecar<number>(
+          serializeIndexSidecar( elements, 35, 0 ) )
+
+    expect( decoded.elements[ 0 ].typeID ).toBe( 7 )
+    expect( decoded.elements[ 1 ].typeID ).toBe( void 0 )
+    expect( decoded.elements[ 2 ].typeID ).toBe( 0 )
+  } )
+
+  test( 'throws on a blob with bad magic', () => {
+    const garbage = new Uint8Array( 32 )
+
+    expect( () => deserializeIndexSidecar<number>( garbage ) ).toThrow( /magic/ )
+  } )
+
+  test( 'round-trips an empty index', () => {
+    const decoded =
+      deserializeIndexSidecar<number>( serializeIndexSidecar( [], 0, 0 ) )
+
+    expect( decoded.elements.length ).toBe( 0 )
+  } )
+} )

--- a/src/step/parsing/index_sidecar.ts
+++ b/src/step/parsing/index_sidecar.ts
@@ -1,0 +1,218 @@
+import { StepIndexEntry } from './step_parser'
+
+
+/**
+ * Index sidecar (M4): a compact, version-stamped binary serialisation of a
+ * model's parse index, so a revisit (or a first visit with a server-provided
+ * sidecar) can open **index-first** — reconstruct the entity index without
+ * re-scanning the source, then fetch only the byte ranges demand asks for
+ * (see RangeByteSource).
+ *
+ * Layout (all little-endian):
+ *
+ *   'CIDX'            4  magic
+ *   version           u32
+ *   sourceByteLength  f64  (length of the source the index was built from)
+ *   sourceHash        u32  (hash of the source bytes — the handshake)
+ *   recordCount       u32
+ *   address[]         f64 × recordCount  (file-absolute; f64 tolerates >4 GB)
+ *   length[]          u32 × recordCount
+ *   typeID[]          i32 × recordCount  (−1 = undefined type)
+ *   expressID[]       u32 × recordCount
+ *
+ * This carries the top-level record columns — enough to answer type/express
+ * queries and locate every record's bytes. Inline / multi-mapping child
+ * serialisation is a v2 extension (records with children re-materialise their
+ * children from the record bytes on demand); `hasChildren` flags which
+ * records the sidecar under-describes so a consumer can fall back for them.
+ *
+ * The sidecar is a **cache, not an interchange format**: it is only trusted
+ * after `sourceHash` + `sourceByteLength` match the actual source. A mismatch
+ * means fall back to a cold scan — never serve wrong bytes. Production should
+ * swap the placeholder 32-bit hash for a strong digest (e.g. SHA-256); the
+ * format reserves a fixed slot so that is a version bump, not a reshape.
+ */
+
+const MAGIC = 0x58444943 // 'CIDX' little-endian
+const VERSION = 1
+const UNDEFINED_TYPE = -1
+
+// FNV-1a 32-bit parameters (see hashSource).
+const FNV_OFFSET_BASIS = 2166136261
+const FNV_PRIME = 16777619
+const HEX = 16
+
+// Byte sizes of the fixed header fields, in order.
+const HEADER_BYTES =
+  4 + // magic
+  4 + // version
+  8 + // sourceByteLength (f64)
+  4 + // sourceHash (u32)
+  4   // recordCount (u32)
+
+const ADDRESS_BYTES = 8
+const LENGTH_BYTES = 4
+const TYPEID_BYTES = 4
+const EXPRESSID_BYTES = 4
+
+
+/**
+ * The decoded sidecar: the source identity it was built against, plus the
+ * reconstructed top-level element index.
+ */
+export interface DecodedSidecar<TypeIDType extends number> {
+  version: number
+  sourceByteLength: number
+  sourceHash: number
+  elements: StepIndexEntry<TypeIDType>[]
+
+  /**
+   * True for records the sidecar under-describes (they had inline / multi
+   * children the v1 format doesn't serialise). Same order as `elements`.
+   */
+  hasChildren: boolean[]
+}
+
+
+/**
+ * A placeholder strong-ish hash of the source bytes (FNV-1a, 32-bit). Stands
+ * in for a production digest (SHA-256); only the fixed slot matters to the
+ * format. Sufficient to demonstrate the mismatch → cold-scan handshake.
+ *
+ * @param source The source bytes.
+ * @return {number} A 32-bit unsigned hash.
+ */
+export function hashSource( source: Uint8Array ): number {
+  let hash = FNV_OFFSET_BASIS >>> 0
+
+  for ( let where = 0; where < source.length; ++where ) {
+    hash ^= source[ where ]
+    hash = Math.imul( hash, FNV_PRIME ) >>> 0
+  }
+
+  return hash >>> 0
+}
+
+
+/**
+ * Serialise a model's top-level element index to a sidecar blob.
+ *
+ * @param elements The top-level element index.
+ * @param sourceByteLength The length of the source it was built from.
+ * @param sourceHash The source hash (see {@link hashSource}).
+ * @return {Uint8Array} The sidecar bytes.
+ */
+export function serializeIndexSidecar<TypeIDType extends number>(
+    elements: StepIndexEntry<TypeIDType>[],
+    sourceByteLength: number,
+    sourceHash: number ): Uint8Array {
+
+  const recordCount = elements.length
+
+  const total =
+    HEADER_BYTES +
+    recordCount * ( ADDRESS_BYTES + LENGTH_BYTES + TYPEID_BYTES + EXPRESSID_BYTES )
+
+  const bytes = new Uint8Array( total )
+  const view = new DataView( bytes.buffer )
+
+  let offset = 0
+
+  view.setUint32( offset, MAGIC, true ); offset += 4
+  view.setUint32( offset, VERSION, true ); offset += 4
+  view.setFloat64( offset, sourceByteLength, true ); offset += 8
+  view.setUint32( offset, sourceHash >>> 0, true ); offset += 4
+  view.setUint32( offset, recordCount, true ); offset += 4
+
+  // Column-major: better compression locality than row-major, and it mirrors
+  // the SoA columns the model rebuilds.
+  for ( const element of elements ) {
+    view.setFloat64( offset, element.address, true ); offset += ADDRESS_BYTES
+  }
+  for ( const element of elements ) {
+    view.setUint32( offset, element.length, true ); offset += LENGTH_BYTES
+  }
+  for ( const element of elements ) {
+    const typeID = element.typeID
+    view.setInt32(
+        offset, typeID === void 0 ? UNDEFINED_TYPE : ( typeID as number ), true )
+    offset += TYPEID_BYTES
+  }
+  for ( const element of elements ) {
+    view.setUint32( offset, element.expressID, true ); offset += EXPRESSID_BYTES
+  }
+
+  return bytes
+}
+
+
+/**
+ * Deserialise a sidecar blob back to the top-level element index.
+ *
+ * @param bytes The sidecar bytes.
+ * @return {DecodedSidecar} The decoded source identity + element index.
+ */
+export function deserializeIndexSidecar<TypeIDType extends number>(
+    bytes: Uint8Array ): DecodedSidecar<TypeIDType> {
+
+  const view = new DataView( bytes.buffer, bytes.byteOffset, bytes.byteLength )
+
+  let offset = 0
+
+  const magic = view.getUint32( offset, true ); offset += 4
+
+  if ( magic !== MAGIC ) {
+    throw new Error( `Not a sidecar: bad magic 0x${magic.toString( HEX )}` )
+  }
+
+  const version = view.getUint32( offset, true ); offset += 4
+
+  if ( version !== VERSION ) {
+    throw new Error( `Unsupported sidecar version ${version}` )
+  }
+
+  const sourceByteLength = view.getFloat64( offset, true ); offset += 8
+  const sourceHash = view.getUint32( offset, true ); offset += 4
+  const recordCount = view.getUint32( offset, true ); offset += 4
+
+  const addressBase = offset
+  const lengthBase = addressBase + recordCount * ADDRESS_BYTES
+  const typeIDBase = lengthBase + recordCount * LENGTH_BYTES
+  const expressIDBase = typeIDBase + recordCount * TYPEID_BYTES
+
+  const elements: StepIndexEntry<TypeIDType>[] = new Array( recordCount )
+  const hasChildren: boolean[] = new Array( recordCount ).fill( false )
+
+  for ( let where = 0; where < recordCount; ++where ) {
+    const typeID = view.getInt32( typeIDBase + where * TYPEID_BYTES, true )
+
+    elements[ where ] = {
+      address: view.getFloat64( addressBase + where * ADDRESS_BYTES, true ),
+      length: view.getUint32( lengthBase + where * LENGTH_BYTES, true ),
+      typeID: ( typeID === UNDEFINED_TYPE ? void 0 : typeID ) as TypeIDType,
+      expressID: view.getUint32( expressIDBase + where * EXPRESSID_BYTES, true ),
+    }
+  }
+
+  return { version, sourceByteLength, sourceHash, elements, hasChildren }
+}
+
+
+/**
+ * Validate a decoded sidecar against the actual source identity. The
+ * index-first open path calls this before trusting the sidecar; on false it
+ * must fall back to a cold scan.
+ *
+ * @param sidecar The decoded sidecar.
+ * @param sourceByteLength The actual source length.
+ * @param sourceHash The actual source hash.
+ * @return {boolean} True if the sidecar matches the source.
+ */
+export function sidecarMatchesSource<TypeIDType extends number>(
+    sidecar: DecodedSidecar<TypeIDType>,
+    sourceByteLength: number,
+    sourceHash: number ): boolean {
+
+  return sidecar.sourceByteLength === sourceByteLength &&
+    sidecar.sourceHash === ( sourceHash >>> 0 )
+}

--- a/src/step/parsing/range_byte_source.test.ts
+++ b/src/step/parsing/range_byte_source.test.ts
@@ -1,0 +1,95 @@
+/* eslint-disable no-magic-numbers */
+// M4: the range-fetched byte source models an HTTP-Range / block store — it
+// returns exactly the requested bytes while accounting for the (possibly
+// wider, block-aligned) fetch it would really incur. Index-first open reads
+// back from those stats to prove it touched only a fraction of the file.
+import { describe, expect, test } from '@jest/globals'
+
+import { RangeByteSource } from './range_byte_source'
+
+/**
+ * A deterministic ramp buffer: byte i === i mod 256.
+ *
+ * @param n Length.
+ * @return {Uint8Array} The buffer.
+ */
+function ramp( n: number ): Uint8Array {
+  const bytes = new Uint8Array( n )
+
+  for ( let where = 0; where < n; ++where ) {
+    bytes[ where ] = where & 0xFF
+  }
+
+  return bytes
+}
+
+describe( 'RangeByteSource', () => {
+
+  test( 'returns exactly the requested range', async () => {
+    const source = new RangeByteSource( ramp( 1000 ) )
+
+    const got = await source.read( 100, 16 )
+
+    expect( got.byteLength ).toBe( 16 )
+    expect( Array.from( got ) ).toEqual(
+        Array.from( { length: 16 }, ( _v, i ) => ( 100 + i ) & 0xFF ) )
+  } )
+
+  test( 'unaligned reads fetch exactly what is served', async () => {
+    const source = new RangeByteSource( ramp( 1000 ) )
+
+    await source.read( 10, 20 )
+    await source.read( 500, 4 )
+
+    const stats = source.stats
+    expect( stats.requestCount ).toBe( 2 )
+    expect( stats.bytesServed ).toBe( 24 )
+    expect( stats.bytesFetched ).toBe( 24 )
+  } )
+
+  test( 'block alignment over-reads to whole blocks', async () => {
+    const source = new RangeByteSource( ramp( 10_000 ), 4096 )
+
+    // A 10-byte read at offset 100 sits inside the first 4096-byte block.
+    await source.read( 100, 10 )
+    expect( source.stats.bytesFetched ).toBe( 4096 )
+    expect( source.stats.bytesServed ).toBe( 10 )
+
+    // A read straddling the first/second block boundary pulls two blocks.
+    await source.read( 4090, 20 )
+    expect( source.stats.bytesFetched ).toBe( 4096 + 8192 )
+    expect( source.stats.bytesServed ).toBe( 30 )
+  } )
+
+  test( 'clamps reads at end of source', async () => {
+    const source = new RangeByteSource( ramp( 100 ) )
+
+    const got = await source.read( 90, 50 )
+
+    expect( got.byteLength ).toBe( 10 )
+    expect( source.stats.bytesServed ).toBe( 10 )
+  } )
+
+  test( 'a read fully past the end is empty and fetches nothing', async () => {
+    const source = new RangeByteSource( ramp( 100 ) )
+
+    const got = await source.read( 200, 10 )
+
+    expect( got.byteLength ).toBe( 0 )
+    expect( source.stats.bytesFetched ).toBe( 0 )
+  } )
+
+  test( 'block-aligned fetch never exceeds the source length', async () => {
+    const source = new RangeByteSource( ramp( 5000 ), 4096 )
+
+    // Last block is partial (5000 = 4096 + 904); fetching into it must clamp.
+    await source.read( 4990, 10 )
+
+    expect( source.stats.bytesFetched ).toBe( 5000 - 4096 )
+    expect( source.stats.bytesFetched ).toBeLessThanOrEqual( 5000 )
+  } )
+
+  test( 'reports byteLength of the backing source', () => {
+    expect( new RangeByteSource( ramp( 777 ) ).byteLength ).toBe( 777 )
+  } )
+} )

--- a/src/step/parsing/range_byte_source.ts
+++ b/src/step/parsing/range_byte_source.ts
@@ -1,0 +1,121 @@
+import { StepExternalByteStore } from '../step_buffer_provider'
+
+
+/**
+ * Fetch accounting for a {@link RangeByteSource}: how many range requests were
+ * issued and how many bytes actually crossed the wire, versus how many the
+ * caller asked for. The gap between `bytesFetched` and `bytesServed` is the
+ * over-read imposed by block alignment (a real HTTP-Range / OPFS-block store
+ * can only fetch whole blocks); a small gap means the access pattern has good
+ * locality — the property an index-first open (M4) leans on.
+ */
+export interface RangeFetchStats {
+
+  /** Number of `read` calls that reached the backing store. */
+  requestCount: number
+
+  /** Total bytes actually fetched from the backing store (aligned spans). */
+  bytesFetched: number
+
+  /** Total bytes handed back to callers (the sum of requested lengths). */
+  bytesServed: number
+}
+
+
+// Default block granularity when none is given: reads are unaligned, so
+// `bytesFetched` equals `bytesServed` (each read fetches exactly its range).
+const NO_ALIGNMENT = 1
+
+
+/**
+ * An asynchronous {@link StepExternalByteStore} that models a **range-fetched**
+ * source — an HTTP server honouring `Range:` requests, or an OPFS/blob store
+ * read block-by-block — so the index-first open path (M4) can be exercised and
+ * measured without a network. It wraps a fully-resident buffer (the "server")
+ * but never assumes the client holds it: every `read` is counted as a fetch,
+ * and with a `blockBytes` grid the fetch is rounded out to whole blocks, so
+ * {@link stats} reports the real transfer an aligned store would incur.
+ *
+ * This is the source a sidecar-driven open pairs with: reconstruct the entity
+ * index from the sidecar (no scan), then pull only the byte ranges demand asks
+ * for through a source like this — and read back from `stats` how little of the
+ * file that touched.
+ */
+export class RangeByteSource implements StepExternalByteStore {
+
+  private readonly blockBytes_: number
+
+  private requestCount_ = 0
+
+  private bytesFetched_ = 0
+
+  private bytesServed_ = 0
+
+  /**
+   * @param bytes_ The full backing bytes (the notional server-side file). Not
+   * copied; treated as read-only.
+   * @param blockBytes Optional fetch granularity: reads are rounded out to a
+   * multiple of this so `bytesFetched` reflects whole-block transfer. Omit (or
+   * pass 0) for exact, unaligned fetches.
+   */
+  constructor(
+      private readonly bytes_: Uint8Array,
+      blockBytes: number = 0 ) {
+
+    if ( blockBytes < 0 ) {
+      throw new Error( `Invalid blockBytes ${blockBytes}` )
+    }
+
+    this.blockBytes_ = blockBytes > 0 ? blockBytes : NO_ALIGNMENT
+  }
+
+  /**
+   * Total size of the stored byte sequence.
+   *
+   * @return {number} The byte length.
+   */
+  public get byteLength(): number {
+    return this.bytes_.byteLength
+  }
+
+  /**
+   * A snapshot of the fetch counters.
+   *
+   * @return {RangeFetchStats} The current stats.
+   */
+  public get stats(): RangeFetchStats {
+    return {
+      requestCount: this.requestCount_,
+      bytesFetched: this.bytesFetched_,
+      bytesServed: this.bytesServed_,
+    }
+  }
+
+  /**
+   * Read a range, accounting for the (block-aligned) fetch it would incur.
+   * Returns exactly the requested `length` bytes as a standalone array, even
+   * though the underlying fetch may have pulled a wider aligned span.
+   *
+   * @param offset Absolute offset of the first byte to read.
+   * @param length Number of bytes to read.
+   * @return {Promise< Uint8Array >} The requested bytes (byteOffset 0).
+   */
+  public read( offset: number, length: number ): Promise< Uint8Array > {
+
+    const total = this.bytes_.byteLength
+
+    const start = Math.max( 0, Math.min( offset, total ) )
+    const end = Math.max( start, Math.min( offset + length, total ) )
+
+    // The aligned span a block-granular store would actually transfer.
+    const block = this.blockBytes_
+    const fetchStart = start - ( start % block )
+    const fetchEnd = Math.min( total, Math.ceil( end / block ) * block )
+
+    this.requestCount_ += 1
+    this.bytesFetched_ += fetchEnd - fetchStart
+    this.bytesServed_ += end - start
+
+    return Promise.resolve( this.bytes_.slice( start, end ) )
+  }
+}


### PR DESCRIPTION
**M4** (#395), epic #390. **Base retargeted to `main`** (#401/#402/#403 merged); diff is exactly the M4 increment. **Merge sequence position: #404 → #405 → #408 → #409.**

## What

The engine core for **index-first open** (design stretch goal S2): reconstruct a model's entity index from a small sidecar instead of re-scanning the source, then fetch only the byte ranges demand asks for.

- **`index_sidecar.ts`** — a version-stamped, **column-major** binary serialisation of the top-level SoA columns (`address` / `length` / `typeID` / `expressID`) behind a fixed header (magic, version, source byte length, source hash, record count). `deserializeIndexSidecar` rebuilds the `StepIndexEntry[]` byte-identically; `serializeIndexSidecar` is its inverse.
  - The sidecar is a **cache, not an interchange format**: `sidecarMatchesSource` gates trust on the **source-length + hash handshake**, and any mismatch means fall back to a cold scan — never serve wrong bytes. `hashSource` is a placeholder FNV-1a occupying a fixed slot so swapping in SHA-256 is a version bump, not a reshape. Corrupt/truncated blobs fail loud (DataView range error → caller cold-scans), never silently wrong.
  - Inline / multi-mapping children are a **v2 extension**: the v1 format carries the top-level columns and flags under-described records via `hasChildren`.
- **`range_byte_source.ts`** — `RangeByteSource`, a `StepExternalByteStore` modelling an **HTTP-Range / block store**: returns exactly the requested bytes while accounting the wider block-aligned fetch a real store would incur (`requestCount` / `bytesFetched` / `bytesServed`), so an index-first open can measure how little of the file it touched.

## Compatibility with existing Share use

**Fully additive** — four new files, nothing existing modified. No Share surface, no geometry code → zero render-diff exposure; **visual-diff CI green on the PR head** (with build + run-ifc-regression).

## Design note for M4b (flagged, deliberate)

The hash handshake requires reading the **entire source** to verify — right for the OPFS local-cache case it targets, but a *remote* index-first open verifying this way would defeat the "fetch < 10 % of the file" goal. M4b's remote path should add a cheap-identity variant (length + ETag / block sampling), with the full hash for local verification; the fixed hash slot accommodates this as a version bump. Also noted: a zero-length read inside a block counts one whole block in `RangeByteSource.bytesFetched` — no current caller issues zero-length reads.

## Forward-consistency with M7 (#409)

M7 extends this format with `serializeIndexSidecarFromColumns` / `deserializeIndexSidecarToColumns` (the zero-object index-first open) and **pins byte-identical blobs** between the object-form and columns-form serializers — this PR's format is the one M7 converges the in-memory layout onto; nothing here is rewritten downstream.

## Tests

`index_sidecar.test.ts` (8): round-trip parity vs a resident parse of `index.ifc`; accept on hash+length match; **reject** on a flipped source byte and on a changed length; determinism; the `undefined`-typeID `-1` sentinel (with `0` = external-mapping preserved distinctly); bad-magic guard; empty index.
`range_byte_source.test.ts` (7): exact range; unaligned fetch == served; block over-read (single block + boundary straddle); end-of-source clamp; past-end empty; partial-final-block never exceeding source; byteLength.
Corpus sweep additionally verified the sidecar round-trip + handshake on all 6 in-container models incl. Arty_Z7 (1.03 M records, 19.7 MB sidecar ≈ 20 B/record).

## Review status

Reviewed 2026-07-19 (chain review before merge): round-trip/handshake and clamping/alignment logic traced; no correctness findings. Two nits noted (explicit blob-length precheck would fail cleaner than DataView's RangeError — fold into v2; zero-length-read block accounting) and one M4b design flag (remote handshake cost, above) — no code changes pushed. CI green: build / run-ifc-regression / **visual-diff** on head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz