### PR TITLE
Add OpenModelStreamed: columnar streamed open through the web-ifc shim

### DIFF
--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -269,6 +269,46 @@ export class IfcAPI {
   }
 
   /**
+   * Streamed-open variant of OpenModelAsync (conway extension;
+   * feature-detect with typeof api.OpenModelStreamed === 'function').
+   * IFC input parses through the streaming columnar indexer, so the
+   * model's record index is columnar from birth and the classic
+   * per-record object phase — the dominant JS-heap cost of parsing
+   * large models — never exists. Everything downstream is identical to
+   * OpenModelAsync: same cooperative geometry extraction, same
+   * meshes/properties surface, and SpillModelSource works afterwards
+   * as usual.
+   *
+   * Never does worse than OpenModelAsync: non-IFC formats and any
+   * streamed-parse failure fall back to the classic path internally,
+   * so -1 here means the classic open would have failed too.
+   *
+   * @param data containing IFC data (bytes)
+   * @param settings settings for loading the model
+   * @return {Promise<number>} model ID
+   */
+  async OpenModelStreamed(data: Uint8Array, settings?: Loadersettings): Promise<number> {
+
+    // Reserve the ID before the first await — see OpenModelAsync.
+    const modelIdResult = this.globalModelIDCounter++
+
+    const result =
+      await IfcApiModelPassthroughFactory.fromStreamed(
+          modelIdResult,
+          data,
+          this.wasmModule,
+          settings)
+
+    if ( result === void 0 ) {
+      return -1
+    }
+
+    this.models.set( modelIdResult, result )
+
+    return modelIdResult
+  }
+
+  /**
    * Set conway's console-echo log threshold, web-ifc compatible surface
    * (numeric LogLevel enum). Embedders (e.g. Share) use this to quiet a
    * clean load's console down to warnings/errors — conway issue #301.

--- a/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
@@ -99,6 +99,48 @@ export class IfcApiModelPassthroughFactory {
   }
 
   /**
+   * Streamed-open twin of fromAsync (used by OpenModelStreamed): IFC
+   * models parse through the streaming columnar indexer (no per-record
+   * object phase — see IfcApiProxyIfc.createStreamed); everything else
+   * behaves like fromAsync. Non-IFC formats and any streamed-open
+   * failure fall back to the classic cooperative path, so this never
+   * does worse than fromAsync — the safety net behind embedder
+   * feature flags.
+   *
+   * @param modelID
+   * @param data
+   * @param wasmModule
+   * @param settings
+   * @return {Promise<IfcApiModelPassthrough | undefined>}
+   */
+  public static async fromStreamed(
+      modelID: number,
+      data: Uint8Array,
+      wasmModule: any,
+      settings?: Loadersettings ): Promise<IfcApiModelPassthrough | undefined> {
+
+    const modelFormat = ModelFormatDetector.detect( new ParsingBuffer( data ) )
+
+    if ( modelFormat === ModelFormatType.IFC ) {
+
+      try {
+
+        return await IfcApiProxyIfc.createStreamed(modelID, data, wasmModule, settings)
+
+      } catch ( e ) {
+
+        const message = e instanceof Error ? e.message : String( e )
+
+        Logger.warning(
+            `Streamed open failed for model ${modelID}, ` +
+            `falling back to classic open: ${message}`)
+      }
+    }
+
+    return IfcApiModelPassthroughFactory.fromAsync(modelID, data, wasmModule, settings)
+  }
+
+  /**
    * Cooperative twin of from() (used by OpenModelAsync): the data parse
    * runs with periodic event-loop yields so progress UI can repaint
    * (issue #301 §2) for IFC and AP214/AP203/AP242 alike. IFC geometry

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -26,6 +26,10 @@ import { formatModelLine } from '../../core/progress_log'
 import { extractModelInfo } from '../../loaders/loading_utilities'
 import IfcStepParser from '../../ifc/ifc_step_parser'
 import ParsingBuffer from '../../parsing/parsing_buffer'
+import { BufferByteSource } from '../../step/parsing/byte_source'
+import {
+  buildColumnarIndexStreaming,
+} from '../../step/parsing/streaming_index_builder'
 import { StepHeader } from '../../step/parsing/step_parser'
 import { ExtractResult } from '../../index'
 import { IfcGeometryExtraction } from '../../ifc/ifc_geometry_extraction'
@@ -36,6 +40,12 @@ import { shimIfcEntityMap, shimIfcEntityReverseMap } from './shim_schema_mapping
 import { EntityTypesIfcCount } from '../../ifc/ifc4_gen/entity_types_ifc.gen'
 import { IfcProduct, IfcRoot } from '../../ifc/ifc4_gen'
 import { CanonicalMeshType } from '../../index'
+
+/* Moving-window size for the streamed columnar parse (matches the
+ * ifc_stream_open default; the window bounds parse-time scratch, not
+ * the source buffer, which the model keeps resident here). */
+// eslint-disable-next-line no-magic-numbers
+const STREAMED_PARSE_POOL_BYTES = 1024 * 1024
 
 /**
  * Everything parse/extraction produces that the proxy constructor's tail
@@ -265,6 +275,34 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       settings?: Loadersettings ): Promise<IfcApiProxyIfc> {
 
     const loadState = await IfcApiProxyIfc.parseAndExtractAsync(
+        modelID, data, new ConwayGeometry(wasmModule), settings)
+
+    return new IfcApiProxyIfc(modelID, data, wasmModule, settings, loadState)
+  }
+
+  /**
+   * Streamed-open construction (conway extension, used by
+   * OpenModelStreamed): the parse runs through the streaming columnar
+   * indexer, so the model's index is columnar from birth and the
+   * per-record object phase — the dominant JS-heap cost of the classic
+   * parse on large models — never exists. Geometry extraction is the
+   * same cooperative path OpenModelAsync uses, and everything
+   * downstream (meshes, properties, SpillModelSource) behaves
+   * identically to a classic open.
+   *
+   * @param modelID The model ID being opened.
+   * @param data The IFC data buffer.
+   * @param wasmModule The wasm module.
+   * @param settings Loader settings (ON_PROGRESS is honored).
+   * @return {Promise<IfcApiProxyIfc>} The constructed proxy.
+   */
+  public static async createStreamed(
+      modelID: number,
+      data: Uint8Array,
+      wasmModule: any,
+      settings?: Loadersettings ): Promise<IfcApiProxyIfc> {
+
+    const loadState = await IfcApiProxyIfc.parseColumnarAndExtractAsync(
         modelID, data, new ConwayGeometry(wasmModule), settings)
 
     return new IfcApiProxyIfc(modelID, data, wasmModule, settings, loadState)
@@ -507,6 +545,117 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     if (extractionResult !== ExtractResult.COMPLETE) {
       Logger.error('[OpenModel]: Error extracting geometry, exiting...')
+      statistics?.setLoadStatus('FAIL')
+      throw new Error( 'Couldn\'t extract model' )
+    }
+
+    statistics?.setProductCount(model.typeCount(IfcProduct))
+    statistics?.setGeometryTypeCounts(conwayGeometry.geometryTypeCounts)
+
+    return {
+      conwaywasm,
+      allTimeStart,
+      stepHeader,
+      model,
+      scene,
+      conwayGeometry,
+      geometryTimeInMs: endTime - startTime,
+    }
+  }
+
+  /**
+   * Streamed twin of parseAndExtractAsync: the data parse runs through
+   * the streaming columnar indexer over a moving window instead of the
+   * per-record object parse, so the index is columnar from birth (no
+   * object phase). The source buffer stays resident behind the model —
+   * extraction and synchronous property reads behave exactly like a
+   * classic open, and `spillSourceToExternalStore` works afterwards as
+   * usual.
+   *
+   * The columnar build is a single synchronous pass (no mid-parse
+   * yields yet), so the 'dataParse' progress phase reports its
+   * boundaries without intermediate ticks; extraction remains
+   * cooperative. Throws when the streamed parse is anything but
+   * COMPLETE — the caller (OpenModelStreamed) falls back to the
+   * classic path, which tolerates recoverable parses.
+   *
+   * @param modelID The model ID being opened.
+   * @param data The IFC data buffer.
+   * @param conwaywasm The conway geometry wasm wrapper.
+   * @param settings Loader settings (ON_PROGRESS is honored).
+   * @return {Promise<IfcProxyLoadState>} Everything the constructor tail needs.
+   */
+  private static async parseColumnarAndExtractAsync(
+      modelID: number,
+      data: Uint8Array,
+      conwaywasm: ConwayGeometry,
+      settings?: Loadersettings ): Promise<IfcProxyLoadState> {
+
+    const tracker = IfcApiProxyIfc.makeTracker(settings)
+
+    const allTimeStart = Date.now()
+    const parser = IfcStepParser.Instance
+    const bufferInput = new ParsingBuffer(data)
+
+    tracker?.beginPhase('headerParse', 'bytes', data.length)
+
+    // Header parsed standalone first so the model line fires before the
+    // full parse, exactly like the classic path (the columnar build
+    // re-reads the tiny header internally; the cost is negligible).
+    const [stepHeader, result0] = parser.parseHeader(bufferInput)
+
+    Logger.createStatistics(modelID)
+
+    const statistics = Logger.getStatistics(modelID)
+
+    IfcApiProxyIfc.reportHeaderParseResult(result0, bufferInput, modelID)
+
+    const modelInfo = extractModelInfo(stepHeader, data.length)
+
+    Logger.info(formatModelLine(modelInfo))
+    settings?.ON_MODEL_INFO?.(modelInfo)
+
+    tracker?.beginPhase('dataParse', 'bytes', data.length)
+
+    const parseStartTime = Date.now()
+
+    const { columns, result } = buildColumnarIndexStreaming(
+        new BufferByteSource(data), parser, STREAMED_PARSE_POOL_BYTES)
+
+    const parseEndTime = Date.now()
+
+    tracker?.endPhase(data.length)
+
+    if (result !== ParseResult.COMPLETE) {
+      Logger.warning(`[OpenModelStreamed]: streamed parse result ${result}`)
+      statistics?.setLoadStatus('PARSE_FAIL')
+      throw new Error( 'Streamed parse did not complete' )
+    }
+
+    const model = new IfcStepModel(data, columns)
+
+    statistics?.setParseTime(parseEndTime - parseStartTime)
+
+    const conwayGeometry = new IfcGeometryExtraction(conwaywasm, model)
+
+    tracker?.beginPhase('geometry', 'products')
+
+    const geometryTick = tracker !== void 0 ?
+      (completed: number, total: number) => {
+        tracker.setPhaseTotal(total)
+        tracker.update(completed)
+      } : void 0
+
+    const startTime = Date.now()
+    const [extractionResult, scene] =
+      await conwayGeometry.extractIFCGeometryDataAsync(geometryTick)
+
+    const endTime = Date.now()
+
+    tracker?.endPhase()
+
+    if (extractionResult !== ExtractResult.COMPLETE) {
+      Logger.error('[OpenModelStreamed]: Error extracting geometry, exiting...')
       statistics?.setLoadStatus('FAIL')
       throw new Error( 'Couldn\'t extract model' )
     }

--- a/src/compat/web-ifc/ifc_api_streamed_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_streamed_open.test.ts
@@ -1,0 +1,145 @@
+/* eslint-disable no-magic-numbers */
+// Integration tests for OpenModelStreamed (streamed columnar open).
+//
+// Parity requirement: a model opened through the streaming columnar
+// indexer must be indistinguishable downstream from a classic
+// OpenModel — same meshes (ids, placements, colors), same property
+// reads, same spatial structure — and SpillModelSource must work
+// afterwards exactly as it does on a classic open. The fallback
+// contract (never worse than OpenModelAsync) is pinned via a factory
+// spy: a successful streamed open must not have silently taken the
+// classic path.
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, jest, test } from '@jest/globals'
+
+import { InMemoryStepByteStore } from '../../step/step_buffer_provider'
+import { FlatMesh, IfcAPI } from './ifc_api'
+import { IfcApiModelPassthroughFactory } from './ifc_api_model_passthrough_factory'
+
+const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
+
+let api: IfcAPI
+let buffer: Uint8Array
+
+/**
+ * Capture StreamAllMeshes output as plain comparable objects.
+ *
+ * @param modelID The model to stream.
+ * @return {object[]} One entry per mesh with its placed geometries.
+ */
+function captureMeshes( modelID: number ): object[] {
+
+  const captured: object[] = []
+
+  api.StreamAllMeshes( modelID, ( mesh: FlatMesh ) => {
+
+    const geometries: object[] = []
+
+    for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+
+      const placed = mesh.geometries.get( where )
+
+      geometries.push( {
+        color: placed.color,
+        geometryExpressID: placed.geometryExpressID,
+        flatTransformation: [ ...placed.flatTransformation ],
+      } )
+    }
+
+    captured.push( { expressID: mesh.expressID, geometries } )
+  } )
+
+  return captured
+}
+
+beforeAll( async () => {
+  api = new IfcAPI()
+  await api.Init()
+
+  buffer = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+}, 120000 )
+
+describe( 'OpenModelStreamed', () => {
+
+  test( 'meshes and properties match a classic OpenModel exactly', async () => {
+
+    const fallback = jest.spyOn( IfcApiModelPassthroughFactory, 'fromAsync' )
+
+    const streamedID = await api.OpenModelStreamed( buffer, SETTINGS )
+
+    // A successful streamed open must be the streamed path, not a
+    // silent fallback (which would make the parity below vacuous).
+    expect( streamedID ).toBeGreaterThanOrEqual( 0 )
+    expect( fallback ).not.toHaveBeenCalled()
+    fallback.mockRestore()
+
+    const classicID = api.OpenModel( buffer, SETTINGS )
+
+    expect( classicID ).toBeGreaterThanOrEqual( 0 )
+
+    // Mesh parity: ids, placements, colors.
+    expect( captureMeshes( streamedID ) ).toEqual( captureMeshes( classicID ) )
+
+    // Property parity across every record.
+    const classicPassthrough = api.getPassthrough( classicID )!
+    const lineIDs = classicPassthrough.getAllLines()
+
+    expect( lineIDs.size() ).toBeGreaterThan( 10 )
+    expect( api.getPassthrough( streamedID )!.getAllLines().size() )
+        .toBe( lineIDs.size() )
+
+    for ( let where = 0; where < lineIDs.size(); ++where ) {
+
+      const expressID = lineIDs.get( where )
+
+      expect( await api.properties.getItemProperties( streamedID, expressID ) )
+          .toEqual( await api.properties.getItemProperties( classicID, expressID ) )
+    }
+
+    // Spatial structure parity (names mode — Share's consumption).
+    expect( await api.properties.getSpatialStructure( streamedID, 'names' ) )
+        .toEqual( await api.properties.getSpatialStructure( classicID, 'names' ) )
+
+    api.CloseModel( streamedID )
+    api.CloseModel( classicID )
+  }, 240000 )
+
+  test( 'SpillModelSource works after a streamed open', async () => {
+
+    const modelID = await api.OpenModelStreamed( buffer, SETTINGS )
+    const passthrough = api.getPassthrough( modelID )!
+
+    // Snapshot a spread of records through the resident path.
+    const lineIDs = passthrough.getAllLines()
+    const sampled = new Map<number, unknown>()
+
+    for ( let where = 0; where < lineIDs.size(); where += 7 ) {
+
+      const expressID = lineIDs.get( where )
+
+      sampled.set( expressID, await api.properties.getItemProperties( modelID, expressID ) )
+    }
+
+    // Tiny windows force straddles + LRU eviction on the fixture.
+    const spilled = api.SpillModelSource(
+        modelID, new InMemoryStepByteStore( buffer ), 512, 3 )
+
+    expect( spilled ).toBe( true )
+
+    for ( const [ expressID, expected ] of sampled ) {
+
+      expect( await api.properties.getItemProperties( modelID, expressID ) )
+          .toEqual( expected )
+    }
+
+    api.CloseModel( modelID )
+  }, 240000 )
+
+  test( 'unparseable input returns -1 (streamed and fallback both refuse)', async () => {
+
+    const garbage = new Uint8Array( [ 0, 1, 2, 3, 42, 255, 254, 253 ] )
+
+    expect( await api.OpenModelStreamed( garbage, SETTINGS ) ).toBe( -1 )
+  }, 120000 )
+} )


### PR DESCRIPTION
## What

The shim entry Share needs to consume the streaming work (epic #390): `IfcAPI.OpenModelStreamed(data, settings): Promise<number>`.

IFC input parses through the streaming columnar indexer (`buildColumnarIndexStreaming`, M7/#409), so the model's record index is **columnar from birth** and the classic per-record object phase — the dominant JS-heap cost of parsing large models (~100MB+ retained on a 1M-record model; several× that on PSB-class files) — never exists. The source buffer stays resident behind the model, geometry extraction is the same cooperative path `OpenModelAsync` uses (yields for progress UI), and everything downstream — `StreamAllMeshes`, properties, spatial structure, `SpillModelSource` — behaves identically to a classic open.

## Safety contract

`OpenModelStreamed` **never does worse than `OpenModelAsync`**: non-IFC formats (AP214/AP203/AP242) and any streamed-open failure fall back to the classic cooperative path inside `IfcApiModelPassthroughFactory.fromStreamed`, so a `-1` means the classic open would have failed too. This is the runtime safety net beneath embedder feature flags (Share's `streamOpen` flag branches on this entry; the flag reverts the call site, the fallback guards the streamed path itself).

## Scope note

This integration keeps the source buffer resident until the embedder's existing `SpillModelSource` step (unchanged), and whole-model extraction (unchanged). The windowed-from-birth + demand-extraction pipeline (Phase B pump + tile pools) is the next Share milestone — it needs renderer-side changes and is deliberately not part of this flag flip.

## Tests

`src/compat/web-ifc/ifc_api_streamed_open.test.ts` (real wasm, `data/index.ifc`):
- **Mesh parity** with a classic `OpenModel`: ids, placements (flat transformations), colors — exact `toEqual`.
- **Property parity** across every record (`getItemProperties` sweep) + spatial structure (`names` mode, Share's consumption).
- **Fallback pinning**: a successful streamed open must not have silently taken the classic path (factory spy), so the parity assertions can't pass vacuously.
- **Spill-after-streamed-open**: `SpillModelSource` with tiny windows (straddles + LRU eviction), property reads identical after.
- **Unparseable input** returns `-1` (both paths refuse).

Full compat suite locally: 7 suites, 34/34 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_