### PR TITLE
CI: gate perf benchmarks behind rc-* tags instead of every merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,8 @@ on:
     # Skip the heavy build + IFC regression on doc-only PRs. paths-ignore
     # skips the workflow only when EVERY changed file matches — a PR that
     # also touches code/config still runs the full suite. Push-to-main
-    # (auto-publish, perf) is intentionally left unfiltered below.
+    # (auto-publish) and rc-tag pushes (perf) are intentionally left
+    # unfiltered below.
     # NOTE: if `build` / `run-ifc-regression` are *required* status checks
     # in branch protection, a path-skipped run reports nothing and the PR
     # waits forever — switch to a per-job `if:` gate instead (a skipped-by-if
@@ -17,9 +18,19 @@ on:
       - 'docs/**'
   push:
     branches: [main]
+    # Release-candidate tags trigger the EXTENDED suite (the perf-three-*
+    # benchmarks). Those benchmarks used to run on every merge — the largest
+    # CI cost line (~38 large-runner-min/merge, mostly the 24-min private H3
+    # run) — but per-commit perf is redundant while perf is actively reviewed
+    # per-model at PR time. Now a full perf sweep runs only when a human
+    # blesses a prod-worthy point by pushing an `rc-*` tag. auto-publish's
+    # own `<version>` tags are numeric (e.g. 1.399.1234) and do NOT match
+    # `rc-*`, so continuous-release tagging never triggers this path.
+    tags:
+      - 'rc-*'
   # Manual runs from any branch (Actions > CI > Run workflow) so the
-  # perf jobs — normally push-to-main only — can be exercised and debugged
-  # on a branch without merging. auto-publish stays push:main-only.
+  # perf jobs — normally rc-tag only — can be exercised and debugged on a
+  # branch without cutting a tag. auto-publish stays push:main-only.
   workflow_dispatch:
 
 # Cancel superseded runs so a rapid series of pushes to the same PR doesn't
@@ -709,7 +720,12 @@ jobs:
   # ---------------------------------------------------------------------------
   perf-three-public:
     needs: run-ifc-regression
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    # Extended suite: runs on an `rc-*` release-candidate tag (a manual
+    # prod-blessing) or on-demand via workflow_dispatch — NOT on plain merges
+    # to main. build + run-ifc-regression (ungated) still run on the tag, so
+    # the candidate tarball this job benchmarks is produced; auto-publish is
+    # main-branch-only and does not fire on a tag ref.
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/rc-')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04-8vcpu-32gb-300gbssd
     # Full set locally takes ~10 min; H3 build + clone adds ~5-10 min. Cap at
     # 60 to bound runner-minute cost on a hung benchmark.
@@ -1016,7 +1032,12 @@ jobs:
   # ---------------------------------------------------------------------------
   perf-three-private:
     needs: run-ifc-regression
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    # Extended suite: runs on an `rc-*` release-candidate tag (a manual
+    # prod-blessing) or on-demand via workflow_dispatch — NOT on plain merges
+    # to main. build + run-ifc-regression (ungated) still run on the tag, so
+    # the candidate tarball this job benchmarks is produced; auto-publish is
+    # main-branch-only and does not fire on a tag ref.
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/rc-')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04-8vcpu-32gb-300gbssd
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
## Summary

Cuts the largest CI cost line by moving the `perf-three-public` / `perf-three-private` benchmarks off the per-merge path and onto an explicit **release-candidate tag** gate. Continuous npm publishing on every green merge is unchanged.

Follow-up to the concurrency-cancellation change (PR #399, already merged). Same cost-reduction branch, fresh commit on top of current `main`.

## Why

Measured per-job wall times on the `8vcpu-32gb` runner (all billed as *Actions Linux 16-core*, the only line item that bills above $0):

| job | per merge (before) |
| --- | --- |
| build | ~2.8 min |
| run-ifc-regression | ~5.1 min |
| auto-publish | ~2.0 min |
| **perf-three-public** | **~11.3 min** |
| **perf-three-private** | **~27.0 min** (24 min is one H3 step) |

The two perf jobs were ~**80%** of every merge and ran on **every** push to `main`. Per-commit perf attribution is redundant while perf is being actively reviewed per-model at PR time (the `run-ifc-regression` perf table + the visual diff on changed models). A full corpus sweep is only genuinely needed when blessing a prod-worthy point.

The perf **runner size is deliberately left at 8-vcpu** — for a benchmark that headroom buys low-variance timings, not throughput, so shrinking it would just make the numbers noisier.

## What changed

Single file, `.github/workflows/build.yml`:

- Added `rc-*` to the `push` tag filter.
- Re-gated both perf jobs from `push && ref == refs/heads/main` to `push && startsWith(ref, refs/tags/rc-) || workflow_dispatch`.
- Refreshed the now-stale trigger comments.

### Behavior by event

| Event | Runs | Perf? | Publishes? |
| --- | --- | --- | --- |
| pull_request | build · regression · visual-diff | no | no |
| merge → main | build · regression · auto-publish | no | **yes (unchanged)** |
| push `rc-*` tag | build · regression · perf-three-public + private | **yes** | no |
| workflow_dispatch | build · regression · perf | yes | no |

On an `rc-*` tag, `build` + `run-ifc-regression` are ungated so the candidate tarball the perf jobs benchmark is still produced; `auto-publish` is main-branch-only and does not fire on a tag ref. `auto-publish`'s own numeric `<version>` tags don't match `rc-*`, so continuous-release tagging never triggers this path (verified in the gating).

## How to bless a release candidate

```bash
git tag rc-2026-07-21 <sha-on-main>
git push origin rc-2026-07-21
```

Runs the extended perf suite on the isolated runner; the perf comment + delta (rc-vs-previous-rc) posts as before.

## Note

On an `rc-*` run the perf jobs parse a PR number from the blessed commit message (existing logic), so the results comment lands on whatever PR that commit came from. Harmless, and arguably useful since it's the state being blessed — but if a GitHub Release or job-summary target is preferred, that's a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyCxwn1wc35pkBiM9VC64V

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyCxwn1wc35pkBiM9VC64V)_