### PR TITLE
Design addendum + deferred streamed open / ExtractGeometryBatch (demand rendering slice A)

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -679,3 +679,36 @@ implementation a later arc):
   `design/new/step-regression.md`
 - Compat surface these APIs land on: `design/new/web-ifc-compat-surface.md`
 - Share consumers & product goals: [Share `design/new/lazy-properties-memory.md`](https://github.com/bldrs-ai/Share/blob/main/design/new/lazy-properties-memory.md)
+
+
+## Status addendum — 2026-07-21 (post-launch + browser-MT spike)
+
+**Shipped and launched.** The parse/index plane (M0–M2, M4, M7) and the
+demand machinery (M3, mem system, C++ TilePool + bindings, per-product
+extraction seam, `IfcTileAssetExtractor`, residency pump) are merged and
+released. Share consumes the streamed columnar open in production
+(default-on `OpenModelStreamed` via the compat shim, `disableStreamOpen`
+revert). Packaging landed as plane namespaces —
+`@bldrs-ai/conway/stream`, `/demand`, `/mem` — with the shim reframed as
+a retiring adapter. PSB (860 MB, 9.7 M records) measured on the shipped
+path: parse 13.4 s / +376 MB where the object phase used to blow up the
+heap; whole clean-tab load 52.6 s.
+
+**Browser-MT finding (Share #1610, conway-geom #148).** The assumption
+that flipping cross-origin isolation would buy ~2.8× on load-time
+geometry is refuted for the browser: profiled on PSB, that phase is
+~75 % serial JS extraction driver (record deserialization, parameter
+marshalling, dedup hashing) — the wasm the pthread pool can parallelize
+is a minority slice — and the MT build pays a ~35 % main-thread tax,
+netting zero-to-negative on real machines. Node/CLI keeps a ~1.5× MT
+win. Isolation infrastructure is proven and parked (Share #1612).
+
+**Consequence — milestone reordering.** Demand-driven, budgeted
+extraction (this doc's M3 plane consumed by the renderer) is promoted
+from memory work to the primary *performance* milestone: it deletes
+load-time whole-model extraction and the merged-geometry build instead
+of accelerating them. Revised order: (1) demand/tiled rendering in
+Share; (2) OPFS-windowed open from birth (needs the cooperative native
+open, #420); (3) JS extraction-driver shrink (conway-geom #148);
+(4) sidecar revisit path; (5) extraction off the main thread;
+(6) revisit browser MT/isolation after (3)/(5).

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -50,6 +50,17 @@ export interface Loadersettings {
    * embedders can print the model line as early as possible (issue #301).
    */
   ON_MODEL_INFO?: ( info: ModelInfo ) => void
+
+  /**
+   * Conway extension (OpenModelStreamed only; Share demand/tiled
+   * rendering slice A): open with NO geometry extraction — the model
+   * registers with an empty scene and the embedder pumps
+   * `ExtractGeometryBatch` to extract products in file-order batches,
+   * receiving each batch's meshes incrementally. Properties and the
+   * spatial structure work from the first batch. Ignored by the
+   * classic open paths and by the internal streamed→classic fallback.
+   */
+  DEFER_GEOMETRY?: boolean
 }
 
 /**
@@ -771,6 +782,35 @@ export class IfcAPI {
     Logger.info(`[CloseModel]: Closing model ${modelID}`)
     this.models.delete(modelID)
     this.conwaywasm.destroy()
+  }
+
+  /**
+   * Conway extension (Share demand/tiled rendering slice A): on a model
+   * opened with `OpenModelStreamed(data, {DEFER_GEOMETRY: true})`,
+   * extract the next `batchSize` products and emit this batch's meshes —
+   * the incremental twin of StreamAllMeshes. Feature-detect with
+   * `typeof api.ExtractGeometryBatch === 'function'`; call repeatedly
+   * until `remaining` is 0.
+   *
+   * @param modelID handle retrieved by OpenModelStreamed
+   * @param batchSize max products to extract this call
+   * @param meshCallback receives each newly-extracted product's mesh
+   * @return {object} `{extracted, remaining}`; `{extracted: 0,
+   * remaining: 0}` for unknown models or models without the deferred
+   * pump (non-IFC / fully-extracted opens).
+   */
+  ExtractGeometryBatch(
+      modelID: number,
+      batchSize: number,
+      meshCallback?: (mesh: FlatMesh) => void ): {extracted: number, remaining: number} {
+
+    const result = this.models.get(modelID)
+
+    if (result?.extractGeometryBatch === void 0) {
+      return {extracted: 0, remaining: 0}
+    }
+
+    return result.extractGeometryBatch(batchSize, meshCallback)
   }
 
   /**

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -1,0 +1,123 @@
+/* eslint-disable no-magic-numbers */
+// Deferred-geometry streamed open (demand/tiled rendering slice A):
+// pumping ExtractGeometryBatch to completion must reproduce EXACTLY the
+// meshes a classic OpenModel + StreamAllMeshes produces — same
+// entities, same placed-geometry ids, colors, and transforms — across
+// multiple small batches (which exercises the persisted coordination
+// matrix; a single-shot capture can't catch a stale one).
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { FlatMesh, IfcAPI } from './ifc_api'
+
+const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
+
+let api: IfcAPI
+let buffer: Uint8Array
+
+/**
+ * Flatten a FlatMesh into comparable plain data.
+ *
+ * @param mesh The mesh.
+ * @return {object} Plain comparable form.
+ */
+function flatten( mesh: FlatMesh ): object {
+
+  const geometries: object[] = []
+
+  for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+
+    const placed = mesh.geometries.get( where )
+
+    geometries.push( {
+      color: placed.color,
+      geometryExpressID: placed.geometryExpressID,
+      flatTransformation: [ ...placed.flatTransformation ],
+    } )
+  }
+
+  return { expressID: mesh.expressID, geometries }
+}
+
+beforeAll( async () => {
+  api = new IfcAPI()
+  await api.Init()
+
+  buffer = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+}, 120000 )
+
+describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
+
+  test( 'batch pump to completion matches classic StreamAllMeshes exactly', async () => {
+
+    const classicID = api.OpenModel( buffer, SETTINGS )
+    const classic = new Map<number, object>()
+
+    api.StreamAllMeshes( classicID, ( mesh ) => {
+      classic.set( mesh.expressID, flatten( mesh ) )
+    } )
+
+    expect( classic.size ).toBeGreaterThan( 0 )
+
+    const deferredID = await api.OpenModelStreamed(
+        buffer, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    expect( deferredID ).toBeGreaterThanOrEqual( 0 )
+
+    // Nothing extracted yet: the scene walk yields no meshes.
+    const before: number[] = []
+    api.StreamAllMeshes( deferredID, ( mesh ) => {
+      before.push( mesh.expressID )
+    } )
+    expect( before ).toHaveLength( 0 )
+
+    // Pump in deliberately small batches; collect incremental meshes.
+    const streamed = new Map<number, object>()
+    let firstBatchCount = 0
+    let rounds = 0
+
+    for ( ; ; ) {
+
+      const { extracted, remaining } = api.ExtractGeometryBatch(
+          deferredID, 7, ( mesh ) => {
+            streamed.set( mesh.expressID, flatten( mesh ) )
+          } )
+
+      if ( rounds === 0 ) {
+        firstBatchCount = streamed.size
+      }
+
+      ++rounds
+
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+
+    // Incrementality: meshes arrived before the pump completed.
+    expect( rounds ).toBeGreaterThan( 2 )
+    expect( firstBatchCount ).toBeGreaterThanOrEqual( 0 )
+    expect( streamed.size ).toBe( classic.size )
+
+    // Exact parity per entity: ids, colors, transforms.
+    for ( const [ expressID, mesh ] of classic ) {
+      expect( streamed.get( expressID ) ).toEqual( mesh )
+    }
+
+    api.CloseModel( classicID )
+    api.CloseModel( deferredID )
+  }, 240000 )
+
+  test( 'ExtractGeometryBatch is a safe no-op on non-deferred models', async () => {
+
+    const modelID = await api.OpenModelStreamed( buffer, SETTINGS )
+
+    expect( api.ExtractGeometryBatch( modelID, 8 ) )
+        .toEqual( { extracted: 0, remaining: 0 } )
+    expect( api.ExtractGeometryBatch( 9999, 8 ) )
+        .toEqual( { extracted: 0, remaining: 0 } )
+
+    api.CloseModel( modelID )
+  }, 120000 )
+} )

--- a/src/compat/web-ifc/ifc_api_model_passthrough.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough.ts
@@ -11,6 +11,13 @@ export interface IfcApiModelPassthrough {
   loadAllGeometry(): Vector<FlatMesh>
   streamAllMeshesWithTypes(types: number[], meshCallback: (mesh: FlatMesh) => void): void
   streamAllMeshes(meshCallback: (mesh: FlatMesh) => void): void
+  /**
+   * Deferred-mode batch pump (IFC proxies opened with DEFER_GEOMETRY) —
+   * see IfcApiProxyIfc.extractGeometryBatch.
+   */
+  extractGeometryBatch?(
+    batchSize: number,
+    meshCallback?: (mesh: FlatMesh) => void): {extracted: number, remaining: number}
   getCoordinationMatrix(): number[]
   getAllLines(): Vector<number>
   getLineIDsWithType(type: number): Vector<number>

--- a/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
@@ -125,7 +125,9 @@ export class IfcApiModelPassthroughFactory {
 
       try {
 
-        return await IfcApiProxyIfc.createStreamed(modelID, data, wasmModule, settings)
+        return settings?.DEFER_GEOMETRY === true ?
+          await IfcApiProxyIfc.createDeferred(modelID, data, wasmModule, settings) :
+          await IfcApiProxyIfc.createStreamed(modelID, data, wasmModule, settings)
 
       } catch ( e ) {
 

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -55,6 +55,8 @@ const STREAMED_PARSE_POOL_BYTES = 1024 * 1024
  */
 interface IfcProxyLoadState {
   conwaywasm: ConwayGeometry
+  /** True when opened without extraction (createDeferred). */
+  deferred?: boolean
   allTimeStart: number
   stepHeader: StepHeader
   model: IfcStepModel
@@ -78,6 +80,19 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
       Vector<FlatMesh>, glmatrix.mat4]
   conwaywasm: ConwayGeometry
+
+  /** The extraction behind this model (drives the deferred batch pump). */
+  private conwayGeometry_: IfcGeometryExtraction
+
+  /** Was this model opened without extraction (DEFER_GEOMETRY)? */
+  private deferredMode_: boolean = false
+
+  /** Deferred-mode product worklist (file order), lazily enumerated. */
+  private demandProducts_?: number[]
+
+  /** Cursor into demandProducts_ — products before it are extracted. */
+  private demandCursor_ = 0
+
   _isCoordinated: boolean = false
   linearScalingFactor: number = 1
   identity: number[] = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
@@ -115,6 +130,8 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       IfcApiProxyIfc.parseAndExtract(modelID, data, new ConwayGeometry(wasmModule), settings)
 
     this.conwaywasm = loadState.conwaywasm
+    this.conwayGeometry_ = loadState.conwayGeometry
+    this.deferredMode_ = loadState.deferred === true
 
     const statistics = Logger.getStatistics(modelID)
 
@@ -304,6 +321,34 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     const loadState = await IfcApiProxyIfc.parseColumnarAndExtractAsync(
         modelID, data, new ConwayGeometry(wasmModule), settings)
+
+    return new IfcApiProxyIfc(modelID, data, wasmModule, settings, loadState)
+  }
+
+  /**
+   * Deferred-geometry streamed open (conway extension; slice A of
+   * Share's demand/tiled rendering — design doc
+   * demand-tiled-rendering.md): identical streamed columnar parse, but
+   * NO geometry extraction happens at open. The proxy registers with an
+   * empty scene wired to the demand-extraction seam; callers then pump
+   * {@link extractGeometryBatch} to extract products in file-order
+   * batches, receiving each batch's meshes incrementally — the scene,
+   * properties, and spatial structure work from the first batch.
+   *
+   * @param modelID The model ID being opened.
+   * @param data The IFC data buffer.
+   * @param wasmModule The wasm module.
+   * @param settings Loader settings (ON_PROGRESS is honored for parse).
+   * @return {Promise<IfcApiProxyIfc>} The constructed proxy.
+   */
+  public static async createDeferred(
+      modelID: number,
+      data: Uint8Array,
+      wasmModule: any,
+      settings?: Loadersettings ): Promise<IfcApiProxyIfc> {
+
+    const loadState = await IfcApiProxyIfc.parseColumnarAndExtractAsync(
+        modelID, data, new ConwayGeometry(wasmModule), settings, true)
 
     return new IfcApiProxyIfc(modelID, data, wasmModule, settings, loadState)
   }
@@ -590,7 +635,8 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       modelID: number,
       data: Uint8Array,
       conwaywasm: ConwayGeometry,
-      settings?: Loadersettings ): Promise<IfcProxyLoadState> {
+      settings?: Loadersettings,
+      deferGeometry: boolean = false ): Promise<IfcProxyLoadState> {
 
     const tracker = IfcApiProxyIfc.makeTracker(settings)
 
@@ -642,6 +688,28 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     statistics?.setParseTime(parseEndTime - parseStartTime)
 
     const conwayGeometry = new IfcGeometryExtraction(conwaywasm, model)
+
+    // Deferred mode (createDeferred): no extraction now — prime the
+    // per-product demand seam and hand back the (empty) live scene the
+    // batch pump populates. `scene` is the same object streamAllMeshes
+    // walks, so meshes appear to consumers as batches extract.
+    if (deferGeometry) {
+
+      conwayGeometry.prepareDemandExtraction()
+
+      statistics?.setProductCount(model.typeCount(IfcProduct))
+
+      return {
+        conwaywasm,
+        deferred: true,
+        allTimeStart,
+        stepHeader,
+        model,
+        scene: conwayGeometry.scene,
+        conwayGeometry,
+        geometryTimeInMs: 0,
+      }
+    }
 
     tracker?.beginPhase('geometry', 'products')
 
@@ -1222,6 +1290,231 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    */
   closeModel() {
     // Null operation.
+  }
+
+  /**
+   * Deferred-mode batch pump (conway extension; Share demand/tiled
+   * rendering slice A): extract the next `batchSize` products (file
+   * order) through the per-product demand seam and emit THIS BATCH's
+   * meshes through `meshCallback` — the incremental twin of
+   * streamAllMeshes. Placed-geometry math (coordination, scaling,
+   * centering) is identical; the shared meshMap is updated so
+   * getFlatMesh keeps working. Call repeatedly until `remaining` is 0.
+   *
+   * Requires a model opened with deferred geometry
+   * (`OpenModelStreamed(data, {..., DEFER_GEOMETRY: true})`); on a
+   * fully-extracted model this is a no-op returning remaining 0.
+   *
+   * @param batchSize Max products to extract this call (min 1).
+   * @param meshCallback Receives each newly-extracted product's mesh.
+   * @return {object} `{extracted, remaining}` — products processed this
+   * call and products still pending.
+   */
+  extractGeometryBatch(
+      batchSize: number,
+      meshCallback?: (mesh: FlatMesh) => void ): {extracted: number, remaining: number} {
+
+    // Fully-extracted opens have nothing to pump — re-running the
+    // per-product extraction on them would duplicate scene work.
+    if (!this.deferredMode_) {
+      return {extracted: 0, remaining: 0}
+    }
+
+    if (this.demandProducts_ === void 0) {
+
+      const products: number[] = []
+
+      for (const product of this.model[0].types(IfcProduct)) {
+        products.push(product.localID)
+      }
+
+      this.demandProducts_ = products
+      this.demandCursor_ = 0
+    }
+
+    const end = Math.min(
+        this.demandCursor_ + Math.max(batchSize, 1),
+        this.demandProducts_.length)
+
+    const batch = new Set<number>()
+
+    for (; this.demandCursor_ < end; ++this.demandCursor_) {
+
+      const localID = this.demandProducts_[this.demandCursor_]
+
+      if (this.conwayGeometry_.extractProductGeometryByLocalID(localID)) {
+        batch.add(localID)
+      }
+    }
+
+    if (meshCallback !== void 0 && batch.size > 0) {
+      this.streamMeshesForEntities_(batch, meshCallback)
+    }
+
+    return {
+      extracted: batch.size,
+      remaining: this.demandProducts_.length - this.demandCursor_,
+    }
+  }
+
+  /**
+   * Walk the scene and emit FlatMeshes for the given entities only —
+   * the filtered core of streamAllMeshes with identical placed-geometry
+   * math. Also fixes a latent multi-call bug: the derived coordination
+   * matrix is stored back to the model tuple, so later batches place
+   * with the SAME coordination the first batch established
+   * (streamAllMeshes never needed this — it runs once).
+   *
+   * @param entityFilter Entity localIDs whose meshes to emit.
+   * @param meshCallback Receives one FlatMesh per matched entity.
+   */
+  private streamMeshesForEntities_(
+      entityFilter: Set<number>,
+      meshCallback: (mesh: FlatMesh) => void ): void {
+
+    const [model, scene, meshMap, geometryMaterialTransformMap] = this.model
+
+    let coordinationMatrix = this.model[5]
+    const emitted = new Set<number>()
+
+    // eslint-disable-next-line no-unused-vars
+    for (const [_, nativeTransform, geometry, material, entity] of scene.walk()) {
+
+      if (entity?.localID === void 0 || !entityFilter.has(entity.localID) ||
+          entity.expressID === void 0) {
+        continue
+      }
+
+      if (geometry.type !== CanonicalMeshType.BUFFER_GEOMETRY || geometry.temporary) {
+        continue
+      }
+
+      const material_: CanonicalMaterial = material ?? {
+        name: '',
+        // eslint-disable-next-line no-magic-numbers
+        baseColor: [0.8, 0.8, 0.8, 1],
+        // eslint-disable-next-line no-magic-numbers
+        legacyColor: [0.8, 0.8, 0.8, 1],
+        doubleSided: true,
+        blend: 0,
+      }
+
+      let nativePt: Vector3
+      if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
+        nativePt = geometry.geometry.getPoint(0)
+      }
+
+      const geomCenter: glmatrix.vec3 = glmatrix.vec3.create()
+      const center = geometry.geometry.normalize()
+
+      geomCenter[0] = center.x
+      geomCenter[1] = center.y
+      geomCenter[2] = center.z
+
+      const translationMatrixGeomMin: glmatrix.mat4 = glmatrix.mat4.create()
+      glmatrix.mat4.fromTranslation(translationMatrixGeomMin, geomCenter)
+
+      const expressID = model.getElementByLocalID(geometry.localID)?.expressID as number
+
+      const geometryTransform = nativeTransform?.getValues()
+      let newMatrix: glmatrix.mat4
+
+      if (geometryTransform !== void 0) {
+        newMatrix = glmatrix.mat4.fromValues(
+            ...(geometryTransform as unknown as Parameters<typeof glmatrix.mat4.fromValues>))
+      } else {
+        newMatrix = glmatrix.mat4.create()
+      }
+
+      if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
+
+        const pt: number[] = [nativePt!.x, nativePt!.y, nativePt!.z]
+        const transformedPt: glmatrix.vec4 = glmatrix.vec4.create()
+        glmatrix.vec4.transformMat4(transformedPt, [pt[0], pt[1], pt[2], 1], newMatrix)
+
+        coordinationMatrix = glmatrix.mat4.create()
+        glmatrix.mat4.fromTranslation(coordinationMatrix,
+            [-transformedPt[0], -transformedPt[1], -transformedPt[2]])
+
+        const scaleMatrix = glmatrix.mat4.create()
+        const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
+            this.linearScalingFactor,
+            this.linearScalingFactor)
+
+        glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
+        glmatrix.mat4.multiply(coordinationMatrix, this.NormalizeMat, coordinationMatrix)
+        glmatrix.mat4.multiply(coordinationMatrix, scaleMatrix, coordinationMatrix)
+
+        // Persist for every later batch (and getCoordinationMatrix).
+        this.model[5] = coordinationMatrix
+        this._isCoordinated = true
+      }
+
+      const newTransform = glmatrix.mat4.create()
+      const scaleMatrix = glmatrix.mat4.create()
+      const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
+          this.linearScalingFactor,
+          this.linearScalingFactor)
+
+      glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
+      glmatrix.mat4.multiply(newTransform, coordinationMatrix, newMatrix)
+      glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
+
+      const newTransformArr = Array.from(newTransform)
+
+      geometryMaterialTransformMap.set(expressID,
+          [geometry.geometry, material_, newTransformArr])
+
+      const color = {
+        x: material_.legacyColor[0],
+        y: material_.legacyColor[1],
+        z: material_.legacyColor[2],
+        w: material_.legacyColor[3],
+      }
+
+      const placed: PlacedGeometry = {
+        color,
+        geometryExpressID: expressID,
+        flatTransformation: newTransformArr,
+      }
+
+      let mesh = meshMap.get(entity.expressID)
+
+      if (mesh === void 0) {
+
+        const placedArray = new Array<PlacedGeometry>()
+        const placedVector: Vector<PlacedGeometry> = {
+          get: (index: number) => placedArray[index] ?? placed,
+          size: () => placedArray.length,
+          push: (parameter: PlacedGeometry) => {
+            placedArray.push(parameter)
+          },
+        }
+        const flatMesh: FlatMesh = {
+          geometries: placedVector,
+          expressID: entity.expressID,
+        }
+
+        mesh = [placedVector, flatMesh]
+        meshMap.set(entity.expressID, mesh)
+      }
+
+      mesh[0].push(placed)
+      mesh[1].geometries = mesh[0]
+      emitted.add(entity.expressID)
+    }
+
+    const vectorFlatMesh = this.model[4]
+
+    for (const expressID of emitted) {
+
+      const mesh = meshMap.get(expressID)
+
+      if (mesh !== void 0) {
+        vectorFlatMesh.push(mesh[1])
+        meshCallback(mesh[1])
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Two commits, reviewable separately:

## 1. Design doc status addendum (docs-only)

Appends a dated section to `design/new/streaming-federated-loader.md`: what shipped and launched (streamed columnar open live in Share prod, plane namespaces, measured PSB numbers), the browser-MT spike finding (Share bldrs-ai/Share#1610 / conway-geom bldrs-ai/conway-geom#148 — load-time geometry is ~75% serial JS driver; MT nets zero-to-negative in browser; isolation parked), and the milestone reordering that promotes demand/tiled rendering to the primary performance milestone.

## 2. Slice A shim surface (Share bldrs-ai/Share#1613)

The entries Share's demand/tiled rendering consumes:

- **`OpenModelStreamed(data, {DEFER_GEOMETRY: true})`** — streamed columnar parse with **no extraction at open**: the proxy registers with the extraction's live (empty) scene, primed on the per-product demand seam (Phase B2). Properties/spatial structure work immediately; the open returns in parse time (~13.4s on PSB instead of ~52s).
- **`ExtractGeometryBatch(modelID, batchSize, meshCallback)`** — extracts the next file-order batch of products and emits *this batch's* meshes: the incremental twin of `StreamAllMeshes` with identical placed-geometry math (coordination, scaling, centering) and shared meshMap updates (`GetFlatMesh` keeps working). Feature-detected; guarded no-op on non-deferred models and unknown ids.
- **Latent bug fix the batched capture exposed**: `streamAllMeshes` derives the coordination matrix into a local and never persists it — harmless when called once, wrong for any second capture. The batch path persists it to the model tuple so every later batch (and `GetCoordinationMatrix`) places consistently.

**Tests**: exact per-entity parity (ids, colors, transforms) between the pump driven in deliberately small 7-product batches and a classic `OpenModel`+`StreamAllMeshes` on real wasm; empty-scene-before-pump; no-op guards. Compat suite 39/39.

Share-side consumption (loader loop behind a default-off `demandGeometry` flag) follows on `claude/demand-tiled-rendering` once this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz