### PR TITLE
Complete the Phase B chain: land B2 + B3 content on main

### DIFF
--- a/src/ifc/ifc_demand_extraction.test.ts
+++ b/src/ifc/ifc_demand_extraction.test.ts
@@ -1,0 +1,155 @@
+/* eslint-disable no-magic-numbers, @typescript-eslint/no-explicit-any */
+// Phase B2: per-product demand extraction must produce the same meshes the
+// whole-model walk produces — same products with geometry, same vertex and
+// index counts per product — since both now run the same deduplicated
+// per-product body (extractProductGeometry).
+import fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { IfcGeometryExtraction } from './ifc_geometry_extraction'
+import { ParseResult } from '../step/parsing/step_parser'
+import IfcStepParser from './ifc_step_parser'
+import IfcStepModel from './ifc_step_model'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import { ExtractResult } from '../core/shared_constants'
+import { IfcProduct } from './ifc4_gen'
+
+let conwayGeometry: ConwayGeometry
+
+/**
+ * Parse a fresh model from index.ifc (models are stateful; each extraction
+ * mode gets its own).
+ *
+ * @return {IfcStepModel} The parsed model.
+ */
+function freshModel(): IfcStepModel {
+  const bytes: Buffer = fs.readFileSync( 'data/index.ifc' )
+  const input = new ParsingBuffer( bytes )
+
+  expect( IfcStepParser.Instance.parseHeader( input )[ 1 ] )
+      .toBe( ParseResult.COMPLETE )
+
+  const [ , model ] = IfcStepParser.Instance.parseDataToModel( input )
+
+  expect( model ).toBeDefined()
+  return model as IfcStepModel
+}
+
+/**
+ * Collect per-localID mesh signatures (vertex + triangle counts) from a
+ * model's extracted geometry.
+ *
+ * @param extraction The extraction whose model geometry to summarise.
+ * @return {Map<number, string>} localID → "vertexCount/triangleCount".
+ */
+function meshSignatures( extraction: IfcGeometryExtraction ): Map<number, string> {
+
+  const signatures = new Map<number, string>()
+
+  for ( const mesh of extraction.model.geometry ) {
+
+    const geometry = ( mesh as any ).geometry
+
+    if ( geometry === void 0 || typeof geometry.getVertexCount !== 'function' ) {
+      continue
+    }
+
+    signatures.set(
+        ( mesh as any ).localID,
+        `${geometry.getVertexCount()}/${geometry.getTriangleCount()}` )
+  }
+
+  return signatures
+}
+
+beforeAll( async () => {
+  conwayGeometry = new ConwayGeometry()
+  expect( await conwayGeometry.initialize() ).toBe( true )
+} )
+
+describe( 'per-product demand extraction (Phase B2)', () => {
+
+  test( 'demand extraction over all products matches the whole-model walk', () => {
+
+    // Whole-model walk (the CI-anchored path).
+    const wholeExtraction =
+      new IfcGeometryExtraction( conwayGeometry, freshModel() )
+
+    expect( wholeExtraction.extractIFCGeometryData()[ 0 ] )
+        .toBe( ExtractResult.COMPLETE )
+
+    const wholeSignatures = meshSignatures( wholeExtraction )
+    expect( wholeSignatures.size ).toBeGreaterThan( 0 )
+
+    // Demand path: prepare once, then extract every product individually.
+    const demandModel = freshModel()
+    const demandExtraction =
+      new IfcGeometryExtraction( conwayGeometry, demandModel )
+
+    demandExtraction.prepareDemandExtraction()
+
+    let extractedProducts = 0
+
+    for ( const product of demandModel.types( IfcProduct ) ) {
+      if ( demandExtraction.extractProductGeometryByLocalID( product.localID ) ) {
+        ++extractedProducts
+      }
+    }
+
+    expect( extractedProducts ).toBeGreaterThan( 0 )
+
+    const demandSignatures = meshSignatures( demandExtraction )
+
+    // Same set of products with geometry, same mesh shape per product.
+    expect( demandSignatures ).toEqual( wholeSignatures )
+  } )
+
+  test( 'a single product extracts on demand without the whole-model walk', () => {
+
+    // Whole-model reference signatures (mesh localIDs key representation
+    // items, not products — so parity is checked per matching key).
+    const reference = new IfcGeometryExtraction( conwayGeometry, freshModel() )
+    reference.extractIFCGeometryData()
+    const referenceSignatures = meshSignatures( reference )
+
+    const model = freshModel()
+    const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+
+    // Extract single products on the fresh model until one yields a mesh —
+    // proving a lone product materialises without the whole-model walk.
+    let produced = 0
+
+    for ( const product of model.types( IfcProduct ) ) {
+      extraction.extractProductGeometryByLocalID( product.localID )
+      produced = meshSignatures( extraction ).size
+
+      if ( produced > 0 ) {
+        break
+      }
+    }
+
+    expect( produced ).toBeGreaterThan( 0 )
+    expect( produced ).toBeLessThan( referenceSignatures.size )
+
+    // Every mesh the single extraction produced matches the reference's
+    // mesh for the same key exactly.
+    for ( const [ localID, signature ] of meshSignatures( extraction ) ) {
+      expect( referenceSignatures.get( localID ) ).toBe( signature )
+    }
+  } )
+
+  test( 'a non-product local ID is refused', () => {
+
+    const model = freshModel()
+    const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+
+    // localID 0 in index.ifc is not an IfcProduct (first record is a root
+    // non-product entity in this fixture; the assertion below guards that).
+    const first = model.getElementByLocalID( 0 )
+    expect( first instanceof IfcProduct ).toBe( false )
+
+    expect( extraction.extractProductGeometryByLocalID( 0 ) ).toBe( false )
+  } )
+} )

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -5907,6 +5907,300 @@ export class IfcGeometryExtraction {
     } */
   }
 
+
+  // Guards prepareExtractionMaps_ so the demand path and the whole-model
+  // walk can both trigger it without duplicating work.
+  private extractionMapsPrepared_ = false
+
+  /**
+   * One-time extraction setup shared by the whole-model walk and the
+   * per-product demand path (Phase B2): linear scaling factor and the
+   * cross-product maps (materials, material definitions, rel-voids, styled
+   * items). Idempotent.
+   */
+  private prepareExtractionMaps_(): void {
+
+    if ( this.extractionMapsPrepared_ ) {
+      return
+    }
+
+    this.extractionMapsPrepared_ = true
+
+    this.extractLinearScalingFactor()
+
+    // populate relMaterialsMap
+    const relAssociatesMaterials = this.model.types(IfcRelAssociatesMaterial)
+
+    for (const relAssociateMaterial of relAssociatesMaterials) {
+      const relatingMaterial = relAssociateMaterial.RelatingMaterial
+      try {
+        const relatedObjects = relAssociateMaterial.RelatedObjects
+        for (const relatedObject of relatedObjects) {
+          const product = relatedObject
+
+          if (product instanceof IfcProduct) {
+            if (product instanceof IfcOpeningElement ||
+              product instanceof IfcSpace ||
+              product instanceof IfcOpeningStandardCase) {
+              continue
+            }
+
+            // save mapping of IfcProduct --> IfcMaterial
+            this.materials.relMaterialsMap.set(
+                product.localID,
+                relatingMaterial.localID)
+          } else {
+            //     Logger.warning(`type other than IfcProduct: ${EntityTypesIfc[product.type]}`)
+          }
+        }
+      } catch (ex) {
+        if (ex instanceof Error) {
+          if (MATERIAL_RELATED_OBJECTS_PERMISSIVE) {
+            Logger.error('Error processing relatingMaterial expressID: ' +
+              `${relatingMaterial.expressID}, error: ${ex.message}`)
+          } else {
+            throw ex
+          }
+        } else {
+          Logger.error('Unknown exception processing IfcRelAssociateMaterials.')
+        }
+      }
+    }
+
+    // populate MaterialDefinitionsMap
+    this.populateMaterialDefinitionsMap()
+
+    // populate relvoids map
+    this.populateRelVoidsMap()
+
+    // populate styled items map
+    this.populateStyledItemsMap()
+  }
+
+  /**
+   * Prepare for per-product demand extraction (Phase B2) without running the
+   * whole-model walk: populates the shared extraction maps so
+   * {@link extractProductGeometryByLocalID} can extract any single product.
+   * Idempotent; the whole-model walk shares the same preparation.
+   */
+  public prepareDemandExtraction(): void {
+    this.prepareExtractionMaps_()
+  }
+
+  /**
+   * Extract one product's geometry into the scene by local ID — the demand
+   * path's entry (Phase B2). Requires {@link prepareDemandExtraction} (or a
+   * prior whole-model walk) so the shared maps exist.
+   *
+   * Note: products that are targets of IfcRelAggregates whose relating
+   * object carries rel-voids get those master voids only on the whole-model
+   * walk; the demand path extracts the product's own voids. The parity gate
+   * for this seam is the whole-model digest CI.
+   *
+   * @param localID The product's local ID.
+   * @return {boolean} True if the local ID was an IfcProduct and was
+   * extracted; false if it wasn't a product.
+   */
+  public extractProductGeometryByLocalID( localID: number ): boolean {
+
+    this.prepareExtractionMaps_()
+
+    const element = this.model.getElementByLocalID( localID )
+
+    if ( !( element instanceof IfcProduct ) ) {
+      return false
+    }
+
+    this.extractProductGeometry( element )
+
+    return true
+  }
+
+  /**
+   * Extract one product's geometry into the scene: placement, material /
+   * style extraction, representation items (including mapped items) and
+   * rel-void application. The deduplicated body of the whole-model walk's
+   * two product loops (plain products + rel-aggregates), shared with the
+   * per-product demand path.
+   *
+   * @param product The product to extract.
+   * @param precomputedRelVoids Optional caller-owned rel-voids (the
+   * rel-aggregates "master" case): when supplied the caller retains
+   * ownership and this method does not delete the mesh vector; when
+   * omitted, voids are extracted per product and freed here.
+   */
+  extractProductGeometry(
+      product: IfcProduct,
+      precomputedRelVoids?: [NativeVectorGeometry, number[]] ): void {
+
+    this.scene.clearParentStack()
+
+    const isSpace =
+          product instanceof IfcOpeningElement ||
+          product instanceof IfcSpace ||
+          product instanceof IfcOpeningStandardCase
+
+    const objectPlacement = product.ObjectPlacement
+
+    if (objectPlacement !== null) {
+
+      this.extractPlacement(objectPlacement)
+    }
+
+    const representations = product.Representation
+
+    if (representations === null) {
+      return
+    }
+
+
+    // extract styledItem material
+    const styledItemID: number | undefined =
+      this.extractMaterialStyle(product)
+
+    let hasRelVoid: boolean = false
+    const extractRelVoidsResult = precomputedRelVoids ?? this.extractRelVoids(product)
+    let relVoidsMeshVector: NativeVectorGeometry | undefined
+    let relVoidLocalIDs: number[] | undefined
+
+    if (extractRelVoidsResult !== void 0) {
+
+      [relVoidsMeshVector, relVoidLocalIDs] = extractRelVoidsResult
+    }
+
+    if (relVoidsMeshVector !== void 0) {
+      hasRelVoid = true
+    }
+
+    if (styledItemID !== void 0) {
+      // optimization: extract the first representation item and cache
+      // the styleID to apply to the rest of the product geometry
+      const styledItem = this.model.getElementByLocalID(styledItemID)
+      let reusableStyleID: number | undefined
+
+      for (const representation of representations.Representations) {
+
+        if (representation instanceof IfcShapeRepresentation) {
+
+          // this check is essential -
+          // if RepresentationIdentifier !== Body or Facetation we must skip it
+          if (representation.RepresentationIdentifier !== 'Body' &&
+            representation.RepresentationIdentifier !== 'Facetation') {
+            continue
+          }
+        }
+
+        for (const item of representation.Items) {
+
+          if ( item instanceof IfcMappedItem ) {
+
+            this.extractMappedItem(item, product, hasRelVoid, isSpace)
+
+          } else {
+
+            try {
+
+              this.extractRepresentationItem(item, product.localID, hasRelVoid, isSpace)
+
+              if (hasRelVoid) {
+                this.applyRelVoidToRepresentation(
+                    item,
+                    relVoidsMeshVector!,
+                    product.localID,
+                    relVoidLocalIDs!,
+                    void 0,
+                    isSpace)
+              }
+            } catch ( error ) {
+
+              if ( error instanceof Error ) {
+
+                Logger.error( `Error extracting representation item\n\t${error.message}\n\tExpress ID: #${item.expressID}`)
+              } else {
+
+                Logger.error( `Error extracting representation item\n\tExpress ID: #${item.expressID}`)
+              }
+
+            }
+          }
+
+          const styledItemLocalID_ = this.materials.styledItemMap.get(item.localID)
+
+          if (styledItemLocalID_ !== undefined) {
+            const styledItem_ =
+              this.model.getElementByLocalID(styledItemLocalID_) as IfcStyledItem
+            this.extractStyledItem(styledItem_)
+          } else if (reusableStyleID !== void 0) {
+            this.materials.addGeometryMapping(item.localID, reusableStyleID)
+          } else if (styledItem instanceof IfcStyledItem) {
+            // here we have the styled item, apply it to all geometry in this IfcProduct
+            reusableStyleID = this.extractStyledItem(styledItem, item)
+          }
+        }
+      }
+
+    } else {
+      for (const representation of representations.Representations) {
+
+        if (representation instanceof IfcShapeRepresentation) {
+
+          // this check is essential -
+          // if RepresentationIdentifier !== Body or Facetation we must skip it
+          if (representation.RepresentationIdentifier !== 'Body' &&
+            representation.RepresentationIdentifier !== 'Facetation') {
+            continue
+          }
+        }
+
+        for (const item of representation.Items) {
+
+          if ( item instanceof IfcMappedItem ) {
+
+            this.extractMappedItem(item, product, hasRelVoid, isSpace)
+
+          } else {
+
+            try {
+              this.extractRepresentationItem(item, product.localID, hasRelVoid, isSpace)
+
+              if (hasRelVoid) {
+
+                this.applyRelVoidToRepresentation(
+                    item,
+                    relVoidsMeshVector!,
+                    product.localID,
+                    relVoidLocalIDs!,
+                    void 0,
+                    isSpace)
+              }
+
+              const styledItemLocalID_ = this.materials.styledItemMap.get(item.localID)
+              if (styledItemLocalID_ !== void 0) {
+                const styledItem_ =
+                  this.model.getElementByLocalID(styledItemLocalID_) as IfcStyledItem
+                this.extractStyledItem(styledItem_)
+              }
+            } catch ( error ) {
+
+              if ( error instanceof Error ) {
+
+                Logger.error( `Error extracting representation item\n\t${error.message}\n\t${error.stack}\n\tExpress ID: #${item.localID}`)
+              } else {
+
+                Logger.error( `Unknown error extracting representation item Express ID: #${item.localID}`)
+
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if ( precomputedRelVoids === void 0 ) {
+      relVoidsMeshVector?.delete()
+    }
+  }
+
   /**
    * Extract the geometry data from the IFC
    *
@@ -6006,11 +6300,7 @@ export class IfcGeometryExtraction {
 
     let result: ExtractResult = ExtractResult.INCOMPLETE
 
-    this.extractLinearScalingFactor()
     const previousMemoizationState = this.model.elementMemoization
-
-    // populate relMaterialsMap
-    const relAssociatesMaterials = this.model.types(IfcRelAssociatesMaterial)
 
     try {
 
@@ -6023,50 +6313,7 @@ export class IfcGeometryExtraction {
         this.model.elementMemoization = false
       }
 
-      for (const relAssociateMaterial of relAssociatesMaterials) {
-        const relatingMaterial = relAssociateMaterial.RelatingMaterial
-        try {
-          const relatedObjects = relAssociateMaterial.RelatedObjects
-          for (const relatedObject of relatedObjects) {
-            const product = relatedObject
-
-            if (product instanceof IfcProduct) {
-              if (product instanceof IfcOpeningElement ||
-                product instanceof IfcSpace ||
-                product instanceof IfcOpeningStandardCase) {
-                continue
-              }
-
-              // save mapping of IfcProduct --> IfcMaterial
-              this.materials.relMaterialsMap.set(
-                  product.localID,
-                  relatingMaterial.localID)
-            } else {
-              //     Logger.warning(`type other than IfcProduct: ${EntityTypesIfc[product.type]}`)
-            }
-          }
-        } catch (ex) {
-          if (ex instanceof Error) {
-            if (MATERIAL_RELATED_OBJECTS_PERMISSIVE) {
-              Logger.error('Error processing relatingMaterial expressID: ' +
-                `${relatingMaterial.expressID}, error: ${ex.message}`)
-            } else {
-              throw ex
-            }
-          } else {
-            Logger.error('Unknown exception processing IfcRelAssociateMaterials.')
-          }
-        }
-      }
-
-      // populate MaterialDefinitionsMap
-      this.populateMaterialDefinitionsMap()
-
-      // populate relvoids map
-      this.populateRelVoidsMap()
-
-      // populate styled items map
-      this.populateStyledItemsMap()
+      this.prepareExtractionMaps_()
 
       const products = this.model.types(IfcProduct)
 
@@ -6081,168 +6328,7 @@ export class IfcGeometryExtraction {
 
         yield [++completedItems, totalItems]
 
-        this.scene.clearParentStack()
-
-        const isSpace =
-              product instanceof IfcOpeningElement ||
-              product instanceof IfcSpace ||
-              product instanceof IfcOpeningStandardCase
-
-        const objectPlacement = product.ObjectPlacement
-
-        if (objectPlacement !== null) {
-
-          this.extractPlacement(objectPlacement)
-        }
-
-        const representations = product.Representation
-
-        if (representations !== null) {
-
-          // extract styledItem material
-          const styledItemID: number | undefined =
-            this.extractMaterialStyle(product)
-
-          let hasRelVoid: boolean = false
-          const extractRelVoidsResult = this.extractRelVoids(product)
-          let relVoidsMeshVector: NativeVectorGeometry | undefined
-          let relVoidLocalIDs: number[] | undefined
-
-          if (extractRelVoidsResult !== void 0) {
-
-            [relVoidsMeshVector, relVoidLocalIDs] = extractRelVoidsResult
-          }
-
-          if (relVoidsMeshVector !== void 0) {
-            hasRelVoid = true
-          }
-
-          if (styledItemID !== void 0) {
-            // optimization: extract the first representation item and cache
-            // the styleID to apply to the rest of the product geometry
-            const styledItem = this.model.getElementByLocalID(styledItemID)
-            let reusableStyleID: number | undefined
-
-            for (const representation of representations.Representations) {
-
-              if (representation instanceof IfcShapeRepresentation) {
-
-                // this check is essential -
-                // if RepresentationIdentifier !== Body or Facetation we must skip it
-                if (representation.RepresentationIdentifier !== 'Body' &&
-                  representation.RepresentationIdentifier !== 'Facetation') {
-                  continue
-                }
-              }
-
-              for (const item of representation.Items) {
-
-                if ( item instanceof IfcMappedItem ) {
-
-                  this.extractMappedItem(item, product, hasRelVoid, isSpace)
-
-                } else {
-
-                  try {
-
-                    this.extractRepresentationItem(item, product.localID, hasRelVoid, isSpace)
-
-                    if (hasRelVoid) {
-                      this.applyRelVoidToRepresentation(
-                          item,
-                          relVoidsMeshVector!,
-                          product.localID,
-                          relVoidLocalIDs!,
-                          void 0,
-                          isSpace)
-                    }
-                  } catch ( error ) {
-
-                    if ( error instanceof Error ) {
-
-                      Logger.error( `Error extracting representation item\n\t${error.message}\n\tExpress ID: #${item.expressID}`)
-                    } else {
-
-                      Logger.error( `Error extracting representation item\n\tExpress ID: #${item.expressID}`)
-                    }
-
-                  }
-                }
-
-                const styledItemLocalID_ = this.materials.styledItemMap.get(item.localID)
-
-                if (styledItemLocalID_ !== undefined) {
-                  const styledItem_ =
-                    this.model.getElementByLocalID(styledItemLocalID_) as IfcStyledItem
-                  this.extractStyledItem(styledItem_)
-                } else if (reusableStyleID !== void 0) {
-                  this.materials.addGeometryMapping(item.localID, reusableStyleID)
-                } else if (styledItem instanceof IfcStyledItem) {
-                  // here we have the styled item, apply it to all geometry in this IfcProduct
-                  reusableStyleID = this.extractStyledItem(styledItem, item)
-                }
-              }
-            }
-
-          } else {
-            for (const representation of representations.Representations) {
-
-              if (representation instanceof IfcShapeRepresentation) {
-
-                // this check is essential -
-                // if RepresentationIdentifier !== Body or Facetation we must skip it
-                if (representation.RepresentationIdentifier !== 'Body' &&
-                  representation.RepresentationIdentifier !== 'Facetation') {
-                  continue
-                }
-              }
-
-              for (const item of representation.Items) {
-
-                if ( item instanceof IfcMappedItem ) {
-
-                  this.extractMappedItem(item, product, hasRelVoid, isSpace)
-
-                } else {
-
-                  try {
-                    this.extractRepresentationItem(item, product.localID, hasRelVoid, isSpace)
-
-                    if (hasRelVoid) {
-
-                      this.applyRelVoidToRepresentation(
-                          item,
-                          relVoidsMeshVector!,
-                          product.localID,
-                          relVoidLocalIDs!,
-                          void 0,
-                          isSpace)
-                    }
-
-                    const styledItemLocalID_ = this.materials.styledItemMap.get(item.localID)
-                    if (styledItemLocalID_ !== void 0) {
-                      const styledItem_ =
-                        this.model.getElementByLocalID(styledItemLocalID_) as IfcStyledItem
-                      this.extractStyledItem(styledItem_)
-                    }
-                  } catch ( error ) {
-
-                    if ( error instanceof Error ) {
-
-                      Logger.error( `Error extracting representation item\n\t${error.message}\n\t${error.stack}\n\tExpress ID: #${item.localID}`)
-                    } else {
-
-                      Logger.error( `Unknown error extracting representation item Express ID: #${item.localID}`)
-
-                    }
-                  }
-                }
-              }
-            }
-          }
-
-          relVoidsMeshVector?.delete()
-        }
+        this.extractProductGeometry(product)
       }
 
       const relAggregates = this.model.types(IfcRelAggregates)
@@ -6270,185 +6356,7 @@ export class IfcGeometryExtraction {
 
             if ( productRepresentation instanceof IfcProduct ) {
 
-              const isSpace =
-                productRepresentation instanceof IfcOpeningElement ||
-                productRepresentation instanceof IfcSpace ||
-                productRepresentation instanceof IfcOpeningStandardCase
-
-              const product = productRepresentation
-
-              this.scene.clearParentStack()
-
-              const objectPlacement = product.ObjectPlacement
-
-              if (objectPlacement !== null) {
-
-                this.extractPlacement(objectPlacement)
-              }
-
-              const representations = product.Representation
-
-              if ( representations !== null ) {
-
-                // extract styledItem material
-                const styledItemID: number | undefined =
-                  this.extractMaterialStyle(product)
-
-                const extractRelVoidsResult = masterRelVoids ?? this.extractRelVoids(product)
-
-                let hasRelVoid: boolean = false
-
-                let relVoidsMeshVector: NativeVectorGeometry | undefined
-                let relVoidLocalIDs: number[] | undefined
-
-                if (extractRelVoidsResult !== void 0) {
-
-                  [relVoidsMeshVector, relVoidLocalIDs] = extractRelVoidsResult
-                }
-
-                if (relVoidsMeshVector !== void 0) {
-                  hasRelVoid = true
-                }
-
-                if ( styledItemID !== void 0 ) {
-
-                  // optimization: extract the first representation item and cache
-                  // the styleID to apply to the rest of the product geometry
-                  const styledItem = this.model.getElementByLocalID(styledItemID)
-
-                  let reusableStyleID: number | undefined
-
-                  for (const representation of representations.Representations) {
-
-                    if (representation instanceof IfcShapeRepresentation) {
-
-                      // this check is essential -
-                      // if RepresentationIdentifier !== Body or Facetation we must skip it
-                      if (representation.RepresentationIdentifier !== 'Body' &&
-                        representation.RepresentationIdentifier !== 'Facetation') {
-                        continue
-                      }
-                    }
-
-                    for (const item of representation.Items) {
-
-                      if ( item instanceof IfcMappedItem ) {
-
-                        this.extractMappedItem(item, product, hasRelVoid, isSpace)
-
-                      } else {
-
-                        try {
-                          
-                          this.extractRepresentationItem(item, product.localID, hasRelVoid, isSpace)
-
-                          if (hasRelVoid) {
-                            this.applyRelVoidToRepresentation(
-                                item,
-                                relVoidsMeshVector!,
-                                product.localID,
-                                relVoidLocalIDs!,
-                                void 0,
-                                isSpace)
-                          } 
-                        } catch ( error ) {
-
-                          if ( error instanceof Error ) {
-
-                            Logger.error( `Error extracting rel aggregate representation item\n\t${error.message}\n\t${error.stack}\n\t Express ID: #${item.expressID}`)
-                          } else {
-
-                            Logger.error( `Unknown error extracting rel aggregate representation item Express ID: #${item.expressID}`)
-
-                          }
-                        }
-                      }
-
-                      const styledItemLocalID_ = this.materials.styledItemMap.get(item.localID)
-
-                      if (styledItemLocalID_ !== undefined) {
-
-                        const styledItem_ =
-                          this.model.getElementByLocalID(styledItemLocalID_) as IfcStyledItem
-
-                        this.extractStyledItem(styledItem_)
-
-                      } else if (reusableStyleID !== void 0) {
-
-                        this.materials.addGeometryMapping(item.localID, reusableStyleID)
-
-                      } else if (styledItem instanceof IfcStyledItem) {
-
-                        // here we have the styled item, apply it to all geometry in this IfcProduct
-                        reusableStyleID = this.extractStyledItem(styledItem, item)
-                      }
-                      
-                    }
-                  }
-                } else {
-
-                  for (const representation of representations.Representations) {
-
-                    if (representation instanceof IfcShapeRepresentation) {
-
-                      // this check is essential -
-                      // if RepresentationIdentifier !== Body or Facetation we must skip it
-                      if (representation.RepresentationIdentifier !== 'Body' &&
-                        representation.RepresentationIdentifier !== 'Facetation') {
-                        continue
-                      }
-                    }
-
-                    for (const item of representation.Items) {
-
-                      if ( item instanceof IfcMappedItem ) {
-
-                        this.extractMappedItem(item, product, hasRelVoid, isSpace)
-
-                      } else {
-
-                        try {
-
-                          this.extractRepresentationItem(item, product.localID, hasRelVoid, isSpace)
-
-                          if (hasRelVoid) {
-                            this.applyRelVoidToRepresentation(
-                                item,
-                                relVoidsMeshVector!,
-                                product.localID,
-                                relVoidLocalIDs!,
-                                void 0,
-                                isSpace)
-                          }
-
-                          const styledItemLocalID_ = this.materials.styledItemMap.get(item.localID)
-
-                          if (styledItemLocalID_ !== void 0) {
-                            const styledItem_ =
-                              this.model.getElementByLocalID(styledItemLocalID_) as IfcStyledItem
-                            this.extractStyledItem(styledItem_)
-                          }
-                            
-                        } catch ( error ) {
-
-                          if ( error instanceof Error ) {
-
-                            Logger.error( `Error extracting rel aggregate representation item\n\t${error.message}\n\t${error.stack}\n\t Express ID: #${item.expressID}`)
-                          } else {
-
-                            Logger.error( `Unknown error extracting rel aggregate representation item Express ID: #${item.expressID}`)
-
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-
-                if ( masterRelVoids === void 0 ) {
-                  relVoidsMeshVector?.delete()
-                }
-              }
+              this.extractProductGeometry( productRepresentation, masterRelVoids )
             }
           }
 

--- a/src/ifc/ifc_stream_open.test.ts
+++ b/src/ifc/ifc_stream_open.test.ts
@@ -1,0 +1,104 @@
+/* eslint-disable no-magic-numbers */
+// Phase B3: the release-facing streamed open — fixed-memory columnar parse
+// over a ByteSource, model over a windowed store, columns exposed for the
+// revisit sidecar — behaves like a resident open for reads once ranges are
+// resident.
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import ParsingBuffer from '../parsing/parsing_buffer'
+import IfcStepParser from './ifc_step_parser'
+import { openStreamedIfcModel } from './ifc_stream_open'
+import { BufferByteSource } from '../step/parsing/byte_source'
+import { InMemoryStepByteStore } from '../step/step_buffer_provider'
+import { ParseResult } from '../step/parsing/step_parser'
+import {
+  hashSource,
+  serializeIndexSidecarFromColumns,
+  deserializeIndexSidecarToColumns,
+  sidecarMatchesSource,
+} from '../step/parsing/index_sidecar'
+import { IfcRoot } from './ifc4_gen'
+
+let bytes: Uint8Array
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let residentModel: any
+
+beforeAll( () => {
+  bytes = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+  const input = new ParsingBuffer( bytes )
+  IfcStepParser.Instance.parseHeader( input )
+  residentModel = IfcStepParser.Instance.parseDataToModel( input )[ 1 ]
+} )
+
+describe( 'openStreamedIfcModel (Phase B3)', () => {
+
+  test( 'opens a model matching the resident parse, with header and columns', () => {
+    const open = openStreamedIfcModel(
+        new BufferByteSource( bytes ),
+        new InMemoryStepByteStore( bytes ),
+        { pool: 4 * 1024 } )
+
+    expect( open.result ).toBe( ParseResult.COMPLETE )
+    expect( open.model ).toBeDefined()
+    expect( open.header.headers.size ).toBeGreaterThan( 0 )
+    expect( open.columns.firstInlineElement ).toBeGreaterThan( 0 )
+
+    const streamedRoots = new Set( open.model!.expressIDsOfTypes( IfcRoot ) )
+    const residentRoots = new Set( residentModel.expressIDsOfTypes( IfcRoot ) )
+    expect( streamedRoots ).toEqual( residentRoots )
+  } )
+
+  test( 'reads work after ensureResident (the windowed contract)', async () => {
+    const open = openStreamedIfcModel(
+        new BufferByteSource( bytes ),
+        new InMemoryStepByteStore( bytes ) )
+
+    const model = open.model!
+    const expressID = [ ...model.expressIDsOfTypes( IfcRoot ) ][ 0 ] as number
+
+    await model.ensureResidentByExpressID( expressID )
+
+    const element = model.getElementByExpressID( expressID )
+    expect( element?.expressID ).toBe( expressID )
+  } )
+
+  test( 'record events fire live during the open', () => {
+    let events = 0
+
+    openStreamedIfcModel(
+        new BufferByteSource( bytes ),
+        new InMemoryStepByteStore( bytes ),
+        { onRecordIndexed: () => void ++events } )
+
+    expect( events ).toBe(
+        openStreamedIfcModel(
+            new BufferByteSource( bytes ),
+            new InMemoryStepByteStore( bytes ) ).columns.firstInlineElement )
+  } )
+
+  test( 'the returned columns serialize to a trustable revisit sidecar', () => {
+    const open = openStreamedIfcModel(
+        new BufferByteSource( bytes ),
+        new InMemoryStepByteStore( bytes ) )
+
+    const hash = hashSource( bytes )
+    const sidecar =
+      serializeIndexSidecarFromColumns( open.columns, bytes.byteLength, hash )
+
+    const restored = deserializeIndexSidecarToColumns<number>( sidecar )
+
+    expect( sidecarMatchesSource(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        restored as any, bytes.byteLength, hash ) ).toBe( true )
+    expect( restored.columns.count ).toBe( open.columns.firstInlineElement )
+  } )
+
+  test( 'rejects a store whose length disagrees with the source', () => {
+    expect( () => openStreamedIfcModel(
+        new BufferByteSource( bytes ),
+        new InMemoryStepByteStore( bytes.subarray( 0, 100 ) ) ) )
+        .toThrow( /does not match/ )
+  } )
+} )

--- a/src/ifc/ifc_stream_open.ts
+++ b/src/ifc/ifc_stream_open.ts
@@ -1,0 +1,125 @@
+import { ByteSource } from '../step/parsing/byte_source'
+import { StepIndexColumns } from '../step/parsing/columnar_index'
+import {
+  buildColumnarIndexStreaming,
+  StreamingIndexStats,
+} from '../step/parsing/streaming_index_builder'
+import { ParseResult, StepHeader } from '../step/parsing/step_parser'
+import {
+  StepExternalByteStore,
+  WindowedStepBufferProvider,
+} from '../step/step_buffer_provider'
+import EntityTypesIfc from './ifc4_gen/entity_types_ifc.gen'
+import IfcStepModel from './ifc_step_model'
+import IfcStepParser from './ifc_step_parser'
+
+
+/**
+ * Options for a streamed IFC open. All optional; defaults suit a browser
+ * worker over an OPFS-backed store.
+ */
+export interface StreamedIfcOpenOptions {
+
+  /** Parse window size in bytes (default 1 MiB). */
+  pool?: number
+
+  /** Windowed provider chunk size (default: provider's). */
+  chunkBytes?: number
+
+  /** Windowed provider LRU cap in chunks (default: provider's). */
+  maxResidentChunks?: number
+
+  /**
+   * Live per-record event `(localID, expressID, typeID)` — the M2 seam for
+   * incremental consumers (type index, roots, cross-refs) that run while
+   * the model is still parsing. Must be synchronous and cheap.
+   */
+  onRecordIndexed?:
+    ( localID: number, expressID: number, typeID: EntityTypesIfc | undefined ) => void
+}
+
+
+/**
+ * The result of a streamed IFC open: the windowed-source model plus the
+ * artifacts a consumer needs around it.
+ */
+export interface StreamedIfcOpen {
+
+  /** The model over the windowed source (undefined if the parse failed). */
+  model: IfcStepModel | undefined
+
+  /** The parse result. */
+  result: ParseResult
+
+  /** The STEP header (available even on some failed parses). */
+  header: StepHeader
+
+  /**
+   * The columnar index the model was built from. Hand to
+   * `serializeIndexSidecarFromColumns` (with a source hash) to produce the
+   * revisit sidecar — the columns ARE the sidecar payload (M7 identity).
+   */
+  columns: StepIndexColumns<EntityTypesIfc>
+
+  /** Window diagnostics from the streaming build. */
+  stats: StreamingIndexStats
+}
+
+
+// eslint-disable-next-line no-magic-numbers
+const DEFAULT_STREAM_POOL_BYTES = 1024 * 1024
+
+
+/**
+ * Open an IFC model from a streamed source with a **fixed-memory parse**
+ * (the release-facing Phase B API; composes M0/M1a/M7):
+ *
+ *  - the index builds through a moving window over `source` — the source is
+ *    never resident in the JS heap, and the index is columnar from birth
+ *    (no per-record object phase);
+ *  - the model reads source bytes on demand through a windowed LRU provider
+ *    over `store` (`ensureResidentByLocalID`/`ByExpressID` page ranges in
+ *    before synchronous reads — see `DemandResidencyPump` for the demand
+ *    orchestration).
+ *
+ * The typical browser wiring: a worker streams the network body **through**
+ * to OPFS while feeding the same bytes to `source`; `store` reads back from
+ * OPFS. `source.byteLength` and `store.byteLength` must agree.
+ *
+ * @param source The sequential parse source.
+ * @param store The random-access store the model reads from afterwards.
+ * @param options See {@link StreamedIfcOpenOptions}.
+ * @return {StreamedIfcOpen} The model + header, columns, and diagnostics.
+ */
+export function openStreamedIfcModel(
+    source: ByteSource,
+    store: StepExternalByteStore,
+    options?: StreamedIfcOpenOptions ): StreamedIfcOpen {
+
+  if ( store.byteLength !== source.byteLength ) {
+    throw new Error(
+        `Streaming store byteLength ${store.byteLength} does not match ` +
+        `source byteLength ${source.byteLength}` )
+  }
+
+  const { header, columns, result, stats } = buildColumnarIndexStreaming(
+      source,
+      IfcStepParser.Instance,
+      options?.pool ?? DEFAULT_STREAM_POOL_BYTES,
+      options?.onRecordIndexed )
+
+  if ( result !== ParseResult.COMPLETE ) {
+    return { model: void 0, result, header, columns, stats }
+  }
+
+  const provider = new WindowedStepBufferProvider(
+      store, options?.chunkBytes, options?.maxResidentChunks )
+
+  return {
+    model: new IfcStepModel( void 0, columns, provider ),
+    result,
+    header,
+    columns,
+    stats,
+  }
+}

--- a/src/ifc/ifc_tile_extractor.test.ts
+++ b/src/ifc/ifc_tile_extractor.test.ts
@@ -1,0 +1,143 @@
+/* eslint-disable no-magic-numbers, @typescript-eslint/no-explicit-any */
+// Phase B3: the production TileAssetExtractor drives the per-product demand
+// seam (B2) and commits reified meshes through the wasm tile surface —
+// verified with real extraction and recording commit bindings, composed all
+// the way up through the queue + pump.
+import fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { IfcGeometryExtraction } from './ifc_geometry_extraction'
+import { IfcTileAssetExtractor, TileCommitBindings } from './ifc_tile_extractor'
+import { ParseResult } from '../step/parsing/step_parser'
+import IfcStepParser from './ifc_step_parser'
+import IfcStepModel from './ifc_step_model'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import { createWasmTileBackend } from '../core/geometry_tile_bindings'
+import { DemandGeometryQueue } from '../core/demand_geometry_queue'
+import { DemandResidencyPump } from '../core/demand_residency_pump'
+import { IfcProduct } from './ifc4_gen'
+
+let conwayGeometry: ConwayGeometry
+
+/**
+ * @return {IfcStepModel} A fresh parsed model of index.ifc.
+ */
+function freshModel(): IfcStepModel {
+  const bytes: Buffer = fs.readFileSync( 'data/index.ifc' )
+  const input = new ParsingBuffer( bytes )
+  expect( IfcStepParser.Instance.parseHeader( input )[ 1 ] ).toBe( ParseResult.COMPLETE )
+  const [ , model ] = IfcStepParser.Instance.parseDataToModel( input )
+  return model as IfcStepModel
+}
+
+/**
+ * Recording fake of the commit surface: accepts every init/commit/release,
+ * records ids, verifies commit receives a live reified geometry.
+ *
+ * @return {object} `{ bindings, committed, released }`.
+ */
+function recordingBindings(): {
+  bindings: TileCommitBindings, committed: number[], released: number[],
+} {
+  const committed: number[] = []
+  const released: number[] = []
+
+  const bindings = {
+    initGeometryTilePool: () => true,
+    geometryTilePoolInitialized: () => true,
+    commitGeometryTile: ( assetID: number, geometry: any ) => {
+      // A real reified geometry must be handed over.
+      expect( typeof geometry.GetVertexDataSize ).toBe( 'function' )
+      expect( geometry.GetVertexDataSize() ).toBeGreaterThan( 0 )
+      committed.push( assetID )
+      return true
+    },
+    commitGeometryTileBytes: () => true,
+    retainGeometryTile: () => true,
+    releaseGeometryTile: ( assetID: number ) => {
+      released.push( assetID )
+      return true
+    },
+    geometryTileResident: ( assetID: number ) =>
+      committed.includes( assetID ) && !released.includes( assetID ),
+    geometryTileRefCount: () => 1,
+    geometryTileByteSize: () => 0,
+    geometryTileSegmentCount: () => 0,
+    geometryTileSegmentAddress: () => 0,
+    geometryTileSegmentByteLength: () => 0,
+    geometryTileVertexByteLength: () => 0,
+    geometryTileIndexByteLength: () => 0,
+    geometryTilePoolBytesInUse: () => 0,
+    geometryTilePoolTotalBytes: () => 0,
+    geometryTilePoolFreeChunks: () => 0,
+    geometryTilePoolFailedCommits: () => 0,
+  } as TileCommitBindings
+
+  return { bindings, committed, released }
+}
+
+beforeAll( async () => {
+  conwayGeometry = new ConwayGeometry()
+  expect( await conwayGeometry.initialize() ).toBe( true )
+} )
+
+describe( 'IfcTileAssetExtractor (Phase B3)', () => {
+
+  test( 'assetsOf extracts on first ask, caches, and sizes at reified cost', () => {
+    const model = freshModel()
+    const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+    const { bindings } = recordingBindings()
+    const extractor = new IfcTileAssetExtractor( extraction, bindings )
+
+    // Find a product with geometry.
+    let assets: ReturnType<typeof extractor.assetsOf> = []
+    let productID = -1
+
+    for ( const product of model.types( IfcProduct ) ) {
+      assets = extractor.assetsOf( product.localID )
+      if ( assets.length > 0 ) {
+        productID = product.localID
+        break
+      }
+    }
+
+    expect( assets.length ).toBeGreaterThan( 0 )
+
+    for ( const asset of assets ) {
+      expect( asset.byteSize ).toBeGreaterThan( 8 ) // header + payload
+    }
+
+    // Cached: second ask returns the same array without re-extraction.
+    expect( extractor.assetsOf( productID ) ).toBe( assets )
+  } )
+
+  test( 'full composition: pump → queue → tiles → extractor → wasm commit', async () => {
+    const model = freshModel()
+    const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+    const { bindings, committed, released } = recordingBindings()
+    const extractor = new IfcTileAssetExtractor( extraction, bindings )
+
+    const backend = createWasmTileBackend( bindings, extractor, 64 * 1024 * 1024, 4096 )
+    const queue = new DemandGeometryQueue( backend.tiles, 64 * 1024 * 1024 )
+    const pump = new DemandResidencyPump( queue, model )
+
+    for ( const product of model.types( IfcProduct ) ) {
+      pump.request( product.localID, 1 )
+    }
+
+    // Drain admission in batches.
+    while ( pump.pendingCount > 0 ) {
+      const result = await pump.pump()
+      expect( result.prefetchFailures ).toBe( 0 )
+    }
+
+    expect( committed.length ).toBeGreaterThan( 0 )
+    expect( queue.stats.residentCount ).toBeGreaterThan( 0 )
+
+    // Evicting everything releases every committed wasm tile.
+    queue.evictAll()
+    expect( new Set( released ) ).toEqual( new Set( committed ) )
+  } )
+} )

--- a/src/ifc/ifc_tile_extractor.ts
+++ b/src/ifc/ifc_tile_extractor.ts
@@ -68,11 +68,21 @@ export class IfcTileAssetExtractor implements TileAssetExtractor {
   }
 
   /**
-   * The assets (produced meshes) for a product, extracting it on first ask.
+   * The assets (meshes) a product references, extracting it on first ask.
+   *
+   * Attribution walks the product's **representation-item closure**
+   * (recursing through mapped items into their shared source
+   * representations) and claims every item that has an extracted mesh —
+   * NOT a before/after diff of the mesh set. The distinction is the
+   * mapped-item case: a shared source's meshes already exist when the
+   * second product asks, so a diff would omit them and its tile would not
+   * hold references to geometry it renders. Closure attribution is
+   * extraction-order independent.
    *
    * @param productLocalID The product's local ID.
-   * @return {GeometryAsset<number>[]} One asset per produced mesh, keyed by
-   * the mesh's representation-item localID, sized at exact reified cost.
+   * @return {GeometryAsset<number>[]} One asset per referenced mesh, keyed
+   * by the mesh's representation-item localID (shared across products for
+   * mapped sources), sized at exact reified cost.
    */
   public assetsOf( productLocalID: number ): GeometryAsset<number>[] {
 
@@ -82,31 +92,17 @@ export class IfcTileAssetExtractor implements TileAssetExtractor {
       return cached
     }
 
-    const geometry = this.extraction_.model.geometry
-
-    // Snapshot existing mesh keys so this product's contribution is the
-    // difference. O(meshes) per first ask — acceptable for the demand path;
-    // an extraction-side "produced meshes" report can replace it if
-    // profiling ever flags it.
-    const before = new Set<number>()
-
-    for ( const mesh of geometry ) {
-      before.add( mesh.localID )
-    }
-
     this.extraction_.extractProductGeometryByLocalID( productLocalID )
 
+    const geometry = this.extraction_.model.geometry
     const assets: GeometryAsset<number>[] = []
 
-    for ( const mesh of geometry ) {
+    for ( const itemLocalID of this.representationItemIDs_( productLocalID ) ) {
 
-      if ( before.has( mesh.localID ) ) {
-        continue
-      }
+      const mesh = geometry.getByLocalID( itemLocalID )
 
-      const wasmGeometry =
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ( mesh as any ).geometry
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wasmGeometry = ( mesh as any )?.geometry
 
       if ( wasmGeometry === void 0 ||
         typeof wasmGeometry.GetVertexDataSize !== 'function' ) {
@@ -117,12 +113,63 @@ export class IfcTileAssetExtractor implements TileAssetExtractor {
         wasmGeometry.GetVertexDataSize() * FLOAT_BYTES +
         wasmGeometry.GetIndexDataSize() * INDEX_BYTES
 
-      assets.push( { assetID: mesh.localID, byteSize } )
+      assets.push( { assetID: itemLocalID, byteSize } )
     }
 
     this.assetsByProduct_.set( productLocalID, assets )
 
     return assets
+  }
+
+  /**
+   * The localIDs of every representation item in a product's Body /
+   * Facetation representations, recursing through mapped items into their
+   * (shared) source representations — the key space extraction stores
+   * meshes under.
+   *
+   * @param productLocalID The product's local ID.
+   * @return {Set<number>} The representation-item localIDs.
+   */
+  private representationItemIDs_( productLocalID: number ): Set<number> {
+
+    const ids = new Set<number>()
+    const element = this.extraction_.model.getElementByLocalID( productLocalID )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const representations = ( element as any )?.Representation?.Representations
+
+    if ( representations === void 0 || representations === null ) {
+      return ids
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const addItems = ( items: any[] ): void => {
+      for ( const item of items ) {
+
+        ids.add( item.localID )
+
+        // Mapped item: recurse into the shared source representation.
+        const source = item.MappingSource?.MappedRepresentation?.Items
+
+        if ( source !== void 0 && source !== null ) {
+          addItems( source )
+        }
+      }
+    }
+
+    for ( const representation of representations ) {
+
+      const identifier = representation.RepresentationIdentifier
+
+      if ( identifier !== null && identifier !== 'Body' &&
+        identifier !== 'Facetation' ) {
+        continue
+      }
+
+      addItems( representation.Items )
+    }
+
+    return ids
   }
 
   /**

--- a/src/ifc/ifc_tile_extractor.ts
+++ b/src/ifc/ifc_tile_extractor.ts
@@ -1,0 +1,150 @@
+import {
+  GeometryTilePoolBindings,
+  TileAssetExtractor,
+} from '../core/geometry_tile_bindings'
+import { GeometryAsset } from '../core/geometry_tile_pool'
+import { IfcGeometryExtraction } from './ifc_geometry_extraction'
+
+
+/**
+ * The wasm module surface the extractor commits through: the tile pool
+ * bindings plus the Geometry-taking commit (embind `commitGeometryTile`,
+ * which serialises a reified Geometry's payload straight into pool chunks).
+ */
+export interface TileCommitBindings extends GeometryTilePoolBindings {
+
+  /**
+   * Commit a reified geometry's payload into the wasm tile pool.
+   *
+   * @param assetID The tile's asset id.
+   * @param geometry The wasm Geometry object (reified on access).
+   * @return {boolean} True on success.
+   */
+  commitGeometryTile( assetID: number, geometry: unknown ): boolean
+}
+
+
+// Reified payload framing: 8-byte header + float vertex data + u32 indices
+// (tile_pool_api.h layout).
+const TILE_HEADER_BYTES = 8
+const FLOAT_BYTES = 4
+const INDEX_BYTES = 4
+
+
+/**
+ * The production {@link TileAssetExtractor} (Phase B3): drives the
+ * per-product demand extraction seam (Phase B2) and commits the resulting
+ * meshes into the wasm tile pool.
+ *
+ * Asset identity: one asset per produced **mesh**, keyed by the mesh's
+ * localID (the representation item). Mapped items reuse representation
+ * geometry across products, so shared representations become shared assets —
+ * the sharing the pools refcount.
+ *
+ * Contract notes:
+ * - `assetsOf` runs the (expensive) per-product extraction on first call and
+ *   caches the asset list; sizes are exact reified byte costs, so the TS
+ *   accounting layer admits with real numbers. This front-loads cost into
+ *   `assetsOf` by design — see `GeometryTilePool.extract`'s pricing pass.
+ * - `materialize` commits an already-extracted mesh into the pool;
+ *   `discard` releases the wasm tile. The CPU-side canonical mesh is left in
+ *   place in this phase (serving uploads from tiles — and dropping the fat
+ *   working geometry — is the Phase C flip).
+ */
+export class IfcTileAssetExtractor implements TileAssetExtractor {
+
+  /** Product localID → its assets, cached after first extraction. */
+  private readonly assetsByProduct_ = new Map<number, GeometryAsset<number>[]>()
+
+  /**
+   * @param extraction_ The geometry extraction (its model provides meshes).
+   * @param bindings_ The wasm tile pool surface to commit through.
+   */
+  constructor(
+    private readonly extraction_: IfcGeometryExtraction,
+    private readonly bindings_: TileCommitBindings ) {
+
+    this.extraction_.prepareDemandExtraction()
+  }
+
+  /**
+   * The assets (produced meshes) for a product, extracting it on first ask.
+   *
+   * @param productLocalID The product's local ID.
+   * @return {GeometryAsset<number>[]} One asset per produced mesh, keyed by
+   * the mesh's representation-item localID, sized at exact reified cost.
+   */
+  public assetsOf( productLocalID: number ): GeometryAsset<number>[] {
+
+    const cached = this.assetsByProduct_.get( productLocalID )
+
+    if ( cached !== void 0 ) {
+      return cached
+    }
+
+    const geometry = this.extraction_.model.geometry
+
+    // Snapshot existing mesh keys so this product's contribution is the
+    // difference. O(meshes) per first ask — acceptable for the demand path;
+    // an extraction-side "produced meshes" report can replace it if
+    // profiling ever flags it.
+    const before = new Set<number>()
+
+    for ( const mesh of geometry ) {
+      before.add( mesh.localID )
+    }
+
+    this.extraction_.extractProductGeometryByLocalID( productLocalID )
+
+    const assets: GeometryAsset<number>[] = []
+
+    for ( const mesh of geometry ) {
+
+      if ( before.has( mesh.localID ) ) {
+        continue
+      }
+
+      const wasmGeometry =
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ( mesh as any ).geometry
+
+      if ( wasmGeometry === void 0 ||
+        typeof wasmGeometry.GetVertexDataSize !== 'function' ) {
+        continue
+      }
+
+      const byteSize = TILE_HEADER_BYTES +
+        wasmGeometry.GetVertexDataSize() * FLOAT_BYTES +
+        wasmGeometry.GetIndexDataSize() * INDEX_BYTES
+
+      assets.push( { assetID: mesh.localID, byteSize } )
+    }
+
+    this.assetsByProduct_.set( productLocalID, assets )
+
+    return assets
+  }
+
+  /**
+   * Commit one extracted mesh into the wasm tile pool.
+   *
+   * @param assetID The mesh (representation item) localID.
+   */
+  public extractIntoTile( assetID: number ): void {
+
+    const mesh = this.extraction_.model.geometry.getByLocalID( assetID )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wasmGeometry = ( mesh as any )?.geometry
+
+    if ( wasmGeometry === void 0 ) {
+      throw new Error( `No extracted mesh for asset ${assetID}` )
+    }
+
+    if ( !this.bindings_.commitGeometryTile( assetID, wasmGeometry ) ) {
+      throw new Error(
+          `Wasm tile commit failed for asset ${assetID} — ` +
+          'the scheduler budget must not exceed the pool budget' )
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,3 +30,38 @@ export {
   formatSeconds,
   stageLabel,
 } from './core/progress_log'
+
+// --- Streaming / demand-geometry surface (epic #390; design doc
+// design/new/streaming-federated-loader.md). The release-facing API for
+// fixed-memory opens and demand-driven residency.
+export { openStreamedIfcModel, StreamedIfcOpen, StreamedIfcOpenOptions } from './ifc/ifc_stream_open'
+export { ByteSource, BufferByteSource } from './step/parsing/byte_source'
+export {
+  StepExternalByteStore,
+  InMemoryStepByteStore,
+  StepBufferProvider,
+  WindowedStepBufferProvider,
+} from './step/step_buffer_provider'
+export { StepIndexColumns } from './step/parsing/columnar_index'
+export {
+  serializeIndexSidecarFromColumns,
+  deserializeIndexSidecarToColumns,
+  sidecarMatchesSource,
+  hashSource,
+} from './step/parsing/index_sidecar'
+export { StreamingRecordDispatcher, RecordHandler } from './step/parsing/streaming_record_dispatcher'
+export { IncrementalTypeIndex } from './step/parsing/incremental_type_index'
+export { DemandGeometryQueue, GeometryTiles, DemandQueueStats } from './core/demand_geometry_queue'
+export { DemandResidencyPump, ResidencyPrefetcher, PumpResult } from './core/demand_residency_pump'
+export {
+  GeometryTilePoolBindings,
+  TileAssetExtractor,
+  WasmTileBackend,
+  createWasmTileBackend,
+  readGeometryTilePayload,
+  GeometryTilePayload,
+} from './core/geometry_tile_bindings'
+export { IfcTileAssetExtractor, TileCommitBindings } from './ifc/ifc_tile_extractor'
+export { ChunkedPool, ChunkSpan } from './core/mem/chunked_pool'
+export { SharedAssetPool } from './core/mem/shared_asset_pool'
+export { GeometryTilePool, InstanceAssetSource, GeometryAsset } from './core/geometry_tile_pool'


### PR DESCRIPTION
**Reconciliation PR — merge this and the release chain is complete.**

The #413/#414/#415 merges ran **top-down**: #413 landed Phase B on `main`, but #414 then merged into the `claude/stream-phase-b` *branch* and #415 into the `claude/stream-phase-b2` *branch* — so B2 (per-product demand extraction) and B3 (tile extractor + `openStreamedIfcModel` + package exports) cascaded into the side branches instead of main. (Stacked chains need bottom-up merging, as with the earlier #402→#401 pattern; my sequencing note should have been louder.)

Nothing was lost: this branch's tip contains exactly the B2 + B3 content as reviewed (including the two review fixes `3f803f7` — already on main via #413 — and `a2847c4`, the mapped-item attribution fix). **Verified to merge clean into main locally** (no conflicts: the reconciled commits touch disjoint files).

The diff of this PR against main is precisely the reviewed B2 + B3 increments:
- per-product demand extraction (deduplicated product body + parity tests, visual-diffs already blessed on #414),
- `IfcTileAssetExtractor` (closure attribution), `openStreamedIfcModel`, package exports, full-composition tests.

Merging this into `main` (normal merge) completes what #414/#415 were meant to land; the auto-publish on main then mints the release Share bumps to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_