### PR TITLE
Phase B: wasm tile backend composition + async residency pump

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -466,6 +466,7 @@ not stubbed:
 | **M4a** | index sidecar + `RangeByteSource` | M4b: Share sidecar cache + index-first open |
 | **M5a** | model-URI, shared budget, registry, cross-ref, composition | M5b: loader registration, budget wiring, UI links |
 | **M7** | columns-first index build (no object phase); sidecar ⇄ columns identity | resident `parseDataToModel` still object-form (unchanged by design — CI byte-parity anchor) |
+| **Phase B** | wasm tile-pool bindings typing + `createWasmTileBackend` (TS accounting over the physical pool, budgets mirrored) + `DemandResidencyPump` (async `ensureResident` → sync extract admission) + segment-walk payload reader | B2: `TileAssetExtractor` over the real extraction pipeline (per-product wasm extract → `commitGeometryTile`); Phase C: Share camera priorities + GPU upload/dispose |
 
 **M7 — columns-first index (landed).** The corpus sweep exposed the last
 structural memory problem on the parse plane: the streamed build still

--- a/src/core/demand_residency_pump.test.ts
+++ b/src/core/demand_residency_pump.test.ts
@@ -1,0 +1,190 @@
+/* eslint-disable no-magic-numbers */
+// Phase B: the pump must guarantee source residency BEFORE the synchronous
+// extract runs, admit strictly by priority under the batch cap, coalesce
+// re-entrant cycles, and survive prefetch failures without stalling.
+import { describe, expect, test } from '@jest/globals'
+
+import { DemandGeometryQueue, GeometryTiles } from './demand_geometry_queue'
+import { DemandResidencyPump, ResidencyPrefetcher } from './demand_residency_pump'
+
+/**
+ * A mock tiles backend that records extraction order and asserts every
+ * extracted product was made resident first.
+ *
+ * @param residentSource Set the prefetcher fills.
+ * @return {object} `{ tiles, extracted }`.
+ */
+function residencyCheckedTiles( residentSource: Set<number> ): {
+  tiles: GeometryTiles, extracted: number[],
+} {
+  const extracted: number[] = []
+
+  const tiles: GeometryTiles = {
+    extract( id ) {
+      if ( !residentSource.has( id ) ) {
+        throw new Error( `extract(${id}) before source residency` )
+      }
+      extracted.push( id )
+      return 10
+    },
+    release() { /* tiles free */ },
+  }
+
+  return { tiles, extracted }
+}
+
+/**
+ * A controllable prefetcher: records call order; optionally fails given ids.
+ *
+ * @param residentSource The set fulfilled prefetches add to.
+ * @param failIDs IDs whose prefetch rejects.
+ * @return {object} `{ prefetcher, calls }`.
+ */
+function mockPrefetcher( residentSource: Set<number>, failIDs: Set<number> = new Set() ): {
+  prefetcher: ResidencyPrefetcher, calls: number[],
+} {
+  const calls: number[] = []
+
+  const prefetcher: ResidencyPrefetcher = {
+    ensureResidentByLocalID: async ( localID ) => {
+      calls.push( localID )
+      if ( failIDs.has( localID ) ) {
+        throw new Error( `range fetch failed for ${localID}` )
+      }
+      residentSource.add( localID )
+    },
+  }
+
+  return { prefetcher, calls }
+}
+
+describe( 'DemandResidencyPump', () => {
+
+  test( 'prefetches source bytes before any synchronous extract', async () => {
+    const residentSource = new Set<number>()
+    const { tiles, extracted } = residencyCheckedTiles( residentSource )
+    const { prefetcher, calls } = mockPrefetcher( residentSource )
+    const pump = new DemandResidencyPump(
+        new DemandGeometryQueue( tiles, 1000 ), prefetcher )
+
+    pump.request( 1, 10 )
+    pump.request( 2, 20 )
+
+    const result = await pump.pump()
+
+    // The residency-checked tiles throw if this ordering ever breaks.
+    expect( result.extracted ).toBe( 2 )
+    expect( new Set( calls ) ).toEqual( new Set( [ 1, 2 ] ) )
+    expect( extracted ).toEqual( [ 2, 1 ] ) // still priority-ordered
+  } )
+
+  test( 'admits strictly by priority under the batch cap', async () => {
+    const residentSource = new Set<number>()
+    const { tiles, extracted } = residencyCheckedTiles( residentSource )
+    const { prefetcher, calls } = mockPrefetcher( residentSource )
+    const queue = new DemandGeometryQueue( tiles, 1_000_000 )
+    const pump = new DemandResidencyPump( queue, prefetcher, 3 )
+
+    for ( let id = 0; id < 10; ++id ) {
+      pump.request( id, id ) // rising priority: 7, 8, 9 are most wanted
+    }
+
+    await pump.pump()
+
+    expect( new Set( calls ) ).toEqual( new Set( [ 7, 8, 9 ] ) )
+    expect( extracted ).toEqual( [ 9, 8, 7 ] )
+    expect( pump.pendingCount ).toBe( 7 )
+
+    await pump.pump()
+    expect( extracted ).toEqual( [ 9, 8, 7, 6, 5, 4 ] )
+  } )
+
+  test( 'requesting a resident product refreshes ranking without prefetch', async () => {
+    const residentSource = new Set<number>()
+    const { tiles } = residencyCheckedTiles( residentSource )
+    const { prefetcher, calls } = mockPrefetcher( residentSource )
+    const queue = new DemandGeometryQueue( tiles, 1000 )
+    const pump = new DemandResidencyPump( queue, prefetcher )
+
+    pump.request( 1, 10 )
+    await pump.pump()
+    expect( calls ).toEqual( [ 1 ] )
+
+    // Re-request while resident: no new prefetch, no new pending entry.
+    pump.request( 1, 99 )
+    expect( pump.pendingCount ).toBe( 0 )
+    await pump.pump()
+    expect( calls ).toEqual( [ 1 ] )
+  } )
+
+  test( 'a failed prefetch re-queues and later retries; others proceed', async () => {
+    const residentSource = new Set<number>()
+    const { tiles, extracted } = residencyCheckedTiles( residentSource )
+    const failIDs = new Set( [ 2 ] )
+    const { prefetcher } = mockPrefetcher( residentSource, failIDs )
+    const pump = new DemandResidencyPump(
+        new DemandGeometryQueue( tiles, 1000 ), prefetcher )
+
+    pump.request( 1, 10 )
+    pump.request( 2, 20 )
+
+    const first = await pump.pump()
+
+    expect( first.prefetchFailures ).toBe( 1 )
+    expect( extracted ).toEqual( [ 1 ] )
+    expect( pump.pendingCount ).toBe( 1 ) // 2 re-queued
+
+    // The transient failure clears; the retry succeeds.
+    failIDs.clear()
+    const second = await pump.pump()
+
+    expect( second.prefetchFailures ).toBe( 0 )
+    expect( extracted ).toEqual( [ 1, 2 ] )
+  } )
+
+  test( 're-entrant pump calls coalesce onto the in-flight cycle', async () => {
+    const residentSource = new Set<number>()
+    const { tiles } = residencyCheckedTiles( residentSource )
+    const { prefetcher, calls } = mockPrefetcher( residentSource )
+    const pump = new DemandResidencyPump(
+        new DemandGeometryQueue( tiles, 1000 ), prefetcher )
+
+    pump.request( 1, 10 )
+
+    const a = pump.pump()
+    const b = pump.pump()
+
+    expect( b ).toBe( a ) // same promise, no interleaved second cycle
+    await a
+    expect( calls ).toEqual( [ 1 ] )
+
+    // After settling, pump() starts a fresh cycle.
+    pump.request( 2, 5 )
+    await pump.pump()
+    expect( calls ).toEqual( [ 1, 2 ] )
+  } )
+
+  test( 'an empty admission cycle still drains the queue-side pending set', async () => {
+    const residentSource = new Set<number>( [ 1, 2 ] )
+    const { tiles, extracted } = residencyCheckedTiles( residentSource )
+    const { prefetcher } = mockPrefetcher( residentSource )
+    // Tiny budget: only one of the two fits per pump; the loser stays
+    // pending inside the QUEUE (deferred by budget), not the pump.
+    const queue = new DemandGeometryQueue( tiles, 10 )
+    const pump = new DemandResidencyPump( queue, prefetcher )
+
+    pump.request( 1, 10 )
+    pump.request( 2, 20 )
+    await pump.pump()
+
+    expect( extracted ).toEqual( [ 2 ] )
+    expect( queue.stats.pendingCount ).toBe( 1 )
+
+    // No new admissions; the cycle still gives the queue its pump call.
+    // (1 cannot displace 2 at this budget, so it stays pending — the point
+    // is the queue got the chance.)
+    const result = await pump.pump()
+    expect( result.extracted ).toBe( 0 )
+    expect( queue.stats.pendingCount ).toBe( 1 )
+  } )
+} )

--- a/src/core/demand_residency_pump.ts
+++ b/src/core/demand_residency_pump.ts
@@ -1,0 +1,194 @@
+import { DemandGeometryQueue } from './demand_geometry_queue'
+
+
+/**
+ * The async half of demand-driven geometry (Phase B): source-byte residency.
+ *
+ * Extraction is synchronous by design (the wasm extract reads source bytes
+ * through `StepBufferProvider.acquire`), but a windowed/streamed source pages
+ * bytes in asynchronously (`ensureResident`). This pump owns that seam: it
+ * admits demand, prefetches the source ranges for the most-wanted products,
+ * and only then forwards them to the synchronous {@link DemandGeometryQueue}
+ * — so a `pump()` never hits a non-resident range mid-extract.
+ */
+export interface ResidencyPrefetcher {
+
+  /**
+   * Page in the source byte ranges a product's extraction will read.
+   * `StepModelBase.ensureResidentByLocalID` satisfies this shape.
+   *
+   * @param localID The product's local ID.
+   * @return {Promise<void>} Resolves when resident.
+   */
+  ensureResidentByLocalID( localID: number ): Promise<void>
+}
+
+
+/** Outcome of one pump cycle, for telemetry and tests. */
+export interface PumpResult {
+
+  /** Tiles extracted this cycle (from the queue's pump). */
+  extracted: number
+
+  /** Products whose prefetch failed this cycle (re-queued for retry). */
+  prefetchFailures: number
+}
+
+
+// Defaults chosen for frame-cooperative pumping: enough per cycle to fill
+// quickly, small enough that a cycle stays well under a frame budget once
+// extraction costs are real. Both are tunable per call site.
+const DEFAULT_BATCH = 32
+
+
+/**
+ * Admission + prefetch orchestration in front of a {@link DemandGeometryQueue}.
+ *
+ * Consumers `request()` products as demand changes (the pump owns admission —
+ * don't request on the queue directly); each async `pump()` cycle:
+ *
+ *  1. selects the top-priority pending batch,
+ *  2. awaits source residency for the batch (failures re-queue for retry
+ *     and are reported, never thrown — one bad range must not stall the
+ *     viewport),
+ *  3. forwards the resident products to the queue and runs its synchronous
+ *     pump under the same batch cap.
+ *
+ * Re-entrant calls coalesce: a `pump()` while one is in flight returns the
+ * in-flight cycle's promise rather than interleaving prefetch batches.
+ * Products already resident in the queue skip prefetch entirely (their
+ * ranking refresh is forwarded immediately).
+ */
+export class DemandResidencyPump {
+
+  /** Pending admission: product localID → highest requested priority. */
+  private readonly pending_ = new Map<number, number>()
+
+  private inFlight_: Promise<PumpResult> | undefined
+
+  /**
+   * @param queue_ The synchronous demand queue (extraction + budget).
+   * @param prefetcher_ Source-byte residency (the model / buffer provider).
+   * @param batch_ Max products prefetched + extracted per pump cycle.
+   */
+  constructor(
+    private readonly queue_: DemandGeometryQueue,
+    private readonly prefetcher_: ResidencyPrefetcher,
+    private readonly batch_: number = DEFAULT_BATCH ) {
+
+    if ( batch_ < 1 ) {
+      throw new Error( `Invalid batch ${batch_}` )
+    }
+  }
+
+  /**
+   * Request a product at a demand priority. Resident products forward
+   * immediately (ranking refresh); others queue for the next pump cycle at
+   * the highest priority requested so far.
+   *
+   * @param productLocalID The product to materialise.
+   * @param priority The demand priority (higher = more wanted).
+   */
+  public request( productLocalID: number, priority: number ): void {
+
+    if ( this.queue_.isResident( productLocalID ) ) {
+      this.queue_.request( productLocalID, priority )
+      return
+    }
+
+    const existing = this.pending_.get( productLocalID )
+
+    this.pending_.set(
+        productLocalID,
+        existing === void 0 ? priority : Math.max( existing, priority ) )
+  }
+
+  /**
+   * @return {number} Products awaiting admission (not yet prefetched).
+   */
+  public get pendingCount(): number {
+    return this.pending_.size
+  }
+
+  /**
+   * Run one admission cycle (see class docs). Coalesces with an in-flight
+   * cycle.
+   *
+   * @return {Promise<PumpResult>} The cycle's outcome.
+   */
+  public pump(): Promise<PumpResult> {
+
+    if ( this.inFlight_ !== void 0 ) {
+      return this.inFlight_
+    }
+
+    this.inFlight_ = this.pumpCycle_().finally( () => {
+      this.inFlight_ = void 0
+    } )
+
+    return this.inFlight_
+  }
+
+  /**
+   * One cycle: select top batch → prefetch → forward + queue pump.
+   *
+   * @return {Promise<PumpResult>} The cycle's outcome.
+   */
+  private async pumpCycle_(): Promise<PumpResult> {
+
+    const batch = this.takeTopPending_()
+
+    if ( batch.length === 0 ) {
+      // Nothing to admit; still give the queue a chance to fill from its own
+      // pending set (e.g. entries deferred by an earlier budget refusal).
+      return { extracted: this.queue_.pump( this.batch_ ), prefetchFailures: 0 }
+    }
+
+    const outcomes = await Promise.allSettled( batch.map(
+        ( [ productLocalID ] ) =>
+          this.prefetcher_.ensureResidentByLocalID( productLocalID ) ) )
+
+    let prefetchFailures = 0
+
+    for ( let where = 0; where < batch.length; ++where ) {
+
+      const [ productLocalID, priority ] = batch[ where ]
+
+      if ( outcomes[ where ].status === 'fulfilled' ) {
+        this.queue_.request( productLocalID, priority )
+        continue
+      }
+
+      // Failed prefetch: re-queue for a later cycle (transient store errors
+      // retry; persistent ones keep surfacing in the failure count).
+      ++prefetchFailures
+      this.request( productLocalID, priority )
+    }
+
+    return { extracted: this.queue_.pump( this.batch_ ), prefetchFailures }
+  }
+
+  /**
+   * Remove and return the top-priority pending entries, up to the batch cap.
+   *
+   * @return {[number, number][]} `[productLocalID, priority]` pairs.
+   */
+  private takeTopPending_(): [number, number][] {
+
+    if ( this.pending_.size === 0 ) {
+      return []
+    }
+
+    const entries = [ ...this.pending_.entries() ]
+
+    entries.sort( ( a, b ) => b[ 1 ] - a[ 1 ] )
+
+    const batch = entries.slice( 0, this.batch_ )
+
+    for ( const [ productLocalID ] of batch ) {
+      this.pending_.delete( productLocalID )
+    }
+
+    return batch
+  }
+}

--- a/src/core/geometry_tile_bindings.test.ts
+++ b/src/core/geometry_tile_bindings.test.ts
@@ -1,0 +1,256 @@
+/* eslint-disable no-magic-numbers */
+// Phase B: the wasm-backed tile composition — TS accounting over the module's
+// physical pool — and the segment-walk payload reader, verified against a
+// faithful in-memory fake of the embind surface (same layout, same chunking,
+// same non-contiguous segments a fragmented pool produces).
+import { describe, expect, test } from '@jest/globals'
+
+import { DemandGeometryQueue } from './demand_geometry_queue'
+import {
+  GeometryTilePoolBindings,
+  TileAssetExtractor,
+  createWasmTileBackend,
+  readGeometryTilePayload,
+} from './geometry_tile_bindings'
+import { GeometryAsset } from './geometry_tile_pool'
+
+const HEADER_BYTES = 8
+
+/**
+ * A faithful in-memory fake of the wasm tile pool bindings: a byte "heap"
+ * carved into chunks with a LIFO freelist, tiles committed as (possibly
+ * non-contiguous) chunk lists — the same observable behaviour as the C++
+ * TilePool through the embind surface.
+ *
+ * @return {object} `{ bindings, heap, commitPayload }` where commitPayload
+ * scatter-commits a payload built from header+floats+indices.
+ */
+function fakeWasmPool(): {
+  bindings: GeometryTilePoolBindings,
+  heap: Uint8Array,
+  commitPayload: ( assetID: number, floats: number[], indices: number[] ) => boolean,
+} {
+  const HEAP_BYTES = 64 * 1024
+  const heap = new Uint8Array( HEAP_BYTES )
+
+  let chunkBytes = 0
+  let regionBase = 0
+  let freeList: number[] = []
+  const tiles = new Map<number, { chunks: number[], byteSize: number, refCount: number }>()
+  let failedCommits = 0
+  let totalChunks = 0
+
+  const bindings: GeometryTilePoolBindings = {
+    initGeometryTilePool: ( budget, chunk ) => {
+      if ( chunk < 16 || budget < chunk ) {
+        return false
+      }
+      chunkBytes = chunk
+      totalChunks = Math.floor( budget / chunk )
+      regionBase = 1024 // nonzero base, like a real heap allocation
+      freeList = []
+      for ( let c = totalChunks - 1; c >= 0; --c ) {
+        freeList.push( c )
+      }
+      tiles.clear()
+      return true
+    },
+    geometryTilePoolInitialized: () => chunkBytes > 0,
+    commitGeometryTileBytes: ( assetID, sourceAddress, byteLength ) => {
+      const needed = Math.ceil( byteLength / chunkBytes )
+      if ( tiles.has( assetID ) || needed > freeList.length ) {
+        ++failedCommits
+        return false
+      }
+      const chunks: number[] = []
+      let copied = 0
+      for ( let where = 0; where < needed; ++where ) {
+        const chunk = freeList.pop() as number
+        chunks.push( chunk )
+        const span = Math.min( byteLength - copied, chunkBytes )
+        heap.set(
+            heap.subarray( sourceAddress + copied, sourceAddress + copied + span ),
+            regionBase + chunk * chunkBytes )
+        copied += span
+      }
+      tiles.set( assetID, { chunks, byteSize: byteLength, refCount: 1 } )
+      return true
+    },
+    retainGeometryTile: ( assetID ) => {
+      const tile = tiles.get( assetID )
+      if ( tile === void 0 ) {
+        return false
+      }
+      ++tile.refCount
+      return true
+    },
+    releaseGeometryTile: ( assetID ) => {
+      const tile = tiles.get( assetID )
+      if ( tile === void 0 ) {
+        return false
+      }
+      if ( --tile.refCount > 0 ) {
+        return false
+      }
+      freeList.push( ...tile.chunks )
+      tiles.delete( assetID )
+      return true
+    },
+    geometryTileResident: ( assetID ) => tiles.has( assetID ),
+    geometryTileRefCount: ( assetID ) => tiles.get( assetID )?.refCount ?? 0,
+    geometryTileByteSize: ( assetID ) => tiles.get( assetID )?.byteSize ?? 0,
+    geometryTileSegmentCount: ( assetID ) => tiles.get( assetID )?.chunks.length ?? 0,
+    geometryTileSegmentAddress: ( assetID, segment ) => {
+      const tile = tiles.get( assetID )
+      if ( tile === void 0 || segment >= tile.chunks.length ) {
+        return 0
+      }
+      return regionBase + tile.chunks[ segment ] * chunkBytes
+    },
+    geometryTileSegmentByteLength: ( assetID, segment ) => {
+      const tile = tiles.get( assetID )
+      if ( tile === void 0 || segment >= tile.chunks.length ) {
+        return 0
+      }
+      return Math.min( tile.byteSize - segment * chunkBytes, chunkBytes )
+    },
+    geometryTileVertexByteLength: ( assetID ) => {
+      const address = bindings.geometryTileSegmentAddress( assetID, 0 )
+      return address === 0 ?
+        0 : new DataView( heap.buffer ).getUint32( address, true )
+    },
+    geometryTileIndexByteLength: ( assetID ) => {
+      const address = bindings.geometryTileSegmentAddress( assetID, 0 )
+      return address === 0 ?
+        0 : new DataView( heap.buffer ).getUint32( address + 4, true )
+    },
+    geometryTilePoolBytesInUse: () => ( totalChunks - freeList.length ) * chunkBytes,
+    geometryTilePoolTotalBytes: () => totalChunks * chunkBytes,
+    geometryTilePoolFreeChunks: () => freeList.length,
+    geometryTilePoolFailedCommits: () => failedCommits,
+  }
+
+  // Stage a payload high in the fake heap and scatter-commit it.
+  const commitPayload = ( assetID: number, floats: number[], indices: number[] ): boolean => {
+    const staging = HEAP_BYTES - 8192
+    const view = new DataView( heap.buffer, staging )
+    view.setUint32( 0, floats.length * 4, true )
+    view.setUint32( 4, indices.length * 4, true )
+    floats.forEach( ( value, i ) => view.setFloat32( HEADER_BYTES + i * 4, value, true ) )
+    indices.forEach( ( value, i ) =>
+      view.setUint32( HEADER_BYTES + floats.length * 4 + i * 4, value, true ) )
+
+    return bindings.commitGeometryTileBytes(
+        assetID, staging, HEADER_BYTES + floats.length * 4 + indices.length * 4 )
+  }
+
+  return { bindings, heap, commitPayload }
+}
+
+describe( 'createWasmTileBackend', () => {
+
+  test( 'composes TS accounting over the wasm pool end to end with the queue', () => {
+    const { bindings, commitPayload } = fakeWasmPool()
+
+    // Two products share one representation; extraction commits real bytes.
+    const composition: Record<number, GeometryAsset<number>[]> = {
+      1: [ { assetID: 100, byteSize: 200 } ],
+      2: [ { assetID: 100, byteSize: 200 }, { assetID: 200, byteSize: 100 } ],
+    }
+    const extracted: number[] = []
+
+    const extractor: TileAssetExtractor = {
+      assetsOf: ( id ) => composition[ id ] ?? [],
+      extractIntoTile: ( assetID ) => {
+        extracted.push( assetID )
+        if ( !commitPayload( assetID, [ 1, 2, 3 ], [ 0, 1, 2 ] ) ) {
+          throw new Error( 'commit failed' )
+        }
+      },
+    }
+
+    const backend = createWasmTileBackend( bindings, extractor, 4096, 64 )
+    const queue = new DemandGeometryQueue( backend.tiles, 4096 )
+
+    queue.request( 1, 10 )
+    queue.request( 2, 20 )
+    queue.pump()
+
+    // Shared asset extracted once; both tiles resident wasm-side.
+    expect( extracted ).toEqual( [ 100, 200 ] )
+    expect( bindings.geometryTileResident( 100 ) ).toBe( true )
+    expect( bindings.geometryTileResident( 200 ) ).toBe( true )
+
+    // Evicting product 2 releases only its unique asset (100 is shared).
+    queue.evictAll()
+    expect( bindings.geometryTileResident( 100 ) ).toBe( false )
+    expect( bindings.geometryTileResident( 200 ) ).toBe( false )
+    expect( bindings.geometryTilePoolBytesInUse() ).toBe( 0 )
+  } )
+
+  test( 'rejects a config the wasm pool refuses', () => {
+    const { bindings } = fakeWasmPool()
+    const extractor: TileAssetExtractor = {
+      assetsOf: () => [],
+      extractIntoTile: () => { /* never called */ },
+    }
+
+    expect( () => createWasmTileBackend( bindings, extractor, 4096, 8 ) )
+        .toThrow( /rejected init/ )
+  } )
+} )
+
+describe( 'readGeometryTilePayload', () => {
+
+  test( 'gathers a multi-segment payload back to exact typed arrays', () => {
+    const { bindings, heap, commitPayload } = fakeWasmPool()
+    bindings.initGeometryTilePool( 4096, 64 )
+
+    // 40 floats + 20 indices + header = 248 bytes over 64-byte chunks →
+    // 4 non-contiguous segments with a partial tail.
+    const floats = Array.from( { length: 40 }, ( _v, i ) => i * 0.5 )
+    const indices = Array.from( { length: 20 }, ( _v, i ) => i * 3 )
+
+    expect( commitPayload( 7, floats, indices ) ).toBe( true )
+    expect( bindings.geometryTileSegmentCount( 7 ) ).toBe( 4 )
+
+    const payload = readGeometryTilePayload( bindings, heap, 7 )
+
+    expect( Array.from( payload.vertexData ) ).toEqual( floats )
+    expect( Array.from( payload.indexData ) ).toEqual( indices )
+    expect( bindings.geometryTileVertexByteLength( 7 ) ).toBe( 160 )
+    expect( bindings.geometryTileIndexByteLength( 7 ) ).toBe( 80 )
+  } )
+
+  test( 'survives freelist fragmentation (interleaved tiles)', () => {
+    const { bindings, heap, commitPayload } = fakeWasmPool()
+    bindings.initGeometryTilePool( 4096, 64 )
+
+    commitPayload( 1, [ 1, 1, 1, 1 ], [ 1 ] )
+    commitPayload( 2, Array( 30 ).fill( 2 ), [ 2, 2 ] )
+    bindings.releaseGeometryTile( 1 )
+    // Tile 3's chunks interleave with tile 2's.
+    const floats = Array.from( { length: 25 }, ( _v, i ) => i + 0.25 )
+    commitPayload( 3, floats, [ 9, 8, 7 ] )
+
+    const payload = readGeometryTilePayload( bindings, heap, 3 )
+    expect( Array.from( payload.vertexData ) ).toEqual( floats )
+    expect( Array.from( payload.indexData ) ).toEqual( [ 9, 8, 7 ] )
+  } )
+
+  test( 'rejects a non-resident tile and a corrupt header', () => {
+    const { bindings, heap, commitPayload } = fakeWasmPool()
+    bindings.initGeometryTilePool( 4096, 64 )
+
+    expect( () => readGeometryTilePayload( bindings, heap, 42 ) )
+        .toThrow( /not resident/ )
+
+    commitPayload( 5, [ 1 ], [ 2 ] )
+    // Corrupt the header's vertex byte length in place.
+    const address = bindings.geometryTileSegmentAddress( 5, 0 )
+    new DataView( heap.buffer ).setUint32( address, 9999, true )
+
+    expect( () => readGeometryTilePayload( bindings, heap, 5 ) )
+        .toThrow( /inconsistent/ )
+  } )
+} )

--- a/src/core/geometry_tile_bindings.ts
+++ b/src/core/geometry_tile_bindings.ts
@@ -112,6 +112,11 @@ export function createWasmTileBackend(
     budgetBytes: number,
     chunkBytes: number ): WasmTileBackend {
 
+  // TS pool first: if the config is invalid on the TS side (non-integer or
+  // degenerate chunking), fail before touching the wasm pool so no
+  // initialized-but-unowned wasm region is left behind.
+  const pool = new ChunkedPool( budgetBytes, chunkBytes )
+
   if ( !bindings.initGeometryTilePool( budgetBytes, chunkBytes ) ) {
     throw new Error(
         `Wasm tile pool rejected init (budget ${budgetBytes}, ` +
@@ -127,8 +132,6 @@ export function createWasmTileBackend(
       bindings.releaseGeometryTile( assetID )
     },
   }
-
-  const pool = new ChunkedPool( budgetBytes, chunkBytes )
 
   return { pool, tiles: new GeometryTilePool<number>( pool, source ) }
 }

--- a/src/core/geometry_tile_bindings.ts
+++ b/src/core/geometry_tile_bindings.ts
@@ -1,0 +1,208 @@
+import { ChunkedPool } from './mem/chunked_pool'
+import {
+  GeometryAsset,
+  GeometryTilePool,
+  InstanceAssetSource,
+} from './geometry_tile_pool'
+
+
+/**
+ * The wasm module's geometry tile pool surface (conway-geom
+ * `tile_pool_api.h` via the embind bindings in conway-api.cpp) — Phase B of
+ * the demand-geometry track. Typed narrowly here rather than through the
+ * vendored module d.ts; asset ids and sizes cross the boundary as JS numbers
+ * (< 2^53 by construction).
+ *
+ * Division of labour (see "Resident memory: two regimes" in the design doc):
+ * the TS side (`ChunkedPool` + `SharedAssetPool` + `GeometryTilePool`) is the
+ * accounting/policy layer — it holds no payload bytes — while the wasm
+ * `TilePool` owns the physical chunks. In this composition the TS layer calls
+ * `materialize`/`discard` exactly once per residency, so the wasm-side
+ * refcount stays at 1 for TS-managed tiles; the wasm refcounting exists for
+ * future direct-C++ holders, not for this path.
+ */
+export interface GeometryTilePoolBindings {
+
+  initGeometryTilePool( budgetBytes: number, chunkBytes: number ): boolean
+  geometryTilePoolInitialized(): boolean
+
+  commitGeometryTileBytes(
+    assetID: number, sourceAddress: number, byteLength: number ): boolean
+
+  retainGeometryTile( assetID: number ): boolean
+  releaseGeometryTile( assetID: number ): boolean
+  geometryTileResident( assetID: number ): boolean
+  geometryTileRefCount( assetID: number ): number
+  geometryTileByteSize( assetID: number ): number
+
+  geometryTileSegmentCount( assetID: number ): number
+  geometryTileSegmentAddress( assetID: number, segment: number ): number
+  geometryTileSegmentByteLength( assetID: number, segment: number ): number
+  geometryTileVertexByteLength( assetID: number ): number
+  geometryTileIndexByteLength( assetID: number ): number
+
+  geometryTilePoolBytesInUse(): number
+  geometryTilePoolTotalBytes(): number
+  geometryTilePoolFreeChunks(): number
+  geometryTilePoolFailedCommits(): number
+}
+
+
+/**
+ * The domain extractor the wasm-backed source delegates to: which assets a
+ * product is made of, and how to run the wasm extract → tessellate →
+ * `commitGeometryTile` for one asset. Implemented over the real extraction
+ * pipeline in the Phase B wiring of `IfcModelGeometry`; tests use recording
+ * fakes.
+ */
+export interface TileAssetExtractor {
+
+  /**
+   * The assets (representation geometries) a product requires resident,
+   * with their reified byte sizes. Mapped items return the same assetID from
+   * many products — the sharing the pools are built around.
+   *
+   * @param productLocalID The product's local ID.
+   * @return {GeometryAsset<number>[]} The product's assets.
+   */
+  assetsOf( productLocalID: number ): GeometryAsset<number>[]
+
+  /**
+   * Extract + tessellate one asset and commit its reified payload into the
+   * wasm tile pool (`commitGeometryTile`). Called exactly once per residency.
+   * Must throw if the commit fails — under the budget invariant it cannot,
+   * so a failure is a contract violation, not a recoverable state.
+   *
+   * @param assetID The asset to materialise.
+   */
+  extractIntoTile( assetID: number ): void
+}
+
+
+/**
+ * The Phase B backend composition: the TS accounting stack
+ * (`ChunkedPool` → `GeometryTilePool`) wired over the wasm tile pool, ready
+ * to hand to `DemandGeometryQueue`.
+ */
+export interface WasmTileBackend {
+
+  /** The TS accounting pool (mirrors the wasm pool's budget and chunking). */
+  pool: ChunkedPool
+
+  /** The `GeometryTiles` backend for the demand queue. */
+  tiles: GeometryTilePool<number>
+}
+
+
+/**
+ * Initialise the wasm tile pool and build the TS accounting stack over it,
+ * with identical budget and chunking on both sides so the TS all-or-nothing
+ * admission mirrors the wasm pool's exactly (the queue-budget ≤ pool-budget
+ * invariant then guarantees a wasm commit can never fail mid-extract).
+ *
+ * @param bindings The wasm module's tile pool surface.
+ * @param extractor The domain extract/commit implementation.
+ * @param budgetBytes The resident geometry budget (both sides).
+ * @param chunkBytes The chunk size (both sides; ≥ the wasm 16-byte floor).
+ * @return {WasmTileBackend} The composed backend.
+ */
+export function createWasmTileBackend(
+    bindings: GeometryTilePoolBindings,
+    extractor: TileAssetExtractor,
+    budgetBytes: number,
+    chunkBytes: number ): WasmTileBackend {
+
+  if ( !bindings.initGeometryTilePool( budgetBytes, chunkBytes ) ) {
+    throw new Error(
+        `Wasm tile pool rejected init (budget ${budgetBytes}, ` +
+        `chunk ${chunkBytes})` )
+  }
+
+  const source: InstanceAssetSource<number> = {
+    assetsOf: ( productLocalID ) => extractor.assetsOf( productLocalID ),
+    materialize: ( assetID ) => {
+      extractor.extractIntoTile( assetID )
+    },
+    discard: ( assetID ) => {
+      bindings.releaseGeometryTile( assetID )
+    },
+  }
+
+  const pool = new ChunkedPool( budgetBytes, chunkBytes )
+
+  return { pool, tiles: new GeometryTilePool<number>( pool, source ) }
+}
+
+
+/**
+ * A resident tile's reified payload, gathered from the wasm pool's segments
+ * into typed arrays ready for GPU upload (three.js BufferAttributes). The
+ * arrays are standalone copies — valid after the tile is evicted.
+ */
+export interface GeometryTilePayload {
+  vertexData: Float32Array
+  indexData: Uint32Array
+}
+
+// Geometry tile payload layout (tile_pool_api.h): 8-byte header of two u32
+// byte lengths, then float vertex data, then u32 index data.
+const TILE_HEADER_BYTES = 8
+
+
+/**
+ * Gather a resident tile's payload out of the wasm heap by walking its
+ * (generally non-contiguous) segments. This is the copying consumption path;
+ * a zero-copy per-segment upload can walk the same segment accessors
+ * directly.
+ *
+ * @param bindings The wasm module's tile pool surface.
+ * @param heap The module's HEAPU8 view (re-read after any wasm memory
+ * growth; pass the module's current view, do not cache across calls).
+ * @param assetID The resident tile to read.
+ * @return {GeometryTilePayload} The gathered payload.
+ */
+export function readGeometryTilePayload(
+    bindings: GeometryTilePoolBindings,
+    heap: Uint8Array,
+    assetID: number ): GeometryTilePayload {
+
+  const byteSize = bindings.geometryTileByteSize( assetID )
+
+  if ( byteSize < TILE_HEADER_BYTES ) {
+    throw new Error( `Tile ${assetID} is not resident or has no header` )
+  }
+
+  const gathered = new Uint8Array( byteSize )
+
+  let copied = 0
+
+  const segments = bindings.geometryTileSegmentCount( assetID )
+
+  for ( let segment = 0; segment < segments; ++segment ) {
+    const address = bindings.geometryTileSegmentAddress( assetID, segment )
+    const length = bindings.geometryTileSegmentByteLength( assetID, segment )
+
+    gathered.set( heap.subarray( address, address + length ), copied )
+    copied += length
+  }
+
+  const view = new DataView( gathered.buffer )
+  const vertexBytes = view.getUint32( 0, true )
+  const indexBytes = view.getUint32( 4, true )
+
+  if ( TILE_HEADER_BYTES + vertexBytes + indexBytes !== byteSize ) {
+    throw new Error(
+        `Tile ${assetID} header inconsistent with payload size ` +
+        `(${vertexBytes} + ${indexBytes} + ${TILE_HEADER_BYTES} !== ${byteSize})` )
+  }
+
+  // Slice to aligned standalone buffers (gathered's offsets are 8/`+vertex`,
+  // which may misalign Float32Array/Uint32Array views over the same buffer).
+  const vertexData = new Float32Array(
+      gathered.buffer.slice( TILE_HEADER_BYTES, TILE_HEADER_BYTES + vertexBytes ) )
+  const indexData = new Uint32Array(
+      gathered.buffer.slice(
+          TILE_HEADER_BYTES + vertexBytes, TILE_HEADER_BYTES + vertexBytes + indexBytes ) )
+
+  return { vertexData, indexData }
+}


### PR DESCRIPTION
First post-stack increment (epic #390): the connective tissue between the merged streaming stack (#401–#409) and the wasm `TilePool` (conway-geom #147). Bumps the conway-geom pin to `f340780` (TilePool + bindings). **Chain: #413 → #414 → #415 → release.**

## What

- **`GeometryTilePoolBindings`** — narrow typed surface over the embind tile functions (verified end-to-end against the real wasm build in conway-geom #147).
- **`createWasmTileBackend`** — TS accounting stack (`ChunkedPool` → `GeometryTilePool`) over the physical wasm pool, identical budget/chunking both sides: TS all-or-nothing admission mirrors the wasm pool exactly, so the queue-budget ≤ pool-budget invariant guarantees a wasm commit can never fail mid-extract. TS calls `materialize`/`discard` exactly once per residency → wasm refcount pinned at 1, no double-count drift.
- **`DemandResidencyPump`** — the async half: owns admission ahead of the synchronous queue; top-priority batch → `await ensureResidentByLocalID` → forward + pump under the batch cap, so **a pump never hits a non-resident range mid-extract**. Prefetch failures re-queue + count (never throw); re-entrant pumps coalesce; resident products refresh ranking without prefetch.
- **`readGeometryTilePayload`** — segment-walk gather from the wasm heap to standalone aligned typed arrays for GPU upload.
- `TileAssetExtractor` seam (implemented in #415).

## Compatibility

Fully additive; nothing calls the new surface until #415 wires it. No Share surface, no geometry behavior.

## Review status (chain review 2026-07-20)

One nit found and fixed (`3f803f7`): an invalid config the TS `ChunkedPool` rejects (e.g. non-integer chunkBytes) previously threw **after** the wasm pool was initialized, leaving an initialized-but-unowned wasm region — the TS pool is now constructed first so config failures happen at zero state. Also noted (documented, not changed): a persistently failing prefetch re-queues every cycle by design — callers should back off on a sustained non-zero `prefetchFailures`; `takeTopPending_` sorts the pending set per cycle (fine at batch scale, swap for a heap if profiling says so).

## Tests (11)

Pump: residency-before-extract **proven** by a checked mock backend (extract throws if unprefetched); strict priority admission across cycles; resident re-request skips prefetch; failure re-queue + retry; re-entrant coalescing (promise identity); empty-admission cycles still drain the queue's deferred set. Bindings: end-to-end composition with the queue over a faithful embind fake (nonzero-base chunked heap, LIFO freelist, scatter commits) incl. shared-asset once-materialization and last-holder release; refused init; byte-exact multi-segment gather incl. fragmented interleaving; corrupt-header rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz