### PR TITLE
M7: columns-first index build — the parse writes SoA columns directly, no object phase

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -465,6 +465,30 @@ not stubbed:
 | **M3** | demand-geometry queue (budget + eviction); chunked tile pool + refcounted assets (`src/core/mem/`) | conway-geom C++ tile-pool twin (surface narrowed — see "Resident memory: two regimes") |
 | **M4a** | index sidecar + `RangeByteSource` | M4b: Share sidecar cache + index-first open |
 | **M5a** | model-URI, shared budget, registry, cross-ref, composition | M5b: loader registration, budget wiring, UI links |
+| **M7** | columns-first index build (no object phase); sidecar ⇄ columns identity | resident `parseDataToModel` still object-form (unchanged by design — CI byte-parity anchor) |
+
+**M7 — columns-first index (landed).** The corpus sweep exposed the last
+structural memory problem on the parse plane: the streamed build still
+materialised the index as one JS object per record (~90 B each) before the
+model compacted them to SoA columns — ~1 GB of transient objects on a
+PSB-class file to produce ~200 MB of columns. M7 gives the parser an
+optional `StepIndexSink`; `ColumnarIndexSink` encodes each completed
+top-level record **straight into chunked-segment typed-array columns**
+(the rare records with inline children / multi-mappings keep their object
+form, exactly the set the model retains today), and `StepModelBase` /
+`StepTypeIndexer` gained from-columns construction that adopts the
+columns without any object walk. `parseStreamToModel` now uses this path.
+Parity is pinned test-for-test against the object path — byte-identical
+internal columns and type index on IFC and on AP214 inline/multi-mapping
+fixtures. The sidecar converged with the in-memory layout: serialize
+reads columns directly (blob byte-identical to the object-form
+serializer) and `deserializeIndexSidecarToColumns` restores columns with
+**no per-record objects anywhere between sidecar bytes and a constructed
+model** — the zero-rebuild index-first open. Sweep (retained heap, GC'd):
+Arty 90.6 → 44.5 MB, Schependomlaan 107.6 → 32.5 MB vs the object-streamed
+path; columnar is also the fastest build on Arty. Extrapolated PSB-class:
+index build working set drops from ~1 GB to roughly the columns
+themselves (~200 MB).
 
 The recurring shape: **settle the deterministic engine policy against a
 mock/synthetic backend now, so the queue/format/addressing is correct and

--- a/scripts/stream_corpus_sweep.mjs
+++ b/scripts/stream_corpus_sweep.mjs
@@ -57,6 +57,9 @@ async function parserFor( filePath ) {
 }
 
 function peakHeapMB() {
+  // Collect before measuring so the number is the phase's *retained* heap
+  // (its true working set), not transient garbage awaiting GC.
+  globalThis.gc?.()
   const usage = process.memoryUsage()
   return ( usage.heapUsed + usage.arrayBuffers ) / ( 1024 * 1024 )
 }
@@ -83,6 +86,17 @@ async function streamedIndex( filePath ) {
   return { ...r, ms }
 }
 
+async function columnarIndex( filePath ) {
+  const { buildColumnarIndexStreaming } = await import( '../compiled/src/step/parsing/streaming_index_builder.js' )
+  const parser = await parserFor( filePath )
+  const source = new FdByteSource( filePath )
+  const t0 = performance.now()
+  const r = buildColumnarIndexStreaming( source, parser, POOL_BYTES )
+  const ms = performance.now() - t0
+  source.close()
+  return { ...r, ms }
+}
+
 async function runChild( phase, filePath ) {
   if ( phase === 'resident' ) {
     const r = await residentIndex( filePath )
@@ -102,11 +116,23 @@ async function runChild( phase, filePath ) {
     return
   }
 
-  // verify: byte-identical index + sidecar round-trip.
+  if ( phase === 'columnar' ) {
+    const r = await columnarIndex( filePath )
+    console.log( JSON.stringify( {
+      records: r.columns.firstInlineElement, rows: r.columns.count,
+      result: r.result, ms: r.ms, peakMB: peakHeapMB(),
+    } ) )
+    return
+  }
+
+  // verify: byte-identical index (object-streamed AND columnar) + sidecar
+  // round-trip.
   const resident = await residentIndex( filePath )
   const streamed = await streamedIndex( filePath )
+  const columnar = await columnarIndex( filePath )
 
   let identical = resident.elements.length === streamed.elements.length
+  let columnsIdentical = resident.elements.length === columnar.columns.firstInlineElement
   let firstDiff = -1
 
   if ( identical ) {
@@ -117,6 +143,18 @@ async function runChild( phase, filePath ) {
           a.typeID !== b.typeID || a.expressID !== b.expressID ) {
         identical = false
         firstDiff = i
+        break
+      }
+    }
+  }
+
+  if ( columnsIdentical ) {
+    const c = columnar.columns
+    for ( let i = 0; i < resident.elements.length; ++i ) {
+      const a = resident.elements[ i ]
+      if ( a.address !== c.address[ i ] || a.length !== c.length[ i ] ||
+          ( a.typeID ?? -1 ) !== c.typeID[ i ] || a.expressID !== c.expressID[ i ] ) {
+        columnsIdentical = false
         break
       }
     }
@@ -150,14 +188,14 @@ async function runChild( phase, filePath ) {
   const rejects = !sidecarMatchesSource( decoded, mutated.byteLength, hashSource( mutated ) )
 
   console.log( JSON.stringify( {
-    records: resident.elements.length, identical, firstDiff,
+    records: resident.elements.length, identical, columnsIdentical, firstDiff,
     sidecarBytes: blob.byteLength, sidecarOK, handshakeRejects: rejects,
   } ) )
 }
 
 function spawnChild( phase, filePath ) {
   const out = execFileSync( process.execPath, [
-    process.argv[ 1 ], '--child', phase, filePath,
+    '--expose-gc', process.argv[ 1 ], '--child', phase, filePath,
   ], { encoding: 'utf8', maxBuffer: 1 << 24, cwd: path.dirname( path.dirname( new URL( import.meta.url ).pathname ) ) } )
   const lines = out.trim().split( '\n' )
   return JSON.parse( lines[ lines.length - 1 ] )
@@ -182,6 +220,7 @@ async function main() {
 
     const resident = spawnChild( 'resident', full )
     const stream = spawnChild( 'stream', full )
+    const columnar = spawnChild( 'columnar', full )
     const verify = spawnChild( 'verify', full )
 
     rows.push( {
@@ -190,23 +229,25 @@ async function main() {
       records: resident.records,
       residentMs: resident.ms.toFixed( 0 ),
       streamMs: stream.ms.toFixed( 0 ),
+      columnarMs: columnar.ms.toFixed( 0 ),
       residentPeakMB: resident.peakMB.toFixed( 1 ),
       streamPeakMB: stream.peakMB.toFixed( 1 ),
-      slides: stream.slides,
+      columnarPeakMB: columnar.peakMB.toFixed( 1 ),
       identical: verify.identical,
-      sidecarMB: ( verify.sidecarBytes / ( 1024 * 1024 ) ).toFixed( 2 ),
+      columnsOK: verify.columnsIdentical,
       sidecarOK: verify.sidecarOK && verify.handshakeRejects,
     } )
   }
 
   console.table( rows )
 
-  const bad = rows.filter( ( r ) => !r.identical || !r.sidecarOK )
+  const bad = rows.filter( ( r ) => !r.identical || !r.columnsOK || !r.sidecarOK )
   if ( bad.length > 0 ) {
     console.error( `FAIL: ${bad.map( ( r ) => r.model ).join( ', ' )}` )
     process.exit( 1 )
   }
-  console.error( 'All models: byte-identical streamed index + sidecar round-trip OK' )
+  console.error(
+      'All models: byte-identical streamed + columnar index, sidecar round-trip OK' )
 }
 
 main().catch( ( e ) => {

--- a/src/AP214E3_2010/ap214_step_model.ts
+++ b/src/AP214E3_2010/ap214_step_model.ts
@@ -2,6 +2,7 @@ import EntityTypesAP214, {EntityTypesAP214Count} from './AP214E3_2010_gen/entity
 import StepModelBase from '../step/step_model_base'
 import SchemaAP214 from './AP214E3_2010_gen/schema_ap214.gen'
 import {StepIndexEntry} from '../step/parsing/step_parser'
+import {StepIndexColumns} from '../step/parsing/columnar_index'
 import {StepTypeIndexer} from '../step/indexing/step_type_indexer'
 import {MultiIndexSet} from '../indexing/multi_index_set'
 import { AP214ModelGeometry } from './ap214_model_geometry'
@@ -36,9 +37,9 @@ export default class AP214StepModel extends StepModelBase< EntityTypesAP214 > {
    */
   constructor(
       buffer: Uint8Array,
-      elementIndex: StepIndexEntry< EntityTypesAP214 >[] ) {
+      elementIndex: StepIndexEntry< EntityTypesAP214 >[] | StepIndexColumns< EntityTypesAP214 > ) {
     super( SchemaAP214, buffer, elementIndex )
 
-    this.typeIndex = indexerInstance.create( elementIndex )
+    this.typeIndex = indexerInstance.createFor( elementIndex )
   }
 }

--- a/src/ifc/ifc_step_model.ts
+++ b/src/ifc/ifc_step_model.ts
@@ -2,6 +2,7 @@ import EntityTypesIfc, {EntityTypesIfcCount} from './ifc4_gen/entity_types_ifc.g
 import StepModelBase from '../step/step_model_base'
 import SchemaIfc from './ifc4_gen/schema_ifc.gen'
 import {StepIndexEntry} from '../step/parsing/step_parser'
+import {StepIndexColumns} from '../step/parsing/columnar_index'
 import {StepTypeIndexer} from '../step/indexing/step_type_indexer'
 import {MultiIndexSet} from '../indexing/multi_index_set'
 import { IfcModelGeometry } from './ifc_model_geometry'
@@ -42,10 +43,10 @@ export default class IfcStepModel extends StepModelBase< EntityTypesIfc > {
    */
   constructor(
       buffer: Uint8Array | undefined,
-      elementIndex: StepIndexEntry< EntityTypesIfc >[],
+      elementIndex: StepIndexEntry< EntityTypesIfc >[] | StepIndexColumns< EntityTypesIfc >,
       provider?: StepBufferProvider ) {
     super( SchemaIfc, buffer, elementIndex, provider )
 
-    this.typeIndex = indexerInstance.create( elementIndex )
+    this.typeIndex = indexerInstance.createFor( elementIndex )
   }
 }

--- a/src/ifc/ifc_step_parser.ts
+++ b/src/ifc/ifc_step_parser.ts
@@ -4,7 +4,7 @@ import EntityTypesIfc from './ifc4_gen/entity_types_ifc.gen'
 import EntitTypesIfcSearch from './ifc4_gen/entity_types_search.gen'
 import IfcStepModel from './ifc_step_model'
 import { ByteSource } from '../step/parsing/byte_source'
-import { buildIndexStreaming } from '../step/parsing/streaming_index_builder'
+import { buildColumnarIndexStreaming } from '../step/parsing/streaming_index_builder'
 import {
   StepExternalByteStore,
   WindowedStepBufferProvider,
@@ -106,12 +106,14 @@ export default class IfcStepParser extends StepParser< EntityTypesIfc > {
           `source byteLength ${source.byteLength}` )
     }
 
-    const { elements, result } =
-      buildIndexStreaming( source, this, opts?.pool ?? DEFAULT_STREAM_POOL_BYTES )
+    // Columnar build (M7): the index goes straight into SoA columns — the
+    // per-record object phase never exists, so peak heap is window + columns.
+    const { columns, result } =
+      buildColumnarIndexStreaming( source, this, opts?.pool ?? DEFAULT_STREAM_POOL_BYTES )
 
     const provider =
       new WindowedStepBufferProvider( store, opts?.chunkBytes, opts?.maxResidentChunks )
 
-    return [result, new IfcStepModel( void 0, elements, provider )]
+    return [result, new IfcStepModel( void 0, columns, provider )]
   }
 }

--- a/src/step/indexing/step_type_indexer.ts
+++ b/src/step/indexing/step_type_indexer.ts
@@ -4,6 +4,7 @@ import {
   initCountCompactedElements32State,
 } from '../../indexing/bit_operations'
 import { MultiIndexSet } from '../../indexing/multi_index_set'
+import { StepIndexColumns } from '../parsing/columnar_index'
 import { StepIndexEntry } from '../parsing/step_parser'
 
 /**
@@ -19,6 +20,103 @@ export class StepTypeIndexer< TypeIDType extends number > {
    */
   public constructor( typeCount: number ) {
     this.elementCounter_ = new Int32Array( typeCount << 1 )
+  }
+
+  /**
+   * Create a type index from either index form — the parsed object array or
+   * the columnar index (M7).
+   *
+   * @param index The element index, object or columnar.
+   * @return {MultiIndexSet} The created multi-set index.
+   */
+  public createFor(
+      index: StepIndexEntry< TypeIDType >[] | StepIndexColumns< TypeIDType > ):
+      MultiIndexSet< TypeIDType > {
+
+    return Array.isArray( index ) ? this.create( index ) : this.createFromColumns( index )
+  }
+
+  /**
+   * Create a type index straight from the columnar index — the same
+   * membership `create` produces from the unfolded object array: every row's
+   * concrete type (top-level + inline; −1 rows skipped) plus the
+   * multi-mapping subtypes of retained complex entries at their parent's
+   * dense index.
+   *
+   * @param columns The columnar index.
+   * @return {MultiIndexSet} The created multi-set index.
+   */
+  public createFromColumns(
+      columns: StepIndexColumns< TypeIDType > ): MultiIndexSet< TypeIDType > {
+
+    for ( let where = 0, end = this.elementCounter_.length; where < end; where += 2 ) {
+      initCountCompactedElements32State( this.elementCounter_, where )
+    }
+
+    const elementCounter = this.elementCounter_
+    const prefixSum      = new Uint32Array( ( this.elementCounter_.length >>> 1 ) + 1 )
+    const typeIDs        = columns.typeID
+    const count          = columns.count
+
+    // Walk retained complex entries alongside the rows (their keys ascend in
+    // localID order) so multi-mapping subtypes interleave at their parent's
+    // dense index — the object path's exact output order.
+    const walkRows = ( addOne: ( denseIndex: number, typeID: number ) => void ): void => {
+
+      const complexIterator = columns.complexEntries?.entries()
+      let nextComplex = complexIterator?.next()
+
+      for ( let denseIndex = 0; denseIndex < count; ++denseIndex ) {
+        const typeID = typeIDs[ denseIndex ]
+
+        if ( typeID >= 0 ) {
+          addOne( denseIndex, typeID )
+        }
+
+        if ( nextComplex !== void 0 && !nextComplex.done &&
+            nextComplex.value[ 0 ] === denseIndex ) {
+
+          for ( const subElement of nextComplex.value[ 1 ].multiMapping ?? [] ) {
+            const subTypeID = subElement.typeID
+
+            if ( subTypeID !== void 0 ) {
+              addOne( denseIndex, subTypeID as number )
+            }
+          }
+
+          nextComplex = ( complexIterator as
+            IterableIterator<[number, StepIndexEntry<TypeIDType>]> ).next()
+        }
+      }
+    }
+
+    walkRows( ( denseIndex, typeID ) => {
+      prefixSum[ typeID + 1 ] =
+        addCompactedElementCount32State( denseIndex, elementCounter, typeID << 1 )
+    } )
+
+    for ( let prefixSumIndex = 2, prefixSumEnd = prefixSum.length;
+      prefixSumIndex < prefixSumEnd;
+      ++prefixSumIndex ) {
+      prefixSum[ prefixSumIndex ] += prefixSum[ prefixSumIndex - 1 ]
+    }
+
+    for ( let where = 0, end = this.elementCounter_.length; where < end; where += 2 ) {
+      initCountCompactedElements32State( this.elementCounter_, where )
+    }
+
+    const indexOutput = new Uint32Array( prefixSum[ prefixSum.length - 1 ] << 1 )
+
+    walkRows( ( denseIndex, typeID ) => {
+      addCompactedElement32State(
+          denseIndex,
+          elementCounter,
+          indexOutput,
+          typeID << 1,
+          prefixSum[ typeID ] << 1 )
+    } )
+
+    return new MultiIndexSet< TypeIDType >( prefixSum, indexOutput )
   }
 
   /**

--- a/src/step/parsing/columnar_index.test.ts
+++ b/src/step/parsing/columnar_index.test.ts
@@ -1,0 +1,185 @@
+/* eslint-disable no-magic-numbers, @typescript-eslint/no-explicit-any */
+// M7: the columnar (no-object-phase) index build must produce a model
+// indistinguishable from the object-path build — identical SoA columns,
+// identical lookup behaviour, identical type index — including on AP214
+// fixtures with inline entities and multi-mappings, the paths the object
+// walk handles specially.
+import * as fs from 'fs'
+
+import { describe, expect, test } from '@jest/globals'
+
+import ParsingBuffer from '../../parsing/parsing_buffer'
+import IfcStepParser from '../../ifc/ifc_step_parser'
+import IfcStepModel from '../../ifc/ifc_step_model'
+import AP214StepParser from '../../AP214E3_2010/ap214_step_parser'
+import AP214StepModel from '../../AP214E3_2010/ap214_step_model'
+import { BufferByteSource } from './byte_source'
+import { buildColumnarIndexStreaming } from './streaming_index_builder'
+import { ColumnarIndexSink } from './columnar_index'
+import { ParseResult, StepIndexEntry } from './step_parser'
+import { IfcProduct, IfcRoot } from '../../ifc/ifc4_gen'
+
+/**
+ * Parse a file resident via the object path and return buffer + elements.
+ *
+ * @param path The file to parse.
+ * @param parser The parser instance for its schema.
+ * @return {object} `{ bytes, elements }`.
+ */
+function objectParse( path: string, parser: any ):
+    { bytes: Uint8Array, elements: StepIndexEntry<number>[] } {
+  const bytes = new Uint8Array( fs.readFileSync( path ) )
+  const input = new ParsingBuffer( bytes )
+  parser.parseHeader( input )
+  const [ index, result ] = parser.parseDataBlock( input )
+  expect( result ).toBe( ParseResult.COMPLETE )
+  return { bytes, elements: index.elements }
+}
+
+/**
+ * Assert two models have byte-identical internal columns and equal type
+ * indexes across every type either contains.
+ *
+ * @param a First model.
+ * @param b Second model.
+ */
+function expectModelParity( a: any, b: any ): void {
+
+  expect( a.count_ ).toBe( b.count_ )
+  expect( a.firstInlineElement_ ).toBe( b.firstInlineElement_ )
+
+  expect( Array.from( a.address_ ) ).toEqual( Array.from( b.address_ ) )
+  expect( Array.from( a.length_ ) ).toEqual( Array.from( b.length_ ) )
+  expect( Array.from( a.typeID_ ) ).toEqual( Array.from( b.typeID_ ) )
+  expect( Array.from( a.expressID_ ) ).toEqual( Array.from( b.expressID_ ) )
+
+  const typesA = new Set( a.typeIndex.types() )
+  const typesB = new Set( b.typeIndex.types() )
+
+  expect( typesA ).toEqual( typesB )
+
+  for ( const type of typesA ) {
+    expect( b.typeIndex.count( type ) ).toBe( a.typeIndex.count( type ) )
+  }
+}
+
+describe( 'columnar index build (M7)', () => {
+
+  test( 'IFC: columnar streamed model matches the object-path model', () => {
+    const path = 'data/index.ifc'
+    const { bytes, elements } = objectParse( path, IfcStepParser.Instance )
+    const objectModel = new IfcStepModel( bytes, elements ) as any
+
+    const { columns, result } = buildColumnarIndexStreaming(
+        new BufferByteSource( bytes ), IfcStepParser.Instance as any, 4 * 1024 )
+
+    expect( result ).toBe( ParseResult.COMPLETE )
+
+    const columnarModel = new IfcStepModel( bytes, columns as any ) as any
+
+    expectModelParity( objectModel, columnarModel )
+
+    // Behavioural spot checks through the public surface.
+    const roots = new Set( objectModel.expressIDsOfTypes( IfcRoot ) )
+    expect( new Set( columnarModel.expressIDsOfTypes( IfcRoot ) ) ).toEqual( roots )
+    expect( new Set( columnarModel.expressIDsOfTypes( IfcProduct ) ) )
+        .toEqual( new Set( objectModel.expressIDsOfTypes( IfcProduct ) ) )
+
+    for ( const expressID of roots ) {
+      expect( columnarModel.getElementByExpressID( expressID )?.expressID )
+          .toBe( objectModel.getElementByExpressID( expressID )?.expressID )
+    }
+  } )
+
+  test.each( [
+    [ 'as1-oc-214.stp' ],
+    [ 'ap214-mapped-item-test.step' ],
+    [ 'ap214-multibody-part.step' ],
+  ] )( 'AP214 (inline/multi-mapping): parity on %s', ( name ) => {
+    const path = `data/${name}`
+    const { bytes, elements } = objectParse( path, AP214StepParser.Instance )
+    const objectModel = new AP214StepModel( bytes, elements ) as any
+
+    const { columns, result } = buildColumnarIndexStreaming(
+        new BufferByteSource( bytes ), AP214StepParser.Instance as any, 4 * 1024 )
+
+    expect( result ).toBe( ParseResult.COMPLETE )
+
+    const columnarModel = new AP214StepModel( bytes, columns as any ) as any
+
+    // Inline entities must actually be present for these fixtures to prove
+    // the unfold path (guard against a silently trivial test).
+    if ( name !== 'as1-oc-214.stp' ) {
+      expect( columnarModel.count_ ).toBeGreaterThan( columnarModel.firstInlineElement_ )
+    }
+
+    expectModelParity( objectModel, columnarModel )
+  } )
+
+  test( 'the sink drops simple records but retains complex ones', () => {
+    const sink = new ColumnarIndexSink<number>()
+
+    sink.pushTopLevel( { address: 0, length: 10, typeID: 5, expressID: 1 } )
+    sink.pushTopLevel( {
+      address: 10, length: 20, typeID: 0, expressID: 2,
+      multiMapping: [ { address: 12, length: 5, typeID: 7 } ],
+    } )
+
+    const columns = sink.finalize()
+
+    expect( columns.firstInlineElement ).toBe( 2 )
+    expect( columns.count ).toBe( 2 )
+    expect( columns.complexEntries?.size ).toBe( 1 )
+    expect( columns.complexEntries?.get( 1 )?.multiMapping?.[ 0 ].typeID ).toBe( 7 )
+    expect( Array.from( columns.typeID ) ).toEqual( [ 5, 0 ] )
+  } )
+
+  test( 'inline entities unfold in the model object-walk order', () => {
+    const sink = new ColumnarIndexSink<number>()
+
+    // Two parents with children; first parent's child itself has a child.
+    // Object-path order: parents (0,1), then first-level children in parent
+    // order (2 = p0c, 3 = p1c), then second-level (4 = p0c's child).
+    sink.pushTopLevel( {
+      address: 0, length: 10, typeID: 1, expressID: 1,
+      inlineEntities: [ {
+        address: 2, length: 3, typeID: 10,
+        inlineEntities: [ { address: 3, length: 1, typeID: 20 } ],
+      } ],
+    } )
+    sink.pushTopLevel( {
+      address: 10, length: 10, typeID: 2, expressID: 2,
+      inlineEntities: [ { address: 12, length: 3, typeID: 11 } ],
+    } )
+
+    const columns = sink.finalize()
+
+    expect( columns.firstInlineElement ).toBe( 2 )
+    expect( columns.count ).toBe( 5 )
+    expect( Array.from( columns.typeID ) ).toEqual( [ 1, 2, 10, 11, 20 ] )
+    expect( Array.from( columns.address ) ).toEqual( [ 0, 10, 2, 12, 3 ] )
+  } )
+
+  test( 'reset rewinds for the grow-and-restart', () => {
+    const sink = new ColumnarIndexSink<number>()
+
+    sink.pushTopLevel( { address: 0, length: 1, typeID: 1, expressID: 9 } )
+    sink.reset()
+    sink.pushTopLevel( { address: 5, length: 2, typeID: 3, expressID: 1 } )
+
+    const columns = sink.finalize()
+
+    expect( columns.count ).toBe( 1 )
+    expect( Array.from( columns.address ) ).toEqual( [ 5 ] )
+    expect( columns.expressIdsSorted ).toBe( true )
+  } )
+
+  test( 'detects unsorted express IDs', () => {
+    const sink = new ColumnarIndexSink<number>()
+
+    sink.pushTopLevel( { address: 0, length: 1, typeID: 1, expressID: 10 } )
+    sink.pushTopLevel( { address: 1, length: 1, typeID: 1, expressID: 5 } )
+
+    expect( sink.finalize().expressIdsSorted ).toBe( false )
+  } )
+} )

--- a/src/step/parsing/columnar_index.ts
+++ b/src/step/parsing/columnar_index.ts
@@ -1,0 +1,262 @@
+import {
+  StepIndexEntry,
+  StepIndexEntryBase,
+  StepIndexSink,
+} from './step_parser'
+
+
+/**
+ * The entity index in its **columnar (SoA) form** — the same packed typed-array
+ * columns `StepModelBase` compacts the object index into at construction, but
+ * produced *directly by the parse* so the per-record object phase never exists
+ * (M7; "Structural memory" in the design doc).
+ *
+ * Layout mirrors the model's internal columns exactly:
+ *
+ *   [0, firstInlineElement)   top-level records, in parse order (localID)
+ *   [firstInlineElement, count)  inline entities, in the model's unfold order
+ *
+ * `expressID` covers only the top-level range (inline entities have none).
+ * `typeID` uses −1 for "no concrete type" (matching the sidecar sentinel);
+ * 0 is a valid type (external mapping). The rare records with children —
+ * inline entities or a multi-mapping — are additionally retained as objects
+ * in `complexEntries` / consumed during the unfold, exactly the set the model
+ * keeps today; everything else is scalars only.
+ */
+export interface StepIndexColumns<TypeIDType> {
+
+  address: Uint32Array
+  length: Uint32Array
+  typeID: Int32Array
+  expressID: Uint32Array
+
+  /** Total rows (top-level + inline). */
+  count: number
+
+  /** Top-level record count == start of the inline range. */
+  firstInlineElement: number
+
+  /** Records with a multiMapping, keyed by localID (rare; retained). */
+  complexEntries?: Map<number, StepIndexEntry<TypeIDType>>
+
+  /** True if top-level express IDs arrived in non-decreasing order. */
+  expressIdsSorted: boolean
+}
+
+
+/** Type sentinel for "no concrete type" in the typeID column. */
+export const COLUMN_UNDEFINED_TYPE = -1
+
+// Records per growth segment. 64 K rows × 16 B ≈ 1 MB per segment — growth
+// never copies previously written rows, and finalize concatenates one column
+// at a time so the transient overhead is one column's segments, not 2× the
+// index.
+// eslint-disable-next-line no-magic-numbers
+const SEGMENT_ROWS = 64 * 1024
+
+
+/** One growth segment of the four scalar columns. */
+interface ColumnSegment {
+  address: Uint32Array
+  length: Uint32Array
+  typeID: Int32Array
+  expressID: Uint32Array
+}
+
+
+/**
+ * A {@link StepIndexSink} that encodes top-level records straight into
+ * chunked-segment typed-array columns, so the parse holds **no per-record
+ * objects** for the (overwhelmingly common) simple records. Records with
+ * children keep their object form — inline entities are unfolded into the
+ * inline column range at {@link finalize}, and multi-mapping holders are
+ * retained for the model's `complexEntries`, matching the object path's
+ * behaviour entry-for-entry.
+ *
+ * `reset` supports the streaming builder's rare grow-and-restart: columns
+ * rewind to empty without reallocating the first segment.
+ */
+export class ColumnarIndexSink<TypeIDType extends number>
+implements StepIndexSink<TypeIDType> {
+
+  private segments_: ColumnSegment[] = []
+
+  private count_ = 0
+
+  /** Entries with inlineEntities and/or multiMapping, keyed by localID. */
+  private retained_ = new Map<number, StepIndexEntry<TypeIDType>>()
+
+  private expressIdsSorted_ = true
+
+  private previousExpressID_ = 0
+
+  /**
+   * @return {number} Top-level records pushed so far.
+   */
+  public get topLevelCount(): number {
+    return this.count_
+  }
+
+  /**
+   * Encode one completed top-level record into the columns. The entry object
+   * is not kept unless it carries children (inline entities / multi-mapping).
+   *
+   * @param entry The completed top-level index entry.
+   */
+  public pushTopLevel( entry: StepIndexEntry<TypeIDType> ): void {
+
+    const localID = this.count_++
+    const segmentIndex = Math.floor( localID / SEGMENT_ROWS )
+    const row = localID % SEGMENT_ROWS
+
+    if ( segmentIndex === this.segments_.length ) {
+      this.segments_.push( {
+        address: new Uint32Array( SEGMENT_ROWS ),
+        length: new Uint32Array( SEGMENT_ROWS ),
+        typeID: new Int32Array( SEGMENT_ROWS ),
+        expressID: new Uint32Array( SEGMENT_ROWS ),
+      } )
+    }
+
+    const segment = this.segments_[ segmentIndex ]
+
+    segment.address[ row ] = entry.address
+    segment.length[ row ] = entry.length
+    segment.typeID[ row ] =
+      entry.typeID === void 0 ? COLUMN_UNDEFINED_TYPE : ( entry.typeID as number )
+    segment.expressID[ row ] = entry.expressID
+
+    if ( entry.expressID < this.previousExpressID_ ) {
+      this.expressIdsSorted_ = false
+    }
+
+    this.previousExpressID_ = entry.expressID
+
+    if ( entry.inlineEntities !== void 0 || entry.multiMapping !== void 0 ) {
+      this.retained_.set( localID, entry )
+    }
+  }
+
+  /**
+   * Rewind to empty (the streaming builder's grow-and-restart). The first
+   * segment is kept for reuse.
+   */
+  public reset(): void {
+    this.segments_.length = Math.min( this.segments_.length, 1 )
+    this.count_ = 0
+    this.retained_.clear()
+    this.expressIdsSorted_ = true
+    this.previousExpressID_ = 0
+  }
+
+  /**
+   * Assemble the final columns: concatenate the top-level segments (one
+   * column at a time, bounding transient overhead to a single column's
+   * segments) and unfold retained inline entities into the inline range in
+   * the model's exact unfold order.
+   *
+   * @return {StepIndexColumns} The finished columnar index.
+   */
+  public finalize(): StepIndexColumns<TypeIDType> {
+
+    const topLevel = this.count_
+
+    // Unfold inline entities exactly as StepModelBase does over the object
+    // array: scan in localID order appending children, then keep scanning
+    // the appended region (children of children follow all first-level
+    // children). Only retained entries can contribute — simple records have
+    // no children by construction.
+    const unfolded: StepIndexEntryBase<TypeIDType>[] = []
+
+    for ( const entry of this.retained_.values() ) {
+      if ( entry.inlineEntities !== void 0 ) {
+        unfolded.push( ...entry.inlineEntities )
+      }
+    }
+
+    for ( let where = 0; where < unfolded.length; ++where ) {
+
+      const inlineEntities = unfolded[ where ].inlineEntities
+
+      if ( inlineEntities !== void 0 ) {
+        unfolded.push( ...inlineEntities )
+      }
+    }
+
+    const count = topLevel + unfolded.length
+
+    const address = concatColumn( this.segments_, 'address', topLevel, count )
+    const length = concatColumn( this.segments_, 'length', topLevel, count )
+
+    const typeID = new Int32Array( count )
+
+    for ( let segment = 0; segment * SEGMENT_ROWS < topLevel; ++segment ) {
+      const rows = Math.min( SEGMENT_ROWS, topLevel - segment * SEGMENT_ROWS )
+      typeID.set(
+          this.segments_[ segment ].typeID.subarray( 0, rows ),
+          segment * SEGMENT_ROWS )
+    }
+
+    const expressID = concatColumn( this.segments_, 'expressID', topLevel, topLevel )
+
+    for ( let where = 0; where < unfolded.length; ++where ) {
+
+      const entry = unfolded[ where ]
+      const row = topLevel + where
+
+      address[ row ] = entry.address
+      length[ row ] = entry.length
+      typeID[ row ] =
+        entry.typeID === void 0 ? COLUMN_UNDEFINED_TYPE : ( entry.typeID as number )
+    }
+
+    let complexEntries: Map<number, StepIndexEntry<TypeIDType>> | undefined
+
+    for ( const [ localID, entry ] of this.retained_ ) {
+      if ( entry.multiMapping !== void 0 ) {
+        ( complexEntries ??= new Map() ).set( localID, entry )
+      }
+    }
+
+    return {
+      address,
+      length,
+      typeID,
+      expressID,
+      count,
+      firstInlineElement: topLevel,
+      complexEntries,
+      expressIdsSorted: this.expressIdsSorted_,
+    }
+  }
+}
+
+
+/**
+ * Concatenate one Uint32 column's segments into a final array of
+ * `finalLength`, copying `rows` valid rows.
+ *
+ * @param segments The growth segments.
+ * @param column Which column to concatenate.
+ * @param rows Valid rows across the segments.
+ * @param finalLength Length of the final array (≥ rows; the tail is for
+ * inline rows filled by the caller).
+ * @return {Uint32Array} The concatenated column.
+ */
+function concatColumn(
+    segments: ColumnSegment[],
+    column: 'address' | 'length' | 'expressID',
+    rows: number,
+    finalLength: number ): Uint32Array {
+
+  const result = new Uint32Array( finalLength )
+
+  for ( let segment = 0; segment * SEGMENT_ROWS < rows; ++segment ) {
+    const valid = Math.min( SEGMENT_ROWS, rows - segment * SEGMENT_ROWS )
+    result.set(
+        segments[ segment ][ column ].subarray( 0, valid ),
+        segment * SEGMENT_ROWS )
+  }
+
+  return result
+}

--- a/src/step/parsing/index_sidecar.test.ts
+++ b/src/step/parsing/index_sidecar.test.ts
@@ -12,10 +12,14 @@ import IfcStepParser from '../../ifc/ifc_step_parser'
 import { StepIndexEntry } from './step_parser'
 import {
   deserializeIndexSidecar,
+  deserializeIndexSidecarToColumns,
   hashSource,
   serializeIndexSidecar,
+  serializeIndexSidecarFromColumns,
   sidecarMatchesSource,
 } from './index_sidecar'
+import { BufferByteSource } from './byte_source'
+import { buildColumnarIndexStreaming } from './streaming_index_builder'
 
 /**
  * Parse index.ifc resident and return its top-level element index plus the
@@ -132,5 +136,43 @@ describe( 'index sidecar', () => {
       deserializeIndexSidecar<number>( serializeIndexSidecar( [], 0, 0 ) )
 
     expect( decoded.elements.length ).toBe( 0 )
+  } )
+
+  test( 'columns-form serialize is byte-identical to the object-form blob (M7)', () => {
+    const { bytes, elements } = residentIndex()
+    const hash = hashSource( bytes )
+
+    const { columns } = buildColumnarIndexStreaming(
+        new BufferByteSource( bytes ),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ( IfcStepParser as any ).Instance, 4096 )
+
+    const fromObjects = serializeIndexSidecar( elements, bytes.byteLength, hash )
+    const fromColumns =
+      serializeIndexSidecarFromColumns( columns, bytes.byteLength, hash )
+
+    expect( fromColumns ).toEqual( fromObjects )
+  } )
+
+  test( 'deserializes straight to columns for the index-first open (M7)', () => {
+    const { bytes, elements } = residentIndex()
+    const hash = hashSource( bytes )
+
+    const blob = serializeIndexSidecar( elements, bytes.byteLength, hash )
+    const restored = deserializeIndexSidecarToColumns<number>( blob )
+
+    expect( restored.sourceByteLength ).toBe( bytes.byteLength )
+    expect( restored.sourceHash ).toBe( hash )
+    expect( restored.columns.count ).toBe( elements.length )
+    expect( restored.columns.firstInlineElement ).toBe( elements.length )
+    expect( restored.columns.expressIdsSorted ).toBe( true )
+
+    for ( let where = 0; where < elements.length; ++where ) {
+      expect( restored.columns.address[ where ] ).toBe( elements[ where ].address )
+      expect( restored.columns.length[ where ] ).toBe( elements[ where ].length )
+      expect( restored.columns.expressID[ where ] ).toBe( elements[ where ].expressID )
+      expect( restored.columns.typeID[ where ] )
+          .toBe( elements[ where ].typeID ?? -1 )
+    }
   } )
 } )

--- a/src/step/parsing/index_sidecar.ts
+++ b/src/step/parsing/index_sidecar.ts
@@ -1,3 +1,4 @@
+import { StepIndexColumns } from './columnar_index'
 import { StepIndexEntry } from './step_parser'
 
 
@@ -195,6 +196,138 @@ export function deserializeIndexSidecar<TypeIDType extends number>(
   }
 
   return { version, sourceByteLength, sourceHash, elements, hasChildren }
+}
+
+
+/**
+ * Serialise a columnar index (M7) to a sidecar blob — same format as
+ * {@link serializeIndexSidecar}, byte for byte, but read straight off the SoA
+ * columns so no object index is needed. Only the top-level range is carried
+ * (the v1 format; inline rows re-materialise from record bytes on demand).
+ *
+ * @param columns The columnar index.
+ * @param sourceByteLength The length of the source it was built from.
+ * @param sourceHash The source hash (see {@link hashSource}).
+ * @return {Uint8Array} The sidecar bytes.
+ */
+export function serializeIndexSidecarFromColumns<TypeIDType extends number>(
+    columns: StepIndexColumns<TypeIDType>,
+    sourceByteLength: number,
+    sourceHash: number ): Uint8Array {
+
+  const recordCount = columns.firstInlineElement
+
+  const total =
+    HEADER_BYTES +
+    recordCount * ( ADDRESS_BYTES + LENGTH_BYTES + TYPEID_BYTES + EXPRESSID_BYTES )
+
+  const bytes = new Uint8Array( total )
+  const view = new DataView( bytes.buffer )
+
+  let offset = 0
+
+  view.setUint32( offset, MAGIC, true ); offset += 4
+  view.setUint32( offset, VERSION, true ); offset += 4
+  view.setFloat64( offset, sourceByteLength, true ); offset += 8
+  view.setUint32( offset, sourceHash >>> 0, true ); offset += 4
+  view.setUint32( offset, recordCount, true ); offset += 4
+
+  for ( let where = 0; where < recordCount; ++where ) {
+    view.setFloat64( offset, columns.address[ where ], true ); offset += ADDRESS_BYTES
+  }
+  for ( let where = 0; where < recordCount; ++where ) {
+    view.setUint32( offset, columns.length[ where ], true ); offset += LENGTH_BYTES
+  }
+  for ( let where = 0; where < recordCount; ++where ) {
+    // The column already uses the sidecar's −1 sentinel for undefined.
+    view.setInt32( offset, columns.typeID[ where ], true ); offset += TYPEID_BYTES
+  }
+  for ( let where = 0; where < recordCount; ++where ) {
+    view.setUint32( offset, columns.expressID[ where ], true ); offset += EXPRESSID_BYTES
+  }
+
+  return bytes
+}
+
+
+/**
+ * Deserialise a sidecar blob straight to a columnar index (M7) — the
+ * index-first open path: no per-record objects at any point between the
+ * sidecar bytes and a constructed model. Top-level rows only (v1 sidecars
+ * carry no inline rows), so `count === firstInlineElement`.
+ *
+ * @param bytes The sidecar bytes.
+ * @return {{ sourceByteLength: number, sourceHash: number,
+ *  columns: StepIndexColumns }} Source identity + the columnar index.
+ */
+export function deserializeIndexSidecarToColumns<TypeIDType extends number>(
+    bytes: Uint8Array ): {
+  sourceByteLength: number,
+  sourceHash: number,
+  columns: StepIndexColumns<TypeIDType>,
+} {
+
+  const view = new DataView( bytes.buffer, bytes.byteOffset, bytes.byteLength )
+
+  let offset = 0
+
+  const magic = view.getUint32( offset, true ); offset += 4
+
+  if ( magic !== MAGIC ) {
+    throw new Error( `Not a sidecar: bad magic 0x${magic.toString( HEX )}` )
+  }
+
+  const version = view.getUint32( offset, true ); offset += 4
+
+  if ( version !== VERSION ) {
+    throw new Error( `Unsupported sidecar version ${version}` )
+  }
+
+  const sourceByteLength = view.getFloat64( offset, true ); offset += 8
+  const sourceHash = view.getUint32( offset, true ); offset += 4
+  const recordCount = view.getUint32( offset, true ); offset += 4
+
+  const address = new Uint32Array( recordCount )
+  const length = new Uint32Array( recordCount )
+  const typeID = new Int32Array( recordCount )
+  const expressID = new Uint32Array( recordCount )
+
+  let sorted = true
+  let previous = 0
+
+  for ( let where = 0; where < recordCount; ++where ) {
+    address[ where ] = view.getFloat64( offset, true ); offset += ADDRESS_BYTES
+  }
+  for ( let where = 0; where < recordCount; ++where ) {
+    length[ where ] = view.getUint32( offset, true ); offset += LENGTH_BYTES
+  }
+  for ( let where = 0; where < recordCount; ++where ) {
+    typeID[ where ] = view.getInt32( offset, true ); offset += TYPEID_BYTES
+  }
+  for ( let where = 0; where < recordCount; ++where ) {
+    const id = view.getUint32( offset, true ); offset += EXPRESSID_BYTES
+    expressID[ where ] = id
+
+    if ( id < previous ) {
+      sorted = false
+    }
+
+    previous = id
+  }
+
+  return {
+    sourceByteLength,
+    sourceHash,
+    columns: {
+      address,
+      length,
+      typeID,
+      expressID,
+      count: recordCount,
+      firstInlineElement: recordCount,
+      expressIdsSorted: sorted,
+    },
+  }
 }
 
 

--- a/src/step/parsing/step_parser.ts
+++ b/src/step/parsing/step_parser.ts
@@ -44,6 +44,30 @@ export interface StepIndex<TypeIDType> {
 
 }
 
+/**
+ * A consumer of completed top-level index entries, used to divert the parse
+ * away from accumulating the object-form `StepIndex` — the columnar sink
+ * (columnar_index.ts) encodes each entry into typed-array columns and drops
+ * the object unless it carries children. When a sink is supplied, the parse's
+ * returned `StepIndex.elements` stays empty; the sink holds the index.
+ */
+export interface StepIndexSink<TypeIDType> {
+
+  /**
+   * Consume one completed top-level entry (its inlineEntities / multiMapping,
+   * when present, are attached and complete).
+   *
+   * @param entry The completed entry. Ownership transfers to the sink.
+   */
+  pushTopLevel( entry: StepIndexEntry<TypeIDType> ): void
+
+  /**
+   * Rewind to empty — the streaming builder's grow-and-restart re-parses from
+   * the start and re-pushes every record.
+   */
+  reset(): void
+}
+
 export interface Argument {
   type: number
   value: any
@@ -478,9 +502,11 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
       input: ParsingBuffer,
       onRecordBoundary: ( input: ParsingBuffer ) => void,
       onRecordIndexed?: ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
-      onProgress?: ParseProgressCallback ): BlockParseResult<TypeIDType> {
+      onProgress?: ParseProgressCallback,
+      sink?: StepIndexSink<TypeIDType> ): BlockParseResult<TypeIDType> {
 
-    const parser = this.parseDataBlockIncremental( input, onRecordBoundary, onRecordIndexed )
+    const parser =
+      this.parseDataBlockIncremental( input, onRecordBoundary, onRecordIndexed, sink )
 
     while ( true ) {
 
@@ -546,10 +572,23 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
   private* parseDataBlockIncremental(
       input: ParsingBuffer,
       onRecordBoundary?: ( input: ParsingBuffer ) => void,
-      onRecordIndexed?: ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void ):
+      onRecordIndexed?: ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
+      sink?: StepIndexSink<TypeIDType> ):
       Generator<number, BlockParseResult<TypeIDType>, undefined> {
 
     const indexResult: StepIndex<TypeIDType> = { elements: [] }
+
+    // With a sink, completed top-level entries are diverted instead of
+    // accumulated — the object index never materialises (columnar path).
+    let topLevelCount = 0
+
+    const pushEntry = sink !== void 0 ?
+      ( entry: StepIndexEntry<TypeIDType> ) => {
+        sink.pushTopLevel( entry )
+      } :
+      ( entry: StepIndexEntry<TypeIDType> ) => {
+        indexResult.elements.push( entry )
+      }
 
     const match = input.match
     const comment = () => match(commentParser)
@@ -816,9 +855,10 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
           return syntaxError()
         }
 
-        onRecordIndexed?.( indexResult.elements.length, expressID, 0 as TypeIDType )
+        onRecordIndexed?.( topLevelCount, expressID, 0 as TypeIDType )
+        ++topLevelCount
 
-        indexResult.elements.push(
+        pushEntry(
             {
               address: startElement,
               length: input.address - startElement,
@@ -958,9 +998,10 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
         return syntaxError()
       }
 
-      onRecordIndexed?.( indexResult.elements.length, expressID, foundItem )
+      onRecordIndexed?.( topLevelCount, expressID, foundItem )
+      ++topLevelCount
 
-      indexResult.elements.push(
+      pushEntry(
           {
             address: startElement,
             length: input.address - startElement,

--- a/src/step/parsing/streaming_index_builder.ts
+++ b/src/step/parsing/streaming_index_builder.ts
@@ -1,9 +1,11 @@
 import ParsingBuffer from '../../parsing/parsing_buffer'
 import { ByteSource } from './byte_source'
+import { ColumnarIndexSink, StepIndexColumns } from './columnar_index'
 import StepParser, {
   ParseResult,
   StepHeader,
   StepIndexEntry,
+  StepIndexSink,
 } from './step_parser'
 
 
@@ -87,7 +89,8 @@ export function buildIndexStreaming<TypeIDType>(
     parser: StepParser<TypeIDType>,
     pool: number,
     onRecordIndexed?:
-      ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void ):
+      ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
+    sink?: StepIndexSink<TypeIDType> ):
     StreamingIndexResult<TypeIDType> {
 
   const fileSize = source.byteLength
@@ -170,7 +173,8 @@ export function buildIndexStreaming<TypeIDType>(
     }
 
     const [ index, result ] =
-      parser.parseDataBlockStreamed( input, onRecordBoundary, onRecordIndexed )
+      parser.parseDataBlockStreamed(
+          input, onRecordBoundary, onRecordIndexed, void 0, sink )
 
     // A parse that stopped short of true EOF, with the window not spanning to
     // EOF, means a single record overflowed the window: grow and retry.
@@ -179,6 +183,7 @@ export function buildIndexStreaming<TypeIDType>(
 
     if ( stoppedShort && notAtEof ) {
       windowBytes *= 2
+      sink?.reset()
       continue
     }
 
@@ -203,3 +208,47 @@ export function buildIndexStreaming<TypeIDType>(
 // many slides on a small fixture; the pool sweep uses ≥ 128 KB anyway.
 // eslint-disable-next-line no-magic-numbers
 const MIN_WINDOW = 4 * 1024
+
+
+/**
+ * The output of a columnar streaming index build: the index in its SoA
+ * column form (no object phase — see columnar_index.ts), plus the header and
+ * window diagnostics.
+ */
+export interface StreamingColumnarIndexResult<TypeIDType> {
+  header: StepHeader
+  columns: StepIndexColumns<TypeIDType>
+  result: ParseResult
+  stats: StreamingIndexStats
+}
+
+
+/**
+ * Build the entity index by streaming, **directly into typed-array columns**
+ * (M7): identical parse and window behaviour to {@link buildIndexStreaming},
+ * but completed records are encoded straight into a {@link ColumnarIndexSink}
+ * so the per-record object index never materialises. Peak JS heap for the
+ * index build becomes `window + columns` — the object phase (the dominant
+ * heap cost on large models) is gone.
+ *
+ * @param source The byte source.
+ * @param parser The STEP parser (typed to the schema).
+ * @param pool Target window size in bytes.
+ * @param onRecordIndexed Optional per-record event (see buildIndexStreaming).
+ * @return {StreamingColumnarIndexResult} Columns, header, result, stats.
+ */
+export function buildColumnarIndexStreaming<TypeIDType extends number>(
+    source: ByteSource,
+    parser: StepParser<TypeIDType>,
+    pool: number,
+    onRecordIndexed?:
+      ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void ):
+    StreamingColumnarIndexResult<TypeIDType> {
+
+  const sink = new ColumnarIndexSink<TypeIDType>()
+
+  const { header, result, stats } =
+    buildIndexStreaming( source, parser, pool, onRecordIndexed, sink )
+
+  return { header, columns: sink.finalize(), result, stats }
+}

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -1,4 +1,5 @@
 import { StepIndexEntry } from './parsing/step_parser'
+import { StepIndexColumns } from './parsing/columnar_index'
 import { releaseScratchParsingBuffer } from './parsing/step_deserialization_functions'
 import {
   ResidentStepBufferProvider,
@@ -110,10 +111,51 @@ implements Iterable<BaseEntity>, Model {
    */
   constructor(
     public readonly schema: StepEntitySchema< EntityTypeIDs, BaseEntity >,
-    private buffer_: Uint8Array | undefined, elementIndex: StepIndexEntry<EntityTypeIDs>[],
+    private buffer_: Uint8Array | undefined,
+    elementIndex: StepIndexEntry<EntityTypeIDs>[] | StepIndexColumns<EntityTypeIDs>,
     provider?: StepBufferProvider ) {
 
     this.bufferProvider_ = provider ?? new ResidentStepBufferProvider( buffer_ as Uint8Array )
+
+    if ( !Array.isArray( elementIndex ) ) {
+      // Columns path (M7): the parse produced the SoA columns directly (see
+      // columnar_index.ts) — adopt them, build the lookup tables straight off
+      // the columns, and skip the object walk entirely. Inline entities are
+      // already unfolded into [firstInlineElement, count) in the same order
+      // the object path would have produced.
+      const columns = elementIndex
+      const firstInline = columns.firstInlineElement
+      const inlineCount = columns.count - firstInline
+
+      const inlineElementTable = new Uint32Array( inlineCount << 1 )
+
+      for ( let where = 0; where < inlineCount; ++where ) {
+        inlineElementTable[ where << 1 ] = firstInline + where
+        inlineElementTable[ ( where << 1 ) + 1 ] = columns.address[ firstInline + where ]
+      }
+
+      this.inlineAddressMap_ = new InterpolationSearchTable32( inlineElementTable, true )
+
+      const expressIdTable = new Uint32Array( firstInline << 1 )
+
+      for ( let where = 0; where < firstInline; ++where ) {
+        expressIdTable[ where << 1 ] = where
+        expressIdTable[ ( where << 1 ) + 1 ] = columns.expressID[ where ]
+      }
+
+      this.expressIDMap_ =
+        new InterpolationSearchTable32( expressIdTable, columns.expressIdsSorted )
+
+      this.address_            = columns.address
+      this.length_             = columns.length
+      this.typeID_             = columns.typeID
+      this.expressID_          = columns.expressID
+      this.count_              = columns.count
+      this.firstInlineElement_ = firstInline
+      this.complexEntries_     = columns.complexEntries as unknown as
+        Map< number, StepEntityInternalReferencePrivate< EntityTypeIDs, BaseEntity > > | undefined
+      return
+    }
 
     const localElementIndex: StepEntityInternalReferencePrivate<EntityTypeIDs, BaseEntity>[] =
       elementIndex


### PR DESCRIPTION
**M7 — the last conway PR of the streaming stack** (epic #390). **Base retargeted to `main`** (#401–#405, #408 merged). Branch freshened by merging `main` (`b6720f4`), so CI on the head tests **exactly the post-merge state** — including #408's two review fixes, verified carried through (m7 doesn't touch those files).

## Why

The resident model's lookups were already locality-strong (SoA columns, interpolation-search expressID table, CSR type index). The corpus sweep exposed the last structural memory problem on the parse plane: the **build phase** materialised one JS object per record (~90 B) before compacting — ~1 GB of transient objects + a 10 M-allocation GC storm on PSB-class to produce ~200 MB of columns. This PR makes the index **columnar from birth**.

## What

- **`StepIndexSink`** (step_parser.ts) — optional sink on the parse generator / `parseDataBlockStreamed`; completed top-level entries are diverted, never accumulated; localIDs from a counter so the M2 event contract is unchanged. **Object path untouched** — resident `parseDataToModel` (Share's path) behaves exactly as before, keeping CI's byte-parity anchors meaningful.
- **`StepIndexColumns` + `ColumnarIndexSink`** (columnar_index.ts) — the model's exact internal layout, built in chunked 64 K-row segments (growth never recopies; finalize concatenates one column at a time). Rare records with inline children / multi-mappings keep object form — exactly the set the model retains today — with the inline unfold replicating the model's object-walk order entry-for-entry. `reset()` supports grow-and-restart.
- **From-columns construction** — `StepModelBase` builds its lookup tables straight off columns; `StepTypeIndexer.createFromColumns` interleaves complex entries at their dense index (the object path's **exact** CSR output order — producer contract: `complexEntries` keys ascend, true of the sink, the only producer); both models accept either form; **`parseStreamToModel` now uses columns**.
- **Sidecar ⇄ columns identity** (index_sidecar.ts) — `serializeIndexSidecarFromColumns` (blob **byte-identical** to the object-form serializer, pinned by test) and `deserializeIndexSidecarToColumns`: no per-record objects anywhere between sidecar bytes and a constructed model — the zero-rebuild index-first open M4b wires up.

## Numbers (corpus sweep, retained heap after GC, child-process isolated)

| model | records | resident | object-streamed | **columnar** |
|---|---|---|---|---|
| Arty_Z7.stp (55.5 MB) | 1.03 M | 146.1 MB | 90.6 MB | **44.5 MB** (also fastest: 916 ms) |
| Schependomlaan.ifc (47 MB) | 714 K | 154.6 MB | 107.6 MB | **32.5 MB** |

Byte-identical (object-streamed *and* columnar vs resident) + sidecar handshake on all 6 corpus models. Extrapolated PSB-class: index-build working set ~1 GB → ~columns (~200 MB).

## Compatibility with existing Share use

**Fully additive on Share's surface**: the resident object path is untouched; constructor params widened (array | columns) — backward compatible; zero geometry code → zero render-diff exposure. Visual-diff green on every pushed head; CI on the merged head is the exact post-merge state of `main`.

## Review status (chain review, 2026-07-20)

Adversarial pass on sink mechanics (reset/finalize/segments/empty-index), unfold order, `createFromColumns` interleaving, address-width parity (u32 columns match the model's pre-existing 4 GB cap; sidecar f64 over-provisions intentionally). **No findings in M7's own code.** One pre-existing parser oddity surfaced by the pass → **#412**: the INF-recovery path stamps expressIDs across the whole object-mode index (sink mode no-ops it; the two modes would diverge if that path ever fired destructively — the corpus sweep's byte-identical expressID columns on 6/6 models prove it currently doesn't, and the parity tests + sweep are the standing guard). Filed with a fixture ask rather than patched mid-merge — the correct behavior needs an intent decision.

Full suite on the merged head: **303/305** (the 2 failures are the pre-existing environmental AP214 wasm ones, #406).

## Tests

`columnar_index.test.ts` (8): **byte-identical internal columns + equal type index** vs the object-path model on `index.ifc` and three AP214 inline/multi-mapping fixtures (with a guard that fixtures genuinely exercise the inline range); sink retention, unfold order, grow-restart reset, sorted-ID detection.
`index_sidecar.test.ts` (+2): columns-form blob byte-identical to object-form; deserialize-to-columns field parity.
Sweep harness gained the columnar phase + GC-honest measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz