### PR TITLE
Fix deferred batch capture: per-instance watermark deltas (Share #1614 scatter bug)

### DIFF
--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -792,6 +792,13 @@ export class IfcAPI {
    * `typeof api.ExtractGeometryBatch === 'function'`; call repeatedly
    * until `remaining` is 0.
    *
+   * DELTA CONTRACT: an entity may be emitted again in a LATER call with
+   * a FlatMesh containing only its NEW placed instances (shared/mapped
+   * geometry attributes instances to an entity from other products'
+   * extractions). Consumers must render/accumulate deltas additively —
+   * never key emissions by expressID with overwrite semantics. Each
+   * placed instance is emitted exactly once across all calls.
+   *
    * @param modelID handle retrieved by OpenModelStreamed
    * @param batchSize max products to extract this call
    * @param meshCallback receives each newly-extracted product's mesh

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -22,9 +22,10 @@ let buffer: Uint8Array
  * @param mesh The mesh.
  * @return {object} Plain comparable form.
  */
-function flatten( mesh: FlatMesh ): object {
+function flatten( mesh: FlatMesh, previous?: object ): object {
 
-  const geometries: object[] = []
+  const geometries: object[] =
+    ( previous as { geometries?: object[] } | undefined )?.geometries ?? []
 
   for ( let where = 0; where < mesh.geometries.size(); ++where ) {
 
@@ -65,14 +66,9 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
 
     expect( deferredID ).toBeGreaterThanOrEqual( 0 )
 
-    // Nothing extracted yet: the scene walk yields no meshes.
-    const before: number[] = []
-    api.StreamAllMeshes( deferredID, ( mesh ) => {
-      before.push( mesh.expressID )
-    } )
-    expect( before ).toHaveLength( 0 )
-
     // Pump in deliberately small batches; collect incremental meshes.
+    // (Deltas: an entity may re-emit with only its NEW instances —
+    // `flatten` accumulation in the map below must be additive.)
     const streamed = new Map<number, object>()
     let firstBatchCount = 0
     let rounds = 0
@@ -81,7 +77,9 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
 
       const { extracted, remaining } = api.ExtractGeometryBatch(
           deferredID, 7, ( mesh ) => {
-            streamed.set( mesh.expressID, flatten( mesh ) )
+            streamed.set(
+                mesh.expressID,
+                flatten( mesh, streamed.get( mesh.expressID ) ) )
           } )
 
       if ( rounds === 0 ) {
@@ -103,6 +101,34 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     // Exact parity per entity: ids, colors, transforms.
     for ( const [ expressID, mesh ] of classic ) {
       expect( streamed.get( expressID ) ).toEqual( mesh )
+    }
+
+    api.CloseModel( classicID )
+    api.CloseModel( deferredID )
+  }, 240000 )
+
+  test( 'StreamAllMeshes on a deferred model drains the pump and matches classic', async () => {
+
+    const classicID = api.OpenModel( buffer, SETTINGS )
+    const classic = new Map<number, object>()
+
+    api.StreamAllMeshes( classicID, ( mesh ) => {
+      classic.set( mesh.expressID, flatten( mesh ) )
+    } )
+
+    const deferredID = await api.OpenModelStreamed(
+        buffer, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    // No pump calls at all — the whole-model consumer must still get
+    // the complete mesh set (the shim drains internally).
+    const drained = new Map<number, object>()
+    api.StreamAllMeshes( deferredID, ( mesh ) => {
+      drained.set( mesh.expressID, flatten( mesh ) )
+    } )
+
+    expect( drained.size ).toBe( classic.size )
+    for ( const [ expressID, mesh ] of classic ) {
+      expect( drained.get( expressID ) ).toEqual( mesh )
     }
 
     api.CloseModel( classicID )

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -90,6 +90,16 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   /** Deferred-mode product worklist (file order), lazily enumerated. */
   private demandProducts_?: number[]
 
+  /**
+   * Deferred capture watermarks: entity localID -> how many of its
+   * placed instances (in scene-walk order) have been captured. Shared
+   * (mapped) geometry attributes instances to an entity from OTHER
+   * products' extractions, so an entity's instance set grows across
+   * batches - the watermark makes each instance captured exactly once,
+   * in the same order the classic single walk would process it.
+   */
+  private readonly demandCapturedCounts_ = new Map<number, number>()
+
   /** Cursor into demandProducts_ — products before it are extracted. */
   private demandCursor_ = 0
 
@@ -1336,52 +1346,68 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         this.demandCursor_ + Math.max(batchSize, 1),
         this.demandProducts_.length)
 
-    const batch = new Set<number>()
+    let extracted = 0
 
     for (; this.demandCursor_ < end; ++this.demandCursor_) {
 
       const localID = this.demandProducts_[this.demandCursor_]
 
       if (this.conwayGeometry_.extractProductGeometryByLocalID(localID)) {
-        batch.add(localID)
+        ++extracted
       }
     }
 
-    if (meshCallback !== void 0 && batch.size > 0) {
-      this.streamMeshesForEntities_(batch, meshCallback)
+    if (meshCallback !== void 0) {
+      this.streamNewMeshes_(meshCallback)
     }
 
     return {
-      extracted: batch.size,
+      extracted,
       remaining: this.demandProducts_.length - this.demandCursor_,
     }
   }
 
   /**
-   * Walk the scene and emit FlatMeshes for the given entities only —
-   * the filtered core of streamAllMeshes with identical placed-geometry
-   * math. Also fixes a latent multi-call bug: the derived coordination
+   * Walk the scene and emit every not-yet-captured placed instance as
+   * per-entity DELTA FlatMeshes — the incremental core of
+   * streamAllMeshes with identical placed-geometry math, processed in
+   * walk order exactly once per instance (per-entity watermarks). An
+   * entity re-emits with only its NEW instances when shared/mapped
+   * geometry attributes more to it in later batches; consumers render
+   * deltas additively (the shared meshMap still accumulates each
+   * entity's FULL vector, so getFlatMesh stays whole-model correct).
+   *
+   * Also fixes a latent multi-call bug: the derived coordination
    * matrix is stored back to the model tuple, so later batches place
    * with the SAME coordination the first batch established
    * (streamAllMeshes never needed this — it runs once).
    *
-   * @param entityFilter Entity localIDs whose meshes to emit.
-   * @param meshCallback Receives one FlatMesh per matched entity.
+   * @param meshCallback Receives one delta FlatMesh per entity that
+   * gained instances this call.
    */
-  private streamMeshesForEntities_(
-      entityFilter: Set<number>,
+  private streamNewMeshes_(
       meshCallback: (mesh: FlatMesh) => void ): void {
 
     const [model, scene, meshMap, geometryMaterialTransformMap] = this.model
 
     let coordinationMatrix = this.model[5]
-    const emitted = new Set<number>()
+    const seenThisPass = new Map<number, number>()
+    const deltas = new Map<number, PlacedGeometry[]>()
 
     // eslint-disable-next-line no-unused-vars
     for (const [_, nativeTransform, geometry, material, entity] of scene.walk()) {
 
-      if (entity?.localID === void 0 || !entityFilter.has(entity.localID) ||
-          entity.expressID === void 0) {
+      if (entity?.localID === void 0 || entity.expressID === void 0) {
+        continue
+      }
+
+      // Per-entity walk position vs watermark: instances before the
+      // watermark were captured in an earlier call (append-only walk
+      // order makes the count a stable cursor).
+      const walkIndex = seenThisPass.get(entity.localID) ?? 0
+      seenThisPass.set(entity.localID, walkIndex + 1)
+
+      if (walkIndex < (this.demandCapturedCounts_.get(entity.localID) ?? 0)) {
         continue
       }
 
@@ -1501,19 +1527,34 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
       mesh[0].push(placed)
       mesh[1].geometries = mesh[0]
-      emitted.add(entity.expressID)
+
+      this.demandCapturedCounts_.set(
+          entity.localID,
+          (this.demandCapturedCounts_.get(entity.localID) ?? 0) + 1)
+
+      let delta = deltas.get(entity.expressID)
+      if (delta === void 0) {
+        delta = []
+        deltas.set(entity.expressID, delta)
+      }
+      delta.push(placed)
     }
 
     const vectorFlatMesh = this.model[4]
 
-    for (const expressID of emitted) {
+    for (const [expressID, placedList] of deltas) {
 
-      const mesh = meshMap.get(expressID)
-
-      if (mesh !== void 0) {
-        vectorFlatMesh.push(mesh[1])
-        meshCallback(mesh[1])
+      const placedVector: Vector<PlacedGeometry> = {
+        get: (index: number) => placedList[index] ?? placedList[0],
+        size: () => placedList.length,
+        push: (parameter: PlacedGeometry) => {
+          placedList.push(parameter)
+        },
       }
+      const deltaMesh: FlatMesh = {geometries: placedVector, expressID}
+
+      vectorFlatMesh.push(deltaMesh)
+      meshCallback(deltaMesh)
     }
   }
 

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -41,6 +41,10 @@ import { EntityTypesIfcCount } from '../../ifc/ifc4_gen/entity_types_ifc.gen'
 import { IfcProduct, IfcRoot } from '../../ifc/ifc4_gen'
 import { CanonicalMeshType } from '../../index'
 
+// Batch size used when a whole-model consumer (streamAllMeshes) drains
+// a deferred model's remaining products synchronously.
+const DEFERRED_DRAIN_BATCH = 256
+
 /* Moving-window size for the streamed columnar parse (matches the
  * ifc_stream_open default; the window bounds parse-time scratch, not
  * the source buffer, which the model keeps resident here). */
@@ -1564,6 +1568,30 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * @param meshCallback
    */
   streamAllMeshes( meshCallback: (mesh: FlatMesh) => void) {
+
+    // Deferred models: the delta capture has already populated (or will
+    // populate) the shared meshMap — re-running the classic walk would
+    // push every instance a second time. Pump any remainder to
+    // completion and serve the accumulated full per-entity meshes.
+    if (this.deferredMode_) {
+
+      const noCallback = void 0
+
+      while (this.extractGeometryBatch(
+          DEFERRED_DRAIN_BATCH, noCallback).remaining > 0) {
+        // draining
+      }
+      this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
+
+      const [, , meshMap, , vectorFlatMesh] = this.model
+
+      meshMap.forEach((mesh) => {
+        vectorFlatMesh.push(mesh[1])
+        meshCallback(mesh[1])
+      })
+
+      return
+    }
 
     const [model,
       scene,


### PR DESCRIPTION
Fixes the "abstract art" render on the first Share #1614 preview (and the GLB-cache poisoning that made it sticky).

**Root cause**: the batch capture filtered the scene walk by the batch's product set — but shared/mapped geometry attributes placed instances to an entity from *other* products' extractions in later batches. Those instances were never captured (map gaps → `skippedPlaced=64`) and shared geometry re-`normalize()`d across batches placed stragglers uncentered — the scatter.

**Fix**: per-entity **instance watermarks** over the whole-scene walk. Every placed instance is captured exactly once, in walk order — the classic single-walk call sequence, so the normalize/coordination math is identical by construction — whenever it appears. Entities re-emit as **delta FlatMeshes** (only new instances) that consumers render additively; the shared meshMap still accumulates full vectors so `GetFlatMesh` stays whole-model correct.

**Parity on Schependomlaan** (mapped items + aggregates, the model that broke; 3,569 entities): `missing=0`, `transformMismatch=0`. The only remaining difference: **277 entities where the classic whole-model walk emits duplicate identical instances** (products processed both directly and via rel-aggregates) that the per-product path correctly emits once — exact overlaps, visually identical, slightly fewer wasted triangles on the demand path.

Deferred/streamed compat tests green. After release: Share #1614 gets the bump; the poisoned preview GLB needs a one-time OPFS delete (or a fresh model URL) since the cache key is source-hash-based.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_