### PR TITLE
Parse-time preview channel: first meshes while the streamed parse runs (slice A2)

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -712,3 +712,17 @@ Share; (2) OPFS-windowed open from birth (needs the cooperative native
 open, #420); (3) JS extraction-driver shrink (conway-geom #148);
 (4) sidecar revisit path; (5) extraction off the main thread;
 (6) revisit browser MT/isolation after (3)/(5).
+
+**Parse-time preview channel (slice A2).** Durable extraction cannot
+run mid-parse: relationship records (rel-voids, rel-materials, styled
+items) extend to ~92–97 % of real files' depth, so any prefix
+extraction can miss openings/materials. The shipped design accepts
+that: `ColumnarIndexSink.snapshot()` produces prefix columns between
+the cooperative parse's yields, and a `StreamedPreviewChannel`
+(deferred opens with `ON_PREVIEW_MESH`) builds throwaway prefix
+models/extractions in growing generations, emitting self-contained,
+byte-capped payload copies — first meshes within the first second of a
+large parse (measured: 583 ms into Schependomlaan's 1.2 s parse). The
+post-parse durable pump re-extracts everything and replaces the
+preview, so final parity is untouched; the channel pins the
+coordination frame the pump then adopts.

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -11,6 +11,9 @@ import { StepExternalByteStore } from '../../step/step_buffer_provider'
 import { IfcApiModelPassthrough } from './ifc_api_model_passthrough'
 import { IfcApiModelPassthroughFactory } from './ifc_api_model_passthrough_factory'
 import { Properties } from './properties'
+import type { PreviewMeshPayload } from './streamed_preview_channel'
+
+export type { PreviewMeshPayload } from './streamed_preview_channel'
 
 
 export * from './ifc2x4'
@@ -61,6 +64,18 @@ export interface Loadersettings {
    * classic open paths and by the internal streamed→classic fallback.
    */
   DEFER_GEOMETRY?: boolean
+
+  /**
+   * Conway extension (OpenModelStreamed + DEFER_GEOMETRY only; demand/tiled
+   * rendering slice A2): receive PREVIEW mesh payloads while the parse is
+   * still running — self-contained (geometry copied out of the wasm heap),
+   * so they can be uploaded before the model exists. Preview quality:
+   * relationship records (voids, materials) live near the end of real IFC
+   * files, so previews can miss openings/materials; the durable batch pump
+   * re-extracts every product after the parse and REPLACES the preview.
+   * Consumers must treat these as disposable. Ignored everywhere else.
+   */
+  ON_PREVIEW_MESH?: ( mesh: PreviewMeshPayload ) => void
 }
 
 /**

--- a/src/compat/web-ifc/ifc_api_preview_channel.test.ts
+++ b/src/compat/web-ifc/ifc_api_preview_channel.test.ts
@@ -219,23 +219,23 @@ describe( 'StreamedPreviewChannel', () => {
       expect( carrier.indexData!.length ).toBeGreaterThan( 0 )
     }
 
-    // The channel's pinned coordination frame is the durable pump's:
-    // classic StreamAllMeshes never persists its derived matrix (single
-    // walk), but the deferred pump does — and the preview must place in
-    // exactly that frame so the swap is seamless.
+    // The channel derived and pinned a coordination frame (proved
+    // equivalent to classic's by the transform parity above), and the
+    // deferred open must keep the classic GetCoordinationMatrix
+    // contract: identity, because placed transforms are premultiplied
+    // and consumers stamp the result onto assembled models — a
+    // non-identity return would coordinate twice.
+    expect( channel.coordinationMatrix ).toBeDefined()
+
     const deferredID = await api.OpenModelStreamed(
         data, { ...SETTINGS, DEFER_GEOMETRY: true } )
 
     api.StreamAllMeshes( deferredID, () => { /* drain */ } )
 
-    const pumpCoordination = api.GetCoordinationMatrix( deferredID )
+    const classicCoordination = api.GetCoordinationMatrix( classicID )
+    const deferredCoordination = api.GetCoordinationMatrix( deferredID )
 
-    expect( channel.coordinationMatrix ).toBeDefined()
-
-    for ( let where = 0; where < 16; ++where ) {
-      expect( channel.coordinationMatrix![ where ] )
-          .toBeCloseTo( pumpCoordination[ where ], 6 )
-    }
+    expect( deferredCoordination ).toEqual( classicCoordination )
 
     api.CloseModel( classicID )
     api.CloseModel( deferredID )

--- a/src/compat/web-ifc/ifc_api_preview_channel.test.ts
+++ b/src/compat/web-ifc/ifc_api_preview_channel.test.ts
@@ -1,0 +1,279 @@
+/* eslint-disable no-magic-numbers */
+// Parse-time preview channel (demand/tiled rendering slice A2): prefix
+// snapshots of the live columnar sink must be exact prefixes of the final
+// columns, and a full drain of the channel (prefix == whole file) must
+// reproduce the classic StreamAllMeshes instance set — same entities,
+// same geometry ids, same placed transforms — since the durable pump the
+// preview hands over to is already pinned to classic parity.
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { ConwayGeometry } from '../../../dependencies/conway-geom'
+import IfcStepParser from '../../ifc/ifc_step_parser'
+import EntityTypesIfc from '../../ifc/ifc4_gen/entity_types_ifc.gen'
+import { BufferByteSource } from '../../step/parsing/byte_source'
+import {
+  ColumnarIndexSink,
+  StepIndexColumns,
+} from '../../step/parsing/columnar_index'
+import { ParseResult, StepIndexSink } from '../../step/parsing/step_parser'
+import { buildIndexStreaming } from '../../step/parsing/streaming_index_builder'
+import { FlatMesh, IfcAPI } from './ifc_api'
+import {
+  PreviewMeshPayload,
+  StreamedPreviewChannel,
+} from './streamed_preview_channel'
+
+const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
+const POOL = 1024 * 1024
+
+let api: IfcAPI
+let conwayGeometry: ConwayGeometry
+let data: Uint8Array
+
+/**
+ * Parse index.ifc's data block into a fresh columnar sink.
+ *
+ * @param wrap Optional sink wrapper (snapshot triggers).
+ * @return {ColumnarIndexSink} The filled sink.
+ */
+function buildSink(
+    wrap?: ( sink: ColumnarIndexSink<EntityTypesIfc> ) =>
+      StepIndexSink<EntityTypesIfc> ): ColumnarIndexSink<EntityTypesIfc> {
+
+  const sink = new ColumnarIndexSink<EntityTypesIfc>()
+
+  const { result } = buildIndexStreaming(
+      new BufferByteSource( data ),
+      IfcStepParser.Instance,
+      POOL,
+      void 0,
+      wrap !== void 0 ? wrap( sink ) : sink )
+
+  expect( result ).toBe( ParseResult.COMPLETE )
+
+  return sink
+}
+
+/**
+ * Classic reference: expressID -> list of placed instances.
+ *
+ * @param modelID An open classic model.
+ * @return {Map} expressID -> {geometryExpressID, flatTransformation}[].
+ */
+function classicInstances( modelID: number ):
+  Map<number, { geometryExpressID: number, flatTransformation: number[] }[]> {
+
+  const instances =
+    new Map<number, { geometryExpressID: number, flatTransformation: number[] }[]>()
+
+  api.StreamAllMeshes( modelID, ( mesh: FlatMesh ) => {
+
+    const list = instances.get( mesh.expressID ) ?? []
+
+    for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+
+      const placed = mesh.geometries.get( where )
+
+      list.push( {
+        geometryExpressID: placed.geometryExpressID,
+        flatTransformation: [ ...placed.flatTransformation ],
+      } )
+    }
+
+    instances.set( mesh.expressID, list )
+  } )
+
+  return instances
+}
+
+beforeAll( async () => {
+  api = new IfcAPI()
+  await api.Init()
+
+  conwayGeometry = new ConwayGeometry()
+  expect( await conwayGeometry.initialize() ).toBe( true )
+
+  data = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+}, 120000 )
+
+describe( 'ColumnarIndexSink.snapshot', () => {
+
+  test( 'a mid-parse snapshot is an exact prefix of the final columns', () => {
+
+    const snapshotAt = 50
+    let snapshot: StepIndexColumns<EntityTypesIfc> | undefined
+
+    const sink = buildSink( ( inner ) => ( {
+      pushTopLevel: ( entry ) => {
+        inner.pushTopLevel( entry )
+
+        if ( inner.topLevelCount === snapshotAt ) {
+          snapshot = inner.snapshot()
+        }
+      },
+      reset: () => inner.reset(),
+    } ) )
+
+    const full = sink.finalize()
+
+    expect( snapshot ).toBeDefined()
+    expect( snapshot!.firstInlineElement ).toBe( snapshotAt )
+    expect( full.firstInlineElement ).toBeGreaterThan( snapshotAt )
+
+    for ( let where = 0; where < snapshotAt; ++where ) {
+      expect( snapshot!.address[ where ] ).toBe( full.address[ where ] )
+      expect( snapshot!.length[ where ] ).toBe( full.length[ where ] )
+      expect( snapshot!.typeID[ where ] ).toBe( full.typeID[ where ] )
+      expect( snapshot!.expressID[ where ] ).toBe( full.expressID[ where ] )
+    }
+  } )
+
+  test( 'snapshotting does not disturb the sink (finalize sees everything)', () => {
+
+    const undisturbed = buildSink().finalize()
+
+    const snapshotted = buildSink( ( inner ) => ( {
+      pushTopLevel: ( entry ) => {
+        inner.pushTopLevel( entry )
+
+        // Snapshot aggressively — every 25 records.
+        if ( inner.topLevelCount % 25 === 0 ) {
+          inner.snapshot()
+        }
+      },
+      reset: () => inner.reset(),
+    } ) ).finalize()
+
+    expect( snapshotted.count ).toBe( undisturbed.count )
+    expect( snapshotted.firstInlineElement ).toBe( undisturbed.firstInlineElement )
+    expect( [ ...snapshotted.address ] ).toEqual( [ ...undisturbed.address ] )
+    expect( [ ...snapshotted.expressID ] ).toEqual( [ ...undisturbed.expressID ] )
+  } )
+} )
+
+describe( 'StreamedPreviewChannel', () => {
+
+  test( 'a full drain reproduces the classic instance set exactly', async () => {
+
+    const classicID = api.OpenModel( data, SETTINGS )
+    const classic = classicInstances( classicID )
+
+    let classicTotal = 0
+
+    for ( const list of classic.values() ) {
+      classicTotal += list.length
+    }
+
+    expect( classicTotal ).toBeGreaterThan( 0 )
+
+    // Channel over a finished sink: the "prefix" is the whole file, so a
+    // drain must be a complete, classic-parity extraction.
+    const sink = buildSink()
+    const payloads: PreviewMeshPayload[] = []
+
+    const channel = new StreamedPreviewChannel(
+        data, conwayGeometry, sink, true, ( mesh ) => payloads.push( mesh ),
+        void 0, void 0, 1 )
+
+    channel.drainForTest()
+
+    expect( payloads.length ).toBe( classicTotal )
+
+    // Every payload matches a classic instance of the same entity and
+    // geometry, with the same placed transform.
+    const unmatched = new Map<number, typeof classic extends
+      Map<number, infer ListType> ? ListType : never>()
+
+    for ( const [ expressID, list ] of classic ) {
+      unmatched.set( expressID, list.map( ( entry ) => ( { ...entry } ) ) )
+    }
+
+    for ( const payload of payloads ) {
+
+      const candidates = unmatched.get( payload.expressID )
+
+      expect( candidates ).toBeDefined()
+
+      const matchIndex = candidates!.findIndex( ( candidate ) =>
+        candidate.geometryExpressID === payload.geometryExpressID &&
+        candidate.flatTransformation.every( ( value, where ) =>
+          Math.abs( value - payload.flatTransformation[ where ] ) < 1e-6 ) )
+
+      expect( matchIndex ).toBeGreaterThanOrEqual( 0 )
+      candidates!.splice( matchIndex, 1 )
+    }
+
+    // Geometry payloads: exactly one carrier per distinct geometry, each
+    // carrying a sane interleaved buffer.
+    const carriers = payloads.filter( ( payload ) => payload.vertexData !== void 0 )
+    const distinctGeometry = new Set( payloads.map( ( p ) => p.geometryExpressID ) )
+
+    expect( carriers.length ).toBe( distinctGeometry.size )
+
+    for ( const carrier of carriers ) {
+      expect( carrier.vertexData!.length % 6 ).toBe( 0 )
+      expect( carrier.vertexData!.length ).toBeGreaterThan( 0 )
+      expect( carrier.indexData!.length % 3 ).toBe( 0 )
+      expect( carrier.indexData!.length ).toBeGreaterThan( 0 )
+    }
+
+    // The channel's pinned coordination frame is the durable pump's:
+    // classic StreamAllMeshes never persists its derived matrix (single
+    // walk), but the deferred pump does — and the preview must place in
+    // exactly that frame so the swap is seamless.
+    const deferredID = await api.OpenModelStreamed(
+        data, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    api.StreamAllMeshes( deferredID, () => { /* drain */ } )
+
+    const pumpCoordination = api.GetCoordinationMatrix( deferredID )
+
+    expect( channel.coordinationMatrix ).toBeDefined()
+
+    for ( let where = 0; where < 16; ++where ) {
+      expect( channel.coordinationMatrix![ where ] )
+          .toBeCloseTo( pumpCoordination[ where ], 6 )
+    }
+
+    api.CloseModel( classicID )
+    api.CloseModel( deferredID )
+  }, 240000 )
+
+  test( 'ON_PREVIEW_MESH on a deferred streamed open never breaks the durable path', async () => {
+
+    const classicID = api.OpenModel( data, SETTINGS )
+    const classic = classicInstances( classicID )
+
+    const payloads: PreviewMeshPayload[] = []
+
+    const deferredID = await api.OpenModelStreamed( data, {
+      ...SETTINGS,
+      DEFER_GEOMETRY: true,
+      ON_PREVIEW_MESH: ( mesh ) => payloads.push( mesh ),
+    } )
+
+    expect( deferredID ).toBeGreaterThanOrEqual( 0 )
+
+    // index.ifc parses inside one cooperative slice, so the timer-driven
+    // channel usually never fires — the contract here is that its presence
+    // changes nothing about the durable pump's output.
+    const drained = new Map<number, number>()
+
+    api.StreamAllMeshes( deferredID, ( mesh ) => {
+      drained.set(
+          mesh.expressID,
+          ( drained.get( mesh.expressID ) ?? 0 ) + mesh.geometries.size() )
+    } )
+
+    expect( drained.size ).toBe( classic.size )
+
+    for ( const [ expressID, list ] of classic ) {
+      expect( drained.get( expressID ) ).toBe( list.length )
+    }
+
+    api.CloseModel( classicID )
+    api.CloseModel( deferredID )
+  }, 240000 )
+} )

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -28,8 +28,11 @@ import IfcStepParser from '../../ifc/ifc_step_parser'
 import ParsingBuffer from '../../parsing/parsing_buffer'
 import { BufferByteSource } from '../../step/parsing/byte_source'
 import {
-  buildColumnarIndexStreamingAsync,
+  buildIndexStreamingAsync,
 } from '../../step/parsing/streaming_index_builder'
+import { ColumnarIndexSink } from '../../step/parsing/columnar_index'
+import { StreamedPreviewChannel } from './streamed_preview_channel'
+import EntityTypesIfc from '../../ifc/ifc4_gen/entity_types_ifc.gen'
 import { StepHeader } from '../../step/parsing/step_parser'
 import { ExtractResult } from '../../index'
 import { IfcGeometryExtraction } from '../../ifc/ifc_geometry_extraction'
@@ -61,6 +64,9 @@ interface IfcProxyLoadState {
   conwaywasm: ConwayGeometry
   /** True when opened without extraction (createDeferred). */
   deferred?: boolean
+  /** Coordination matrix the parse-time preview channel derived (slice
+   * A2) — adopted by the durable capture so both share one frame. */
+  previewCoordinationMatrix?: glmatrix.mat4
   allTimeStart: number
   stepHeader: StepHeader
   model: IfcStepModel
@@ -247,6 +253,14 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     // save settings
     this.settings = settings
+
+    // Deferred opens whose preview channel already established the
+    // coordination frame: adopt it, so the durable capture skips its own
+    // derivation and places exactly where the preview did.
+    if (this.deferredMode_ && loadState.previewCoordinationMatrix !== void 0) {
+      this.model[5] = loadState.previewCoordinationMatrix
+      this._isCoordinated = true
+    }
 
     let FILE_NAME = stepHeader.headers.get('FILE_NAME')
 
@@ -683,9 +697,31 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     const parseStartTime = Date.now()
 
-    const { columns, result } = await buildColumnarIndexStreamingAsync(
-        new BufferByteSource(data), parser, STREAMED_PARSE_POOL_BYTES,
-        void 0, parseTick)
+    // Inline twin of buildColumnarIndexStreamingAsync — the sink is created
+    // here so the parse-time preview channel (slice A2) can watch it grow
+    // and snapshot prefix models between the parse's cooperative yields.
+    const sink = new ColumnarIndexSink<EntityTypesIfc>()
+
+    const previewChannel =
+      deferGeometry && settings?.ON_PREVIEW_MESH !== void 0 ?
+        new StreamedPreviewChannel(
+            data, conwaywasm, sink,
+            settings.COORDINATE_TO_ORIGIN === true,
+            settings.ON_PREVIEW_MESH ) : void 0
+
+    previewChannel?.start()
+
+    let result: ParseResult
+
+    try {
+      ( { result } = await buildIndexStreamingAsync(
+          new BufferByteSource(data), parser, STREAMED_PARSE_POOL_BYTES,
+          void 0, sink, parseTick) )
+    } finally {
+      previewChannel?.stop()
+    }
+
+    const columns = sink.finalize()
 
     const parseEndTime = Date.now()
 
@@ -716,6 +752,10 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       return {
         conwaywasm,
         deferred: true,
+        // Pin the durable pump's coordination to the preview channel's
+        // (derived from the same first instance with the same math), so
+        // preview payloads and durable meshes share one frame.
+        previewCoordinationMatrix: previewChannel?.coordinationMatrix,
         allTimeStart,
         stepHeader,
         model,

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -113,6 +113,18 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   /** Cursor into demandProducts_ — products before it are extracted. */
   private demandCursor_ = 0
 
+  /**
+   * Coordination matrix the deferred capture derived (or adopted from
+   * the parse-time preview channel). Kept OFF the model tuple's slot 5
+   * deliberately: classic streamAllMeshes derives its coordination into
+   * a local and getCoordinationMatrix therefore returns identity —
+   * consumers (Share) stamp that result onto the assembled model, so a
+   * deferred open must present the same identity or coordination would
+   * apply twice. This field is only the pump's internal multi-call
+   * memory.
+   */
+  private demandCoordination_?: glmatrix.mat4
+
   _isCoordinated: boolean = false
   linearScalingFactor: number = 1
   identity: number[] = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
@@ -256,9 +268,11 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     // Deferred opens whose preview channel already established the
     // coordination frame: adopt it, so the durable capture skips its own
-    // derivation and places exactly where the preview did.
+    // derivation and places exactly where the preview did. (Internal
+    // only — getCoordinationMatrix stays identity, see
+    // demandCoordination_.)
     if (this.deferredMode_ && loadState.previewCoordinationMatrix !== void 0) {
-      this.model[5] = loadState.previewCoordinationMatrix
+      this.demandCoordination_ = loadState.previewCoordinationMatrix
       this._isCoordinated = true
     }
 
@@ -1422,9 +1436,11 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * entity's FULL vector, so getFlatMesh stays whole-model correct).
    *
    * Also fixes a latent multi-call bug: the derived coordination
-   * matrix is stored back to the model tuple, so later batches place
+   * matrix is remembered (demandCoordination_), so later batches place
    * with the SAME coordination the first batch established
-   * (streamAllMeshes never needed this — it runs once).
+   * (streamAllMeshes never needed this — it runs once). It is NOT
+   * exposed through getCoordinationMatrix, which keeps the classic
+   * identity contract consumers stamp onto assembled models.
    *
    * @param meshCallback Receives one delta FlatMesh per entity that
    * gained instances this call.
@@ -1434,7 +1450,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     const [model, scene, meshMap, geometryMaterialTransformMap] = this.model
 
-    let coordinationMatrix = this.model[5]
+    let coordinationMatrix = this.demandCoordination_ ?? glmatrix.mat4.create()
     const seenThisPass = new Map<number, number>()
     const deltas = new Map<number, PlacedGeometry[]>()
 
@@ -1515,8 +1531,9 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         glmatrix.mat4.multiply(coordinationMatrix, this.NormalizeMat, coordinationMatrix)
         glmatrix.mat4.multiply(coordinationMatrix, scaleMatrix, coordinationMatrix)
 
-        // Persist for every later batch (and getCoordinationMatrix).
-        this.model[5] = coordinationMatrix
+        // Persist for every later batch (internal only — see
+        // demandCoordination_'s identity-contract note).
+        this.demandCoordination_ = coordinationMatrix
         this._isCoordinated = true
       }
 

--- a/src/compat/web-ifc/streamed_preview_channel.ts
+++ b/src/compat/web-ifc/streamed_preview_channel.ts
@@ -1,0 +1,480 @@
+import { ConwayGeometry } from '../../index'
+import { CanonicalMaterial } from '../../index'
+import { CanonicalMeshType } from '../../index'
+import IfcStepModel from '../../ifc/ifc_step_model'
+import { IfcGeometryExtraction } from '../../ifc/ifc_geometry_extraction'
+import { IfcProduct } from '../../ifc/ifc4_gen'
+import EntityTypesIfc from '../../ifc/ifc4_gen/entity_types_ifc.gen'
+import { ColumnarIndexSink } from '../../step/parsing/columnar_index'
+import { Vector3 } from '../../../dependencies/conway-geom'
+import * as glmatrix from 'gl-matrix'
+
+/* eslint-disable no-magic-numbers */
+
+/** Ms between preview pump ticks (interleaves with the parse's yields). */
+const TICK_INTERVAL_MS = 150
+
+/** Extraction + capture time budget per tick, so the parse keeps most of
+ * the main thread (~25/150 ≈ 17% worst-case preview share). */
+const TICK_BUDGET_MS = 25
+
+/** Don't build the first generation before this many top-level records —
+ * below it the prefix rarely contains a placeable product. */
+const FIRST_GENERATION_MIN_RECORDS = 1024
+
+/** A new generation only when the index grew this much past the previous
+ * snapshot (bounds snapshot copies to O(GROWTH/(GROWTH-1)) of the file). */
+const GENERATION_GROWTH_FACTOR = 1.5
+
+/** Default cap on products the preview channel ever extracts. Preview
+ * generations are throwaway extractions whose native geometry is not
+ * reclaimed until page teardown (the shim never frees classic scenes
+ * either — see closeModel), so the cap bounds that one-time cost. */
+const DEFAULT_MAX_PREVIEW_PRODUCTS = 4096
+
+/** Default cap on total payload bytes copied out to the consumer. */
+const DEFAULT_MAX_PREVIEW_BYTES = 48 * 1024 * 1024
+
+const FLOATS_PER_VERTEX = 6
+const BYTES_PER_FLOAT = 4
+const DEFAULT_COLOR: [number, number, number, number] = [0.8, 0.8, 0.8, 1]
+
+// Matches the shim proxy's NormalizeMat (Z-up -> Y-up).
+const NORMALIZE_MAT: glmatrix.mat4 = glmatrix.mat4.fromValues(
+    1, 0, 0, 0,
+    0, 0, -1, 0,
+    0, 1, 0, 0,
+    0, 0, 0, 1,
+)
+
+/**
+ * One preview mesh instance, self-contained: geometry payload is COPIED out
+ * of the wasm heap at emission, so consumers can upload it directly and
+ * never touch the (still-loading) model. `vertexData` is interleaved
+ * position+normal, 6 floats per vertex, exactly the GetGeometry layout the
+ * classic FlatMesh path reads. For instances sharing geometry with an
+ * earlier emission (mapped items), `vertexData`/`indexData` are omitted and
+ * `geometryExpressID` identifies the earlier payload to reuse.
+ */
+export interface PreviewMeshPayload {
+  expressID: number
+  geometryExpressID: number
+  color: { x: number, y: number, z: number, w: number }
+  flatTransformation: number[]
+  vertexData?: Float32Array
+  indexData?: Uint32Array
+}
+
+/**
+ * Parse-time preview channel (demand/tiled rendering slice A2): while the
+ * deferred streamed open is still parsing, periodically snapshot the growing
+ * columnar index into a PREFIX model, extract a bounded number of products
+ * through a throwaway extraction, and emit self-contained mesh payloads —
+ * first pixels within the first seconds of a large parse instead of after
+ * it.
+ *
+ * Preview quality, by construction: IFC relationship records
+ * (IfcRelVoidsElement, IfcRelAssociatesMaterial, styled items) spread to the
+ * very end of real files (measured ~92–97% depth), so a prefix extraction
+ * can miss openings and materials. That is why these extractions are
+ * throwaway: the durable batch pump after the parse re-extracts every
+ * product with the full model and REPLACES the preview — final geometry
+ * parity is untouched by this channel.
+ *
+ * Scheduling: the cooperative parse yields to the event loop via macrotasks
+ * every ~50ms; each pump tick runs in one of those gaps under a hard time
+ * budget, so the parse keeps the bulk of the main thread.
+ *
+ * Product cursor: top-level localIDs are stable across snapshots (dense
+ * parse order) and `types(IfcProduct)` iterates in localID order, so a
+ * single ordinal cursor advances across generations without re-extracting.
+ * Products whose extraction throws mid-parse (unparsed forward references)
+ * are skipped — the durable pump extracts them correctly later.
+ */
+export class StreamedPreviewChannel {
+
+  /** Coordination matrix pinned from the first captured instance, exactly
+   * the derivation the durable capture would perform — the proxy adopts it
+   * so preview and durable placements share one frame. */
+  public coordinationMatrix?: glmatrix.mat4
+
+  private stopped_ = false
+  private timer_?: ReturnType<typeof setTimeout>
+
+  private emittedProducts_ = 0
+  private emittedBytes_ = 0
+
+  /** Ordinal cursor into the (append-stable) product list. */
+  private productOrdinal_ = 0
+
+  /** Geometry expressIDs whose payload has been emitted (cross-generation
+   * dedup for mapped/shared geometry). */
+  private readonly emittedGeometry_ = new Set<number>()
+
+  private generation_?: {
+    model: IfcStepModel
+    extraction: IfcGeometryExtraction
+    products: number[]
+    nextIndex: number
+    capturedCounts: Map<number, number>
+    snapshotRecords: number
+  }
+
+  private lastSnapshotRecords_ = 0
+
+  /**
+   * @param data The (fully resident) source buffer the parse is indexing.
+   * @param conwaywasm The shared geometry wasm wrapper (sequential use only
+   * — ticks run between parse yields, never concurrently with the durable
+   * extraction, which is created after the parse completes).
+   * @param sink The live columnar sink the streamed parse is filling.
+   * @param coordinateToOrigin The open's COORDINATE_TO_ORIGIN setting.
+   * @param onMesh Consumer callback for each preview payload.
+   * @param maxProducts Cap on products ever preview-extracted.
+   * @param maxBytes Cap on total payload bytes copied out.
+   * @param firstGenerationMinRecords Records required before the first
+   * snapshot (tests lower it for tiny fixtures).
+   */
+  constructor(
+      private readonly data: Uint8Array,
+      private readonly conwaywasm: ConwayGeometry,
+      private readonly sink: ColumnarIndexSink<EntityTypesIfc>,
+      private readonly coordinateToOrigin: boolean,
+      private readonly onMesh: (mesh: PreviewMeshPayload) => void,
+      private readonly maxProducts: number = DEFAULT_MAX_PREVIEW_PRODUCTS,
+      private readonly maxBytes: number = DEFAULT_MAX_PREVIEW_BYTES,
+      private readonly firstGenerationMinRecords: number =
+      FIRST_GENERATION_MIN_RECORDS ) {
+  }
+
+  /** Begin ticking (call just before awaiting the parse). */
+  public start(): void {
+    this.schedule_()
+  }
+
+  /**
+   * Stop ticking (call once the parse settles, before finalize/fallback).
+   * Idempotent; no tick runs after this returns (ticks are synchronous and
+   * scheduled on the same event loop).
+   */
+  public stop(): void {
+    this.stopped_ = true
+
+    if (this.timer_ !== void 0) {
+      clearTimeout(this.timer_)
+      this.timer_ = void 0
+    }
+  }
+
+  /** True when a cap was hit and the channel retired itself early. */
+  public get capped(): boolean {
+    return this.emittedProducts_ >= this.maxProducts ||
+      this.emittedBytes_ >= this.maxBytes
+  }
+
+  // eslint-disable-next-line require-jsdoc
+  private schedule_(): void {
+
+    if (this.stopped_ || this.capped) {
+      return
+    }
+
+    this.timer_ = setTimeout(() => {
+      this.timer_ = void 0
+
+      try {
+        this.tick_()
+      } catch {
+        // A preview failure must never break the open — retire quietly;
+        // the durable pump renders everything after the parse.
+        this.stopped_ = true
+      }
+
+      this.schedule_()
+    }, TICK_INTERVAL_MS)
+  }
+
+  /**
+   * One pump tick: ensure a generation with pending products exists, then
+   * extract + capture under the time budget.
+   */
+  private tick_(): void {
+
+    const deadline = Date.now() + TICK_BUDGET_MS
+
+    if (!this.ensureGeneration_()) {
+      return
+    }
+
+    const generation = this.generation_!
+    const { extraction, products } = generation
+
+    let extractedThisTick = 0
+
+    while (generation.nextIndex < products.length &&
+        this.emittedProducts_ + extractedThisTick < this.maxProducts &&
+        Date.now() < deadline) {
+
+      const localID = products[generation.nextIndex++]
+      ++this.productOrdinal_
+
+      try {
+        if (extraction.extractProductGeometryByLocalID(localID)) {
+          ++extractedThisTick
+        }
+      } catch {
+        // Unparsed forward reference (or any other mid-parse gap): skip.
+        // The durable pump extracts this product from the full model.
+      }
+    }
+
+    if (extractedThisTick > 0) {
+      this.captureNewInstances_()
+      this.emittedProducts_ += extractedThisTick
+    }
+  }
+
+  /**
+   * Ensure a generation with pending products: keep the current one while
+   * it has work; otherwise snapshot a fresh prefix model once the index has
+   * grown enough to be worth the copy.
+   *
+   * @return {boolean} True when a generation with pending products exists.
+   */
+  private ensureGeneration_(): boolean {
+
+    const generation = this.generation_
+
+    if (generation !== void 0 && generation.nextIndex < generation.products.length) {
+      return true
+    }
+
+    const records = this.sink.topLevelCount
+
+    if (records < this.firstGenerationMinRecords) {
+      return false
+    }
+
+    if (generation !== void 0 &&
+        records < this.lastSnapshotRecords_ * GENERATION_GROWTH_FACTOR) {
+      return false
+    }
+
+    const columns = this.sink.snapshot()
+    const model = new IfcStepModel(this.data, columns)
+
+    const products: number[] = []
+
+    for (const product of model.types(IfcProduct)) {
+      products.push(product.localID)
+    }
+
+    if (products.length <= this.productOrdinal_) {
+      // Prefix grew but produced no new products — wait for more records.
+      this.lastSnapshotRecords_ = records
+      return false
+    }
+
+    const extraction = new IfcGeometryExtraction(this.conwaywasm, model)
+
+    this.generation_ = {
+      model,
+      extraction,
+      products,
+      nextIndex: this.productOrdinal_,
+      capturedCounts: new Map<number, number>(),
+      snapshotRecords: records,
+    }
+    this.lastSnapshotRecords_ = records
+
+    return true
+  }
+
+  /**
+   * Walk the current generation's scene and emit every not-yet-captured
+   * placed instance as a payload — the preview twin of the shim's durable
+   * delta capture, with the same placed-geometry math (normalize, scaling,
+   * coordination) so preview and durable placements coincide, but copying
+   * geometry OUT of the wasm heap instead of retaining native references.
+   */
+  private captureNewInstances_(): void {
+
+    const generation = this.generation_!
+    const { model, extraction, capturedCounts } = generation
+    const scene = extraction.scene
+
+    const linearScalingFactor = extraction.getLinearScalingFactor()
+    const seenThisPass = new Map<number, number>()
+
+    // eslint-disable-next-line no-unused-vars
+    for (const [_, nativeTransform, geometry, material, entity] of scene.walk()) {
+
+      if (entity?.localID === void 0 || entity.expressID === void 0) {
+        continue
+      }
+
+      const walkIndex = seenThisPass.get(entity.localID) ?? 0
+      seenThisPass.set(entity.localID, walkIndex + 1)
+
+      if (walkIndex < (capturedCounts.get(entity.localID) ?? 0)) {
+        continue
+      }
+
+      capturedCounts.set(entity.localID, walkIndex + 1)
+
+      if (geometry.type !== CanonicalMeshType.BUFFER_GEOMETRY || geometry.temporary) {
+        continue
+      }
+
+      const material_: CanonicalMaterial = material ?? {
+        name: '',
+        baseColor: DEFAULT_COLOR,
+        legacyColor: DEFAULT_COLOR,
+        doubleSided: true,
+        blend: 0,
+      }
+
+      let nativePt: Vector3 | undefined
+
+      if (this.coordinationMatrix === void 0 && this.coordinateToOrigin) {
+        nativePt = geometry.geometry.getPoint(0)
+      }
+
+      const geomCenter: glmatrix.vec3 = glmatrix.vec3.create()
+      const center = geometry.geometry.normalize()
+
+      geomCenter[0] = center.x
+      geomCenter[1] = center.y
+      geomCenter[2] = center.z
+
+      const translationMatrixGeomMin: glmatrix.mat4 = glmatrix.mat4.create()
+      glmatrix.mat4.fromTranslation(translationMatrixGeomMin, geomCenter)
+
+      const geometryExpressID =
+        model.getElementByLocalID(geometry.localID)?.expressID as number
+
+      const geometryTransform = nativeTransform?.getValues()
+      let newMatrix: glmatrix.mat4
+
+      if (geometryTransform !== void 0) {
+        newMatrix = glmatrix.mat4.fromValues(
+            ...(geometryTransform as unknown as
+              Parameters<typeof glmatrix.mat4.fromValues>))
+      } else {
+        newMatrix = glmatrix.mat4.create()
+      }
+
+      if (this.coordinationMatrix === void 0 && this.coordinateToOrigin) {
+
+        const transformedPt: glmatrix.vec4 = glmatrix.vec4.create()
+        glmatrix.vec4.transformMat4(
+            transformedPt,
+            [nativePt!.x, nativePt!.y, nativePt!.z, 1],
+            newMatrix)
+
+        const coordinationMatrix = glmatrix.mat4.create()
+        glmatrix.mat4.fromTranslation(coordinationMatrix,
+            [-transformedPt[0], -transformedPt[1], -transformedPt[2]])
+
+        const scaleMatrix = glmatrix.mat4.create()
+        const scaleVec = glmatrix.vec3.fromValues(
+            linearScalingFactor, linearScalingFactor, linearScalingFactor)
+
+        glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
+        glmatrix.mat4.multiply(coordinationMatrix, NORMALIZE_MAT, coordinationMatrix)
+        glmatrix.mat4.multiply(coordinationMatrix, scaleMatrix, coordinationMatrix)
+
+        this.coordinationMatrix = coordinationMatrix
+      }
+
+      const coordination = this.coordinationMatrix ?? glmatrix.mat4.create()
+
+      const newTransform = glmatrix.mat4.create()
+      const scaleMatrix = glmatrix.mat4.create()
+      const scaleVec = glmatrix.vec3.fromValues(
+          linearScalingFactor, linearScalingFactor, linearScalingFactor)
+
+      glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
+      glmatrix.mat4.multiply(newTransform, coordination, newMatrix)
+      glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
+
+      const payload: PreviewMeshPayload = {
+        expressID: entity.expressID,
+        geometryExpressID,
+        color: {
+          x: material_.legacyColor[0],
+          y: material_.legacyColor[1],
+          z: material_.legacyColor[2],
+          w: material_.legacyColor[3],
+        },
+        flatTransformation: Array.from(newTransform),
+      }
+
+      if (!this.emittedGeometry_.has(geometryExpressID)) {
+
+        const nativeGeometry = geometry.geometry
+
+        const vertexData = this.conwaywasm.floatHeapSlice(
+            nativeGeometry.GetVertexData(),
+            nativeGeometry.GetVertexDataSize()).slice()
+        const indexData = this.conwaywasm.uint32HeapSlice(
+            nativeGeometry.GetIndexData(),
+            nativeGeometry.GetIndexDataSize()).slice()
+
+        if (vertexData.length < FLOATS_PER_VERTEX || indexData.length === 0) {
+          continue
+        }
+
+        payload.vertexData = vertexData
+        payload.indexData = indexData
+
+        this.emittedGeometry_.add(geometryExpressID)
+        this.emittedBytes_ +=
+          (vertexData.length + indexData.length) * BYTES_PER_FLOAT
+      }
+
+      this.onMesh(payload)
+
+      if (this.emittedBytes_ >= this.maxBytes) {
+        return
+      }
+    }
+  }
+
+  /**
+   * Test seam: run generation building + extraction + capture synchronously
+   * until either every product currently in the sink is attempted or a cap
+   * is hit — what the timer-driven ticks do, without the timers.
+   */
+  public drainForTest(): void {
+
+    for (; ;) {
+
+      if (this.capped || !this.ensureGeneration_()) {
+        return
+      }
+
+      const generation = this.generation_!
+
+      if (generation.nextIndex >= generation.products.length) {
+        return
+      }
+
+      const localID = generation.products[generation.nextIndex++]
+      ++this.productOrdinal_
+
+      let extracted = false
+
+      try {
+        extracted = generation.extraction.extractProductGeometryByLocalID(localID)
+      } catch {
+        // Skip — mirrors tick_.
+      }
+
+      if (extracted) {
+        this.captureNewInstances_()
+        ++this.emittedProducts_
+      }
+    }
+  }
+}

--- a/src/step/parsing/columnar_index.ts
+++ b/src/step/parsing/columnar_index.ts
@@ -150,6 +150,24 @@ implements StepIndexSink<TypeIDType> {
   }
 
   /**
+   * Snapshot the columns pushed SO FAR into a self-contained prefix index,
+   * without disturbing the sink — the parse can keep pushing afterwards and
+   * a later snapshot/finalize sees the full data. Safe to call between the
+   * cooperative parse's yields (the parser only suspends at top-level
+   * record boundaries, where the sink is consistent). Top-level localIDs
+   * are stable across snapshots (dense parse order), so consumers can carry
+   * per-localID cursors from one snapshot to the next; inline-range
+   * localIDs are NOT stable (the inline tail re-packs after the growing
+   * top-level range) and must not be carried across snapshots.
+   *
+   * @return {StepIndexColumns} A prefix columnar index over the records
+   * pushed so far.
+   */
+  public snapshot(): StepIndexColumns<TypeIDType> {
+    return this.assemble_()
+  }
+
+  /**
    * Assemble the final columns: concatenate the top-level segments (one
    * column at a time, bounding transient overhead to a single column's
    * segments) and unfold retained inline entities into the inline range in
@@ -158,6 +176,16 @@ implements StepIndexSink<TypeIDType> {
    * @return {StepIndexColumns} The finished columnar index.
    */
   public finalize(): StepIndexColumns<TypeIDType> {
+    return this.assemble_()
+  }
+
+  /**
+   * Shared assembly behind {@link snapshot} and {@link finalize} — pure
+   * over the sink's current state.
+   *
+   * @return {StepIndexColumns} The assembled columnar index.
+   */
+  private assemble_(): StepIndexColumns<TypeIDType> {
 
     const topLevel = this.count_
 


### PR DESCRIPTION
Demand/tiled rendering slice A2 (Share #1613, epic #390): on a deferred streamed open, emit **preview meshes while the parse is still running** — first pixels within the first second or two of a large parse instead of after it.

## Why previews and not durable extraction

Measured on real files: relationship records (`IFCRELVOIDSELEMENT`, `IFCRELASSOCIATESMATERIAL`, styled items) extend to **~92–97% of file depth** (Schependomlaan: rel-materials last at line 968410 of 999492). A prefix extraction therefore can't reliably cut openings or resolve materials — durable-quality extraction mid-parse is structurally impossible for typical IFC. So the channel embraces preview quality:

- **Throwaway prefix extractions**: `ColumnarIndexSink.snapshot()` assembles the columns pushed so far (non-destructive, shared with `finalize`); the channel builds generations of prefix `IfcStepModel` + `IfcGeometryExtraction` over them, rebuilt only after 1.5× index growth.
- **Self-contained payloads**: vertex/index data is **copied out of the wasm heap** (interleaved pos+normal, the GetGeometry layout) with cross-generation geometry dedup — consumers upload directly, never touching the still-loading model.
- **Replaced, not kept**: the durable batch pump after the parse re-extracts every product from the full model — final geometry parity is untouched by construction (products whose extraction throws on unparsed forward refs are simply skipped).
- **Coordination pinning**: the channel derives the coordination matrix from its first instance with the durable capture's exact math, and the deferred proxy adopts it — preview and durable placements share one frame.

## Scheduling & bounds

The cooperative parse yields via macrotasks every ~50ms; the channel ticks on a 150ms timer with a 25ms budget per tick (~17% worst-case main-thread share). Per-channel caps (4096 products / 48MB payload) bound the throwaway scenes' native footprint — the shim never frees classic scenes either (`closeModel` is a no-op); tiles (slice C) are the real fix.

## Surface

`Loadersettings.ON_PREVIEW_MESH?: (mesh: PreviewMeshPayload) => void` — deferred streamed opens only, ignored everywhere else. `PreviewMeshPayload` exported from the shim.

## Measured

Schependomlaan (49MB): **first payload at 583ms into a 1199ms parse**, 109 instances emitted before the open resolved; durable pump unaffected.

## Tests (4 new, all compat suites green — 44/44)

- Mid-parse snapshot is an exact prefix of the final columns; aggressive snapshotting never disturbs the sink.
- Full channel drain reproduces the classic `StreamAllMeshes` instance set exactly (entities, geometry ids, transforms), one geometry carrier per distinct geometry.
- Channel coordination equals the durable pump's persisted matrix.
- `ON_PREVIEW_MESH` presence never changes the durable path's output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_