### PR TITLE
Phase B3: production tile extractor + streamed-open API + package exports

### DIFF
--- a/src/ifc/ifc_stream_open.test.ts
+++ b/src/ifc/ifc_stream_open.test.ts
@@ -1,0 +1,104 @@
+/* eslint-disable no-magic-numbers */
+// Phase B3: the release-facing streamed open — fixed-memory columnar parse
+// over a ByteSource, model over a windowed store, columns exposed for the
+// revisit sidecar — behaves like a resident open for reads once ranges are
+// resident.
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import ParsingBuffer from '../parsing/parsing_buffer'
+import IfcStepParser from './ifc_step_parser'
+import { openStreamedIfcModel } from './ifc_stream_open'
+import { BufferByteSource } from '../step/parsing/byte_source'
+import { InMemoryStepByteStore } from '../step/step_buffer_provider'
+import { ParseResult } from '../step/parsing/step_parser'
+import {
+  hashSource,
+  serializeIndexSidecarFromColumns,
+  deserializeIndexSidecarToColumns,
+  sidecarMatchesSource,
+} from '../step/parsing/index_sidecar'
+import { IfcRoot } from './ifc4_gen'
+
+let bytes: Uint8Array
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let residentModel: any
+
+beforeAll( () => {
+  bytes = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+  const input = new ParsingBuffer( bytes )
+  IfcStepParser.Instance.parseHeader( input )
+  residentModel = IfcStepParser.Instance.parseDataToModel( input )[ 1 ]
+} )
+
+describe( 'openStreamedIfcModel (Phase B3)', () => {
+
+  test( 'opens a model matching the resident parse, with header and columns', () => {
+    const open = openStreamedIfcModel(
+        new BufferByteSource( bytes ),
+        new InMemoryStepByteStore( bytes ),
+        { pool: 4 * 1024 } )
+
+    expect( open.result ).toBe( ParseResult.COMPLETE )
+    expect( open.model ).toBeDefined()
+    expect( open.header.headers.size ).toBeGreaterThan( 0 )
+    expect( open.columns.firstInlineElement ).toBeGreaterThan( 0 )
+
+    const streamedRoots = new Set( open.model!.expressIDsOfTypes( IfcRoot ) )
+    const residentRoots = new Set( residentModel.expressIDsOfTypes( IfcRoot ) )
+    expect( streamedRoots ).toEqual( residentRoots )
+  } )
+
+  test( 'reads work after ensureResident (the windowed contract)', async () => {
+    const open = openStreamedIfcModel(
+        new BufferByteSource( bytes ),
+        new InMemoryStepByteStore( bytes ) )
+
+    const model = open.model!
+    const expressID = [ ...model.expressIDsOfTypes( IfcRoot ) ][ 0 ] as number
+
+    await model.ensureResidentByExpressID( expressID )
+
+    const element = model.getElementByExpressID( expressID )
+    expect( element?.expressID ).toBe( expressID )
+  } )
+
+  test( 'record events fire live during the open', () => {
+    let events = 0
+
+    openStreamedIfcModel(
+        new BufferByteSource( bytes ),
+        new InMemoryStepByteStore( bytes ),
+        { onRecordIndexed: () => void ++events } )
+
+    expect( events ).toBe(
+        openStreamedIfcModel(
+            new BufferByteSource( bytes ),
+            new InMemoryStepByteStore( bytes ) ).columns.firstInlineElement )
+  } )
+
+  test( 'the returned columns serialize to a trustable revisit sidecar', () => {
+    const open = openStreamedIfcModel(
+        new BufferByteSource( bytes ),
+        new InMemoryStepByteStore( bytes ) )
+
+    const hash = hashSource( bytes )
+    const sidecar =
+      serializeIndexSidecarFromColumns( open.columns, bytes.byteLength, hash )
+
+    const restored = deserializeIndexSidecarToColumns<number>( sidecar )
+
+    expect( sidecarMatchesSource(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        restored as any, bytes.byteLength, hash ) ).toBe( true )
+    expect( restored.columns.count ).toBe( open.columns.firstInlineElement )
+  } )
+
+  test( 'rejects a store whose length disagrees with the source', () => {
+    expect( () => openStreamedIfcModel(
+        new BufferByteSource( bytes ),
+        new InMemoryStepByteStore( bytes.subarray( 0, 100 ) ) ) )
+        .toThrow( /does not match/ )
+  } )
+} )

--- a/src/ifc/ifc_stream_open.ts
+++ b/src/ifc/ifc_stream_open.ts
@@ -1,0 +1,125 @@
+import { ByteSource } from '../step/parsing/byte_source'
+import { StepIndexColumns } from '../step/parsing/columnar_index'
+import {
+  buildColumnarIndexStreaming,
+  StreamingIndexStats,
+} from '../step/parsing/streaming_index_builder'
+import { ParseResult, StepHeader } from '../step/parsing/step_parser'
+import {
+  StepExternalByteStore,
+  WindowedStepBufferProvider,
+} from '../step/step_buffer_provider'
+import EntityTypesIfc from './ifc4_gen/entity_types_ifc.gen'
+import IfcStepModel from './ifc_step_model'
+import IfcStepParser from './ifc_step_parser'
+
+
+/**
+ * Options for a streamed IFC open. All optional; defaults suit a browser
+ * worker over an OPFS-backed store.
+ */
+export interface StreamedIfcOpenOptions {
+
+  /** Parse window size in bytes (default 1 MiB). */
+  pool?: number
+
+  /** Windowed provider chunk size (default: provider's). */
+  chunkBytes?: number
+
+  /** Windowed provider LRU cap in chunks (default: provider's). */
+  maxResidentChunks?: number
+
+  /**
+   * Live per-record event `(localID, expressID, typeID)` — the M2 seam for
+   * incremental consumers (type index, roots, cross-refs) that run while
+   * the model is still parsing. Must be synchronous and cheap.
+   */
+  onRecordIndexed?:
+    ( localID: number, expressID: number, typeID: EntityTypesIfc | undefined ) => void
+}
+
+
+/**
+ * The result of a streamed IFC open: the windowed-source model plus the
+ * artifacts a consumer needs around it.
+ */
+export interface StreamedIfcOpen {
+
+  /** The model over the windowed source (undefined if the parse failed). */
+  model: IfcStepModel | undefined
+
+  /** The parse result. */
+  result: ParseResult
+
+  /** The STEP header (available even on some failed parses). */
+  header: StepHeader
+
+  /**
+   * The columnar index the model was built from. Hand to
+   * `serializeIndexSidecarFromColumns` (with a source hash) to produce the
+   * revisit sidecar — the columns ARE the sidecar payload (M7 identity).
+   */
+  columns: StepIndexColumns<EntityTypesIfc>
+
+  /** Window diagnostics from the streaming build. */
+  stats: StreamingIndexStats
+}
+
+
+// eslint-disable-next-line no-magic-numbers
+const DEFAULT_STREAM_POOL_BYTES = 1024 * 1024
+
+
+/**
+ * Open an IFC model from a streamed source with a **fixed-memory parse**
+ * (the release-facing Phase B API; composes M0/M1a/M7):
+ *
+ *  - the index builds through a moving window over `source` — the source is
+ *    never resident in the JS heap, and the index is columnar from birth
+ *    (no per-record object phase);
+ *  - the model reads source bytes on demand through a windowed LRU provider
+ *    over `store` (`ensureResidentByLocalID`/`ByExpressID` page ranges in
+ *    before synchronous reads — see `DemandResidencyPump` for the demand
+ *    orchestration).
+ *
+ * The typical browser wiring: a worker streams the network body **through**
+ * to OPFS while feeding the same bytes to `source`; `store` reads back from
+ * OPFS. `source.byteLength` and `store.byteLength` must agree.
+ *
+ * @param source The sequential parse source.
+ * @param store The random-access store the model reads from afterwards.
+ * @param options See {@link StreamedIfcOpenOptions}.
+ * @return {StreamedIfcOpen} The model + header, columns, and diagnostics.
+ */
+export function openStreamedIfcModel(
+    source: ByteSource,
+    store: StepExternalByteStore,
+    options?: StreamedIfcOpenOptions ): StreamedIfcOpen {
+
+  if ( store.byteLength !== source.byteLength ) {
+    throw new Error(
+        `Streaming store byteLength ${store.byteLength} does not match ` +
+        `source byteLength ${source.byteLength}` )
+  }
+
+  const { header, columns, result, stats } = buildColumnarIndexStreaming(
+      source,
+      IfcStepParser.Instance,
+      options?.pool ?? DEFAULT_STREAM_POOL_BYTES,
+      options?.onRecordIndexed )
+
+  if ( result !== ParseResult.COMPLETE ) {
+    return { model: void 0, result, header, columns, stats }
+  }
+
+  const provider = new WindowedStepBufferProvider(
+      store, options?.chunkBytes, options?.maxResidentChunks )
+
+  return {
+    model: new IfcStepModel( void 0, columns, provider ),
+    result,
+    header,
+    columns,
+    stats,
+  }
+}

--- a/src/ifc/ifc_tile_extractor.test.ts
+++ b/src/ifc/ifc_tile_extractor.test.ts
@@ -1,0 +1,143 @@
+/* eslint-disable no-magic-numbers, @typescript-eslint/no-explicit-any */
+// Phase B3: the production TileAssetExtractor drives the per-product demand
+// seam (B2) and commits reified meshes through the wasm tile surface —
+// verified with real extraction and recording commit bindings, composed all
+// the way up through the queue + pump.
+import fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { IfcGeometryExtraction } from './ifc_geometry_extraction'
+import { IfcTileAssetExtractor, TileCommitBindings } from './ifc_tile_extractor'
+import { ParseResult } from '../step/parsing/step_parser'
+import IfcStepParser from './ifc_step_parser'
+import IfcStepModel from './ifc_step_model'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import { createWasmTileBackend } from '../core/geometry_tile_bindings'
+import { DemandGeometryQueue } from '../core/demand_geometry_queue'
+import { DemandResidencyPump } from '../core/demand_residency_pump'
+import { IfcProduct } from './ifc4_gen'
+
+let conwayGeometry: ConwayGeometry
+
+/**
+ * @return {IfcStepModel} A fresh parsed model of index.ifc.
+ */
+function freshModel(): IfcStepModel {
+  const bytes: Buffer = fs.readFileSync( 'data/index.ifc' )
+  const input = new ParsingBuffer( bytes )
+  expect( IfcStepParser.Instance.parseHeader( input )[ 1 ] ).toBe( ParseResult.COMPLETE )
+  const [ , model ] = IfcStepParser.Instance.parseDataToModel( input )
+  return model as IfcStepModel
+}
+
+/**
+ * Recording fake of the commit surface: accepts every init/commit/release,
+ * records ids, verifies commit receives a live reified geometry.
+ *
+ * @return {object} `{ bindings, committed, released }`.
+ */
+function recordingBindings(): {
+  bindings: TileCommitBindings, committed: number[], released: number[],
+} {
+  const committed: number[] = []
+  const released: number[] = []
+
+  const bindings = {
+    initGeometryTilePool: () => true,
+    geometryTilePoolInitialized: () => true,
+    commitGeometryTile: ( assetID: number, geometry: any ) => {
+      // A real reified geometry must be handed over.
+      expect( typeof geometry.GetVertexDataSize ).toBe( 'function' )
+      expect( geometry.GetVertexDataSize() ).toBeGreaterThan( 0 )
+      committed.push( assetID )
+      return true
+    },
+    commitGeometryTileBytes: () => true,
+    retainGeometryTile: () => true,
+    releaseGeometryTile: ( assetID: number ) => {
+      released.push( assetID )
+      return true
+    },
+    geometryTileResident: ( assetID: number ) =>
+      committed.includes( assetID ) && !released.includes( assetID ),
+    geometryTileRefCount: () => 1,
+    geometryTileByteSize: () => 0,
+    geometryTileSegmentCount: () => 0,
+    geometryTileSegmentAddress: () => 0,
+    geometryTileSegmentByteLength: () => 0,
+    geometryTileVertexByteLength: () => 0,
+    geometryTileIndexByteLength: () => 0,
+    geometryTilePoolBytesInUse: () => 0,
+    geometryTilePoolTotalBytes: () => 0,
+    geometryTilePoolFreeChunks: () => 0,
+    geometryTilePoolFailedCommits: () => 0,
+  } as TileCommitBindings
+
+  return { bindings, committed, released }
+}
+
+beforeAll( async () => {
+  conwayGeometry = new ConwayGeometry()
+  expect( await conwayGeometry.initialize() ).toBe( true )
+} )
+
+describe( 'IfcTileAssetExtractor (Phase B3)', () => {
+
+  test( 'assetsOf extracts on first ask, caches, and sizes at reified cost', () => {
+    const model = freshModel()
+    const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+    const { bindings } = recordingBindings()
+    const extractor = new IfcTileAssetExtractor( extraction, bindings )
+
+    // Find a product with geometry.
+    let assets: ReturnType<typeof extractor.assetsOf> = []
+    let productID = -1
+
+    for ( const product of model.types( IfcProduct ) ) {
+      assets = extractor.assetsOf( product.localID )
+      if ( assets.length > 0 ) {
+        productID = product.localID
+        break
+      }
+    }
+
+    expect( assets.length ).toBeGreaterThan( 0 )
+
+    for ( const asset of assets ) {
+      expect( asset.byteSize ).toBeGreaterThan( 8 ) // header + payload
+    }
+
+    // Cached: second ask returns the same array without re-extraction.
+    expect( extractor.assetsOf( productID ) ).toBe( assets )
+  } )
+
+  test( 'full composition: pump → queue → tiles → extractor → wasm commit', async () => {
+    const model = freshModel()
+    const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+    const { bindings, committed, released } = recordingBindings()
+    const extractor = new IfcTileAssetExtractor( extraction, bindings )
+
+    const backend = createWasmTileBackend( bindings, extractor, 64 * 1024 * 1024, 4096 )
+    const queue = new DemandGeometryQueue( backend.tiles, 64 * 1024 * 1024 )
+    const pump = new DemandResidencyPump( queue, model )
+
+    for ( const product of model.types( IfcProduct ) ) {
+      pump.request( product.localID, 1 )
+    }
+
+    // Drain admission in batches.
+    while ( pump.pendingCount > 0 ) {
+      const result = await pump.pump()
+      expect( result.prefetchFailures ).toBe( 0 )
+    }
+
+    expect( committed.length ).toBeGreaterThan( 0 )
+    expect( queue.stats.residentCount ).toBeGreaterThan( 0 )
+
+    // Evicting everything releases every committed wasm tile.
+    queue.evictAll()
+    expect( new Set( released ) ).toEqual( new Set( committed ) )
+  } )
+} )

--- a/src/ifc/ifc_tile_extractor.ts
+++ b/src/ifc/ifc_tile_extractor.ts
@@ -68,11 +68,21 @@ export class IfcTileAssetExtractor implements TileAssetExtractor {
   }
 
   /**
-   * The assets (produced meshes) for a product, extracting it on first ask.
+   * The assets (meshes) a product references, extracting it on first ask.
+   *
+   * Attribution walks the product's **representation-item closure**
+   * (recursing through mapped items into their shared source
+   * representations) and claims every item that has an extracted mesh —
+   * NOT a before/after diff of the mesh set. The distinction is the
+   * mapped-item case: a shared source's meshes already exist when the
+   * second product asks, so a diff would omit them and its tile would not
+   * hold references to geometry it renders. Closure attribution is
+   * extraction-order independent.
    *
    * @param productLocalID The product's local ID.
-   * @return {GeometryAsset<number>[]} One asset per produced mesh, keyed by
-   * the mesh's representation-item localID, sized at exact reified cost.
+   * @return {GeometryAsset<number>[]} One asset per referenced mesh, keyed
+   * by the mesh's representation-item localID (shared across products for
+   * mapped sources), sized at exact reified cost.
    */
   public assetsOf( productLocalID: number ): GeometryAsset<number>[] {
 
@@ -82,31 +92,17 @@ export class IfcTileAssetExtractor implements TileAssetExtractor {
       return cached
     }
 
-    const geometry = this.extraction_.model.geometry
-
-    // Snapshot existing mesh keys so this product's contribution is the
-    // difference. O(meshes) per first ask — acceptable for the demand path;
-    // an extraction-side "produced meshes" report can replace it if
-    // profiling ever flags it.
-    const before = new Set<number>()
-
-    for ( const mesh of geometry ) {
-      before.add( mesh.localID )
-    }
-
     this.extraction_.extractProductGeometryByLocalID( productLocalID )
 
+    const geometry = this.extraction_.model.geometry
     const assets: GeometryAsset<number>[] = []
 
-    for ( const mesh of geometry ) {
+    for ( const itemLocalID of this.representationItemIDs_( productLocalID ) ) {
 
-      if ( before.has( mesh.localID ) ) {
-        continue
-      }
+      const mesh = geometry.getByLocalID( itemLocalID )
 
-      const wasmGeometry =
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ( mesh as any ).geometry
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wasmGeometry = ( mesh as any )?.geometry
 
       if ( wasmGeometry === void 0 ||
         typeof wasmGeometry.GetVertexDataSize !== 'function' ) {
@@ -117,12 +113,63 @@ export class IfcTileAssetExtractor implements TileAssetExtractor {
         wasmGeometry.GetVertexDataSize() * FLOAT_BYTES +
         wasmGeometry.GetIndexDataSize() * INDEX_BYTES
 
-      assets.push( { assetID: mesh.localID, byteSize } )
+      assets.push( { assetID: itemLocalID, byteSize } )
     }
 
     this.assetsByProduct_.set( productLocalID, assets )
 
     return assets
+  }
+
+  /**
+   * The localIDs of every representation item in a product's Body /
+   * Facetation representations, recursing through mapped items into their
+   * (shared) source representations — the key space extraction stores
+   * meshes under.
+   *
+   * @param productLocalID The product's local ID.
+   * @return {Set<number>} The representation-item localIDs.
+   */
+  private representationItemIDs_( productLocalID: number ): Set<number> {
+
+    const ids = new Set<number>()
+    const element = this.extraction_.model.getElementByLocalID( productLocalID )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const representations = ( element as any )?.Representation?.Representations
+
+    if ( representations === void 0 || representations === null ) {
+      return ids
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const addItems = ( items: any[] ): void => {
+      for ( const item of items ) {
+
+        ids.add( item.localID )
+
+        // Mapped item: recurse into the shared source representation.
+        const source = item.MappingSource?.MappedRepresentation?.Items
+
+        if ( source !== void 0 && source !== null ) {
+          addItems( source )
+        }
+      }
+    }
+
+    for ( const representation of representations ) {
+
+      const identifier = representation.RepresentationIdentifier
+
+      if ( identifier !== null && identifier !== 'Body' &&
+        identifier !== 'Facetation' ) {
+        continue
+      }
+
+      addItems( representation.Items )
+    }
+
+    return ids
   }
 
   /**

--- a/src/ifc/ifc_tile_extractor.ts
+++ b/src/ifc/ifc_tile_extractor.ts
@@ -1,0 +1,150 @@
+import {
+  GeometryTilePoolBindings,
+  TileAssetExtractor,
+} from '../core/geometry_tile_bindings'
+import { GeometryAsset } from '../core/geometry_tile_pool'
+import { IfcGeometryExtraction } from './ifc_geometry_extraction'
+
+
+/**
+ * The wasm module surface the extractor commits through: the tile pool
+ * bindings plus the Geometry-taking commit (embind `commitGeometryTile`,
+ * which serialises a reified Geometry's payload straight into pool chunks).
+ */
+export interface TileCommitBindings extends GeometryTilePoolBindings {
+
+  /**
+   * Commit a reified geometry's payload into the wasm tile pool.
+   *
+   * @param assetID The tile's asset id.
+   * @param geometry The wasm Geometry object (reified on access).
+   * @return {boolean} True on success.
+   */
+  commitGeometryTile( assetID: number, geometry: unknown ): boolean
+}
+
+
+// Reified payload framing: 8-byte header + float vertex data + u32 indices
+// (tile_pool_api.h layout).
+const TILE_HEADER_BYTES = 8
+const FLOAT_BYTES = 4
+const INDEX_BYTES = 4
+
+
+/**
+ * The production {@link TileAssetExtractor} (Phase B3): drives the
+ * per-product demand extraction seam (Phase B2) and commits the resulting
+ * meshes into the wasm tile pool.
+ *
+ * Asset identity: one asset per produced **mesh**, keyed by the mesh's
+ * localID (the representation item). Mapped items reuse representation
+ * geometry across products, so shared representations become shared assets —
+ * the sharing the pools refcount.
+ *
+ * Contract notes:
+ * - `assetsOf` runs the (expensive) per-product extraction on first call and
+ *   caches the asset list; sizes are exact reified byte costs, so the TS
+ *   accounting layer admits with real numbers. This front-loads cost into
+ *   `assetsOf` by design — see `GeometryTilePool.extract`'s pricing pass.
+ * - `materialize` commits an already-extracted mesh into the pool;
+ *   `discard` releases the wasm tile. The CPU-side canonical mesh is left in
+ *   place in this phase (serving uploads from tiles — and dropping the fat
+ *   working geometry — is the Phase C flip).
+ */
+export class IfcTileAssetExtractor implements TileAssetExtractor {
+
+  /** Product localID → its assets, cached after first extraction. */
+  private readonly assetsByProduct_ = new Map<number, GeometryAsset<number>[]>()
+
+  /**
+   * @param extraction_ The geometry extraction (its model provides meshes).
+   * @param bindings_ The wasm tile pool surface to commit through.
+   */
+  constructor(
+    private readonly extraction_: IfcGeometryExtraction,
+    private readonly bindings_: TileCommitBindings ) {
+
+    this.extraction_.prepareDemandExtraction()
+  }
+
+  /**
+   * The assets (produced meshes) for a product, extracting it on first ask.
+   *
+   * @param productLocalID The product's local ID.
+   * @return {GeometryAsset<number>[]} One asset per produced mesh, keyed by
+   * the mesh's representation-item localID, sized at exact reified cost.
+   */
+  public assetsOf( productLocalID: number ): GeometryAsset<number>[] {
+
+    const cached = this.assetsByProduct_.get( productLocalID )
+
+    if ( cached !== void 0 ) {
+      return cached
+    }
+
+    const geometry = this.extraction_.model.geometry
+
+    // Snapshot existing mesh keys so this product's contribution is the
+    // difference. O(meshes) per first ask — acceptable for the demand path;
+    // an extraction-side "produced meshes" report can replace it if
+    // profiling ever flags it.
+    const before = new Set<number>()
+
+    for ( const mesh of geometry ) {
+      before.add( mesh.localID )
+    }
+
+    this.extraction_.extractProductGeometryByLocalID( productLocalID )
+
+    const assets: GeometryAsset<number>[] = []
+
+    for ( const mesh of geometry ) {
+
+      if ( before.has( mesh.localID ) ) {
+        continue
+      }
+
+      const wasmGeometry =
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ( mesh as any ).geometry
+
+      if ( wasmGeometry === void 0 ||
+        typeof wasmGeometry.GetVertexDataSize !== 'function' ) {
+        continue
+      }
+
+      const byteSize = TILE_HEADER_BYTES +
+        wasmGeometry.GetVertexDataSize() * FLOAT_BYTES +
+        wasmGeometry.GetIndexDataSize() * INDEX_BYTES
+
+      assets.push( { assetID: mesh.localID, byteSize } )
+    }
+
+    this.assetsByProduct_.set( productLocalID, assets )
+
+    return assets
+  }
+
+  /**
+   * Commit one extracted mesh into the wasm tile pool.
+   *
+   * @param assetID The mesh (representation item) localID.
+   */
+  public extractIntoTile( assetID: number ): void {
+
+    const mesh = this.extraction_.model.geometry.getByLocalID( assetID )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wasmGeometry = ( mesh as any )?.geometry
+
+    if ( wasmGeometry === void 0 ) {
+      throw new Error( `No extracted mesh for asset ${assetID}` )
+    }
+
+    if ( !this.bindings_.commitGeometryTile( assetID, wasmGeometry ) ) {
+      throw new Error(
+          `Wasm tile commit failed for asset ${assetID} — ` +
+          'the scheduler budget must not exceed the pool budget' )
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,3 +30,38 @@ export {
   formatSeconds,
   stageLabel,
 } from './core/progress_log'
+
+// --- Streaming / demand-geometry surface (epic #390; design doc
+// design/new/streaming-federated-loader.md). The release-facing API for
+// fixed-memory opens and demand-driven residency.
+export { openStreamedIfcModel, StreamedIfcOpen, StreamedIfcOpenOptions } from './ifc/ifc_stream_open'
+export { ByteSource, BufferByteSource } from './step/parsing/byte_source'
+export {
+  StepExternalByteStore,
+  InMemoryStepByteStore,
+  StepBufferProvider,
+  WindowedStepBufferProvider,
+} from './step/step_buffer_provider'
+export { StepIndexColumns } from './step/parsing/columnar_index'
+export {
+  serializeIndexSidecarFromColumns,
+  deserializeIndexSidecarToColumns,
+  sidecarMatchesSource,
+  hashSource,
+} from './step/parsing/index_sidecar'
+export { StreamingRecordDispatcher, RecordHandler } from './step/parsing/streaming_record_dispatcher'
+export { IncrementalTypeIndex } from './step/parsing/incremental_type_index'
+export { DemandGeometryQueue, GeometryTiles, DemandQueueStats } from './core/demand_geometry_queue'
+export { DemandResidencyPump, ResidencyPrefetcher, PumpResult } from './core/demand_residency_pump'
+export {
+  GeometryTilePoolBindings,
+  TileAssetExtractor,
+  WasmTileBackend,
+  createWasmTileBackend,
+  readGeometryTilePayload,
+  GeometryTilePayload,
+} from './core/geometry_tile_bindings'
+export { IfcTileAssetExtractor, TileCommitBindings } from './ifc/ifc_tile_extractor'
+export { ChunkedPool, ChunkSpan } from './core/mem/chunked_pool'
+export { SharedAssetPool } from './core/mem/shared_asset_pool'
+export { GeometryTilePool, InstanceAssetSource, GeometryAsset } from './core/geometry_tile_pool'


### PR DESCRIPTION
**Stacked on B2 (#414)** — epic #390. **Top of the release chain**: with this merged, conway's published surface has everything Share needs to turn up the streaming open, and the demand-geometry machine runs end-to-end against real geometry.

## What

- **`IfcTileAssetExtractor`** — the production `TileAssetExtractor` driving B2's per-product seam. Assets are keyed by representation-item localID and attributed by the product's **representation-item closure** (recursing through mapped items into their shared source representations) — extraction-order independent, so mapped-source meshes shared across products are correctly claimed by *every* referencing product's tile (see Review status). Sizes are **exact reified byte costs**; `materialize` commits through the wasm `commitGeometryTile` surface (`TileCommitBindings`). CPU-side canonical meshes stay in place this phase — serving uploads from tiles is the Phase C flip, so zero behavior change for existing render paths.
- **`openStreamedIfcModel`** — the fixed-memory open Share's worker calls: columnar streamed parse over a `ByteSource` (source never JS-resident, no object phase), model over a windowed LRU `store`, returning header + **columns** (serialize directly to the revisit sidecar — the M7 identity) + diagnostics, with live `onRecordIndexed` passthrough.
- **Package exports** (`src/index.ts`): the full streaming/demand surface as the supported release API.

## Review status (chain review 2026-07-20 — one real finding, fixed on the branch)

**`a2847c4` — mapped-item asset attribution.** The original `assetsOf` diffed the mesh set before/after extraction; a mapped item's shared source meshes already exist when the *second* referencing product asks, so the diff omitted them — that product's tile held no reference to geometry it renders, and releasing the first product's tile would have dropped it. Exactly the hazard the refcounted pools exist to prevent, reintroduced one layer up. Fixed by closure attribution (walk `Representation` → items → `MappingSource.MappedRepresentation.Items`, recursive), which is also cheaper than the O(meshes) snapshot. All composition tests re-verified.

Known v1 scope note: aggregate-related products get master rel-voids only via the whole-model walk (documented on the B2 seam); asset sizes for a shared mesh are identical across claimants by determinism.

## The milestone in this PR's tests

The **full composition runs against real geometry for the first time**: `DemandResidencyPump` → `DemandGeometryQueue` → `GeometryTilePool` → `IfcTileAssetExtractor` → real wasm extraction → tile commit, over every product of `index.ifc`, zero prefetch failures, eviction releasing every committed tile. Plus stream-open resident-parity, the `ensureResident` read contract, live record events, columns → sidecar round-trip + handshake, and the length-mismatch guard. Full suite **324/326** (2 = #406).

## What Share turns up after the release

1. **M1b now** (zero geometry risk): worker open via `openStreamedIfcModel` over OPFS write-through.
2. **M4b**: sidecar cache from the returned columns; index-first reopen.
3. **Phase C** (flag-gated): camera priorities → `pump.request`, GPU upload via `readGeometryTilePayload`, dispose-on-evict. Picking per the settled decision: **A first** (keep position+index CPU-side, null normals/UVs on upload — picking unchanged, duplicate ≈ halved), then **B** (GPU ID-buffer picking) as the endgame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz