### PR TITLE
Fix demand-path scatter: freeze the float vertex mirror at mesh add

### DIFF
--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -135,6 +135,66 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     api.CloseModel( deferredID )
   }, 240000 )
 
+  test( 'deferred GetGeometry serves byte-identical vertex content to classic', async () => {
+
+    // The build multiplies GetGeometry FLOAT vertices by captured
+    // transforms, and the float mirror's frame must match the scene
+    // transforms (frozen at mesh add — see IfcModelGeometry.add). A
+    // per-geometry frame shift here renders as scattered pieces even
+    // with perfect transform parity, which transform-only assertions
+    // cannot catch.
+    //
+    // Fresh IfcAPI: CloseModel destroys the shared wasm processor, and
+    // models opened after ANY close serve empty geometry payloads (a
+    // long-standing multi-open shim quirk — browsers open one model per
+    // page). The shared `api` has closed models by the time this runs.
+    const api2 = new IfcAPI()
+    await api2.Init()
+
+    const classicID = api2.OpenModel( buffer, SETTINGS )
+    const geometryIDs = new Set<number>()
+
+    api2.StreamAllMeshes( classicID, ( mesh ) => {
+      for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+        geometryIDs.add( mesh.geometries.get( where ).geometryExpressID )
+      }
+    } )
+
+    const deferredID = await api2.OpenModelStreamed(
+        buffer, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    api2.StreamAllMeshes( deferredID, () => { /* drain */ } )
+
+    let compared = 0
+
+    for ( const geometryID of geometryIDs ) {
+
+      const classicGeometry = api2.GetGeometry( classicID, geometryID )
+      const deferredGeometry = api2.GetGeometry( deferredID, geometryID )
+
+      const classicSize = classicGeometry.GetVertexDataSize()
+
+      if ( classicSize === 0 ) {
+        continue
+      }
+
+      expect( deferredGeometry.GetVertexDataSize() ).toBe( classicSize )
+
+      const classicVertices =
+        api2.GetVertexArray( classicGeometry.GetVertexData(), classicSize )
+      const deferredVertices =
+        api2.GetVertexArray( deferredGeometry.GetVertexData(), classicSize )
+
+      expect( deferredVertices ).toEqual( classicVertices )
+      ++compared
+    }
+
+    expect( compared ).toBeGreaterThan( 0 )
+
+    api2.CloseModel( classicID )
+    api2.CloseModel( deferredID )
+  }, 240000 )
+
   test( 'ExtractGeometryBatch is a safe no-op on non-deferred models', async () => {
 
     const modelID = await api.OpenModelStreamed( buffer, SETTINGS )

--- a/src/core/progress.test.ts
+++ b/src/core/progress.test.ts
@@ -85,15 +85,25 @@ describe( 'ProgressTracker', () => {
 
 describe( 'yieldToEventLoop', () => {
 
-  test( 'lets queued macrotasks run', async () => {
+  test( 'does not starve queued timers', async () => {
 
+    // The yield posts an ordinary task (scheduler.yield / MessageChannel —
+    // deliberately NOT a timer, so background tabs' >=1s setTimeout clamp
+    // cannot collapse a cooperative parse). Message tasks can be serviced
+    // ahead of the timer queue, so a due timer is not guaranteed to run
+    // within ONE yield — the contract is that repeated yielding lets due
+    // timers fire promptly (stall watchdogs stay live during a parse).
     let timerRan = false
 
     setTimeout( () => {
       timerRan = true
     }, 0 )
 
-    await yieldToEventLoop()
+    const MAX_YIELDS = 50
+
+    for ( let where = 0; where < MAX_YIELDS && !timerRan; ++where ) {
+      await yieldToEventLoop()
+    }
 
     expect( timerRan ).toBe( true )
   } )

--- a/src/core/progress.ts
+++ b/src/core/progress.ts
@@ -52,9 +52,35 @@ export const DEFAULT_PROGRESS_INTERVAL_MS = 100
  * repaint progress UI and timers (e.g. stall watchdogs) can fire. Used by the
  * *Async load variants between progress ticks.
  *
- * @return {Promise<void>} A promise resolved on the next timer turn.
+ * Not timer-based where avoidable: background tabs clamp setTimeout to >=1s,
+ * which would collapse a cooperative parse to a ~5% duty cycle the moment
+ * the tab loses focus. scheduler.yield() (and the MessageChannel fallback)
+ * post ordinary tasks, which are not clamped — loads keep their CPU in
+ * backgrounded tabs. setTimeout remains as the last-resort fallback for
+ * environments without either (where throttling doesn't apply anyway).
+ *
+ * @return {Promise<void>} A promise resolved on the next event-loop task.
  */
 export function yieldToEventLoop(): Promise<void> {
+
+  const scheduler =
+    ( globalThis as { scheduler?: { yield?: () => Promise<void> } } ).scheduler
+
+  if ( typeof scheduler?.yield === 'function' ) {
+    return scheduler.yield()
+  }
+
+  if ( typeof MessageChannel === 'function' ) {
+    return new Promise<void>( ( resolve ) => {
+      const channel = new MessageChannel()
+      channel.port1.onmessage = () => {
+        channel.port1.close()
+        resolve()
+      }
+      channel.port2.postMessage( null )
+    } )
+  }
+
   return new Promise<void>( ( resolve ) => {
     setTimeout( resolve, 0 )
   } )

--- a/src/ifc/ifc_model_geometry.ts
+++ b/src/ifc/ifc_model_geometry.ts
@@ -52,9 +52,25 @@ export class IfcModelGeometry implements ModelGeometry {
   /**
    * Add a mesh to the geometry cache.
    *
+   * Freezes the native float vertex mirror at add time (one
+   * GetVertexData call): consumers (the compat GetGeometry surface)
+   * read float vertices whose frame must match the scene transforms,
+   * which are authored against the geometry AS CREATED. Later native
+   * mutations that keep the vertex count (normalize's centering)
+   * deliberately do NOT refresh the mirror, so every extraction path —
+   * whole-model walk, per-product demand pump, parse-time preview —
+   * serves the same creation-frame floats. Without this, paths that
+   * first read vertices only after a centering mutation serve
+   * per-geometry-shifted vertices against unshifted transforms
+   * (Share's demand-path "scatter").
+   *
    * @param mesh
    */
   public add(mesh: CanonicalMesh) {
+
+    if (mesh.type === CanonicalMeshType.BUFFER_GEOMETRY) {
+      mesh.geometry.GetVertexData()
+    }
 
     this.meshes_.set(mesh.localID, mesh)
   }


### PR DESCRIPTION
Fixes the "abstract art" scatter on Share #1614's demand path — the real root cause, which #423 only half-fixed (transforms were never the problem).

## Root cause

The compat build multiplies `GetGeometry` **float** vertices by captured transforms. Scene transforms are authored against geometry **as created**, but a native centering mutation (`Normalize`) shifts the doubles — and the float mirror only refreshes when the vertex *count* changes:

- **Classic whole-model walk**: floats happen to get read before the centering → mirror frozen in the creation frame → correct.
- **Per-product demand pump / parse-time preview channel**: floats first read at build time → regenerated from *centered* doubles → every piece displaced by its own bounds center against unshifted transforms.

Reproduced on Schependomlaan: **4697/4761 geometries with divergent vertex content, zero transform mismatches** — which is why #423's transform-parity verification passed while the browser scattered.

## Fix

`IfcModelGeometry.add` freezes the mirror explicitly (one `GetVertexData` call at mesh add) — the classic path's accident made deterministic and documented. Every extraction path now serves the same creation-frame floats.

Verified: content divergence **0/4761** after the fix; classic output byte-identical to before; transform parity intact with the preview channel active. New test pins deferred `GetGeometry` vertex content byte-identical to classic. (Test uses a fresh `IfcAPI`: models opened after any `CloseModel` serve empty geometry payloads — a pre-existing multi-open quirk of the shared-processor destroy, unrelated to this change.)

## Also: background-tab CPU falloff

`yieldToEventLoop` now posts ordinary tasks (`scheduler.yield()`, MessageChannel fallback) instead of `setTimeout` — background tabs clamp timers to ≥1s, which collapsed cooperative parses to a ~5% duty cycle when the tab lost focus. The progress test now pins the timer-starvation contract (due timers fire across repeated yields).

Tests: 252/252 across compat, ifc, step, and core suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_