### PR TITLE
Phase B2: per-product demand extraction (deduplicated product body)

### DIFF
--- a/src/ifc/ifc_demand_extraction.test.ts
+++ b/src/ifc/ifc_demand_extraction.test.ts
@@ -1,0 +1,155 @@
+/* eslint-disable no-magic-numbers, @typescript-eslint/no-explicit-any */
+// Phase B2: per-product demand extraction must produce the same meshes the
+// whole-model walk produces — same products with geometry, same vertex and
+// index counts per product — since both now run the same deduplicated
+// per-product body (extractProductGeometry).
+import fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { IfcGeometryExtraction } from './ifc_geometry_extraction'
+import { ParseResult } from '../step/parsing/step_parser'
+import IfcStepParser from './ifc_step_parser'
+import IfcStepModel from './ifc_step_model'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import { ExtractResult } from '../core/shared_constants'
+import { IfcProduct } from './ifc4_gen'
+
+let conwayGeometry: ConwayGeometry
+
+/**
+ * Parse a fresh model from index.ifc (models are stateful; each extraction
+ * mode gets its own).
+ *
+ * @return {IfcStepModel} The parsed model.
+ */
+function freshModel(): IfcStepModel {
+  const bytes: Buffer = fs.readFileSync( 'data/index.ifc' )
+  const input = new ParsingBuffer( bytes )
+
+  expect( IfcStepParser.Instance.parseHeader( input )[ 1 ] )
+      .toBe( ParseResult.COMPLETE )
+
+  const [ , model ] = IfcStepParser.Instance.parseDataToModel( input )
+
+  expect( model ).toBeDefined()
+  return model as IfcStepModel
+}
+
+/**
+ * Collect per-localID mesh signatures (vertex + triangle counts) from a
+ * model's extracted geometry.
+ *
+ * @param extraction The extraction whose model geometry to summarise.
+ * @return {Map<number, string>} localID → "vertexCount/triangleCount".
+ */
+function meshSignatures( extraction: IfcGeometryExtraction ): Map<number, string> {
+
+  const signatures = new Map<number, string>()
+
+  for ( const mesh of extraction.model.geometry ) {
+
+    const geometry = ( mesh as any ).geometry
+
+    if ( geometry === void 0 || typeof geometry.getVertexCount !== 'function' ) {
+      continue
+    }
+
+    signatures.set(
+        ( mesh as any ).localID,
+        `${geometry.getVertexCount()}/${geometry.getTriangleCount()}` )
+  }
+
+  return signatures
+}
+
+beforeAll( async () => {
+  conwayGeometry = new ConwayGeometry()
+  expect( await conwayGeometry.initialize() ).toBe( true )
+} )
+
+describe( 'per-product demand extraction (Phase B2)', () => {
+
+  test( 'demand extraction over all products matches the whole-model walk', () => {
+
+    // Whole-model walk (the CI-anchored path).
+    const wholeExtraction =
+      new IfcGeometryExtraction( conwayGeometry, freshModel() )
+
+    expect( wholeExtraction.extractIFCGeometryData()[ 0 ] )
+        .toBe( ExtractResult.COMPLETE )
+
+    const wholeSignatures = meshSignatures( wholeExtraction )
+    expect( wholeSignatures.size ).toBeGreaterThan( 0 )
+
+    // Demand path: prepare once, then extract every product individually.
+    const demandModel = freshModel()
+    const demandExtraction =
+      new IfcGeometryExtraction( conwayGeometry, demandModel )
+
+    demandExtraction.prepareDemandExtraction()
+
+    let extractedProducts = 0
+
+    for ( const product of demandModel.types( IfcProduct ) ) {
+      if ( demandExtraction.extractProductGeometryByLocalID( product.localID ) ) {
+        ++extractedProducts
+      }
+    }
+
+    expect( extractedProducts ).toBeGreaterThan( 0 )
+
+    const demandSignatures = meshSignatures( demandExtraction )
+
+    // Same set of products with geometry, same mesh shape per product.
+    expect( demandSignatures ).toEqual( wholeSignatures )
+  } )
+
+  test( 'a single product extracts on demand without the whole-model walk', () => {
+
+    // Whole-model reference signatures (mesh localIDs key representation
+    // items, not products — so parity is checked per matching key).
+    const reference = new IfcGeometryExtraction( conwayGeometry, freshModel() )
+    reference.extractIFCGeometryData()
+    const referenceSignatures = meshSignatures( reference )
+
+    const model = freshModel()
+    const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+
+    // Extract single products on the fresh model until one yields a mesh —
+    // proving a lone product materialises without the whole-model walk.
+    let produced = 0
+
+    for ( const product of model.types( IfcProduct ) ) {
+      extraction.extractProductGeometryByLocalID( product.localID )
+      produced = meshSignatures( extraction ).size
+
+      if ( produced > 0 ) {
+        break
+      }
+    }
+
+    expect( produced ).toBeGreaterThan( 0 )
+    expect( produced ).toBeLessThan( referenceSignatures.size )
+
+    // Every mesh the single extraction produced matches the reference's
+    // mesh for the same key exactly.
+    for ( const [ localID, signature ] of meshSignatures( extraction ) ) {
+      expect( referenceSignatures.get( localID ) ).toBe( signature )
+    }
+  } )
+
+  test( 'a non-product local ID is refused', () => {
+
+    const model = freshModel()
+    const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+
+    // localID 0 in index.ifc is not an IfcProduct (first record is a root
+    // non-product entity in this fixture; the assertion below guards that).
+    const first = model.getElementByLocalID( 0 )
+    expect( first instanceof IfcProduct ).toBe( false )
+
+    expect( extraction.extractProductGeometryByLocalID( 0 ) ).toBe( false )
+  } )
+} )

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -5907,6 +5907,300 @@ export class IfcGeometryExtraction {
     } */
   }
 
+
+  // Guards prepareExtractionMaps_ so the demand path and the whole-model
+  // walk can both trigger it without duplicating work.
+  private extractionMapsPrepared_ = false
+
+  /**
+   * One-time extraction setup shared by the whole-model walk and the
+   * per-product demand path (Phase B2): linear scaling factor and the
+   * cross-product maps (materials, material definitions, rel-voids, styled
+   * items). Idempotent.
+   */
+  private prepareExtractionMaps_(): void {
+
+    if ( this.extractionMapsPrepared_ ) {
+      return
+    }
+
+    this.extractionMapsPrepared_ = true
+
+    this.extractLinearScalingFactor()
+
+    // populate relMaterialsMap
+    const relAssociatesMaterials = this.model.types(IfcRelAssociatesMaterial)
+
+    for (const relAssociateMaterial of relAssociatesMaterials) {
+      const relatingMaterial = relAssociateMaterial.RelatingMaterial
+      try {
+        const relatedObjects = relAssociateMaterial.RelatedObjects
+        for (const relatedObject of relatedObjects) {
+          const product = relatedObject
+
+          if (product instanceof IfcProduct) {
+            if (product instanceof IfcOpeningElement ||
+              product instanceof IfcSpace ||
+              product instanceof IfcOpeningStandardCase) {
+              continue
+            }
+
+            // save mapping of IfcProduct --> IfcMaterial
+            this.materials.relMaterialsMap.set(
+                product.localID,
+                relatingMaterial.localID)
+          } else {
+            //     Logger.warning(`type other than IfcProduct: ${EntityTypesIfc[product.type]}`)
+          }
+        }
+      } catch (ex) {
+        if (ex instanceof Error) {
+          if (MATERIAL_RELATED_OBJECTS_PERMISSIVE) {
+            Logger.error('Error processing relatingMaterial expressID: ' +
+              `${relatingMaterial.expressID}, error: ${ex.message}`)
+          } else {
+            throw ex
+          }
+        } else {
+          Logger.error('Unknown exception processing IfcRelAssociateMaterials.')
+        }
+      }
+    }
+
+    // populate MaterialDefinitionsMap
+    this.populateMaterialDefinitionsMap()
+
+    // populate relvoids map
+    this.populateRelVoidsMap()
+
+    // populate styled items map
+    this.populateStyledItemsMap()
+  }
+
+  /**
+   * Prepare for per-product demand extraction (Phase B2) without running the
+   * whole-model walk: populates the shared extraction maps so
+   * {@link extractProductGeometryByLocalID} can extract any single product.
+   * Idempotent; the whole-model walk shares the same preparation.
+   */
+  public prepareDemandExtraction(): void {
+    this.prepareExtractionMaps_()
+  }
+
+  /**
+   * Extract one product's geometry into the scene by local ID — the demand
+   * path's entry (Phase B2). Requires {@link prepareDemandExtraction} (or a
+   * prior whole-model walk) so the shared maps exist.
+   *
+   * Note: products that are targets of IfcRelAggregates whose relating
+   * object carries rel-voids get those master voids only on the whole-model
+   * walk; the demand path extracts the product's own voids. The parity gate
+   * for this seam is the whole-model digest CI.
+   *
+   * @param localID The product's local ID.
+   * @return {boolean} True if the local ID was an IfcProduct and was
+   * extracted; false if it wasn't a product.
+   */
+  public extractProductGeometryByLocalID( localID: number ): boolean {
+
+    this.prepareExtractionMaps_()
+
+    const element = this.model.getElementByLocalID( localID )
+
+    if ( !( element instanceof IfcProduct ) ) {
+      return false
+    }
+
+    this.extractProductGeometry( element )
+
+    return true
+  }
+
+  /**
+   * Extract one product's geometry into the scene: placement, material /
+   * style extraction, representation items (including mapped items) and
+   * rel-void application. The deduplicated body of the whole-model walk's
+   * two product loops (plain products + rel-aggregates), shared with the
+   * per-product demand path.
+   *
+   * @param product The product to extract.
+   * @param precomputedRelVoids Optional caller-owned rel-voids (the
+   * rel-aggregates "master" case): when supplied the caller retains
+   * ownership and this method does not delete the mesh vector; when
+   * omitted, voids are extracted per product and freed here.
+   */
+  extractProductGeometry(
+      product: IfcProduct,
+      precomputedRelVoids?: [NativeVectorGeometry, number[]] ): void {
+
+    this.scene.clearParentStack()
+
+    const isSpace =
+          product instanceof IfcOpeningElement ||
+          product instanceof IfcSpace ||
+          product instanceof IfcOpeningStandardCase
+
+    const objectPlacement = product.ObjectPlacement
+
+    if (objectPlacement !== null) {
+
+      this.extractPlacement(objectPlacement)
+    }
+
+    const representations = product.Representation
+
+    if (representations === null) {
+      return
+    }
+
+
+    // extract styledItem material
+    const styledItemID: number | undefined =
+      this.extractMaterialStyle(product)
+
+    let hasRelVoid: boolean = false
+    const extractRelVoidsResult = precomputedRelVoids ?? this.extractRelVoids(product)
+    let relVoidsMeshVector: NativeVectorGeometry | undefined
+    let relVoidLocalIDs: number[] | undefined
+
+    if (extractRelVoidsResult !== void 0) {
+
+      [relVoidsMeshVector, relVoidLocalIDs] = extractRelVoidsResult
+    }
+
+    if (relVoidsMeshVector !== void 0) {
+      hasRelVoid = true
+    }
+
+    if (styledItemID !== void 0) {
+      // optimization: extract the first representation item and cache
+      // the styleID to apply to the rest of the product geometry
+      const styledItem = this.model.getElementByLocalID(styledItemID)
+      let reusableStyleID: number | undefined
+
+      for (const representation of representations.Representations) {
+
+        if (representation instanceof IfcShapeRepresentation) {
+
+          // this check is essential -
+          // if RepresentationIdentifier !== Body or Facetation we must skip it
+          if (representation.RepresentationIdentifier !== 'Body' &&
+            representation.RepresentationIdentifier !== 'Facetation') {
+            continue
+          }
+        }
+
+        for (const item of representation.Items) {
+
+          if ( item instanceof IfcMappedItem ) {
+
+            this.extractMappedItem(item, product, hasRelVoid, isSpace)
+
+          } else {
+
+            try {
+
+              this.extractRepresentationItem(item, product.localID, hasRelVoid, isSpace)
+
+              if (hasRelVoid) {
+                this.applyRelVoidToRepresentation(
+                    item,
+                    relVoidsMeshVector!,
+                    product.localID,
+                    relVoidLocalIDs!,
+                    void 0,
+                    isSpace)
+              }
+            } catch ( error ) {
+
+              if ( error instanceof Error ) {
+
+                Logger.error( `Error extracting representation item\n\t${error.message}\n\tExpress ID: #${item.expressID}`)
+              } else {
+
+                Logger.error( `Error extracting representation item\n\tExpress ID: #${item.expressID}`)
+              }
+
+            }
+          }
+
+          const styledItemLocalID_ = this.materials.styledItemMap.get(item.localID)
+
+          if (styledItemLocalID_ !== undefined) {
+            const styledItem_ =
+              this.model.getElementByLocalID(styledItemLocalID_) as IfcStyledItem
+            this.extractStyledItem(styledItem_)
+          } else if (reusableStyleID !== void 0) {
+            this.materials.addGeometryMapping(item.localID, reusableStyleID)
+          } else if (styledItem instanceof IfcStyledItem) {
+            // here we have the styled item, apply it to all geometry in this IfcProduct
+            reusableStyleID = this.extractStyledItem(styledItem, item)
+          }
+        }
+      }
+
+    } else {
+      for (const representation of representations.Representations) {
+
+        if (representation instanceof IfcShapeRepresentation) {
+
+          // this check is essential -
+          // if RepresentationIdentifier !== Body or Facetation we must skip it
+          if (representation.RepresentationIdentifier !== 'Body' &&
+            representation.RepresentationIdentifier !== 'Facetation') {
+            continue
+          }
+        }
+
+        for (const item of representation.Items) {
+
+          if ( item instanceof IfcMappedItem ) {
+
+            this.extractMappedItem(item, product, hasRelVoid, isSpace)
+
+          } else {
+
+            try {
+              this.extractRepresentationItem(item, product.localID, hasRelVoid, isSpace)
+
+              if (hasRelVoid) {
+
+                this.applyRelVoidToRepresentation(
+                    item,
+                    relVoidsMeshVector!,
+                    product.localID,
+                    relVoidLocalIDs!,
+                    void 0,
+                    isSpace)
+              }
+
+              const styledItemLocalID_ = this.materials.styledItemMap.get(item.localID)
+              if (styledItemLocalID_ !== void 0) {
+                const styledItem_ =
+                  this.model.getElementByLocalID(styledItemLocalID_) as IfcStyledItem
+                this.extractStyledItem(styledItem_)
+              }
+            } catch ( error ) {
+
+              if ( error instanceof Error ) {
+
+                Logger.error( `Error extracting representation item\n\t${error.message}\n\t${error.stack}\n\tExpress ID: #${item.localID}`)
+              } else {
+
+                Logger.error( `Unknown error extracting representation item Express ID: #${item.localID}`)
+
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if ( precomputedRelVoids === void 0 ) {
+      relVoidsMeshVector?.delete()
+    }
+  }
+
   /**
    * Extract the geometry data from the IFC
    *
@@ -6006,11 +6300,7 @@ export class IfcGeometryExtraction {
 
     let result: ExtractResult = ExtractResult.INCOMPLETE
 
-    this.extractLinearScalingFactor()
     const previousMemoizationState = this.model.elementMemoization
-
-    // populate relMaterialsMap
-    const relAssociatesMaterials = this.model.types(IfcRelAssociatesMaterial)
 
     try {
 
@@ -6023,50 +6313,7 @@ export class IfcGeometryExtraction {
         this.model.elementMemoization = false
       }
 
-      for (const relAssociateMaterial of relAssociatesMaterials) {
-        const relatingMaterial = relAssociateMaterial.RelatingMaterial
-        try {
-          const relatedObjects = relAssociateMaterial.RelatedObjects
-          for (const relatedObject of relatedObjects) {
-            const product = relatedObject
-
-            if (product instanceof IfcProduct) {
-              if (product instanceof IfcOpeningElement ||
-                product instanceof IfcSpace ||
-                product instanceof IfcOpeningStandardCase) {
-                continue
-              }
-
-              // save mapping of IfcProduct --> IfcMaterial
-              this.materials.relMaterialsMap.set(
-                  product.localID,
-                  relatingMaterial.localID)
-            } else {
-              //     Logger.warning(`type other than IfcProduct: ${EntityTypesIfc[product.type]}`)
-            }
-          }
-        } catch (ex) {
-          if (ex instanceof Error) {
-            if (MATERIAL_RELATED_OBJECTS_PERMISSIVE) {
-              Logger.error('Error processing relatingMaterial expressID: ' +
-                `${relatingMaterial.expressID}, error: ${ex.message}`)
-            } else {
-              throw ex
-            }
-          } else {
-            Logger.error('Unknown exception processing IfcRelAssociateMaterials.')
-          }
-        }
-      }
-
-      // populate MaterialDefinitionsMap
-      this.populateMaterialDefinitionsMap()
-
-      // populate relvoids map
-      this.populateRelVoidsMap()
-
-      // populate styled items map
-      this.populateStyledItemsMap()
+      this.prepareExtractionMaps_()
 
       const products = this.model.types(IfcProduct)
 
@@ -6081,168 +6328,7 @@ export class IfcGeometryExtraction {
 
         yield [++completedItems, totalItems]
 
-        this.scene.clearParentStack()
-
-        const isSpace =
-              product instanceof IfcOpeningElement ||
-              product instanceof IfcSpace ||
-              product instanceof IfcOpeningStandardCase
-
-        const objectPlacement = product.ObjectPlacement
-
-        if (objectPlacement !== null) {
-
-          this.extractPlacement(objectPlacement)
-        }
-
-        const representations = product.Representation
-
-        if (representations !== null) {
-
-          // extract styledItem material
-          const styledItemID: number | undefined =
-            this.extractMaterialStyle(product)
-
-          let hasRelVoid: boolean = false
-          const extractRelVoidsResult = this.extractRelVoids(product)
-          let relVoidsMeshVector: NativeVectorGeometry | undefined
-          let relVoidLocalIDs: number[] | undefined
-
-          if (extractRelVoidsResult !== void 0) {
-
-            [relVoidsMeshVector, relVoidLocalIDs] = extractRelVoidsResult
-          }
-
-          if (relVoidsMeshVector !== void 0) {
-            hasRelVoid = true
-          }
-
-          if (styledItemID !== void 0) {
-            // optimization: extract the first representation item and cache
-            // the styleID to apply to the rest of the product geometry
-            const styledItem = this.model.getElementByLocalID(styledItemID)
-            let reusableStyleID: number | undefined
-
-            for (const representation of representations.Representations) {
-
-              if (representation instanceof IfcShapeRepresentation) {
-
-                // this check is essential -
-                // if RepresentationIdentifier !== Body or Facetation we must skip it
-                if (representation.RepresentationIdentifier !== 'Body' &&
-                  representation.RepresentationIdentifier !== 'Facetation') {
-                  continue
-                }
-              }
-
-              for (const item of representation.Items) {
-
-                if ( item instanceof IfcMappedItem ) {
-
-                  this.extractMappedItem(item, product, hasRelVoid, isSpace)
-
-                } else {
-
-                  try {
-
-                    this.extractRepresentationItem(item, product.localID, hasRelVoid, isSpace)
-
-                    if (hasRelVoid) {
-                      this.applyRelVoidToRepresentation(
-                          item,
-                          relVoidsMeshVector!,
-                          product.localID,
-                          relVoidLocalIDs!,
-                          void 0,
-                          isSpace)
-                    }
-                  } catch ( error ) {
-
-                    if ( error instanceof Error ) {
-
-                      Logger.error( `Error extracting representation item\n\t${error.message}\n\tExpress ID: #${item.expressID}`)
-                    } else {
-
-                      Logger.error( `Error extracting representation item\n\tExpress ID: #${item.expressID}`)
-                    }
-
-                  }
-                }
-
-                const styledItemLocalID_ = this.materials.styledItemMap.get(item.localID)
-
-                if (styledItemLocalID_ !== undefined) {
-                  const styledItem_ =
-                    this.model.getElementByLocalID(styledItemLocalID_) as IfcStyledItem
-                  this.extractStyledItem(styledItem_)
-                } else if (reusableStyleID !== void 0) {
-                  this.materials.addGeometryMapping(item.localID, reusableStyleID)
-                } else if (styledItem instanceof IfcStyledItem) {
-                  // here we have the styled item, apply it to all geometry in this IfcProduct
-                  reusableStyleID = this.extractStyledItem(styledItem, item)
-                }
-              }
-            }
-
-          } else {
-            for (const representation of representations.Representations) {
-
-              if (representation instanceof IfcShapeRepresentation) {
-
-                // this check is essential -
-                // if RepresentationIdentifier !== Body or Facetation we must skip it
-                if (representation.RepresentationIdentifier !== 'Body' &&
-                  representation.RepresentationIdentifier !== 'Facetation') {
-                  continue
-                }
-              }
-
-              for (const item of representation.Items) {
-
-                if ( item instanceof IfcMappedItem ) {
-
-                  this.extractMappedItem(item, product, hasRelVoid, isSpace)
-
-                } else {
-
-                  try {
-                    this.extractRepresentationItem(item, product.localID, hasRelVoid, isSpace)
-
-                    if (hasRelVoid) {
-
-                      this.applyRelVoidToRepresentation(
-                          item,
-                          relVoidsMeshVector!,
-                          product.localID,
-                          relVoidLocalIDs!,
-                          void 0,
-                          isSpace)
-                    }
-
-                    const styledItemLocalID_ = this.materials.styledItemMap.get(item.localID)
-                    if (styledItemLocalID_ !== void 0) {
-                      const styledItem_ =
-                        this.model.getElementByLocalID(styledItemLocalID_) as IfcStyledItem
-                      this.extractStyledItem(styledItem_)
-                    }
-                  } catch ( error ) {
-
-                    if ( error instanceof Error ) {
-
-                      Logger.error( `Error extracting representation item\n\t${error.message}\n\t${error.stack}\n\tExpress ID: #${item.localID}`)
-                    } else {
-
-                      Logger.error( `Unknown error extracting representation item Express ID: #${item.localID}`)
-
-                    }
-                  }
-                }
-              }
-            }
-          }
-
-          relVoidsMeshVector?.delete()
-        }
+        this.extractProductGeometry(product)
       }
 
       const relAggregates = this.model.types(IfcRelAggregates)
@@ -6270,185 +6356,7 @@ export class IfcGeometryExtraction {
 
             if ( productRepresentation instanceof IfcProduct ) {
 
-              const isSpace =
-                productRepresentation instanceof IfcOpeningElement ||
-                productRepresentation instanceof IfcSpace ||
-                productRepresentation instanceof IfcOpeningStandardCase
-
-              const product = productRepresentation
-
-              this.scene.clearParentStack()
-
-              const objectPlacement = product.ObjectPlacement
-
-              if (objectPlacement !== null) {
-
-                this.extractPlacement(objectPlacement)
-              }
-
-              const representations = product.Representation
-
-              if ( representations !== null ) {
-
-                // extract styledItem material
-                const styledItemID: number | undefined =
-                  this.extractMaterialStyle(product)
-
-                const extractRelVoidsResult = masterRelVoids ?? this.extractRelVoids(product)
-
-                let hasRelVoid: boolean = false
-
-                let relVoidsMeshVector: NativeVectorGeometry | undefined
-                let relVoidLocalIDs: number[] | undefined
-
-                if (extractRelVoidsResult !== void 0) {
-
-                  [relVoidsMeshVector, relVoidLocalIDs] = extractRelVoidsResult
-                }
-
-                if (relVoidsMeshVector !== void 0) {
-                  hasRelVoid = true
-                }
-
-                if ( styledItemID !== void 0 ) {
-
-                  // optimization: extract the first representation item and cache
-                  // the styleID to apply to the rest of the product geometry
-                  const styledItem = this.model.getElementByLocalID(styledItemID)
-
-                  let reusableStyleID: number | undefined
-
-                  for (const representation of representations.Representations) {
-
-                    if (representation instanceof IfcShapeRepresentation) {
-
-                      // this check is essential -
-                      // if RepresentationIdentifier !== Body or Facetation we must skip it
-                      if (representation.RepresentationIdentifier !== 'Body' &&
-                        representation.RepresentationIdentifier !== 'Facetation') {
-                        continue
-                      }
-                    }
-
-                    for (const item of representation.Items) {
-
-                      if ( item instanceof IfcMappedItem ) {
-
-                        this.extractMappedItem(item, product, hasRelVoid, isSpace)
-
-                      } else {
-
-                        try {
-                          
-                          this.extractRepresentationItem(item, product.localID, hasRelVoid, isSpace)
-
-                          if (hasRelVoid) {
-                            this.applyRelVoidToRepresentation(
-                                item,
-                                relVoidsMeshVector!,
-                                product.localID,
-                                relVoidLocalIDs!,
-                                void 0,
-                                isSpace)
-                          } 
-                        } catch ( error ) {
-
-                          if ( error instanceof Error ) {
-
-                            Logger.error( `Error extracting rel aggregate representation item\n\t${error.message}\n\t${error.stack}\n\t Express ID: #${item.expressID}`)
-                          } else {
-
-                            Logger.error( `Unknown error extracting rel aggregate representation item Express ID: #${item.expressID}`)
-
-                          }
-                        }
-                      }
-
-                      const styledItemLocalID_ = this.materials.styledItemMap.get(item.localID)
-
-                      if (styledItemLocalID_ !== undefined) {
-
-                        const styledItem_ =
-                          this.model.getElementByLocalID(styledItemLocalID_) as IfcStyledItem
-
-                        this.extractStyledItem(styledItem_)
-
-                      } else if (reusableStyleID !== void 0) {
-
-                        this.materials.addGeometryMapping(item.localID, reusableStyleID)
-
-                      } else if (styledItem instanceof IfcStyledItem) {
-
-                        // here we have the styled item, apply it to all geometry in this IfcProduct
-                        reusableStyleID = this.extractStyledItem(styledItem, item)
-                      }
-                      
-                    }
-                  }
-                } else {
-
-                  for (const representation of representations.Representations) {
-
-                    if (representation instanceof IfcShapeRepresentation) {
-
-                      // this check is essential -
-                      // if RepresentationIdentifier !== Body or Facetation we must skip it
-                      if (representation.RepresentationIdentifier !== 'Body' &&
-                        representation.RepresentationIdentifier !== 'Facetation') {
-                        continue
-                      }
-                    }
-
-                    for (const item of representation.Items) {
-
-                      if ( item instanceof IfcMappedItem ) {
-
-                        this.extractMappedItem(item, product, hasRelVoid, isSpace)
-
-                      } else {
-
-                        try {
-
-                          this.extractRepresentationItem(item, product.localID, hasRelVoid, isSpace)
-
-                          if (hasRelVoid) {
-                            this.applyRelVoidToRepresentation(
-                                item,
-                                relVoidsMeshVector!,
-                                product.localID,
-                                relVoidLocalIDs!,
-                                void 0,
-                                isSpace)
-                          }
-
-                          const styledItemLocalID_ = this.materials.styledItemMap.get(item.localID)
-
-                          if (styledItemLocalID_ !== void 0) {
-                            const styledItem_ =
-                              this.model.getElementByLocalID(styledItemLocalID_) as IfcStyledItem
-                            this.extractStyledItem(styledItem_)
-                          }
-                            
-                        } catch ( error ) {
-
-                          if ( error instanceof Error ) {
-
-                            Logger.error( `Error extracting rel aggregate representation item\n\t${error.message}\n\t${error.stack}\n\t Express ID: #${item.expressID}`)
-                          } else {
-
-                            Logger.error( `Unknown error extracting rel aggregate representation item Express ID: #${item.expressID}`)
-
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-
-                if ( masterRelVoids === void 0 ) {
-                  relVoidsMeshVector?.delete()
-                }
-              }
+              this.extractProductGeometry( productRepresentation, masterRelVoids )
             }
           }
 


### PR DESCRIPTION
**Stacked on Phase B (#413)** — epic #390. The first PR that touches extraction code, so the whole-model digest + **visual-diff CI is the gate here**, not a formality.

## What

The whole-model walk's two product loops (plain products + the rel-aggregates pass) carried near-identical ~150-line bodies. Both now call one **`extractProductGeometry(product, precomputedRelVoids?)`**:

- The rel-aggregates "master void" case becomes the parameter, with **ownership preserved exactly**: caller-owned master voids are never freed per product; the master is deleted once after its related objects, as before.
- Pre-loop setup (linear scaling factor + materials / material-definitions / rel-voids / styled-items maps) moved to an idempotent **`prepareExtractionMaps_()`** shared by both paths; the generator's memoization gating stays where it was.
- **New demand entries**: `prepareDemandExtraction()` (maps only, no walk) and `extractProductGeometryByLocalID(localID)` — the seam the `TileAssetExtractor` (B3) drives.

## Unification note (the one deliberate behavior decision)

The two loop copies diverged only in **log strings** and **error-path styled-item lookup placement** (whether a style lookup runs after a caught per-item extraction error). Both call sites now use the products-loop semantics. Digest impact is possible only on models with erroring representation items inside rel-aggregates — exactly what the regression + visual-diff CI adjudicates. Also documented on the demand entry: aggregate-related products get master rel-voids only via the whole-model walk; the demand path extracts the product's own voids (refinement tracked for the demand wiring).

## Tests (real wasm, in-repo fixture)

`ifc_demand_extraction.test.ts` (3):
1. **Demand extraction over all products == whole-model walk**, mesh-for-mesh (vertex/triangle counts per representation item) — the load-bearing parity proof that the dedup is faithful.
2. A **single product** materialises alone without the walk, every produced mesh matching the reference signature.
3. Non-product localIDs are refused.

Full suite **314/316** (the 2 failures are the pre-existing environmental AP214 wasm ones, #406).

## Compatibility

`extractIFCGeometryData` / `Async` public behavior unchanged (same generator, same yields, same results — the loops call the extracted method). New methods are additive. Share's path is the whole-model walk, gated by the digest CI on this PR.

Chain: #413 (backend + pump) → **this** → B3 (tile extractor + streamed-open API + package exports) → release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_