### PR TITLE
Fix MT pthread worker spawn in isolated web contexts (Share #1610)

### DIFF
--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -1,4 +1,5 @@
 import { ConwayGeometry, FileHandlerFunction as FileHandlerCallback,
+  setModulePrefix,
  } from '../../index'
 import {versionString} from '../../version/version'
 import Logger, { LogLevel as ConwayLogLevel } from '../../logging/logger'
@@ -70,6 +71,39 @@ const CONWAY_LOG_LEVEL_BY_WEBIFC: Record<LogLevel, ConwayLogLevel> = {
   [LogLevel.LOG_LEVEL_WARN]: ConwayLogLevel.WARNING,
   [LogLevel.LOG_LEVEL_ERROR]: ConwayLogLevel.ERROR,
   [LogLevel.LOG_LEVEL_OFF]: ConwayLogLevel.OFF,
+}
+
+// The directory conway-geom's web init locates wasm from when no
+// embedder path is configured — also the conventional serve location
+// (Share copies Dist/* there at build time).
+const DEFAULT_WEB_WASM_DIRECTORY = '/static/js/'
+
+/**
+ * Normalize an embedder wasm directory (the SetWasmPath value) to the
+ * absolute site path the web engine modules are served from — the
+ * runtime module prefix isolated (multithreaded) contexts import the
+ * engine from. Web wasm paths are site-root-relative by convention
+ * ('./static/js/'); missing input falls back to the same '/static/js/'
+ * directory conway-geom's web init already uses to locate wasm.
+ *
+ * @param wasmPath The embedder-configured wasm directory, if any.
+ * @return {string} Absolute directory with a trailing slash.
+ */
+export function webWasmDirectory(wasmPath: string | undefined): string {
+
+  let directory = wasmPath ?? ''
+
+  if (directory === '') {
+    return DEFAULT_WEB_WASM_DIRECTORY
+  }
+
+  if (directory.startsWith('./')) {
+    directory = directory.substring(1)
+  } else if (!directory.startsWith('/')) {
+    directory = `/${directory}`
+  }
+
+  return directory.endsWith('/') ? directory : `${directory}/`
 }
 
 export interface Vector<T> {
@@ -178,6 +212,20 @@ export class IfcAPI {
     Environment.checkEnvironment()
     Logger.initializeWasmCallbacks()
     Logger.info(versionString)
+
+    // Cross-origin-isolated web contexts select the multithreaded wasm,
+    // whose pthread workers resolve their worker script from the engine
+    // module's own import.meta.url. A bundler-inlined copy of the glue
+    // gives workers a wrong URL (the worker script 404s and MT init dies
+    // with a bare error Event — Share #1610). Setting a runtime module
+    // prefix makes conway-geom import the engine module from the
+    // directory it is actually served from, so import.meta.url — and
+    // therefore the worker script URL — is correct. Web wasm paths are
+    // site-root-relative by convention; no-op outside isolated windows.
+    if (typeof window !== 'undefined' &&
+        (window as { crossOriginIsolated?: boolean }).crossOriginIsolated === true) {
+      setModulePrefix(webWasmDirectory(this.wasmPath))
+    }
     const locateFileHandler: LocateFileHandlerFn = (path, prefix) => {
       // when the wasm module requests the wasm file, we redirect to include the user specified path
       if (path.endsWith('.wasm')) {

--- a/src/compat/web-ifc/web_wasm_directory.test.ts
+++ b/src/compat/web-ifc/web_wasm_directory.test.ts
@@ -1,0 +1,27 @@
+// The wasm-directory normalization behind the isolated-context module
+// prefix (Share #1610): embedder SetWasmPath values are site-root-
+// relative by convention and must come out as absolute directories,
+// since they become runtime dynamic-import prefixes whose resolution
+// must not depend on the page or bundle URL (the pthread worker script
+// URL derives from the imported module's import.meta.url).
+import { describe, expect, test } from '@jest/globals'
+
+import { webWasmDirectory } from './ifc_api'
+
+describe( 'webWasmDirectory', () => {
+
+  test( 'site-root-relative convention absolutizes', () => {
+    expect( webWasmDirectory( './static/js/' ) ).toBe( '/static/js/' )
+    expect( webWasmDirectory( 'static/js/' ) ).toBe( '/static/js/' )
+  } )
+
+  test( 'absolute paths pass through with a trailing slash ensured', () => {
+    expect( webWasmDirectory( '/static/js/' ) ).toBe( '/static/js/' )
+    expect( webWasmDirectory( '/wasm' ) ).toBe( '/wasm/' )
+  } )
+
+  test( 'missing input falls back to the conventional serve directory', () => {
+    expect( webWasmDirectory( undefined ) ).toBe( '/static/js/' )
+    expect( webWasmDirectory( '' ) ).toBe( '/static/js/' )
+  } )
+} )

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 export { ParseResult } from './step/parsing/step_parser'
 export { IfcGeometryExtraction } from './ifc/ifc_geometry_extraction'
 export { IfcPropertyExtraction } from './ifc/ifc_property_extraction'
-export { ConwayGeometry, GeometryObject, FileHandlerFunction} from '../dependencies/conway-geom'
+export {
+  ConwayGeometry,
+  GeometryObject,
+  FileHandlerFunction,
+  setModulePrefix,
+} from '../dependencies/conway-geom'
 export { versionString } from './version/version'
 // Replace your current Logger export with this
 export { default as Logger, LogLevel, LogEntry, LoggingProxy, LogSink } from './logging/logger'


### PR DESCRIPTION
## What

First real-world run of the web MT wasm (bldrs-ai/Share#1612's isolated deploy preview) failed with `worker sent an error! undefined:undefined: undefined` — a bare error `Event`, i.e. the pthread **worker script failed to load**, not a runtime crash.

**Root cause**: this emscripten's ES-module glue spawns workers as `new Worker(new URL("ConwayGeomWasmWebMT.js", import.meta.url), {type:"module"})` and **ignores `mainScriptUrlOrBlob` completely** (zero occurrences in the emitted glue — the `/static/js/` config in `conway_geometry`'s web init is dead code). When a bundler (Share's esbuild) inlines the engine module, `import.meta.url` points at the bundle, so the worker URL resolves to a path that doesn't exist → the worker dies on load.

**Fix**: on shim `Init` in a cross-origin-isolated window, set conway-geom's existing runtime module prefix (`setModulePrefix`) so the engine module is *dynamically imported at runtime* from the directory it's actually served from — the embedder's `SetWasmPath` directory normalized from the site-root-relative convention (`'./static/js/'` → `'/static/js/'`; default matches the web init's existing hard-coded wasm location). The runtime import can't be inlined by bundlers (conway-geom's `dynamicImport` is a `new Function` indirection), so `import.meta.url` — and therefore the worker script URL — is correct.

**Blast radius**: no-op outside isolated windows. Current production (non-isolated → single-threaded, bundled glue) is untouched; only the currently-broken isolated path changes.

Also exports `setModulePrefix` from the root for embedder control.

## Tests

- `webWasmDirectory` normalization pinned (`./static/js/` → `/static/js/`, bare → absolute, trailing slash, default fallback).
- Compat suites green (streamed open, smoke). The isolated-worker path itself is browser-only — verified on the Share #1612 preview after this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_