### PR TITLE
M5: federation MVP core — model-URI addressing, shared budget, registry, cross-ref consumer, composed skeleton

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -396,9 +396,49 @@ Deliberately small first step; each has a measurable exit.
 - **M4 — Range ByteSource + index sidecar.** S2. Exit: second visit to a
   remote PSB with sidecar reaches first pixel without fetching > 10 % of
   the file; property panel opens with < 1 MB fetched.
+  - **M4a — sidecar + range source (engine core, landed).** A
+    version-stamped binary sidecar (`index_sidecar.ts`) serialises the
+    top-level SoA columns (address / length / typeID / expressID,
+    column-major) with a source-length + hash header; deserialise
+    reconstructs the entity index byte-identically (round-trip test vs a
+    resident parse of `index.ifc`). The sidecar is a **cache, not an
+    interchange format** — `sidecarMatchesSource` gates trust on the
+    hash+length handshake and falls back to a cold scan on any mismatch
+    (the placeholder FNV-1a hash swaps for SHA-256 as a version bump, not
+    a reshape). Inline / multi-mapping children are a v2 extension
+    (`hasChildren` flags the records the v1 format under-describes).
+    `RangeByteSource` (a `StepExternalByteStore`) models an HTTP-Range /
+    block store: it returns exactly the requested bytes while accounting
+    for the wider block-aligned fetch it would really incur, so
+    index-first open can read back from `stats` how little of the file it
+    touched. *Remaining for M4b: the OPFS/HTTP sidecar cache round-trip in
+    Share and the wired index-first open path over `RangeByteSource`.*
 - **M5 — Federation MVP.** Two cross-referenced files, shared budgets,
   link navigation, composed skeleton. Exit: a 2-file project browses
   under the same memory budget as either file alone.
+  - **M5a — addressing + registry + composition (engine core, landed).**
+    The addressing spine and the cross-file read side, all engine-side
+    and pure TS. `model_uri.ts` — the universal `modelURI#expressID`
+    {@link EntityAddress}, with format/parse and relative-reference
+    resolution (an `IfcExternalReference.Location` like `../shared/grid.ifc`
+    resolves against the containing model's URI). `shared_byte_budget.ts` —
+    the **per-browser** `SharedByteBudget` every model's queue/pool draws
+    from, so N federated files stay bounded (reserve/release/`overageFor`);
+    this is the invariant that keeps federation from re-growing memory
+    O(N). `model_registry.ts` — `ModelRegistry` keying open models by URI
+    and resolving an address to `(model, expressID)` (an unregistered URI
+    is the cue to open a sibling loader). `cross_reference_registry.ts` —
+    a streaming consumer that collects a model's outbound reference
+    entities (`IfcExternalReference` subtype closure) via the M2
+    dispatcher, then resolves their `Location`s into navigable
+    `CrossReferenceLink`s once readable (two-phase: identify while
+    parsing, resolve on demand — the event stream carries IDs, not
+    attribute strings). `composed_model_skeleton.ts` — `ComposedModelSkeleton`
+    fans a type query across every registered model and yields universal
+    addresses, so "every `IfcWall` in the project" spans files. *Remaining
+    for M5b: register streamed models here from the loader, wire the
+    shared budget into M3's `DemandGeometryQueue`, merge cross-file spatial
+    containment, and the UI link layer.*
 
 M0–M2 are conway-internal and regression-gated (byte-identical index and
 GLB output are the invariants CI already checks). M3 changes *when* work
@@ -406,6 +446,32 @@ happens, not *what* it produces — the per-product mesh digests must stay
 identical, which keeps the visual-diff harness authoritative. M4/M5 add
 new surface and need new test rigs (range-request mock server; two-file
 fixture project).
+
+### Landed engine-core stack (for sequential review)
+
+The whole sequence is up as a **stack of PRs**, each branch based on the
+previous, each a self-contained tested increment — reviewable and mergeable
+in order. Every part is engine-side and pure TS (no wasm, no Share
+dependency), so each rests on the invariants CI already enforces; the
+subsystem-coupled halves (the `Xb` items above) are scoped and deferred,
+not stubbed:
+
+| Milestone | Landed core | Deferred (subsystem-coupled) |
+|-----------|-------------|------------------------------|
+| **M0** | streaming window parse, byte-identical index | — |
+| **M1a** | `parseStreamToModel` (windowed-source model) | M1b: Share OPFS worker |
+| **M2a** | record events + type-set dispatcher | — |
+| **M2b** | incremental type index | multi-mapping (typeID 0) attribution |
+| **M3** | demand-geometry queue (budget + eviction) | conway-geom per-product native free |
+| **M4a** | index sidecar + `RangeByteSource` | M4b: Share sidecar cache + index-first open |
+| **M5a** | model-URI, shared budget, registry, cross-ref, composition | M5b: loader registration, budget wiring, UI links |
+
+The recurring shape: **settle the deterministic engine policy against a
+mock/synthetic backend now, so the queue/format/addressing is correct and
+reviewable independently of the wasm and Share work it will later drive.**
+The two named blockers on the critical path are the conway-geom
+per-product native reclaim (gates M3's production `GeometryTiles`) and the
+Share OPFS/HTTP integration (gates M1b/M4b).
 
 ## Key design decisions (settled with Pablo, 2026-07)
 

--- a/src/core/composed_model_skeleton.test.ts
+++ b/src/core/composed_model_skeleton.test.ts
@@ -1,0 +1,83 @@
+/* eslint-disable no-magic-numbers */
+// M5: the composed view fans a type query across every registered model and
+// yields universal addresses, so "every wall in the project" spans files and
+// each result round-trips back through the registry to its model.
+import { describe, expect, test } from '@jest/globals'
+
+import { ComposedModelSkeleton, TypeQueryableModel } from './composed_model_skeleton'
+import { ModelRegistry } from './model_registry'
+import { SharedByteBudget } from './shared_byte_budget'
+
+/**
+ * A fake type-queryable model returning a fixed express-ID set regardless of
+ * the queried types (the query-closure matching itself is covered by the
+ * incremental-type-index tests; here we exercise cross-model composition).
+ */
+class FakeModel implements TypeQueryableModel<number> {
+
+  /**
+   * @param ids The express IDs this model reports for any query.
+   */
+  constructor( private readonly ids: number[] ) {}
+
+  /**
+   * @return {IterableIterator<number>} The fixed express IDs.
+   */
+  public* expressIDsOfTypes(): IterableIterator<number> {
+    yield* this.ids
+  }
+}
+
+// A dummy constructor to satisfy the query signature (unused by FakeModel).
+const ANY_TYPE = { query: [ 1 ] } as any
+
+describe( 'ComposedModelSkeleton', () => {
+
+  /**
+   * A composed view over two fake models.
+   *
+   * @return {ComposedModelSkeleton} The composed view.
+   */
+  function composed(): ComposedModelSkeleton<number, FakeModel> {
+    const registry = new ModelRegistry<FakeModel>( new SharedByteBudget( 1000 ) )
+    registry.register( 'site/a.ifc', new FakeModel( [ 1, 2 ] ) )
+    registry.register( 'site/b.ifc', new FakeModel( [ 10, 11, 12 ] ) )
+    return new ComposedModelSkeleton<number, FakeModel>( registry )
+  }
+
+  test( 'yields universal addresses across every registered model', () => {
+    const view = composed()
+
+    const addresses = [ ...view.entitiesOfType( ANY_TYPE ) ]
+
+    expect( addresses ).toEqual( [
+      { modelURI: 'site/a.ifc', expressID: 1 },
+      { modelURI: 'site/a.ifc', expressID: 2 },
+      { modelURI: 'site/b.ifc', expressID: 10 },
+      { modelURI: 'site/b.ifc', expressID: 11 },
+      { modelURI: 'site/b.ifc', expressID: 12 },
+    ] )
+  } )
+
+  test( 'counts across the federation', () => {
+    expect( composed().countOfType( ANY_TYPE ) ).toBe( 5 )
+  } )
+
+  test( 'each composed address resolves back to its own model', () => {
+    const view = composed()
+
+    for ( const address of view.entitiesOfType( ANY_TYPE ) ) {
+      const resolved = view.registry.resolve( address )
+      expect( resolved ).toBeDefined()
+      expect( resolved?.expressID ).toBe( address.expressID )
+    }
+  } )
+
+  test( 'an empty registry composes to nothing', () => {
+    const view = new ComposedModelSkeleton<number, FakeModel>(
+        new ModelRegistry<FakeModel>( new SharedByteBudget( 10 ) ) )
+
+    expect( [ ...view.entitiesOfType( ANY_TYPE ) ] ).toEqual( [] )
+    expect( view.countOfType( ANY_TYPE ) ).toBe( 0 )
+  } )
+} )

--- a/src/core/composed_model_skeleton.ts
+++ b/src/core/composed_model_skeleton.ts
@@ -1,0 +1,104 @@
+import { StepEntityConstructorAbstract } from '../step/step_entity_constructor'
+import { EntityAddress } from './model_uri'
+import { ModelRegistry } from './model_registry'
+
+
+/**
+ * A model that can answer a type query — the minimum a federated model must
+ * expose to take part in cross-file composition. Both the resident model's
+ * type index and the streaming {@link IncrementalTypeIndex} satisfy this, so a
+ * composed view works whether its members are fully parsed or still streaming.
+ */
+export interface TypeQueryableModel<TypeIDType extends number> {
+
+  /**
+   * Express IDs of all records of the given types (including subtypes).
+   *
+   * @param types The entity constructors to query.
+   * @return {IterableIterator<number>} The matching express IDs.
+   */
+  expressIDsOfTypes(
+    ...types: StepEntityConstructorAbstract<TypeIDType>[] ): IterableIterator<number>
+}
+
+
+/**
+ * A composed view over every model in a {@link ModelRegistry} (M5 / design S3).
+ *
+ * Federation's read side: a site plan that references per-building files, or a
+ * project split across disciplines, is browsed as **one** model whose entities
+ * carry universal {@link EntityAddress}es (`modelURI#expressID`). A type query
+ * here fans out across all registered members and yields addresses, not bare
+ * express IDs — so "every `IfcWall` in the project" spans files, and each
+ * result round-trips back through {@link ModelRegistry.resolve} to the right
+ * model.
+ *
+ * This is the composition scaffold: it unions the members' type skeletons
+ * under the shared address space. The spatial-containment merge (a site's
+ * `IfcRelAggregates` linking to building files) layers on top by resolving the
+ * cross-file references the {@link CrossReferenceRegistry} discovers — the next
+ * increment, gated on the loader registering streamed models here.
+ */
+export class ComposedModelSkeleton<
+  TypeIDType extends number,
+  H extends TypeQueryableModel<TypeIDType>> {
+
+  /**
+   * @param registry_ The registry whose models this composes over.
+   */
+  constructor( private readonly registry_: ModelRegistry<H> ) {}
+
+  /**
+   * @return {ModelRegistry<H>} The registry backing this composed view.
+   */
+  public get registry(): ModelRegistry<H> {
+    return this.registry_
+  }
+
+  /**
+   * Yield the universal address of every entity of the given types across all
+   * registered models.
+   *
+   * @param types The entity constructors to query (subtype closures unioned).
+   * @return {IterableIterator<EntityAddress>} Addresses of matching entities.
+   * @yields {EntityAddress} Each matching entity's universal address.
+   */
+  public* entitiesOfType(
+      ...types: StepEntityConstructorAbstract<TypeIDType>[] ):
+      IterableIterator<EntityAddress> {
+
+    for ( const modelURI of this.registry_.uris() ) {
+
+      const model = this.registry_.get( modelURI )
+
+      if ( model === void 0 ) {
+        continue
+      }
+
+      for ( const expressID of model.expressIDsOfTypes( ...types ) ) {
+        yield { modelURI, expressID }
+      }
+    }
+  }
+
+  /**
+   * Count entities of the given types across all registered models.
+   *
+   * @param types The entity constructors to count.
+   * @return {number} The total across the federation.
+   */
+  public countOfType(
+      ...types: StepEntityConstructorAbstract<TypeIDType>[] ): number {
+
+    let total = 0
+
+    for ( const model of this.registry_.models() ) {
+      for ( const expressID of model.expressIDsOfTypes( ...types ) ) {
+        void expressID
+        ++total
+      }
+    }
+
+    return total
+  }
+}

--- a/src/core/model_registry.test.ts
+++ b/src/core/model_registry.test.ts
@@ -1,0 +1,81 @@
+/* eslint-disable no-magic-numbers */
+// M5: the registry keys open models by URI, resolves universal addresses to
+// the live model, and hands every model the one shared budget.
+import { describe, expect, test } from '@jest/globals'
+
+import { ModelRegistry } from './model_registry'
+import { SharedByteBudget } from './shared_byte_budget'
+
+/** A stand-in model handle: just its URI. */
+interface FakeModel { uri: string }
+
+describe( 'ModelRegistry', () => {
+
+  /**
+   * A registry with two registered fake models.
+   *
+   * @return {ModelRegistry} The populated registry.
+   */
+  function twoModels(): ModelRegistry<FakeModel> {
+    const registry = new ModelRegistry<FakeModel>( new SharedByteBudget( 1000 ) )
+    registry.register( 'https://ex.com/a.ifc', { uri: 'a' } )
+    registry.register( 'https://ex.com/b.ifc', { uri: 'b' } )
+    return registry
+  }
+
+  test( 'registers, looks up and counts models', () => {
+    const registry = twoModels()
+
+    expect( registry.size ).toBe( 2 )
+    expect( registry.has( 'https://ex.com/a.ifc' ) ).toBe( true )
+    expect( registry.get( 'https://ex.com/b.ifc' )?.uri ).toBe( 'b' )
+    expect( [ ...registry.uris() ].sort() ).toEqual(
+        [ 'https://ex.com/a.ifc', 'https://ex.com/b.ifc' ] )
+  } )
+
+  test( 'resolves an address string to the model and express ID', () => {
+    const registry = twoModels()
+
+    const resolved = registry.resolve( 'https://ex.com/b.ifc#42' )
+    expect( resolved?.model.uri ).toBe( 'b' )
+    expect( resolved?.expressID ).toBe( 42 )
+  } )
+
+  test( 'resolves a pre-parsed address object too', () => {
+    const registry = twoModels()
+
+    const resolved =
+      registry.resolve( { modelURI: 'https://ex.com/a.ifc', expressID: 7 } )
+    expect( resolved?.model.uri ).toBe( 'a' )
+    expect( resolved?.expressID ).toBe( 7 )
+  } )
+
+  test( 'returns undefined for an unregistered model (open-then-retry cue)', () => {
+    const registry = twoModels()
+
+    expect( registry.resolve( 'https://ex.com/missing.ifc#1' ) )
+        .toBeUndefined()
+  } )
+
+  test( 'unregister removes a model', () => {
+    const registry = twoModels()
+
+    expect( registry.unregister( 'https://ex.com/a.ifc' ) ).toBe( true )
+    expect( registry.has( 'https://ex.com/a.ifc' ) ).toBe( false )
+    expect( registry.size ).toBe( 1 )
+  } )
+
+  test( 'rejects registering a URI with a fragment', () => {
+    const registry = new ModelRegistry<FakeModel>( new SharedByteBudget( 10 ) )
+    expect( () => registry.register( 'a.ifc#1', { uri: 'a' } ) ).toThrow( /#/ )
+  } )
+
+  test( 'exposes the one shared budget every model draws from', () => {
+    const budget = new SharedByteBudget( 1000 )
+    const registry = new ModelRegistry<FakeModel>( budget )
+
+    expect( registry.budget ).toBe( budget )
+    registry.budget.reserve( 400 )
+    expect( registry.budget.available ).toBe( 600 )
+  } )
+} )

--- a/src/core/model_registry.ts
+++ b/src/core/model_registry.ts
@@ -1,0 +1,133 @@
+import { EntityAddress, parseEntityAddress } from './model_uri'
+import { SharedByteBudget } from './shared_byte_budget'
+
+
+/**
+ * A model resolved from the registry, paired with the express ID an address
+ * selected within it.
+ */
+export interface ResolvedEntity<H> {
+  model: H
+  expressID: number
+}
+
+
+/**
+ * The set of open models in one browser session (M5 / design S3).
+ *
+ * Federation is a registry of loader instances keyed by **model URI**, all
+ * sharing one {@link SharedByteBudget} so total resident memory is bounded per
+ * browser rather than per model. An {@link EntityAddress} (`modelURI#expressID`)
+ * resolves through here to the live model handle; a URI with no registered
+ * model is the signal to open a sibling loader (its own sidecar/stream) and
+ * register it.
+ *
+ * The registry is deliberately generic over the model handle `H` — it owns
+ * identity, resolution and the shared budget, not the loader. The streaming
+ * loader registers its model instance; higher layers (the composed skeleton,
+ * the UI link layer) query through the same addresses.
+ */
+export class ModelRegistry<H> {
+
+  private readonly byURI_ = new Map<string, H>()
+
+  private readonly budget_: SharedByteBudget
+
+  /**
+   * @param budget The shared per-browser byte budget every registered model
+   * draws from.
+   */
+  constructor( budget: SharedByteBudget ) {
+    this.budget_ = budget
+  }
+
+  /**
+   * @return {SharedByteBudget} The shared budget all registered models draw
+   * from.
+   */
+  public get budget(): SharedByteBudget {
+    return this.budget_
+  }
+
+  /**
+   * @return {number} The number of registered models.
+   */
+  public get size(): number {
+    return this.byURI_.size
+  }
+
+  /**
+   * @return {IterableIterator<string>} The URIs of all registered models.
+   */
+  public uris(): IterableIterator<string> {
+    return this.byURI_.keys()
+  }
+
+  /**
+   * @return {IterableIterator<H>} The registered model handles.
+   */
+  public models(): IterableIterator<H> {
+    return this.byURI_.values()
+  }
+
+  /**
+   * Register (or replace) the model for a URI.
+   *
+   * @param uri The model URI (no `#` fragment).
+   * @param model The model handle.
+   */
+  public register( uri: string, model: H ): void {
+
+    if ( uri.includes( '#' ) ) {
+      throw new Error( `Model URI must not contain '#': ${uri}` )
+    }
+
+    this.byURI_.set( uri, model )
+  }
+
+  /**
+   * Remove a model from the registry.
+   *
+   * @param uri The model URI.
+   * @return {boolean} True if a model was removed.
+   */
+  public unregister( uri: string ): boolean {
+    return this.byURI_.delete( uri )
+  }
+
+  /**
+   * @param uri The model URI.
+   * @return {boolean} True if a model is registered for the URI.
+   */
+  public has( uri: string ): boolean {
+    return this.byURI_.has( uri )
+  }
+
+  /**
+   * @param uri The model URI.
+   * @return {H | undefined} The registered model, or undefined.
+   */
+  public get( uri: string ): H | undefined {
+    return this.byURI_.get( uri )
+  }
+
+  /**
+   * Resolve an entity address to its model + express ID. Returns undefined
+   * when the address's model isn't registered — the caller's cue to open and
+   * register it, then resolve again.
+   *
+   * @param address The entity address, as a URI string or a parsed
+   * {@link EntityAddress}.
+   * @return {ResolvedEntity | undefined} The resolved model + express ID, or
+   * undefined if the model isn't registered.
+   */
+  public resolve( address: string | EntityAddress ): ResolvedEntity<H> | undefined {
+
+    const { modelURI, expressID } =
+      typeof address === 'string' ? parseEntityAddress( address ) : address
+
+    const model = this.byURI_.get( modelURI )
+
+    return model === void 0 ? void 0 : { model, expressID }
+  }
+}

--- a/src/core/model_uri.test.ts
+++ b/src/core/model_uri.test.ts
@@ -1,0 +1,69 @@
+/* eslint-disable no-magic-numbers */
+// M5: universal entity addressing — a model URI plus an express-ID fragment —
+// must round-trip and resolve relative references the way IFC external-ref
+// locations demand.
+import { describe, expect, test } from '@jest/globals'
+
+import {
+  formatEntityAddress,
+  parseEntityAddress,
+  resolveReference,
+} from './model_uri'
+
+describe( 'model URI addressing', () => {
+
+  test( 'formats and parses an entity address round-trip', () => {
+    const uri = formatEntityAddress( 'https://ex.com/part-B.ifc', 4022 )
+
+    expect( uri ).toBe( 'https://ex.com/part-B.ifc#4022' )
+
+    const parsed = parseEntityAddress( uri )
+    expect( parsed.modelURI ).toBe( 'https://ex.com/part-B.ifc' )
+    expect( parsed.expressID ).toBe( 4022 )
+  } )
+
+  test( 'splits on the last # so the model URI keeps earlier structure', () => {
+    // (Model URIs shouldn't carry a '#', but parsing must be unambiguous.)
+    const parsed = parseEntityAddress( 'scheme://h/a#b#42' )
+    expect( parsed.modelURI ).toBe( 'scheme://h/a#b' )
+    expect( parsed.expressID ).toBe( 42 )
+  } )
+
+  test( 'rejects formatting a model URI that contains #', () => {
+    expect( () => formatEntityAddress( 'a#b', 1 ) ).toThrow( /#/ )
+  } )
+
+  test( 'rejects formatting a non-integer or negative express ID', () => {
+    expect( () => formatEntityAddress( 'a', 1.5 ) ).toThrow()
+    expect( () => formatEntityAddress( 'a', -1 ) ).toThrow()
+  } )
+
+  test( 'rejects an address with no fragment or a non-numeric fragment', () => {
+    expect( () => parseEntityAddress( 'a.ifc' ) ).toThrow( /fragment/ )
+    expect( () => parseEntityAddress( 'a.ifc#' ) ).toThrow( /express ID/ )
+    expect( () => parseEntityAddress( 'a.ifc#x' ) ).toThrow( /express ID/ )
+  } )
+
+  test( 'resolves a relative reference against an absolute base URI', () => {
+    expect(
+        resolveReference( 'https://ex.com/site/plan.ifc', '../shared/grid.ifc' ) )
+        .toBe( 'https://ex.com/shared/grid.ifc' )
+
+    expect(
+        resolveReference( 'https://ex.com/site/plan.ifc', 'wing-A.ifc' ) )
+        .toBe( 'https://ex.com/site/wing-A.ifc' )
+  } )
+
+  test( 'passes an already-absolute reference through unchanged', () => {
+    expect(
+        resolveReference( 'https://ex.com/a.ifc', 'https://other.org/b.ifc' ) )
+        .toBe( 'https://other.org/b.ifc' )
+  } )
+
+  test( 'resolves relative references against a scheme-less base', () => {
+    expect( resolveReference( 'project/plan.ifc', 'wing-A.ifc' ) )
+        .toBe( 'project/wing-A.ifc' )
+    expect( resolveReference( 'project/site/plan.ifc', '../grid.ifc' ) )
+        .toBe( 'project/grid.ifc' )
+  } )
+} )

--- a/src/core/model_uri.ts
+++ b/src/core/model_uri.ts
@@ -1,0 +1,135 @@
+/**
+ * Cross-model entity addressing (M5 / design S3).
+ *
+ * Federation turns "thousands of cross-referenced files" from a loader problem
+ * into an addressing problem: every entity has a **universal address** of a
+ * model URI plus an express ID — `https://…/part-B.ifc#4022`. The engine never
+ * holds all the files; it holds a registry of models keyed by URI (see
+ * {@link ModelRegistry}) and resolves an address to a (model, expressID) pair
+ * on demand, opening a sibling loader for a URI it hasn't seen.
+ *
+ * The URI is opaque to the engine except for its `#expressID` fragment: the
+ * scheme, host, path and any version identity live entirely in the model URI,
+ * so "many versions side by side" is expressible without an engine change.
+ */
+
+/**
+ * A universal entity address: which model, and which express ID within it.
+ */
+export interface EntityAddress {
+
+  /** The model's URI (everything left of the `#expressID` fragment). */
+  modelURI: string
+
+  /** The entity's express ID within that model. */
+  expressID: number
+}
+
+
+const FRAGMENT = '#'
+const RADIX = 10
+
+
+/**
+ * Format a model URI + express ID as a single entity address URI.
+ *
+ * @param modelURI The model URI (must not itself contain a `#`).
+ * @param expressID The express ID (a non-negative integer).
+ * @return {string} The `modelURI#expressID` address.
+ */
+export function formatEntityAddress( modelURI: string, expressID: number ): string {
+
+  if ( modelURI.includes( FRAGMENT ) ) {
+    throw new Error( `Model URI must not contain '#': ${modelURI}` )
+  }
+
+  if ( !Number.isInteger( expressID ) || expressID < 0 ) {
+    throw new Error( `Invalid express ID ${expressID}` )
+  }
+
+  return `${modelURI}${FRAGMENT}${expressID}`
+}
+
+
+/**
+ * Parse an entity address URI into its model URI and express ID.
+ *
+ * The split is on the **last** `#`, so a fragment is required; the model URI
+ * is everything before it. A missing or non-integer fragment is an error —
+ * an address without an express ID isn't an entity address.
+ *
+ * @param uri The `modelURI#expressID` address.
+ * @return {EntityAddress} The parsed address.
+ */
+export function parseEntityAddress( uri: string ): EntityAddress {
+
+  const hash = uri.lastIndexOf( FRAGMENT )
+
+  if ( hash < 0 ) {
+    throw new Error( `Entity address has no '#expressID' fragment: ${uri}` )
+  }
+
+  const modelURI = uri.slice( 0, hash )
+  const fragment = uri.slice( hash + 1 )
+
+  if ( fragment.length === 0 || !/^\d+$/.test( fragment ) ) {
+    throw new Error( `Entity address fragment is not an express ID: ${uri}` )
+  }
+
+  return { modelURI, expressID: parseInt( fragment, RADIX ) }
+}
+
+
+/**
+ * Resolve a (possibly relative) reference URI against a base model URI, so an
+ * `IfcExternalReference.Location` like `../shared/grid.ifc` becomes an absolute
+ * model URI addressable in the registry. Absolute references (with a scheme,
+ * or protocol-relative) pass through unchanged.
+ *
+ * Uses the standard URL resolver when the base is absolute; falls back to a
+ * plain path join when the base has no scheme (e.g. a bare filename in tests).
+ *
+ * @param base The base model URI the reference was found in.
+ * @param reference The reference URI (absolute or relative).
+ * @return {string} The resolved absolute reference URI.
+ */
+export function resolveReference( base: string, reference: string ): string {
+
+  // Already absolute (has a scheme like `https:` or is protocol-relative).
+  if ( /^[a-z][a-z0-9+.-]*:/i.test( reference ) || reference.startsWith( '//' ) ) {
+    return reference
+  }
+
+  try {
+    return new URL( reference, base ).toString()
+  } catch {
+    // Base isn't a valid absolute URL (bare filename): join paths manually.
+    const slash = base.lastIndexOf( '/' )
+    const dir = slash < 0 ? '' : base.slice( 0, slash + 1 )
+
+    return normalizePath( dir + reference )
+  }
+}
+
+
+/**
+ * Collapse `.` / `..` segments in a slash-joined path (used only for the
+ * scheme-less fallback in {@link resolveReference}).
+ *
+ * @param path The path to normalise.
+ * @return {string} The normalised path.
+ */
+function normalizePath( path: string ): string {
+
+  const out: string[] = []
+
+  for ( const segment of path.split( '/' ) ) {
+    if ( segment === '..' ) {
+      out.pop()
+    } else if ( segment !== '.' ) {
+      out.push( segment )
+    }
+  }
+
+  return out.join( '/' )
+}

--- a/src/core/shared_byte_budget.test.ts
+++ b/src/core/shared_byte_budget.test.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-magic-numbers */
+// M5: the per-browser shared budget is what keeps federation from re-growing
+// memory O(N) with the number of open models — reservations across all models
+// draw from one ceiling.
+import { describe, expect, test } from '@jest/globals'
+
+import { SharedByteBudget } from './shared_byte_budget'
+
+describe( 'SharedByteBudget', () => {
+
+  test( 'reserves up to the ceiling and refuses to overcommit', () => {
+    const budget = new SharedByteBudget( 1000 )
+
+    expect( budget.reserve( 600 ) ).toBe( true )
+    expect( budget.reserve( 300 ) ).toBe( true )
+    expect( budget.used ).toBe( 900 )
+    expect( budget.available ).toBe( 100 )
+
+    // 200 doesn't fit in the remaining 100 — refused, no change.
+    expect( budget.reserve( 200 ) ).toBe( false )
+    expect( budget.used ).toBe( 900 )
+  } )
+
+  test( 'releasing frees room for later reservations', () => {
+    const budget = new SharedByteBudget( 1000 )
+
+    budget.reserve( 800 )
+    expect( budget.reserve( 300 ) ).toBe( false )
+
+    budget.release( 500 )
+    expect( budget.used ).toBe( 300 )
+    expect( budget.reserve( 300 ) ).toBe( true )
+  } )
+
+  test( 'release clamps at zero (a double release is not corruption)', () => {
+    const budget = new SharedByteBudget( 1000 )
+
+    budget.reserve( 100 )
+    budget.release( 100 )
+    budget.release( 100 )
+    expect( budget.used ).toBe( 0 )
+  } )
+
+  test( 'overageFor reports how much must be evicted before a reservation fits', () => {
+    const budget = new SharedByteBudget( 1000 )
+
+    budget.reserve( 700 )
+    // 500 wanted, 300 available → must evict 200.
+    expect( budget.overageFor( 500 ) ).toBe( 200 )
+    // 200 wanted, 300 available → fits, no eviction.
+    expect( budget.overageFor( 200 ) ).toBe( 0 )
+  } )
+
+  test( 'the ceiling is shared: two models cannot each spend the whole budget', () => {
+    const budget = new SharedByteBudget( 1000 )
+
+    // "Model A" and "model B" both draw from the same budget.
+    expect( budget.reserve( 700 ) ).toBe( true )  // A
+    expect( budget.reserve( 700 ) ).toBe( false ) // B — only 300 left
+    expect( budget.reserve( 300 ) ).toBe( true )  // B fits in the remainder
+    expect( budget.used ).toBe( budget.total )
+  } )
+
+  test( 'rejects an invalid ceiling and negative amounts', () => {
+    expect( () => new SharedByteBudget( 0 ) ).toThrow()
+    const budget = new SharedByteBudget( 10 )
+    expect( () => budget.reserve( -1 ) ).toThrow()
+    expect( () => budget.release( -1 ) ).toThrow()
+  } )
+} )

--- a/src/core/shared_byte_budget.ts
+++ b/src/core/shared_byte_budget.ts
@@ -1,0 +1,99 @@
+/**
+ * A byte budget shared across many models (M5 / design S3).
+ *
+ * The federation invariant: budgets must be **per browser, not per model**, or
+ * opening N cross-referenced files re-introduces O(N) memory. This is the one
+ * accounting primitive that enforces it — every model's demand-geometry queue
+ * and window pool draws from a single {@link SharedByteBudget}, so the total
+ * resident footprint across all open models is bounded no matter how many are
+ * federated in.
+ *
+ * It owns only the accounting (reserve / release / availability); the eviction
+ * policy that frees bytes when a reservation can't be met stays with each
+ * model's scheduler (M3's {@link DemandGeometryQueue}) — the budget just tells
+ * a caller how much it must evict first via {@link overageFor}.
+ */
+export class SharedByteBudget {
+
+  private used_ = 0
+
+  /**
+   * @param totalBytes_ The global ceiling shared across all models.
+   */
+  constructor( private readonly totalBytes_: number ) {
+
+    if ( totalBytes_ <= 0 ) {
+      throw new Error( `Invalid totalBytes ${totalBytes_}` )
+    }
+  }
+
+  /**
+   * @return {number} The global ceiling.
+   */
+  public get total(): number {
+    return this.totalBytes_
+  }
+
+  /**
+   * @return {number} Bytes currently reserved across all models.
+   */
+  public get used(): number {
+    return this.used_
+  }
+
+  /**
+   * @return {number} Bytes still reservable without eviction.
+   */
+  public get available(): number {
+    return this.totalBytes_ - this.used_
+  }
+
+  /**
+   * Try to reserve `bytes` against the shared ceiling. Succeeds (and charges
+   * the budget) only if it fits without exceeding the total; otherwise makes
+   * no change and returns false, leaving the caller to evict and retry.
+   *
+   * @param bytes The bytes to reserve (≥ 0).
+   * @return {boolean} True if reserved.
+   */
+  public reserve( bytes: number ): boolean {
+
+    if ( bytes < 0 ) {
+      throw new Error( `Cannot reserve negative bytes ${bytes}` )
+    }
+
+    if ( bytes > this.available ) {
+      return false
+    }
+
+    this.used_ += bytes
+
+    return true
+  }
+
+  /**
+   * Release previously reserved bytes back to the shared budget.
+   *
+   * @param bytes The bytes to release (≥ 0). Clamped so `used` never goes
+   * negative — a double-release is a no-op past zero, not a corruption.
+   */
+  public release( bytes: number ): void {
+
+    if ( bytes < 0 ) {
+      throw new Error( `Cannot release negative bytes ${bytes}` )
+    }
+
+    this.used_ = Math.max( 0, this.used_ - bytes )
+  }
+
+  /**
+   * How many bytes a caller must evict (anywhere, across any model) before a
+   * reservation of `bytes` would fit. Zero when it already fits.
+   *
+   * @param bytes The desired reservation.
+   * @return {number} The bytes of eviction required (≥ 0).
+   */
+  public overageFor( bytes: number ): number {
+    return Math.max( 0, bytes - this.available )
+  }
+}

--- a/src/step/parsing/cross_reference_registry.test.ts
+++ b/src/step/parsing/cross_reference_registry.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable no-magic-numbers */
+// M5: outbound cross-model references are collected during the parse (by type,
+// via the dispatcher) and resolved to navigable federation links against the
+// source model URI once their Location strings are readable.
+import { describe, expect, test } from '@jest/globals'
+
+import {
+  ReferenceLocationReader,
+  CrossReferenceRegistry,
+} from './cross_reference_registry'
+import { StreamingRecordDispatcher } from './streaming_record_dispatcher'
+import { IfcExternalReference } from '../../ifc/ifc4_gen'
+
+/**
+ * A mock reader over a fixed express-ID → Location map.
+ *
+ * @param locations The express-ID → Location map.
+ * @return {ReferenceLocationReader} The reader.
+ */
+function reader( locations: Record<number, string | null> ): ReferenceLocationReader {
+  return { locationOf: ( expressID ) => locations[ expressID ] }
+}
+
+describe( 'CrossReferenceRegistry', () => {
+
+  test( 'collects references handed to its handler and resolves them', () => {
+    const registry = new CrossReferenceRegistry<number>( 'https://ex.com/site/plan.ifc' )
+
+    // Simulate the dispatcher delivering three reference records.
+    registry.handler( 0, 100, 1 )
+    registry.handler( 1, 200, 1 )
+    registry.handler( 2, 300, 1 )
+
+    expect( registry.count ).toBe( 3 )
+
+    const links = registry.resolve( reader( {
+      100: '../shared/grid.ifc',
+      200: 'https://other.org/lib.ifc',
+      300: 'wing-A.ifc#4022',
+    } ) )
+
+    const byFrom = new Map( links.map( ( l ) => [ l.fromExpressID, l ] ) )
+
+    expect( byFrom.get( 100 )?.targetURI ).toBe( 'https://ex.com/shared/grid.ifc' )
+    expect( byFrom.get( 200 )?.targetURI ).toBe( 'https://other.org/lib.ifc' )
+
+    // A location with a #expressID resolves to a full entity address.
+    const wing = byFrom.get( 300 )
+    expect( wing?.targetURI ).toBe( 'https://ex.com/site/wing-A.ifc#4022' )
+    expect( wing?.targetEntity ).toEqual( {
+      modelURI: 'https://ex.com/site/wing-A.ifc',
+      expressID: 4022,
+    } )
+  } )
+
+  test( 'skips references with no location', () => {
+    const registry = new CrossReferenceRegistry<number>( 'base.ifc' )
+    registry.handler( 0, 1, 1 )
+    registry.handler( 1, 2, 1 )
+
+    const links = registry.resolve( reader( { 1: null, 2: '' } ) )
+    expect( links ).toEqual( [] )
+  } )
+
+  test( 'is idempotent under the streaming grow-restart (dedupes express IDs)', () => {
+    const registry = new CrossReferenceRegistry<number>( 'base.ifc' )
+    registry.handler( 0, 42, 1 )
+    registry.handler( 0, 42, 1 ) // re-fire from localID 0 after a restart
+    expect( registry.count ).toBe( 1 )
+  } )
+
+  test( 'wires to the dispatcher, collecting only the reference types', () => {
+    const registry = new CrossReferenceRegistry<number>( 'base.ifc' )
+    const dispatcher = new StreamingRecordDispatcher<number>()
+    dispatcher.on( [ IfcExternalReference as any ], registry.handler )
+
+    // One record of a matching (subtype-closure) type, one outside it.
+    const matching = ( IfcExternalReference as any ).query[ 0 ] as number
+    const nonMatching = 10_000_000 // not in the reference closure
+
+    dispatcher.onRecordIndexed( 0, 500, matching )
+    dispatcher.onRecordIndexed( 1, 600, nonMatching )
+
+    expect( [ ...registry.expressIDs() ] ).toEqual( [ 500 ] )
+  } )
+} )

--- a/src/step/parsing/cross_reference_registry.ts
+++ b/src/step/parsing/cross_reference_registry.ts
@@ -1,0 +1,150 @@
+import { EntityAddress, resolveReference } from '../../core/model_uri'
+import { RecordHandler } from './streaming_record_dispatcher'
+
+
+/**
+ * Reads the `Location` string of a cross-reference entity by express ID.
+ * Implemented over the finished (or partially materialised) model — a thin
+ * seam so the registry's link resolution is testable without a full model.
+ * `IfcExternalReference.Location` is the canonical field; STEP AP242's external
+ * references expose their location the same way.
+ */
+export interface ReferenceLocationReader {
+
+  /**
+   * @param expressID The cross-reference entity's express ID.
+   * @return {string | null | undefined} Its `Location`, or null/undefined when
+   * absent.
+   */
+  locationOf( expressID: number ): string | null | undefined
+}
+
+
+/**
+ * An outbound federation link discovered from a cross-reference: the
+ * referencing entity in this model, the raw location it declared, and — once
+ * resolved against the model's own URI — the absolute URI (and, if the
+ * location carried a `#expressID` fragment, the entity address) it points at.
+ */
+export interface CrossReferenceLink {
+
+  /** Express ID of the referencing entity in the source model. */
+  fromExpressID: number
+
+  /** The raw `Location` string as authored in the file. */
+  location: string
+
+  /** The location resolved to an absolute URI against the source model URI. */
+  targetURI: string
+
+  /** The target entity address, when the location carried a `#expressID`. */
+  targetEntity?: EntityAddress
+}
+
+
+const FRAGMENT = '#'
+const RADIX = 10
+
+
+/**
+ * Collects a model's **outbound cross-model references** during the streaming
+ * parse and, once locations are readable, resolves them into navigable
+ * federation links (M5 / design S3).
+ *
+ * The links come from IFC's own reference entities — `IfcExternalReference`
+ * and its subtypes (`IfcDocumentReference`, `IfcClassificationReference`,
+ * `IfcLibraryReference`) — and, for STEP AP242, its external references. Two
+ * phases, matching M2's "identify while parsing, resolve on demand":
+ *
+ *  1. **Identify** — subscribe {@link handler} to a
+ *     {@link StreamingRecordDispatcher} for the reference types
+ *     (`dispatcher.on([IfcExternalReference], reg.handler)`); it records the
+ *     express ID of every such record as it streams past. Cheap and idempotent
+ *     (a `Set`), so the rare grow-restart is harmless.
+ *  2. **Resolve** — after parse, {@link resolve} reads each reference's
+ *     `Location` via a {@link ReferenceLocationReader} and resolves it against
+ *     the source model URI, yielding {@link CrossReferenceLink}s the UI renders
+ *     as links. Visiting one opens the target model in the `ModelRegistry`.
+ *
+ * The location read is deferred because the event stream carries only
+ * `(localID, expressID, typeID)` — not attribute strings; pulling `Location`
+ * needs the entity's fields, which is a model read, not a parse event.
+ */
+export class CrossReferenceRegistry<TypeIDType extends number> {
+
+  private readonly fromExpressIDs_ = new Set<number>()
+
+  /**
+   * @param sourceURI_ The URI of the model these references were found in —
+   * the base for resolving relative locations.
+   */
+  constructor( private readonly sourceURI_: string ) {}
+
+  /**
+   * Record one cross-reference entity. Bind to a dispatcher subscription
+   * filtered to the reference types; every record it is handed is taken to be
+   * a cross-reference (the dispatcher does the type filtering).
+   *
+   * @param localID Unused (kept for the RecordHandler shape).
+   * @param expressID The reference entity's express ID.
+   * @param typeID Unused (the dispatcher already matched the type set).
+   */
+  public readonly handler: RecordHandler<TypeIDType> =
+    ( localID: number, expressID: number, typeID: TypeIDType | undefined ): void => {
+      this.fromExpressIDs_.add( expressID )
+    }
+
+  /**
+   * @return {number} The number of cross-references collected.
+   */
+  public get count(): number {
+    return this.fromExpressIDs_.size
+  }
+
+  /**
+   * @return {IterableIterator<number>} The express IDs of the collected
+   * reference entities.
+   */
+  public expressIDs(): IterableIterator<number> {
+    return this.fromExpressIDs_.keys()
+  }
+
+  /**
+   * Resolve the collected references into navigable links by reading each
+   * one's `Location` and resolving it against the source model URI. References
+   * whose location is absent (null / empty) are skipped — they carry no link.
+   *
+   * @param reader Reads the `Location` of an express ID.
+   * @return {CrossReferenceLink[]} The resolved outbound links.
+   */
+  public resolve( reader: ReferenceLocationReader ): CrossReferenceLink[] {
+
+    const links: CrossReferenceLink[] = []
+
+    for ( const fromExpressID of this.fromExpressIDs_ ) {
+
+      const location = reader.locationOf( fromExpressID )
+
+      if ( location === null || location === void 0 || location.length === 0 ) {
+        continue
+      }
+
+      const resolved = resolveReference( this.sourceURI_, location )
+      const link: CrossReferenceLink = { fromExpressID, location, targetURI: resolved }
+
+      // A location may itself address a specific entity (model.ifc#42).
+      const hash = resolved.lastIndexOf( FRAGMENT )
+
+      if ( hash >= 0 && /^\d+$/.test( resolved.slice( hash + 1 ) ) ) {
+        link.targetEntity = {
+          modelURI: resolved.slice( 0, hash ),
+          expressID: parseInt( resolved.slice( hash + 1 ), RADIX ),
+        }
+      }
+
+      links.push( link )
+    }
+
+    return links
+  }
+}


### PR DESCRIPTION
**M5** (#396), epic #390. **Base retargeted to `main`** (#401–#404 merged); diff is exactly the M5 increment. **Merge sequence position: #405 → #408 → #409.**

## What

The engine core for **federation** (design stretch goal S3): universal cross-model addressing plus the cross-file read side. All pure TypeScript — no wasm, no Share dependency.

- **`core/model_uri.ts`** — the universal entity address `modelURI#expressID` (`EntityAddress`), `formatEntityAddress` / `parseEntityAddress`, and `resolveReference` so an `IfcExternalReference.Location` like `../shared/grid.ifc` resolves against the containing model's URI (absolute / protocol-relative / scheme-less bases).
- **`core/shared_byte_budget.ts`** — `SharedByteBudget`, the **per-browser** byte ceiling every model's queue/pool draws from (`reserve` / `release` / `overageFor`). The federation invariant: budgets per browser, not per model, or N cross-referenced files re-introduce O(N) memory.
- **`core/model_registry.ts`** — `ModelRegistry` keys open models by URI, holds the one shared budget, resolves an address to `(model, expressID)`; an unregistered URI is the cue to open a sibling loader and register it.
- **`step/parsing/cross_reference_registry.ts`** — a streaming consumer collecting outbound reference entities (`IfcExternalReference` subtype closure) via the M2 dispatcher, then resolving their `Location`s into navigable `CrossReferenceLink`s (two-phase: identify while parsing, resolve on demand — the event stream carries IDs, not attribute strings).
- **`core/composed_model_skeleton.ts`** — `ComposedModelSkeleton` fans a type query across every registered model and yields universal addresses; each result round-trips back through `ModelRegistry.resolve`.

## Compatibility with existing Share use

**Fully additive** — ten new files + a design-doc update; nothing existing modified. No Share surface, no geometry code → zero render-diff exposure; **visual-diff CI green on the PR head** (with build + run-ifc-regression).

## Naming note

The cross-reference module is named **`CrossReference*`**, not `ExternalReference*`, deliberately: `jest.config.ts` has `modulePathIgnorePatterns: ["external"]` — a bare substring that silently drops any test file whose path contains "external" (tracked as #407; it already excludes `step_external_mapping.test.js`). The IFC domain term stays in the docstrings; only the path avoids the substring. Once #407 is fixed the module could be renamed, or kept — "cross-reference" reads fine for federation.

## Design flag for M5b (deliberate, tracked in scope notes)

`SharedByteBudget` is single-agent state. With "workers for everything", models in different workers can't share this object — M5b's loader-registration work should choose an atomics-backed counter (SharedArrayBuffer) or a single-broker pattern for the cross-worker ceiling. Fine today: the budget's first consumer (the geometry queue) is single-worker.

## Scope — what's M5b

Engine core only. The follow-on: the streaming loader **registering** streamed models into the registry, wiring M3's `DemandGeometryQueue` to draw from the shared budget, the cross-file **spatial-containment** merge, and the UI link layer rendering `CrossReferenceLink`s. That's where the "2-file project browses under the same budget as either file alone" exit criterion lands.

## Tests

29 across 5 suites:
- `model_uri.test.ts` (8): format/parse round-trip; last-`#` split; guards; relative-against-absolute, absolute passthrough, scheme-less resolution.
- `shared_byte_budget.test.ts` (6): reserve/refuse; release frees; clamp at zero; `overageFor`; **shared ceiling** (two models can't each spend the whole budget); input guards.
- `model_registry.test.ts` (7): register/lookup; resolve string + parsed address; unregistered → undefined; unregister; fragment guard; the one shared budget.
- `composed_model_skeleton.test.ts` (4): fan-out; federation count; round-trip resolution; empty registry.
- `cross_reference_registry.test.ts` (4): collect + resolve (relative, absolute, `#expressID` target); skip-empty; grow-restart idempotency; dispatcher type-set wiring.

## Review status

Reviewed 2026-07-19 (chain review before merge): URI/budget/cross-ref semantics traced; no correctness findings. Three nits noted (double-slash on scheme-less-base + absolute-path reference — test-only path; `countOfType` is O(n) traversal — don't call per-frame; the inline fragment parse in `CrossReferenceRegistry` must stay in sync with `parseEntityAddress`) and one M5b design flag (cross-worker budget, above) — no code changes pushed. CI green: build / run-ifc-regression / **visual-diff** on head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz