### PR TITLE
M3 production: general memory system (src/core/mem) + geometry tile-pool narrowing

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -462,7 +462,7 @@ not stubbed:
 | **M1a** | `parseStreamToModel` (windowed-source model) | M1b: Share OPFS worker |
 | **M2a** | record events + type-set dispatcher | — |
 | **M2b** | incremental type index | multi-mapping (typeID 0) attribution |
-| **M3** | demand-geometry queue (budget + eviction) | conway-geom per-product native free |
+| **M3** | demand-geometry queue (budget + eviction); chunked tile pool + refcounted assets (`src/core/mem/`) | conway-geom C++ tile-pool twin (surface narrowed — see "Resident memory: two regimes") |
 | **M4a** | index sidecar + `RangeByteSource` | M4b: Share sidecar cache + index-first open |
 | **M5a** | model-URI, shared budget, registry, cross-ref, composition | M5b: loader registration, budget wiring, UI links |
 
@@ -499,6 +499,85 @@ Share OPFS/HTTP integration (gates M1b/M4b).
    ✓ record events carry localID + mapping, and consumers must tolerate
    one-address-many-entities — the same contract `expressIDsOfTypes`
    documents. Baked into the event payload from day one.
+6. **Resident geometry = explicit chunked pool, not per-product `free()`.**
+   ✓ Decided 2026-07-19 — see "Resident memory: two regimes" below. This
+   resolves the M3 blocker's allocation question and narrows the
+   conway-geom C++ surface to a small tile pool.
+
+
+## Resident memory: two regimes (settled with Pablo, 2026-07-19)
+
+The M3 blocker ("conway-geom needs a per-product native free") hid an
+allocation-policy question: free *into what*? The answer decides whether
+eviction actually returns memory.
+
+**Why the general allocator is the wrong tool here.** Wasm linear memory
+grows and never shrinks — `free()` returns bytes to mimalloc's freelists,
+not to the browser, and there is no page decommit (`madvise`/decommit are
+native-allocator tools wasm doesn't have; `memory.discard` isn't shipped).
+So the tab pays the heap's **high-water mark forever**, and external
+fragmentation under evict/refill churn isn't a throughput nuisance, it's a
+permanent leak: one live allocation above a sea of freed tile space keeps
+it all committed. Per-product `free()` into the general heap — the "modern
+allocators are good now" answer that works natively — fails here.
+
+**The two regimes.** Geometry memory has two structured flows with
+different lifetime shapes, and each gets the allocator that matches:
+
+- **Phase-bounded scratch** (tessellation temporaries): lives for one
+  product's extraction, dies at commit. Already engineered: the AFTP
+  per-thread bump arenas with chunked growth and exact-size commits.
+  Bump/reset, never freed piecemeal. Unchanged by this design.
+- **Demand-bounded residents** (committed tiles, alive until evicted):
+  lifetime is driven by the viewport, unbounded and interleaved — the
+  regime where pools historically break down and people punt to malloc.
+  Instead: **one dedicated region carved into fixed-size chunks**
+  (order 256 KB–1 MB) with a freelist. Commit copies exact-size results
+  from the scratch arena into acquired chunks (the copy already exists —
+  AFTP phase 2 — just redirected); evict pushes chunks back. High-water
+  mark **is the budget by construction**; fragmentation reduces to
+  bounded internal waste in each asset's last chunk.
+
+The general allocator keeps only the residual it is actually good at:
+small, messy-lifetime control structures. Engineer the 95 % with
+structure; punt the 5 % without.
+
+**The abstraction ladder (`src/core/mem/`).** This is high-value code
+we expect to reuse (property caches, sidecar caches, texture-like data),
+so the system is layered general → narrow, with the general layers kept
+deliberately domain-free:
+
+    ChunkedPool        chunks and bytes: budget, freelist, chunk-rounding
+    SharedAssetPool    refcounted *assets* resident in those chunks
+    GeometryTilePool   the geometry narrowing (src/core/): products ⇄ assets
+    DemandGeometryQueue  demand ordering + logical budget (M3, unchanged)
+
+The **instance ⇄ asset** relationship in `SharedAssetPool` is the general
+form of product ⇄ representation (the definition/occurrence split that
+recurs across CAD — AP214 literally says "occurrence"). Storage is keyed
+and refcounted on the asset, so the mapped-item correctness rule holds
+structurally: evicting product A can never free the representation
+product B still renders; chunks return only on the last release.
+
+**Accounting: two views, one invariant.** The queue charges each
+instance the full chunk-rounded cost of every asset it references
+(sharing double-charged — deliberately conservative), while the pool
+counts physical chunks (shared assets stored once). Summed logical
+charges therefore always cover physical use, so with queue budget ≤ pool
+budget an acquire can never fail mid-extract — an invariant the composed
+tests pin. Heavy sharing under-utilises the logical budget; widen it
+once measured, safe direction first.
+
+**The narrowed C++ surface (conway-geom).** What M3 production actually
+needs from wasm shrinks to a mechanical tile pool mirroring the TS spec:
+`tilePool.init(budgetBytes, chunkBytes)` /
+`commitTile(assetID, scratchPtr, byteSize) → chunks` /
+`retainTile(assetID)` / `releaseTile(assetID)` — plus the existing
+extract-into-scratch. No allocator surgery, no arena changes. The TS
+classes are the executable spec and policy layer; the C++ twin owns the
+bytes. GPU-side buffers (three.js) are outside the wasm heap and already
+reclaim on delete — the grow-only trap this design defuses is wasm-side
+specifically.
 
 
 ## Toward editing: product-level CRUD

--- a/scripts/stream_corpus_sweep.mjs
+++ b/scripts/stream_corpus_sweep.mjs
@@ -1,0 +1,215 @@
+/**
+ * Corpus sweep for the streaming parse/index/sidecar plane (M0/M1a/M4).
+ *
+ * For each model, in a child process per phase (so memory peaks are
+ * isolated):
+ *
+ *   resident : read whole file, parseHeader + parseDataBlock  → index,
+ *              peak heap. The baseline.
+ *   stream   : fd ByteSource + buildIndexStreaming (1 MB pool) → index,
+ *              peak heap. The source is NEVER resident in JS.
+ *   verify   : both in one process; asserts the streamed top-level index is
+ *              byte-identical to the resident one, then round-trips the
+ *              index sidecar (serialize → deserialize → compare + hash
+ *              handshake).
+ *
+ * Usage:
+ *   node scripts/stream_corpus_sweep.mjs                # run the sweep
+ *   node scripts/stream_corpus_sweep.mjs --child <phase> <path>   # internal
+ */
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as process from 'node:process'
+
+const POOL_BYTES = 1024 * 1024
+
+const CORPUS = [
+  '/home/user/models/Arty_Z7.stp',
+  '/home/user/test-models-content/ifc/Schependomlaan.ifc',
+  'data/index.ifc',
+  'data/as1-oc-214.stp',
+  'data/ap214-mapped-item-test.step',
+  'data/a-gear-with-3-inch-diameter-and-20-curved-teeth.step',
+]
+
+/** Sync positioned-read ByteSource over a file descriptor (file never JS-resident). */
+class FdByteSource {
+  constructor( filePath ) {
+    this.fd = fs.openSync( filePath, 'r' )
+    this.byteLength = fs.fstatSync( this.fd ).size
+  }
+  read( offset, length, into, intoOffset ) {
+    return fs.readSync( this.fd, into, intoOffset, length, offset )
+  }
+  close() {
+    fs.closeSync( this.fd )
+  }
+}
+
+async function parserFor( filePath ) {
+  if ( filePath.endsWith( '.ifc' ) ) {
+    const { default: IfcStepParser } = await import( '../compiled/src/ifc/ifc_step_parser.js' )
+    return IfcStepParser.Instance
+  }
+  const { default: AP214StepParser } = await import( '../compiled/src/AP214E3_2010/ap214_step_parser.js' )
+  return AP214StepParser.Instance
+}
+
+function peakHeapMB() {
+  const usage = process.memoryUsage()
+  return ( usage.heapUsed + usage.arrayBuffers ) / ( 1024 * 1024 )
+}
+
+async function residentIndex( filePath ) {
+  const { default: ParsingBuffer } = await import( '../compiled/src/parsing/parsing_buffer.js' )
+  const parser = await parserFor( filePath )
+  const bytes = new Uint8Array( fs.readFileSync( filePath ) )
+  const input = new ParsingBuffer( bytes )
+  parser.parseHeader( input )
+  const t0 = performance.now()
+  const [ index, result ] = parser.parseDataBlock( input )
+  return { elements: index.elements, result, ms: performance.now() - t0, bytes }
+}
+
+async function streamedIndex( filePath ) {
+  const { buildIndexStreaming } = await import( '../compiled/src/step/parsing/streaming_index_builder.js' )
+  const parser = await parserFor( filePath )
+  const source = new FdByteSource( filePath )
+  const t0 = performance.now()
+  const r = buildIndexStreaming( source, parser, POOL_BYTES )
+  const ms = performance.now() - t0
+  source.close()
+  return { ...r, ms }
+}
+
+async function runChild( phase, filePath ) {
+  if ( phase === 'resident' ) {
+    const r = await residentIndex( filePath )
+    console.log( JSON.stringify( {
+      records: r.elements.length, result: r.result, ms: r.ms, peakMB: peakHeapMB(),
+    } ) )
+    return
+  }
+
+  if ( phase === 'stream' ) {
+    const r = await streamedIndex( filePath )
+    console.log( JSON.stringify( {
+      records: r.elements.length, result: r.result, ms: r.ms,
+      slides: r.stats.slides, windowBytes: r.stats.windowBytes,
+      maxRecordLen: r.stats.maxRecordLen, peakMB: peakHeapMB(),
+    } ) )
+    return
+  }
+
+  // verify: byte-identical index + sidecar round-trip.
+  const resident = await residentIndex( filePath )
+  const streamed = await streamedIndex( filePath )
+
+  let identical = resident.elements.length === streamed.elements.length
+  let firstDiff = -1
+
+  if ( identical ) {
+    for ( let i = 0; i < resident.elements.length; ++i ) {
+      const a = resident.elements[ i ]
+      const b = streamed.elements[ i ]
+      if ( a.address !== b.address || a.length !== b.length ||
+          a.typeID !== b.typeID || a.expressID !== b.expressID ) {
+        identical = false
+        firstDiff = i
+        break
+      }
+    }
+  }
+
+  const { serializeIndexSidecar, deserializeIndexSidecar, hashSource, sidecarMatchesSource } =
+    await import( '../compiled/src/step/parsing/index_sidecar.js' )
+
+  const hash = hashSource( resident.bytes )
+  const blob = serializeIndexSidecar( streamed.elements, resident.bytes.byteLength, hash )
+  const decoded = deserializeIndexSidecar( blob )
+
+  let sidecarOK = decoded.elements.length === streamed.elements.length &&
+    sidecarMatchesSource( decoded, resident.bytes.byteLength, hash )
+
+  if ( sidecarOK ) {
+    for ( let i = 0; i < decoded.elements.length; ++i ) {
+      const a = streamed.elements[ i ]
+      const b = decoded.elements[ i ]
+      if ( a.address !== b.address || a.length !== b.length ||
+          ( a.typeID ?? -1 ) !== ( b.typeID ?? -1 ) || a.expressID !== b.expressID ) {
+        sidecarOK = false
+        break
+      }
+    }
+  }
+
+  // Handshake must also refuse a mutated source.
+  const mutated = resident.bytes.slice( 0, Math.min( resident.bytes.length, 1 << 20 ) )
+  mutated[ Math.floor( mutated.length / 2 ) ] ^= 0xFF
+  const rejects = !sidecarMatchesSource( decoded, mutated.byteLength, hashSource( mutated ) )
+
+  console.log( JSON.stringify( {
+    records: resident.elements.length, identical, firstDiff,
+    sidecarBytes: blob.byteLength, sidecarOK, handshakeRejects: rejects,
+  } ) )
+}
+
+function spawnChild( phase, filePath ) {
+  const out = execFileSync( process.execPath, [
+    process.argv[ 1 ], '--child', phase, filePath,
+  ], { encoding: 'utf8', maxBuffer: 1 << 24, cwd: path.dirname( path.dirname( new URL( import.meta.url ).pathname ) ) } )
+  const lines = out.trim().split( '\n' )
+  return JSON.parse( lines[ lines.length - 1 ] )
+}
+
+async function main() {
+  if ( process.argv[ 2 ] === '--child' ) {
+    await runChild( process.argv[ 3 ], process.argv[ 4 ] )
+    return
+  }
+
+  const rows = []
+
+  for ( const model of CORPUS ) {
+    const full = path.isAbsolute( model ) ? model : path.resolve( model )
+    if ( !fs.existsSync( full ) ) {
+      console.error( `skip (missing): ${model}` )
+      continue
+    }
+    const sizeMB = fs.statSync( full ).size / ( 1024 * 1024 )
+    process.stderr.write( `sweeping ${path.basename( model )} (${sizeMB.toFixed( 1 )} MB)...\n` )
+
+    const resident = spawnChild( 'resident', full )
+    const stream = spawnChild( 'stream', full )
+    const verify = spawnChild( 'verify', full )
+
+    rows.push( {
+      model: path.basename( model ),
+      sizeMB: sizeMB.toFixed( 1 ),
+      records: resident.records,
+      residentMs: resident.ms.toFixed( 0 ),
+      streamMs: stream.ms.toFixed( 0 ),
+      residentPeakMB: resident.peakMB.toFixed( 1 ),
+      streamPeakMB: stream.peakMB.toFixed( 1 ),
+      slides: stream.slides,
+      identical: verify.identical,
+      sidecarMB: ( verify.sidecarBytes / ( 1024 * 1024 ) ).toFixed( 2 ),
+      sidecarOK: verify.sidecarOK && verify.handshakeRejects,
+    } )
+  }
+
+  console.table( rows )
+
+  const bad = rows.filter( ( r ) => !r.identical || !r.sidecarOK )
+  if ( bad.length > 0 ) {
+    console.error( `FAIL: ${bad.map( ( r ) => r.model ).join( ', ' )}` )
+    process.exit( 1 )
+  }
+  console.error( 'All models: byte-identical streamed index + sidecar round-trip OK' )
+}
+
+main().catch( ( e ) => {
+  console.error( e )
+  process.exit( 1 )
+} )

--- a/src/core/geometry_tile_pool.test.ts
+++ b/src/core/geometry_tile_pool.test.ts
@@ -139,6 +139,21 @@ describe( 'GeometryTilePool', () => {
     expect( () => tiles.release( 2 ) ).toThrow( /un-extracted/ )
   } )
 
+  test( 'a malformed byte size throws before any state changes', () => {
+    // A buggy source returning a negative size must fail at zero state —
+    // no references taken, nothing materialised, pool untouched.
+    const { source, materialized } = mockSource( {
+      1: [ { assetID: 'ok', byteSize: 100 }, { assetID: 'bad', byteSize: -5 } ],
+    } )
+    const pool = new ChunkedPool( 1000, 100 )
+    const tiles = new GeometryTilePool( pool, source )
+
+    expect( () => tiles.extract( 1 ) ).toThrow( /Invalid byte size/ )
+    expect( materialized ).toEqual( [] )
+    expect( pool.bytesInUse ).toBe( 0 )
+    expect( tiles.assets.isResident( 'ok' ) ).toBe( false )
+  } )
+
   test( 'composed with the demand queue: budget holds, shared reps survive eviction', () => {
     // 20 products all sharing one heavy rep, each with a light unique rep —
     // the mapped-item shape (fixtures, repeated windows).

--- a/src/core/geometry_tile_pool.test.ts
+++ b/src/core/geometry_tile_pool.test.ts
@@ -91,6 +91,45 @@ describe( 'GeometryTilePool', () => {
     expect( tiles.assets.pool.bytesInUse ).toBe( 300 )
   } )
 
+  test( 'a failed extract unwinds cleanly, discarding what it materialised', () => {
+    // Asset a fits; asset b cannot (pool holds 2 chunks, b needs 3). The
+    // extract must throw, and the unwind must keep the materialize/discard
+    // pairing for a (which it took to zero references) and leave the pool
+    // exactly as before — a failed extract has no effect.
+    const { source, materialized, discarded } = mockSource( {
+      1: [ { assetID: 'a', byteSize: 100 }, { assetID: 'b', byteSize: 300 } ],
+    } )
+    const pool = new ChunkedPool( 200, 100 )
+    const tiles = new GeometryTilePool( pool, source )
+
+    expect( () => tiles.extract( 1 ) ).toThrow( /exhausted/ )
+
+    expect( materialized ).toEqual( [ 'a' ] )
+    expect( discarded ).toEqual( [ 'a' ] )
+    expect( pool.bytesInUse ).toBe( 0 )
+    expect( tiles.assets.isResident( 'a' ) ).toBe( false )
+  } )
+
+  test( 'a failed extract never discards an asset another instance still holds', () => {
+    // Instance 1 holds shared. Instance 2 wants shared + big; big fails.
+    // The unwind drops 2's reference on shared but must NOT discard it —
+    // instance 1 still renders it.
+    const { source, discarded } = mockSource( {
+      1: [ { assetID: 'shared', byteSize: 100 } ],
+      2: [ { assetID: 'shared', byteSize: 100 }, { assetID: 'big', byteSize: 300 } ],
+    } )
+    const pool = new ChunkedPool( 200, 100 )
+    const tiles = new GeometryTilePool( pool, source )
+
+    tiles.extract( 1 )
+    expect( () => tiles.extract( 2 ) ).toThrow( /exhausted/ )
+
+    expect( discarded ).toEqual( [] )
+    expect( tiles.assets.isResident( 'shared' ) ).toBe( true )
+    expect( tiles.assets.refCountOf( 'shared' ) ).toBe( 1 )
+    expect( pool.bytesInUse ).toBe( 100 )
+  } )
+
   test( 'double extract and unmatched release are errors', () => {
     const { source } = mockSource( { 1: [ { assetID: 'a', byteSize: 10 } ] } )
     const tiles = new GeometryTilePool( new ChunkedPool( 1000, 100 ), source )

--- a/src/core/geometry_tile_pool.test.ts
+++ b/src/core/geometry_tile_pool.test.ts
@@ -1,0 +1,166 @@
+/* eslint-disable no-magic-numbers */
+// M3 production design: the geometry narrowing of the mem system, alone and
+// composed with DemandGeometryQueue. The load-bearing assertions: shared
+// representations are stored once and never freed while any product still
+// holds them, and the queue's logical budget always covers the pool's
+// physical use (so an extract can never blow the pool mid-flight).
+import { describe, expect, test } from '@jest/globals'
+
+import { DemandGeometryQueue } from './demand_geometry_queue'
+import { GeometryAsset, GeometryTilePool, InstanceAssetSource } from './geometry_tile_pool'
+import { ChunkedPool } from './mem/chunked_pool'
+
+/**
+ * A recording mock of the domain half: instance → assets from a fixture map,
+ * with materialize/discard calls captured.
+ *
+ * @param composition Instance → assets fixture.
+ * @return {object} `{ source, materialized, discarded }`.
+ */
+function mockSource( composition: Record<number, GeometryAsset<string>[]> ): {
+  source: InstanceAssetSource<string>,
+  materialized: string[],
+  discarded: string[],
+} {
+  const materialized: string[] = []
+  const discarded: string[] = []
+
+  const source: InstanceAssetSource<string> = {
+    assetsOf: ( instanceID ) => composition[ instanceID ] ?? [],
+    materialize: ( assetID ) => {
+      materialized.push( assetID )
+    },
+    discard: ( assetID ) => {
+      discarded.push( assetID )
+    },
+  }
+
+  return { source, materialized, discarded }
+}
+
+describe( 'GeometryTilePool', () => {
+
+  test( 'a shared representation is materialised once and stored once', () => {
+    // Products 1 and 2 both instance rep-X (mapped item); 2 also has its own.
+    const { source, materialized } = mockSource( {
+      1: [ { assetID: 'rep-X', byteSize: 100 } ],
+      2: [ { assetID: 'rep-X', byteSize: 100 }, { assetID: 'rep-Y', byteSize: 100 } ],
+    } )
+    const tiles = new GeometryTilePool( new ChunkedPool( 1000, 100 ), source )
+
+    tiles.extract( 1 )
+    tiles.extract( 2 )
+
+    expect( materialized ).toEqual( [ 'rep-X', 'rep-Y' ] )
+    // Physically: two assets, 200 bytes — not 300.
+    expect( tiles.assets.pool.bytesInUse ).toBe( 200 )
+    expect( tiles.assets.refCountOf( 'rep-X' ) ).toBe( 2 )
+  } )
+
+  test( 'evicting one product never discards a representation another still renders', () => {
+    const { source, discarded } = mockSource( {
+      1: [ { assetID: 'rep-X', byteSize: 100 } ],
+      2: [ { assetID: 'rep-X', byteSize: 100 } ],
+    } )
+    const tiles = new GeometryTilePool( new ChunkedPool( 1000, 100 ), source )
+
+    tiles.extract( 1 )
+    tiles.extract( 2 )
+
+    tiles.release( 1 )
+    expect( discarded ).toEqual( [] )
+    expect( tiles.assets.isResident( 'rep-X' ) ).toBe( true )
+
+    tiles.release( 2 )
+    expect( discarded ).toEqual( [ 'rep-X' ] )
+    expect( tiles.assets.pool.bytesInUse ).toBe( 0 )
+  } )
+
+  test( 'extract charges the logical (chunk-rounded, fully-charged) cost', () => {
+    const { source } = mockSource( {
+      1: [ { assetID: 'a', byteSize: 150 }, { assetID: 'b', byteSize: 10 } ],
+      2: [ { assetID: 'a', byteSize: 150 } ],
+    } )
+    const tiles = new GeometryTilePool( new ChunkedPool( 1000, 100 ), source )
+
+    // 150 → 200 rounded, 10 → 100 rounded.
+    expect( tiles.extract( 1 ) ).toBe( 300 )
+    // Sharing is deliberately double-charged logically (conservative)...
+    expect( tiles.extract( 2 ) ).toBe( 200 )
+    // ...while physical stays single-stored.
+    expect( tiles.assets.pool.bytesInUse ).toBe( 300 )
+  } )
+
+  test( 'double extract and unmatched release are errors', () => {
+    const { source } = mockSource( { 1: [ { assetID: 'a', byteSize: 10 } ] } )
+    const tiles = new GeometryTilePool( new ChunkedPool( 1000, 100 ), source )
+
+    tiles.extract( 1 )
+    expect( () => tiles.extract( 1 ) ).toThrow( /already extracted/ )
+    expect( () => tiles.release( 2 ) ).toThrow( /un-extracted/ )
+  } )
+
+  test( 'composed with the demand queue: budget holds, shared reps survive eviction', () => {
+    // 20 products all sharing one heavy rep, each with a light unique rep —
+    // the mapped-item shape (fixtures, repeated windows).
+    const composition: Record<number, GeometryAsset<string>[]> = {}
+
+    for ( let id = 0; id < 20; ++id ) {
+      composition[ id ] = [
+        { assetID: 'shared-heavy', byteSize: 400 },
+        { assetID: `unique-${id}`, byteSize: 100 },
+      ]
+    }
+
+    const { source, materialized, discarded } = mockSource( composition )
+    const pool = new ChunkedPool( 4000, 100 )
+    const tiles = new GeometryTilePool( pool, source )
+    // Queue budget == pool budget: the safety invariant under test.
+    const queue = new DemandGeometryQueue( tiles, 4000 )
+
+    // Stream demand across all 20 products with rising priority.
+    for ( let id = 0; id < 20; ++id ) {
+      queue.request( id, id )
+      queue.pump()
+
+      // Physical use never exceeds the logical budget the queue enforces.
+      expect( pool.bytesInUse ).toBeLessThanOrEqual( queue.stats.residentBytes )
+      expect( queue.stats.residentBytes ).toBeLessThanOrEqual( 4000 )
+    }
+
+    // The shared rep was materialised exactly once across all that churn...
+    expect( materialized.filter( ( a ) => a === 'shared-heavy' ).length ).toBe( 1 )
+    // ...and never discarded, because some product always held it.
+    expect( discarded ).not.toContain( 'shared-heavy' )
+
+    // Evicting everything finally discards it and empties the pool.
+    queue.evictAll()
+    expect( discarded ).toContain( 'shared-heavy' )
+    expect( pool.bytesInUse ).toBe( 0 )
+  } )
+
+  test( 'composed queue at exact pool budget never exhausts the pool', () => {
+    // Every product unique (worst case for the invariant: no sharing slack).
+    const composition: Record<number, GeometryAsset<string>[]> = {}
+
+    for ( let id = 0; id < 50; ++id ) {
+      composition[ id ] = [ { assetID: `u-${id}`, byteSize: 190 } ]
+    }
+
+    const { source } = mockSource( composition )
+    const pool = new ChunkedPool( 1000, 100 )
+    const tiles = new GeometryTilePool( pool, source )
+    const queue = new DemandGeometryQueue( tiles, 1000 )
+
+    // 190 rounds to 200 → 5 tiles fit. Churn all 50 through; extract must
+    // never throw pool-exhausted because logical charges cover physical.
+    for ( let id = 0; id < 50; ++id ) {
+      queue.request( id, id )
+      queue.pump()
+    }
+
+    expect( queue.stats.residentCount ).toBe( 5 )
+    expect( pool.bytesInUse ).toBe( 1000 )
+    expect( pool.stats.failedAcquires ).toBe( 0 )
+  } )
+} )

--- a/src/core/geometry_tile_pool.ts
+++ b/src/core/geometry_tile_pool.ts
@@ -116,7 +116,14 @@ export class GeometryTilePool<AssetID> implements GeometryTiles {
     const assets = this.source_.assetsOf( instanceID )
     const pool = this.assets_.pool
 
+    // Validate and price every asset BEFORE taking any references, so a bad
+    // byte size (a source bug) throws at zero state instead of mid-extract
+    // with references already taken. chunkRound throws on negatives.
     let logicalBytes = 0
+
+    for ( const asset of assets ) {
+      logicalBytes += pool.chunkRound( asset.byteSize )
+    }
 
     for ( const asset of assets ) {
 
@@ -145,8 +152,6 @@ export class GeometryTilePool<AssetID> implements GeometryTiles {
       if ( wasAbsent ) {
         this.source_.materialize( asset.assetID )
       }
-
-      logicalBytes += pool.chunkRound( asset.byteSize )
     }
 
     this.held_.set( instanceID, assets )

--- a/src/core/geometry_tile_pool.ts
+++ b/src/core/geometry_tile_pool.ts
@@ -124,12 +124,17 @@ export class GeometryTilePool<AssetID> implements GeometryTiles {
         this.assets_.retain( asset.assetID, asset.byteSize )
 
       if ( !retained ) {
-        // Unwind references already taken so a failed extract has no effect.
+        // Unwind references already taken so a failed extract has no effect —
+        // keeping the materialize/discard pairing: an asset this unwind takes
+        // to zero references must be discarded like any other last release.
         for ( const taken of assets ) {
           if ( taken === asset ) {
             break
           }
-          this.assets_.release( taken.assetID )
+
+          if ( this.assets_.release( taken.assetID ) ) {
+            this.source_.discard( taken.assetID )
+          }
         }
 
         throw new Error(

--- a/src/core/geometry_tile_pool.ts
+++ b/src/core/geometry_tile_pool.ts
@@ -1,0 +1,174 @@
+import { GeometryTiles } from './demand_geometry_queue'
+import { ChunkedPool } from './mem/chunked_pool'
+import { SharedAssetPool } from './mem/shared_asset_pool'
+
+
+/**
+ * One shareable geometry payload an instance needs resident: the asset's
+ * identity and its byte size. For IFC, the asset is a representation's
+ * tessellated geometry and `byteSize` comes from the wasm-side extract.
+ */
+export interface GeometryAsset<AssetID> {
+  assetID: AssetID
+  byteSize: number
+}
+
+
+/**
+ * The domain half the tile pool delegates to: what assets an instance is made
+ * of, and how to materialise / discard one asset's payload. This is the seam
+ * the production conway-geom surface implements (extract → tessellate into
+ * the asset's chunks; discard on last release); tests implement it with
+ * recording mocks.
+ */
+export interface InstanceAssetSource<AssetID> {
+
+  /**
+   * The assets an instance requires resident, with their byte sizes. For a
+   * simple product this is one asset; mapped/instanced representations return
+   * the same assetID from many instances — that sharing is the point.
+   *
+   * @param instanceID The instance (product local ID in the geometry case).
+   * @return {GeometryAsset<AssetID>[]} The instance's assets.
+   */
+  assetsOf( instanceID: number ): GeometryAsset<AssetID>[]
+
+  /**
+   * Materialise an asset's payload (called exactly once per residency, on
+   * the 0→1 reference). In production: run the wasm extract/tessellate and
+   * write the result into the asset's pool chunks.
+   *
+   * @param assetID The asset to materialise.
+   */
+  materialize( assetID: AssetID ): void
+
+  /**
+   * Discard an asset's payload (called exactly once per residency, on the
+   * 1→0 reference, after its chunks are already back in the pool).
+   *
+   * @param assetID The asset to discard.
+   */
+  discard( assetID: AssetID ): void
+}
+
+
+/**
+ * The geometry narrowing of the general memory system (`src/core/mem/`): a
+ * {@link GeometryTiles} backend where a product's "tile" is a set of
+ * refcounted, chunk-resident **assets** in a {@link SharedAssetPool}.
+ *
+ * Composed with {@link DemandGeometryQueue} this completes the M3 resident
+ * design: the queue owns demand ordering and the logical budget; this pool
+ * owns physical residency. Two accounting views, one invariant:
+ *
+ * - **Logical (queue-side):** `extract` charges an instance the full
+ *   chunk-rounded cost of *every* asset it references, shared or not. Sharing
+ *   is thus double-charged logically — deliberately conservative: summed
+ *   logical charges always cover physical use, so with the queue's budget set
+ *   to the pool's budget, an acquire can never fail mid-extract. (Heavy
+ *   sharing under-utilises the logical budget; the production wiring can
+ *   widen the queue budget once measured. The safe direction first.)
+ * - **Physical (pool-side):** `bytesInUse` counts real chunks. Shared assets
+ *   are stored once, refcounted, and freed only on the last release — so
+ *   evicting product A never discards the representation product B still
+ *   renders (the mapped-item correctness rule, held structurally).
+ */
+export class GeometryTilePool<AssetID> implements GeometryTiles {
+
+  private readonly assets_: SharedAssetPool<AssetID>
+
+  private readonly source_: InstanceAssetSource<AssetID>
+
+  /** Assets each extracted instance holds references on. */
+  private readonly held_ = new Map<number, GeometryAsset<AssetID>[]>()
+
+  /**
+   * @param pool The chunk pool residents live in.
+   * @param source The domain half (asset composition + materialise/discard).
+   */
+  constructor( pool: ChunkedPool, source: InstanceAssetSource<AssetID> ) {
+    this.assets_ = new SharedAssetPool<AssetID>( pool )
+    this.source_ = source
+  }
+
+  /**
+   * @return {SharedAssetPool<AssetID>} The refcounted asset layer (physical
+   * accounting lives here / on its pool).
+   */
+  public get assets(): SharedAssetPool<AssetID> {
+    return this.assets_
+  }
+
+  /**
+   * Materialise an instance's tile: take a reference on each of its assets,
+   * materialising the ones not yet resident.
+   *
+   * @param instanceID The instance (product local ID).
+   * @return {number} The instance's logical byte cost (chunk-rounded, every
+   * asset fully charged — see class docs for why sharing is double-charged).
+   */
+  public extract( instanceID: number ): number {
+
+    if ( this.held_.has( instanceID ) ) {
+      throw new Error( `Instance ${instanceID} already extracted` )
+    }
+
+    const assets = this.source_.assetsOf( instanceID )
+    const pool = this.assets_.pool
+
+    let logicalBytes = 0
+
+    for ( const asset of assets ) {
+
+      const { retained, wasAbsent } =
+        this.assets_.retain( asset.assetID, asset.byteSize )
+
+      if ( !retained ) {
+        // Unwind references already taken so a failed extract has no effect.
+        for ( const taken of assets ) {
+          if ( taken === asset ) {
+            break
+          }
+          this.assets_.release( taken.assetID )
+        }
+
+        throw new Error(
+            `Geometry pool exhausted materialising instance ${instanceID} — ` +
+            'the scheduler budget must not exceed the pool budget' )
+      }
+
+      if ( wasAbsent ) {
+        this.source_.materialize( asset.assetID )
+      }
+
+      logicalBytes += pool.chunkRound( asset.byteSize )
+    }
+
+    this.held_.set( instanceID, assets )
+
+    return logicalBytes
+  }
+
+  /**
+   * Release an instance's tile: drop the reference on each of its assets,
+   * discarding those this instance was the last holder of.
+   *
+   * @param instanceID The instance (product local ID).
+   */
+  public release( instanceID: number ): void {
+
+    const assets = this.held_.get( instanceID )
+
+    if ( assets === void 0 ) {
+      throw new Error( `Release of un-extracted instance ${instanceID}` )
+    }
+
+    this.held_.delete( instanceID )
+
+    for ( const asset of assets ) {
+      if ( this.assets_.release( asset.assetID ) ) {
+        this.source_.discard( asset.assetID )
+      }
+    }
+  }
+}

--- a/src/core/mem/chunked_pool.test.ts
+++ b/src/core/mem/chunked_pool.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable no-magic-numbers */
+// mem: the fixed-chunk pool bounds resident memory by construction — acquire
+// rounds to whole chunks, all-or-nothing, and the high-water mark can never
+// exceed the budget.
+import { describe, expect, test } from '@jest/globals'
+
+import { ChunkedPool } from './chunked_pool'
+
+describe( 'ChunkedPool', () => {
+
+  test( 'sizes itself in whole chunks from the byte budget', () => {
+    const pool = new ChunkedPool( 1050, 100 )
+
+    expect( pool.totalChunks ).toBe( 10 )
+    expect( pool.totalBytes ).toBe( 1000 )
+    expect( pool.freeChunks ).toBe( 10 )
+    expect( pool.bytesInUse ).toBe( 0 )
+  } )
+
+  test( 'acquire rounds up to whole chunks', () => {
+    const pool = new ChunkedPool( 1000, 100 )
+
+    const span = pool.acquire( 250 )
+
+    expect( span?.chunks.length ).toBe( 3 )
+    expect( span?.byteSize ).toBe( 250 )
+    expect( pool.bytesInUse ).toBe( 300 )
+    expect( pool.chunkRound( 250 ) ).toBe( 300 )
+  } )
+
+  test( 'acquire is all-or-nothing at exhaustion', () => {
+    const pool = new ChunkedPool( 300, 100 )
+
+    expect( pool.acquire( 200 ) ).toBeDefined()
+
+    // 2 chunks needed, 1 free → refused with no state change.
+    const refused = pool.acquire( 101 )
+    expect( refused ).toBeUndefined()
+    expect( pool.freeChunks ).toBe( 1 )
+    expect( pool.stats.failedAcquires ).toBe( 1 )
+
+    // Exactly one chunk still fits.
+    expect( pool.acquire( 100 ) ).toBeDefined()
+    expect( pool.freeChunks ).toBe( 0 )
+  } )
+
+  test( 'released chunks are reusable (steady-state churn stays bounded)', () => {
+    const pool = new ChunkedPool( 500, 100 )
+
+    for ( let round = 0; round < 50; ++round ) {
+      const a = pool.acquire( 300 )
+      const b = pool.acquire( 200 )
+      expect( a ).toBeDefined()
+      expect( b ).toBeDefined()
+      expect( pool.bytesInUse ).toBe( 500 )
+      pool.release( a! )
+      pool.release( b! )
+      expect( pool.bytesInUse ).toBe( 0 )
+    }
+
+    // The pool never grew: churn recycles the same chunks.
+    expect( pool.totalChunks ).toBe( 5 )
+    expect( pool.stats.acquires ).toBe( 100 )
+    expect( pool.stats.releases ).toBe( 100 )
+  } )
+
+  test( 'a zero-byte acquire holds no chunks but round-trips', () => {
+    const pool = new ChunkedPool( 100, 100 )
+
+    const span = pool.acquire( 0 )
+    expect( span?.chunks.length ).toBe( 0 )
+    expect( pool.freeChunks ).toBe( 1 )
+    pool.release( span! )
+  } )
+
+  test( 'rejects invalid construction', () => {
+    expect( () => new ChunkedPool( 100, 0 ) ).toThrow()
+    expect( () => new ChunkedPool( 50, 100 ) ).toThrow()
+  } )
+} )

--- a/src/core/mem/chunked_pool.ts
+++ b/src/core/mem/chunked_pool.ts
@@ -1,0 +1,208 @@
+/**
+ * A fixed-chunk budget pool — the resident-memory primitive (M3 production
+ * design; see "Resident memory: two regimes" in the design doc).
+ *
+ * The wasm heap grows and never shrinks: `free()` returns bytes to the
+ * allocator's freelists, not to the browser, so the tab pays the heap's
+ * **high-water mark forever** and external fragmentation is a permanent leak,
+ * not a throughput nuisance. General-purpose allocation is therefore the
+ * wrong tool for large, evictable resident data. This pool is the explicit
+ * alternative: one region carved into fixed-size chunks with a freelist —
+ * acquire rounds up to whole chunks, release is O(chunks), and the region's
+ * high-water mark is the budget, by construction. Fragmentation is confined
+ * to bounded internal waste (the tail of the last chunk).
+ *
+ * This TS class is the pool's **accounting/policy half** and the executable
+ * spec for its C++ twin in conway-geom (which owns real bytes inside the wasm
+ * heap). It is also usable directly for JS-side resident budgets (property
+ * caches, sidecar caches) — the abstraction is deliberately not
+ * geometry-specific. The intended layering:
+ *
+ *   ChunkedPool                — chunks and bytes (this file)
+ *   SharedAssetPool            — refcounted assets living in those chunks
+ *   GeometryTilePool           — the geometry narrowing (products ⇄ assets)
+ *
+ * Lifetime regimes, for orientation: *phase-bounded* scratch (tessellation
+ * temporaries) stays on the AFTP bump arenas — reset, never freed piecemeal.
+ * *Demand-bounded* residents (data that lives until evicted) live here. The
+ * general allocator keeps only the small, messy-lifetime residual.
+ */
+
+/**
+ * An acquired run of chunks. `chunks` are chunk indices into the pool's
+ * region (index × chunkBytes = byte offset in the C++ twin); `byteSize` is
+ * the caller's requested size, ≤ `chunks.length × chunkBytes`.
+ */
+export interface ChunkSpan {
+  chunks: number[]
+  byteSize: number
+}
+
+
+/** Runtime counters for a pool, for tests and telemetry. */
+export interface ChunkedPoolStats {
+  totalChunks: number
+  freeChunks: number
+  bytesInUse: number
+  acquires: number
+  releases: number
+  failedAcquires: number
+}
+
+
+/**
+ * A budgeted pool of fixed-size chunks with a freelist. Purely accounting —
+ * see the module docs for how it maps onto real memory.
+ */
+export class ChunkedPool {
+
+  private readonly chunkBytes_: number
+
+  private readonly totalChunks_: number
+
+  /** Free chunk indices (LIFO for locality in the C++ twin). */
+  private readonly freeList_: number[]
+
+  private acquires_ = 0
+
+  private releases_ = 0
+
+  private failedAcquires_ = 0
+
+  /**
+   * @param budgetBytes The pool's total byte budget (rounded down to whole
+   * chunks; must fit at least one chunk).
+   * @param chunkBytes The fixed chunk size in bytes.
+   */
+  constructor( budgetBytes: number, chunkBytes: number ) {
+
+    if ( chunkBytes <= 0 || !Number.isInteger( chunkBytes ) ) {
+      throw new Error( `Invalid chunkBytes ${chunkBytes}` )
+    }
+
+    const totalChunks = Math.floor( budgetBytes / chunkBytes )
+
+    if ( totalChunks < 1 ) {
+      throw new Error(
+          `Budget ${budgetBytes} does not fit one chunk of ${chunkBytes}` )
+    }
+
+    this.chunkBytes_ = chunkBytes
+    this.totalChunks_ = totalChunks
+    this.freeList_ = []
+
+    for ( let chunk = totalChunks - 1; chunk >= 0; --chunk ) {
+      this.freeList_.push( chunk )
+    }
+  }
+
+  /**
+   * @return {number} The fixed chunk size in bytes.
+   */
+  public get chunkBytes(): number {
+    return this.chunkBytes_
+  }
+
+  /**
+   * @return {number} Total chunks in the pool.
+   */
+  public get totalChunks(): number {
+    return this.totalChunks_
+  }
+
+  /**
+   * @return {number} Chunks currently free.
+   */
+  public get freeChunks(): number {
+    return this.freeList_.length
+  }
+
+  /**
+   * @return {number} The pool's total byte capacity (whole chunks).
+   */
+  public get totalBytes(): number {
+    return this.totalChunks_ * this.chunkBytes_
+  }
+
+  /**
+   * @return {number} Physical bytes currently acquired (chunk-rounded).
+   */
+  public get bytesInUse(): number {
+    return ( this.totalChunks_ - this.freeList_.length ) * this.chunkBytes_
+  }
+
+  /**
+   * The physical (chunk-rounded) cost of a byte size — what an acquire of
+   * `bytes` actually consumes. Use this for any budget accounting layered
+   * above the pool so logical charges cover physical use.
+   *
+   * @param bytes The byte size to round.
+   * @return {number} The chunk-rounded byte cost.
+   */
+  public chunkRound( bytes: number ): number {
+
+    if ( bytes < 0 ) {
+      throw new Error( `Invalid byte size ${bytes}` )
+    }
+
+    return Math.ceil( bytes / this.chunkBytes_ ) * this.chunkBytes_
+  }
+
+  /**
+   * Acquire chunks to hold `bytes`. All-or-nothing: returns undefined (and
+   * changes nothing) if the free chunks can't cover the request — the
+   * caller's cue to evict and retry.
+   *
+   * @param bytes The byte size to hold (0 is allowed and acquires no chunks).
+   * @return {ChunkSpan | undefined} The span, or undefined if it can't fit.
+   */
+  public acquire( bytes: number ): ChunkSpan | undefined {
+
+    const needed = Math.ceil( Math.max( 0, bytes ) / this.chunkBytes_ )
+
+    if ( needed > this.freeList_.length ) {
+      ++this.failedAcquires_
+      return void 0
+    }
+
+    const chunks: number[] = new Array( needed )
+
+    for ( let where = 0; where < needed; ++where ) {
+      chunks[ where ] = this.freeList_.pop() as number
+    }
+
+    ++this.acquires_
+
+    return { chunks, byteSize: bytes }
+  }
+
+  /**
+   * Return a span's chunks to the freelist. The span must not be used (or
+   * released) again afterwards.
+   *
+   * @param span The span to release.
+   */
+  public release( span: ChunkSpan ): void {
+
+    for ( const chunk of span.chunks ) {
+      this.freeList_.push( chunk )
+    }
+
+    span.chunks.length = 0
+    ++this.releases_
+  }
+
+  /**
+   * @return {ChunkedPoolStats} A snapshot of runtime counters.
+   */
+  public get stats(): ChunkedPoolStats {
+    return {
+      totalChunks: this.totalChunks_,
+      freeChunks: this.freeList_.length,
+      bytesInUse: this.bytesInUse,
+      acquires: this.acquires_,
+      releases: this.releases_,
+      failedAcquires: this.failedAcquires_,
+    }
+  }
+}

--- a/src/core/mem/shared_asset_pool.test.ts
+++ b/src/core/mem/shared_asset_pool.test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable no-magic-numbers */
+// mem: assets are stored once and refcounted — the sharing layer's rule is
+// that a release never frees an asset another holder still references.
+import { describe, expect, test } from '@jest/globals'
+
+import { ChunkedPool } from './chunked_pool'
+import { SharedAssetPool } from './shared_asset_pool'
+
+describe( 'SharedAssetPool', () => {
+
+  test( 'first retain acquires chunks and reports wasAbsent', () => {
+    const assets = new SharedAssetPool<string>( new ChunkedPool( 1000, 100 ) )
+
+    const first = assets.retain( 'rep-A', 250 )
+    expect( first ).toEqual( { retained: true, wasAbsent: true } )
+    expect( assets.isResident( 'rep-A' ) ).toBe( true )
+    expect( assets.physicalBytesOf( 'rep-A' ) ).toBe( 300 )
+    expect( assets.pool.bytesInUse ).toBe( 300 )
+  } )
+
+  test( 'a second retain shares storage instead of duplicating it', () => {
+    const assets = new SharedAssetPool<string>( new ChunkedPool( 1000, 100 ) )
+
+    assets.retain( 'rep-A', 250 )
+    const second = assets.retain( 'rep-A', 250 )
+
+    expect( second ).toEqual( { retained: true, wasAbsent: false } )
+    expect( assets.refCountOf( 'rep-A' ) ).toBe( 2 )
+    // Stored once: physical bytes unchanged.
+    expect( assets.pool.bytesInUse ).toBe( 300 )
+  } )
+
+  test( 'release frees only on the last reference', () => {
+    const assets = new SharedAssetPool<string>( new ChunkedPool( 1000, 100 ) )
+
+    assets.retain( 'rep-A', 100 )
+    assets.retain( 'rep-A', 100 )
+
+    expect( assets.release( 'rep-A' ) ).toBe( false )
+    expect( assets.isResident( 'rep-A' ) ).toBe( true )
+    expect( assets.pool.bytesInUse ).toBe( 100 )
+
+    expect( assets.release( 'rep-A' ) ).toBe( true )
+    expect( assets.isResident( 'rep-A' ) ).toBe( false )
+    expect( assets.pool.bytesInUse ).toBe( 0 )
+  } )
+
+  test( 'retain fails cleanly when the pool cannot fit a new asset', () => {
+    const assets = new SharedAssetPool<string>( new ChunkedPool( 200, 100 ) )
+
+    assets.retain( 'rep-A', 200 )
+
+    const refused = assets.retain( 'rep-B', 100 )
+    expect( refused ).toEqual( { retained: false, wasAbsent: true } )
+    expect( assets.isResident( 'rep-B' ) ).toBe( false )
+
+    // A retain of an already-resident asset still succeeds at full pool.
+    expect( assets.retain( 'rep-A', 200 ).retained ).toBe( true )
+  } )
+
+  test( 'releasing a non-resident asset is an error, not a silent no-op', () => {
+    const assets = new SharedAssetPool<string>( new ChunkedPool( 100, 100 ) )
+
+    expect( () => assets.release( 'ghost' ) ).toThrow( /non-resident/ )
+  } )
+} )

--- a/src/core/mem/shared_asset_pool.ts
+++ b/src/core/mem/shared_asset_pool.ts
@@ -1,0 +1,141 @@
+import { ChunkedPool, ChunkSpan } from './chunked_pool'
+
+
+/**
+ * Refcounted **assets** resident in a {@link ChunkedPool} — the sharing layer
+ * of the memory system (see `src/core/mem/`).
+ *
+ * The general relationship this models: many **instances** reference shared
+ * **assets** (the definition/occurrence split that recurs across CAD — STEP
+ * AP214 literally names it *occurrence*). Concretely for geometry: products
+ * are instances, representation geometry is the asset, and mapped items make
+ * many products share one representation. But nothing here is
+ * geometry-specific — an asset is any refcounted, chunk-resident payload
+ * (a parsed property block, a decoded sidecar, a texture).
+ *
+ * Storage is keyed and refcounted on the **asset**, so the correctness rule
+ * for shared data falls out structurally: releasing one instance's reference
+ * never frees an asset another instance still holds; chunks return to the
+ * pool only on the last release. (Evicting product A must not free the
+ * representation product B still renders — the mapped-item bug a
+ * per-instance store invites.)
+ *
+ * Instance-level bookkeeping (which assets an instance holds, demand
+ * priorities, eviction order) belongs to the layer above — see
+ * `GeometryTilePool` for the geometry narrowing and `DemandGeometryQueue`
+ * for the scheduling policy.
+ */
+export class SharedAssetPool<AssetID> {
+
+  private readonly pool_: ChunkedPool
+
+  private readonly assets_ = new Map<AssetID, { span: ChunkSpan, refCount: number }>()
+
+  /**
+   * @param pool The chunk pool assets reside in.
+   */
+  constructor( pool: ChunkedPool ) {
+    this.pool_ = pool
+  }
+
+  /**
+   * @return {ChunkedPool} The underlying chunk pool.
+   */
+  public get pool(): ChunkedPool {
+    return this.pool_
+  }
+
+  /**
+   * @return {number} The number of resident assets.
+   */
+  public get assetCount(): number {
+    return this.assets_.size
+  }
+
+  /**
+   * Take a reference on an asset, acquiring chunks for it if it is not yet
+   * resident. All-or-nothing: returns false (and changes nothing) only when
+   * the asset is absent and the pool can't fit it — the caller's cue to evict
+   * and retry. A `wasAbsent` result of true tells the caller to materialise
+   * the payload into the asset's chunks (the 0→1 transition).
+   *
+   * @param assetID The asset to reference.
+   * @param byteSize Its payload size (used only on first residency).
+   * @return {{ retained: boolean, wasAbsent: boolean }} Whether the reference
+   * was taken, and whether this was the residency-creating reference.
+   */
+  public retain( assetID: AssetID, byteSize: number ):
+      { retained: boolean, wasAbsent: boolean } {
+
+    const existing = this.assets_.get( assetID )
+
+    if ( existing !== void 0 ) {
+      ++existing.refCount
+      return { retained: true, wasAbsent: false }
+    }
+
+    const span = this.pool_.acquire( byteSize )
+
+    if ( span === void 0 ) {
+      return { retained: false, wasAbsent: true }
+    }
+
+    this.assets_.set( assetID, { span, refCount: 1 } )
+
+    return { retained: true, wasAbsent: true }
+  }
+
+  /**
+   * Drop a reference on an asset. On the last reference (1→0) the asset's
+   * chunks return to the pool and the caller should discard the payload.
+   *
+   * @param assetID The asset to release.
+   * @return {boolean} True if this was the last reference (asset freed).
+   */
+  public release( assetID: AssetID ): boolean {
+
+    const asset = this.assets_.get( assetID )
+
+    if ( asset === void 0 ) {
+      throw new Error( `Release of non-resident asset ${String( assetID )}` )
+    }
+
+    if ( --asset.refCount > 0 ) {
+      return false
+    }
+
+    this.pool_.release( asset.span )
+    this.assets_.delete( assetID )
+
+    return true
+  }
+
+  /**
+   * @param assetID The asset to check.
+   * @return {boolean} True if the asset is resident.
+   */
+  public isResident( assetID: AssetID ): boolean {
+    return this.assets_.has( assetID )
+  }
+
+  /**
+   * @param assetID The asset to query.
+   * @return {number} The asset's current reference count (0 if absent).
+   */
+  public refCountOf( assetID: AssetID ): number {
+    return this.assets_.get( assetID )?.refCount ?? 0
+  }
+
+  /**
+   * @param assetID The asset to query.
+   * @return {number} The asset's physical (chunk-rounded) resident bytes
+   * (0 if absent).
+   */
+  public physicalBytesOf( assetID: AssetID ): number {
+
+    const asset = this.assets_.get( assetID )
+
+    return asset === void 0 ?
+      0 : asset.span.chunks.length * this.pool_.chunkBytes
+  }
+}


### PR DESCRIPTION
**Epic #390** — resolves the M3 (#403) blocker's allocation question. **Base retargeted to `main`** (#401–#405 merged). **Merge sequence position: #408 → #409.**

## Why: two regimes, and why `free()` can't work here

Wasm linear memory grows and never shrinks — `free()` returns bytes to mimalloc's freelists, not the browser, and wasm has none of the virtual-memory tools (page decommit, `madvise`) that make modern native allocators good at long-lived/mixed workloads. The tab pays the heap's **high-water mark forever**, and evict/refill churn turns fragmentation into a permanent leak. Per-product `free()` into the general heap is the wrong design here. The design (doc section *"Resident memory: two regimes"*): **phase-bounded** scratch stays on the AFTP bump arenas; **demand-bounded** residents live in an explicit fixed-chunk pool whose high-water mark is the budget *by construction*.

## What: an abstraction ladder, general → narrow (`src/core/mem/`)

```
ChunkedPool          chunks and bytes: budget, freelist, chunk-rounding      (mem/)
SharedAssetPool      refcounted *assets* resident in those chunks           (mem/)
GeometryTilePool     the geometry narrowing: products ⇄ assets              (core/)
DemandGeometryQueue  demand ordering + logical budget (M3 #403, unchanged)
```

- **`ChunkedPool`** — budgeted fixed-chunk freelist; all-or-nothing `acquire`; span cleared on `release` (double-release of a span is a no-op, not corruption); `chunkRound` for layered accounting. Executable spec for the C++ twin (conway-geom #147), semantics cross-checked chunk-for-chunk.
- **`SharedAssetPool<AssetID>`** — the instance ⇄ asset (occurrence ⇄ definition) relationship; storage keyed and refcounted on the **asset**: releasing one holder never frees what another references; chunks return on last release only.
- **`GeometryTilePool`** — implements `GeometryTiles` so the M3 queue composes **unchanged**; `InstanceAssetSource` is the wasm materialize/discard seam.

**Accounting invariant:** queue charges full chunk-rounded cost per instance (sharing double-charged, conservative); pool stores shared assets once. Logical ≥ physical always, so with queue budget ≤ pool budget an acquire can never fail mid-extract — pinned by composed tests.

## Compatibility with existing Share use

**Fully additive** — new files only (+ design doc + sweep harness). No Share surface, no geometry code → zero render-diff exposure; **visual-diff green** on each pushed head.

## Review status (chain review, 2026-07-19/20 — two findings, both fixed on the branch)

1. **`6676b81` — unwind broke the materialize/discard pairing.** A failed mid-extract retain unwound earlier references without calling `source.discard()` for an asset taken to zero references (derived-state leak on the defensive error path; unreachable in the intended composition because of the budget invariant — which is why the invariant tests never exposed it). Fixed + 2 pinning tests: a failed extract discards exactly what it materialised and leaves the pool untouched; the unwind never discards a shared asset another instance still holds.
2. **`02d5e9f` — malformed byte sizes escaped the unwind entirely.** A negative `byteSize` from a buggy source passed `retain` (negatives round to zero chunks), ran `materialize`, and only then threw from `chunkRound` mid-extract — *outside* the unwind, leaking the references taken so far. Assets are now priced and validated **before any references are taken**, so a bad size fails at zero state. Pinning test added.

Both are error-path state-consistency bugs of the same family, found by adversarial review of paths the happy-path invariant deliberately makes unreachable. All other paths traced clean (span double-release, all-or-nothing refusal, duplicate-assetID symmetry, refcount semantics, the C++ twin cross-check).

## Tests

20 across 3 suites (+ 8 queue tests re-exercised in composition):
- `mem/chunked_pool.test.ts` (6): sizing; rounding; all-or-nothing; 50-round churn reuse; zero-byte span; guards.
- `mem/shared_asset_pool.test.ts` (5): first-retain/`wasAbsent`; shared storage; last-release-frees; clean refusal; ghost-release throws.
- `geometry_tile_pool.test.ts` (9): materialise-once/store-once; shared-rep survives eviction; logical-vs-physical; guards; **failed-extract unwind pairing ×2**; **malformed-size zero-state failure**; two composed queue integrations (physical ≤ logical ≤ budget streamed; exact-budget churn with zero failed acquires).

Also: `scripts/stream_corpus_sweep.mjs` (corpus harness; verified 6/6 models in-container) and the design-doc "Resident memory" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz