### PR TITLE
STEP demand parity: streamed columnar open + deferred unit pump for AP214

### DIFF
--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -4101,38 +4101,57 @@ export class AP214GeometryExtraction {
    * @return {[ExtractResult, AP214SceneBuilder]} - Enum indicating extraction result
    * + Geometry array
    */
-  extractAP214GeometryData(logTime: boolean = false):
-    [ExtractResult, AP214SceneBuilder, AP214ProductShapeMap] {
+  /**
+   * Prepare per-unit demand extraction (STEP demand parity phase 2)
+   * without executing any geometry work: builds the assembly tree and
+   * thunks exactly like the whole-model walk, but the root executions
+   * are captured as an ordered list of UNITS — a childless root is one
+   * unit; a root with children is flattened one level (one unit per
+   * immediate child, in order, then one for the root's own items), so
+   * single-root assemblies still pump progressively per part. Executing
+   * every unit in order then calling {@link finishDemandExtraction}
+   * reproduces the whole-model walk exactly — the classic
+   * {@link extractAP214GeometryData} runs through this same path.
+   * Idempotent.
+   */
+  // eslint-disable-next-line max-lines-per-function
+  public prepareDemandExtraction(): void {
 
-    let result: ExtractResult = ExtractResult.INCOMPLETE
-
-    const startTime = Date.now()
-
-    //  this.extractLinearScalingFactor()
-    const previousMemoizationState = this.model.elementMemoization
-
-    // populate relMaterialsMap
-    // const relAssociatesMaterials = this.model.types(AP214RelAssociatesMaterial)
+    if ( this.demandUnits_ !== void 0 ) {
+      return
+    }
 
     const model = this.model
-  
+
     type MappedSceneNode = {
       children?: [number, number, NativeTransform4x4?][];
       parents?: number;
       thunk?: ( owningLocalID?: number, transform?: NativeTransform4x4 ) => void;
       node?: AP214SceneTransform;
       processed?: boolean;
+      rep?: shape_representation;
+      owningLocalID?: number;
+    }
+
+    type ThunkSlice = {
+      childStart: number;
+      childEnd: number;
+      includeItems: boolean;
     }
 
     const treeMap = new Map<number, MappedSceneNode>()
 
-    const makeThunk = ( representation: shape_representation, owningElementLocalID?: number, mappedTreeNode?: MappedSceneNode ) => {
+    const makeThunk = (
+        representation: shape_representation,
+        owningElementLocalID?: number,
+        mappedTreeNode?: MappedSceneNode,
+        slice?: ThunkSlice ) => {
 
       return ( owningLocalID?: number, parentTransform?: NativeTransform4x4 ) => {
 
         owningLocalID ??= owningElementLocalID
 
-        const mappedItem = mappedTreeNode !== void 0 || parentTransform !== void 0 
+        const mappedItem = mappedTreeNode !== void 0 || parentTransform !== void 0
 
         const entryTransformDepth = this.scene.stackLength
         const currentParent = this.scene.currentParent
@@ -4143,10 +4162,15 @@ export class AP214GeometryExtraction {
             parentTransform,
             true,
           )
-        } 
+        }
 
-        if ( mappedTreeNode?.children !== void 0 ) {
-          for ( const [childLocalID, childOwningLocalID, childTransform] of mappedTreeNode.children ) {
+        if ( mappedTreeNode?.children !== void 0 &&
+            ( slice === void 0 || slice.childStart !== slice.childEnd ) ) {
+          const sliceChildren = slice !== void 0 ?
+            mappedTreeNode.children.slice( slice.childStart, slice.childEnd ) :
+            mappedTreeNode.children
+
+          for ( const [childLocalID, childOwningLocalID, childTransform] of sliceChildren ) {
             const mappedChild = treeMap.get( childLocalID )!
             const enterChildStackDepth = this.scene.stackLength
             const enterChildParent = this.scene.currentParent
@@ -4199,9 +4223,11 @@ export class AP214GeometryExtraction {
           }
         }
                 
-        for ( const item of representation.items ) {
+        const includeItems = slice?.includeItems ?? true
 
-          try {             
+        for ( const item of includeItems ? representation.items : [] ) {
+
+          try {
             if ( item instanceof placement ) {
               this.extractPlacement( item, mappedItem )
               continue
@@ -4242,14 +4268,26 @@ export class AP214GeometryExtraction {
       }
     }
 
-    try {
+    // Roots the whole-model walk would execute, in execution order —
+    // expanded into units at the end of preparation (children arrays
+    // are final only once every edge loop has run).
+    const pendingRoots: {
+      node: MappedSceneNode,
+      scaleTransform?: NativeTransform4x4,
+    }[] = []
 
+    {
       this.scene.clearParentStack()
 
       // 256 meg limit for memoization - smaller models get a big
       // win from memoization, but much larger models it uses far too much heap.
-       
+
       const MEMOIZATION_THRESHOLD = 256 * 1024 * 1024
+
+      // Remembered for finishDemandExtraction / the classic wrapper's
+      // finally — the pump spans many calls, so restoration cannot live
+      // in a single method's finally anymore.
+      this.demandMemoizationRestore_ = this.model.elementMemoization
 
       if ( this.lowMemoryMode || model.bufferBytesize > MEMOIZATION_THRESHOLD ) {
         this.model.elementMemoization = false
@@ -4342,6 +4380,8 @@ export class AP214GeometryExtraction {
           sourceNode = { parents: 1 }
           treeMap.set( sourceID, sourceNode )
           sourceNode.thunk = makeThunk( sourceShape, owningLocalID, sourceNode )
+          sourceNode.rep = sourceShape
+          sourceNode.owningLocalID = owningLocalID
         } else {
           sourceNode.parents ??= 0
           ++sourceNode.parents
@@ -4393,6 +4433,8 @@ export class AP214GeometryExtraction {
         }
 
         sourceNode.thunk = makeThunk( sourceShape, owningLocalID, sourceNode )
+        sourceNode.rep = sourceShape
+        sourceNode.owningLocalID = owningLocalID
 
         let targetNode = treeMap.get( targetID )       
         if ( targetNode === void 0 ) {
@@ -4428,6 +4470,8 @@ export class AP214GeometryExtraction {
         const mappedTreeNode = treeNode
         const thunk = makeThunk( shapeRepresentation, owningElementLocalID, mappedTreeNode )
         mappedTreeNode.thunk = thunk
+        mappedTreeNode.rep = shapeRepresentation
+        mappedTreeNode.owningLocalID = owningElementLocalID
 
         if ( !hasMappedNode ) {
           mappedTreeNode.processed = true
@@ -4444,8 +4488,14 @@ export class AP214GeometryExtraction {
               this.uniformScaleAffine( this.identity3DNativeMatrix, 1.0 / sourceUnitInM )
           }
 
-          // not an assembly mapped item, just extract the representation
-          thunk( void 0, scaleTransform )
+          // not an assembly mapped item — capture as a pending root
+          // instead of executing inline (these nodes are childless by
+          // construction: they were absent from the tree before this
+          // loop, and all edges were added by the earlier loops).
+          pendingRoots.push( {
+            node: mappedTreeNode,
+            scaleTransform,
+          } )
           continue
         }
       }
@@ -4470,14 +4520,15 @@ export class AP214GeometryExtraction {
         const mappedTreeNode = treeNode
         const owningElementLocalID = shapeRepresentation.localID
         mappedTreeNode.thunk = makeThunk( shapeRepresentation, owningElementLocalID, mappedTreeNode )
+        mappedTreeNode.rep = shapeRepresentation
+        mappedTreeNode.owningLocalID = owningElementLocalID
       }
 
-      // All thunks are set, now we can execute the full
-      // assembly tree.
+      // All thunks are set — capture remaining assembly-tree roots as
+      // pending roots in the exact order the whole-model walk executed
+      // them.
       for ( const [sourceID, mappedNode] of treeMap.entries() ) {
         if ( ( mappedNode.parents ?? 0 ) === 0 && mappedNode.thunk !== void 0 && mappedNode.processed !== true ) {
-
-          //this.scene.clearParentStack()
 
           const shapeRepresentation = this.model.getTypedElementByLocalID( sourceID, shape_representation )! as shape_representation
           const sourceShapeContext = 
@@ -4492,34 +4543,169 @@ export class AP214GeometryExtraction {
               this.uniformScaleAffine( this.identity3DNativeMatrix, 1.0 / sourceUnitInM )
           }
 
-          // not an assembly mapped item, just extract the representation
-          mappedNode.thunk( void 0, scaleTransform )
+          pendingRoots.push( { node: mappedNode, scaleTransform } )
         }
       }
-      
-      // Run any deferred face tessellation across the native thread pool
-      // before geometry can be read or temporaries freed.
-      this.finalizeStagedFaces()
 
-      if ( RegressionCaptureState.memoization !== MemoizationCapture.FULL ) {
-        this.model.geometry.deleteTemporaries()
+      // Expand pending roots into ordered execution units: childless
+      // roots run their original thunk whole; roots with children are
+      // flattened one level — one unit per immediate child (in order),
+      // then one for the root's own representation items, matching the
+      // thunk body's children-then-items order exactly.
+      const units: ( () => void )[] = []
+
+      for ( const root of pendingRoots ) {
+
+        const node = root.node
+        const scaleTransform = root.scaleTransform
+        const childCount = node.children?.length ?? 0
+
+        if ( childCount === 0 || node.rep === void 0 ) {
+          units.push( () => node.thunk!( void 0, scaleTransform ) )
+          continue
+        }
+
+        for ( let child = 0; child < childCount; ++child ) {
+          const sliced = makeThunk( node.rep, node.owningLocalID, node,
+              { childStart: child, childEnd: child + 1, includeItems: false } )
+          units.push( () => sliced( void 0, scaleTransform ) )
+        }
+
+        const itemsOnly = makeThunk( node.rep, node.owningLocalID, node,
+            { childStart: 0, childEnd: 0, includeItems: true } )
+        units.push( () => itemsOnly( void 0, scaleTransform ) )
       }
 
-      result = ExtractResult.COMPLETE
+      this.demandUnits_ = units
+    }
+  }
 
-      // free buffer at the end if you don't need it anymore
-      if (this.pointBuffer?.pointer) {
-        this.wasmModule._free(this.pointBuffer.pointer)
-        this.pointBuffer = null
+  // Ordered pending execution units built by prepareDemandExtraction;
+  // demandCursor_ tracks how many have run (the pump's progress).
+  private demandUnits_?: ( () => void )[]
+  private demandCursor_ = 0
+  private demandMemoizationRestore_?: boolean
+
+  /**
+   * Total demand units (see prepareDemandExtraction).
+   *
+   * @return {number} The unit count (0 before preparation).
+   */
+  public get demandUnitCount(): number {
+    return this.demandUnits_?.length ?? 0
+  }
+
+  /**
+   * Units already executed by extractDemandUnitBatch.
+   *
+   * @return {number} The cursor.
+   */
+  public get demandUnitCursor(): number {
+    return this.demandCursor_
+  }
+
+  /**
+   * Execute the next `count` demand units (STEP demand parity phase 2)
+   * — the per-unit pump behind the shim's ExtractGeometryBatch for
+   * AP214 models. Staged face tessellation is finalized after every
+   * batch so captured geometry is complete and readable.
+   *
+   * @param count Max units to execute this call (min 1).
+   * @return {number} Units actually executed.
+   */
+  public extractDemandUnitBatch( count: number ): number {
+
+    const units = this.demandUnits_
+
+    if ( units === void 0 ) {
+      return 0
+    }
+
+    const end = Math.min( this.demandCursor_ + Math.max( count, 1 ), units.length )
+    let executed = 0
+
+    for ( ; this.demandCursor_ < end; ++this.demandCursor_ ) {
+      try {
+        units[ this.demandCursor_ ]()
+        ++executed
+      } catch ( ex ) {
+        if ( ex instanceof Error ) {
+          Logger.error( `Error processing demand unit: \n\t${ex.name}\n\t${ex.message}` )
+        } else {
+          Logger.error( `Unknown exception processing demand unit (${ex})` )
+        }
       }
-      return [result, this.scene, this.productShapeMap]
+    }
+
+    // Deferred face tessellation must land before geometry is read.
+    this.finalizeStagedFaces()
+
+    return executed
+  }
+
+  /**
+   * Complete a demand extraction after every unit has run: final staged
+   * tessellation, temporaries cleanup, point-buffer release and
+   * memoization restore — the tail the whole-model walk runs.
+   *
+   * @return {[ExtractResult, AP214SceneBuilder, AP214ProductShapeMap]}
+   * The completed extraction result.
+   */
+  public finishDemandExtraction():
+    [ExtractResult, AP214SceneBuilder, AP214ProductShapeMap] {
+
+    this.finalizeStagedFaces()
+
+    if ( RegressionCaptureState.memoization !== MemoizationCapture.FULL ) {
+      this.model.geometry.deleteTemporaries()
+    }
+
+    if (this.pointBuffer?.pointer) {
+      this.wasmModule._free(this.pointBuffer.pointer)
+      this.pointBuffer = null
+    }
+
+    if ( this.demandMemoizationRestore_ !== void 0 ) {
+      this.model.elementMemoization = this.demandMemoizationRestore_
+      this.demandMemoizationRestore_ = void 0
+    }
+
+    return [ExtractResult.COMPLETE, this.scene, this.productShapeMap]
+  }
+
+  /**
+   * Whole-model extraction: prepare + run every demand unit + finish —
+   * a single code path with the per-unit pump, so pumped and classic
+   * extractions are identical by construction.
+   *
+   * @param logTime Unused (kept for call compatibility).
+   * @return {[ExtractResult, AP214SceneBuilder, AP214ProductShapeMap]}
+   * The completed extraction result.
+   */
+  // eslint-disable-next-line no-unused-vars
+  extractAP214GeometryData(logTime: boolean = false):
+    [ExtractResult, AP214SceneBuilder, AP214ProductShapeMap] {
+
+    try {
+
+      this.prepareDemandExtraction()
+
+      while ( this.demandCursor_ < this.demandUnitCount ) {
+        this.extractDemandUnitBatch( this.demandUnitCount )
+      }
+
+      return this.finishDemandExtraction()
 
     } finally {
       // Ensure no staged face jobs outlive extraction (their target
       // geometry may be freed once the model is invalidated), even if
       // extraction exits through an exception.
       this.finalizeStagedFaces()
-      this.model.elementMemoization = previousMemoizationState
+
+      if ( this.demandMemoizationRestore_ !== void 0 ) {
+        this.model.elementMemoization = this.demandMemoizationRestore_
+        this.demandMemoizationRestore_ = void 0
+      }
     }
   }
 

--- a/src/AP214E3_2010/ap214_model_geometry.ts
+++ b/src/AP214E3_2010/ap214_model_geometry.ts
@@ -20,10 +20,20 @@ export class AP214ModelGeometry implements ModelGeometry {
   /**
    * Add a mesh to this geometry collection.
    *
+   * Freezes the native float vertex mirror at add time, exactly like
+   * IfcModelGeometry.add (see its note): consumers read float vertices
+   * whose frame must match the scene transforms, which are authored
+   * against the geometry AS CREATED — later count-preserving native
+   * mutations (normalize's centering) must not shift the served frame.
+   *
    * @param mesh
    * @param parentLocalID
    */
   public add( mesh: CanonicalMesh, parentLocalID? : number ): void {
+
+    if ( mesh.type === CanonicalMeshType.BUFFER_GEOMETRY ) {
+      mesh.geometry.GetVertexData()
+    }
 
     this.meshes_.set( mesh.localID, mesh )
 

--- a/src/compat/web-ifc/ap214_streamed_open.test.ts
+++ b/src/compat/web-ifc/ap214_streamed_open.test.ts
@@ -130,23 +130,100 @@ describe( 'OpenModelStreamed on AP214 STEP input', () => {
     // and poisons later opens (pre-existing multi-open quirk).
   }, 240000 )
 
-  test( 'DEFER_GEOMETRY on STEP input is accepted; the pump is a no-op', async () => {
+  test.each( FIXTURES )(
+      'deferred unit pump to completion matches classic exactly: %s', async ( fixture ) => {
+
+        const data = new Uint8Array( fs.readFileSync( fixture ) )
+
+        const classicID = api.OpenModel( data, SETTINGS )
+        const classic = capture( classicID )
+
+        expect( classic.size ).toBeGreaterThan( 0 )
+
+        const deferredID = await api.OpenModelStreamed(
+            data, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+        expect( deferredID ).toBeGreaterThanOrEqual( 0 )
+
+        // Pump in deliberately small unit batches, accumulating delta
+        // emissions additively per entity.
+        const pumped =
+          new Map<number, { geometryExpressID: number, flatTransformation: number[] }[]>()
+        let rounds = 0
+
+        for ( ; ; ) {
+
+          const { extracted, remaining } = api.ExtractGeometryBatch(
+              deferredID, 2, ( mesh ) => {
+
+                const list = pumped.get( mesh.expressID ) ?? []
+
+                for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+                  const placed = mesh.geometries.get( where )
+                  list.push( {
+                    geometryExpressID: placed.geometryExpressID,
+                    flatTransformation: [ ...placed.flatTransformation ],
+                  } )
+                }
+
+                pumped.set( mesh.expressID, list )
+              } )
+
+          ++rounds
+
+          if ( remaining === 0 && extracted === 0 ) {
+            break
+          }
+        }
+
+        expect( rounds ).toBeGreaterThan( 1 )
+        expect( pumped.size ).toBe( classic.size )
+
+        for ( const [ expressID, classicList ] of classic ) {
+
+          const pumpedList = pumped.get( expressID )
+
+          expect( pumpedList ).toBeDefined()
+          expect( pumpedList!.length ).toBe( classicList.length )
+
+          // Instance sets match (order may differ across unit batches):
+          // every classic instance has an exactly-matching pumped one.
+          const unmatched = pumpedList!.map( ( entry ) => entry )
+
+          for ( const reference of classicList ) {
+            const matchIndex = unmatched.findIndex( ( candidate ) =>
+              candidate.geometryExpressID === reference.geometryExpressID &&
+              candidate.flatTransformation.every( ( value, where ) =>
+                Math.abs( value - reference.flatTransformation[ where ] ) < 1e-9 ) )
+
+            expect( matchIndex ).toBeGreaterThanOrEqual( 0 )
+            unmatched.splice( matchIndex, 1 )
+          }
+        }
+
+        // No CloseModel: closing destroys the shared wasm processor and
+        // degrades later opens (pre-existing multi-open quirk).
+      }, 240000 )
+
+  test( 'StreamAllMeshes on a deferred STEP model drains the pump and matches classic', async () => {
 
     const data = new Uint8Array( fs.readFileSync( FIXTURES[ 0 ] ) )
+
+    const classicID = api.OpenModel( data, SETTINGS )
+    const classic = capture( classicID )
 
     const deferredID = await api.OpenModelStreamed(
         data, { ...SETTINGS, DEFER_GEOMETRY: true } )
 
-    expect( deferredID ).toBeGreaterThanOrEqual( 0 )
+    // No pump calls at all — the whole-model consumer must still get
+    // the complete mesh set (the proxy drains internally).
+    const drained = capture( deferredID )
 
-    // STEP extraction is not deferred yet (phase 2): the pump no-ops
-    // and whole-model consumers use StreamAllMeshes, exactly the
-    // contract Share's demand branch falls back on.
-    expect( api.ExtractGeometryBatch( deferredID, 8 ) )
-        .toEqual( { extracted: 0, remaining: 0 } )
+    expect( drained.size ).toBe( classic.size )
 
-    const captured = capture( deferredID )
+    for ( const [ expressID, classicList ] of classic ) {
+      expect( drained.get( expressID )?.length ).toBe( classicList.length )
+    }
 
-    expect( captured.size ).toBeGreaterThan( 0 )
   }, 240000 )
 } )

--- a/src/compat/web-ifc/ap214_streamed_open.test.ts
+++ b/src/compat/web-ifc/ap214_streamed_open.test.ts
@@ -1,0 +1,152 @@
+/* eslint-disable no-magic-numbers */
+// STEP demand parity phase 1: the streamed columnar open for AP214 must
+// reproduce the classic open exactly — same entities, same placed
+// instances and transforms, and byte-identical GetGeometry vertex
+// content (the served float frame must match the scene transforms; see
+// AP214ModelGeometry.add's mirror-freeze note).
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { FlatMesh, IfcAPI } from './ifc_api'
+
+const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
+
+// Fixtures with real served geometry (as1-assembly is structure-only —
+// zero meshes even classically; ap214-multibody-part's geometry ids
+// serve no vertex data through GetGeometry on the classic path either).
+const FIXTURES = [
+  'data/nema-23-76mm.step',
+  'data/a-gear-with-3-inch-diameter-and-20-curved-teeth.step',
+]
+
+let api: IfcAPI
+
+/**
+ * Capture per-entity placed instances from a model.
+ *
+ * @param modelID The open model.
+ * @return {Map} expressID -> {geometryExpressID, flatTransformation}[].
+ */
+function capture( modelID: number ):
+  Map<number, { geometryExpressID: number, flatTransformation: number[] }[]> {
+
+  const instances =
+    new Map<number, { geometryExpressID: number, flatTransformation: number[] }[]>()
+
+  api.StreamAllMeshes( modelID, ( mesh: FlatMesh ) => {
+
+    const list = instances.get( mesh.expressID ) ?? []
+
+    for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+
+      const placed = mesh.geometries.get( where )
+
+      list.push( {
+        geometryExpressID: placed.geometryExpressID,
+        flatTransformation: [ ...placed.flatTransformation ],
+      } )
+    }
+
+    instances.set( mesh.expressID, list )
+  } )
+
+  return instances
+}
+
+beforeAll( async () => {
+  api = new IfcAPI()
+  await api.Init()
+}, 120000 )
+
+describe( 'OpenModelStreamed on AP214 STEP input', () => {
+
+  test.each( FIXTURES )( 'streamed open matches classic exactly: %s', async ( fixture ) => {
+
+    const data = new Uint8Array( fs.readFileSync( fixture ) )
+
+    const classicID = api.OpenModel( data, SETTINGS )
+    const classic = capture( classicID )
+
+    expect( classic.size ).toBeGreaterThan( 0 )
+
+    const streamedID = await api.OpenModelStreamed( data, SETTINGS )
+
+    expect( streamedID ).toBeGreaterThanOrEqual( 0 )
+
+    const streamed = capture( streamedID )
+
+    expect( streamed.size ).toBe( classic.size )
+
+    for ( const [ expressID, classicList ] of classic ) {
+
+      const streamedList = streamed.get( expressID )
+
+      expect( streamedList ).toBeDefined()
+      expect( streamedList!.length ).toBe( classicList.length )
+
+      for ( let where = 0; where < classicList.length; ++where ) {
+        expect( streamedList![ where ].geometryExpressID )
+            .toBe( classicList[ where ].geometryExpressID )
+        expect( streamedList![ where ].flatTransformation )
+            .toEqual( classicList[ where ].flatTransformation )
+      }
+    }
+
+    // Vertex content: the streamed open's GetGeometry must serve
+    // byte-identical floats to classic for every placed geometry.
+    const geometryIDs = new Set<number>()
+
+    for ( const list of classic.values() ) {
+      for ( const placed of list ) {
+        geometryIDs.add( placed.geometryExpressID )
+      }
+    }
+
+    let compared = 0
+
+    for ( const geometryID of geometryIDs ) {
+
+      const classicGeometry = api.GetGeometry( classicID, geometryID )
+      const streamedGeometry = api.GetGeometry( streamedID, geometryID )
+
+      const classicSize = classicGeometry.GetVertexDataSize()
+
+      if ( classicSize === 0 ) {
+        continue
+      }
+
+      expect( streamedGeometry.GetVertexDataSize() ).toBe( classicSize )
+
+      expect( api.GetVertexArray( streamedGeometry.GetVertexData(), classicSize ) )
+          .toEqual( api.GetVertexArray( classicGeometry.GetVertexData(), classicSize ) )
+
+      ++compared
+    }
+
+    expect( compared ).toBeGreaterThan( 0 )
+
+    // No CloseModel here: closing destroys the shared wasm processor
+    // and poisons later opens (pre-existing multi-open quirk).
+  }, 240000 )
+
+  test( 'DEFER_GEOMETRY on STEP input is accepted; the pump is a no-op', async () => {
+
+    const data = new Uint8Array( fs.readFileSync( FIXTURES[ 0 ] ) )
+
+    const deferredID = await api.OpenModelStreamed(
+        data, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    expect( deferredID ).toBeGreaterThanOrEqual( 0 )
+
+    // STEP extraction is not deferred yet (phase 2): the pump no-ops
+    // and whole-model consumers use StreamAllMeshes, exactly the
+    // contract Share's demand branch falls back on.
+    expect( api.ExtractGeometryBatch( deferredID, 8 ) )
+        .toEqual( { extracted: 0, remaining: 0 } )
+
+    const captured = capture( deferredID )
+
+    expect( captured.size ).toBeGreaterThan( 0 )
+  }, 240000 )
+} )

--- a/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
@@ -139,21 +139,20 @@ export class IfcApiModelPassthroughFactory {
       }
     }
 
-    // STEP demand parity phase 1: AP214 (and the AP203/AP242
-    // fall-throughs) get the streamed columnar open — index columnar
-    // from birth, no per-record object phase. Extraction is still the
-    // whole-model walk (DEFER_GEOMETRY is accepted but not yet deferred
-    // for STEP; the pump no-ops and consumers fall back to
-    // StreamAllMeshes), so the deferred pump and preview channel can
-    // follow without a surface change.
+    // STEP demand parity: AP214 (and the AP203/AP242 fall-throughs)
+    // get the streamed columnar open — index columnar from birth, no
+    // per-record object phase — and, with DEFER_GEOMETRY, the deferred
+    // assembly-tree unit pump (phase 2), so STEP models stream
+    // progressively through ExtractGeometryBatch just like IFC.
     if ( modelFormat === ModelFormatType.AP214 ||
       modelFormat === ModelFormatType.AP203 ||
       modelFormat === ModelFormatType.AP242 ) {
 
       try {
 
-        return await IfcApiProxyAP214.createStreamed(
-            modelID, data, wasmModule, settings)
+        return settings?.DEFER_GEOMETRY === true ?
+          await IfcApiProxyAP214.createDeferred(modelID, data, wasmModule, settings) :
+          await IfcApiProxyAP214.createStreamed(modelID, data, wasmModule, settings)
 
       } catch ( e ) {
 

--- a/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
@@ -139,6 +139,32 @@ export class IfcApiModelPassthroughFactory {
       }
     }
 
+    // STEP demand parity phase 1: AP214 (and the AP203/AP242
+    // fall-throughs) get the streamed columnar open — index columnar
+    // from birth, no per-record object phase. Extraction is still the
+    // whole-model walk (DEFER_GEOMETRY is accepted but not yet deferred
+    // for STEP; the pump no-ops and consumers fall back to
+    // StreamAllMeshes), so the deferred pump and preview channel can
+    // follow without a surface change.
+    if ( modelFormat === ModelFormatType.AP214 ||
+      modelFormat === ModelFormatType.AP203 ||
+      modelFormat === ModelFormatType.AP242 ) {
+
+      try {
+
+        return await IfcApiProxyAP214.createStreamed(
+            modelID, data, wasmModule, settings)
+
+      } catch ( e ) {
+
+        const message = e instanceof Error ? e.message : String( e )
+
+        Logger.warning(
+            `Streamed STEP open failed for model ${modelID}, ` +
+            `falling back to classic open: ${message}`)
+      }
+    }
+
     return IfcApiModelPassthroughFactory.fromAsync(modelID, data, wasmModule, settings)
   }
 

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -49,6 +49,11 @@ const STREAMED_PARSE_POOL_BYTES = 1024 * 1024
 // finishes a deferred model synchronously.
 const DEFERRED_DRAIN_BATCH_AP214 = 256
 
+// Divisor mapping consumer batch sizes (tuned for IFC's per-product
+// granularity) onto AP214's chunkier per-part units — see
+// extractGeometryBatch.
+const AP214_UNITS_PER_PRODUCT_BATCH = 16
+
 /**
  * Everything parse/extraction produces that the proxy constructor's tail
  * (mesh vectors, statistics) consumes — precomputed by createAsync so the
@@ -1191,7 +1196,14 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
 
     const extraction = this.conwayGeometry_
 
-    const extracted = extraction.extractDemandUnitBatch(batchSize)
+    // Consumers tune batchSize for IFC's fine-grained products (Share
+    // pumps 64); AP214 units are whole parts/subassemblies — orders of
+    // magnitude chunkier (Arty: ~57 units for ~12s of geometry). Scale
+    // the requested batch down so STEP loads stay progressive without
+    // any consumer knowing the schema.
+    const units = Math.max(1, Math.floor(batchSize / AP214_UNITS_PER_PRODUCT_BATCH))
+
+    const extracted = extraction.extractDemandUnitBatch(units)
     const remaining = extraction.demandUnitCount - extraction.demandUnitCursor
 
     if (remaining === 0 && !this.demandFinished_) {

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -45,6 +45,10 @@ import EntityTypesAP214 from '../../AP214E3_2010/AP214E3_2010_gen/entity_types_a
 // eslint-disable-next-line no-magic-numbers
 const STREAMED_PARSE_POOL_BYTES = 1024 * 1024
 
+// Units drained per call when a whole-model consumer (streamAllMeshes)
+// finishes a deferred model synchronously.
+const DEFERRED_DRAIN_BATCH_AP214 = 256
+
 /**
  * Everything parse/extraction produces that the proxy constructor's tail
  * (mesh vectors, statistics) consumes — precomputed by createAsync so the
@@ -53,6 +57,8 @@ const STREAMED_PARSE_POOL_BYTES = 1024 * 1024
  */
 interface Ap214ProxyLoadState {
   conwaywasm: ConwayGeometry
+  /** True when opened without extraction (createDeferred). */
+  deferred?: boolean
   allTimeStart: number
   stepHeader: StepHeader
   model: AP214StepModel
@@ -74,6 +80,30 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
       Map<number, [GeometryObject, CanonicalMaterial, number[]]>,
       Vector<FlatMesh>, glmatrix.mat4]
   conwaywasm: ConwayGeometry
+
+  /** The extraction behind this model (drives the deferred unit pump). */
+  private conwayGeometry_!: AP214GeometryExtraction
+
+  /** Was this model opened without extraction (DEFER_GEOMETRY)? */
+  private deferredMode_: boolean = false
+
+  /** Has finishDemandExtraction run (deferred models, once)? */
+  private demandFinished_: boolean = false
+
+  /**
+   * Deferred capture watermarks: entity localID -> how many of its
+   * placed instances (scene-walk order) have been captured — mirrors
+   * the IFC proxy's delta capture; see its demandCapturedCounts_ note.
+   */
+  private readonly demandCapturedCounts_ = new Map<number, number>()
+
+  /**
+   * Coordination matrix the deferred capture derived. Internal
+   * multi-call memory only — getCoordinationMatrix keeps the classic
+   * identity contract (see the IFC proxy's demandCoordination_ note).
+   */
+  private demandCoordination_?: glmatrix.mat4
+
   _isCoordinated: boolean = false
   linearScalingFactor: number = 1
   identity: number[] = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
@@ -173,6 +203,8 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
       IfcApiProxyAP214.parseAndExtract(modelID, data, new ConwayGeometry(wasmModule), settings)
 
     this.conwaywasm = loadState.conwaywasm
+    this.conwayGeometry_ = loadState.conwayGeometry
+    this.deferredMode_ = loadState.deferred === true
 
     const statistics = Logger.getStatistics(modelID)
 
@@ -371,6 +403,31 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
   }
 
   /**
+   * Deferred streamed construction (STEP demand parity phase 2): the
+   * streamed columnar parse runs, the assembly tree is prepared, but NO
+   * geometry units execute — the batch pump (extractGeometryBatch)
+   * extracts them progressively afterwards. The AP214 twin of
+   * IfcApiProxyIfc.createDeferred.
+   *
+   * @param modelID The model ID being opened.
+   * @param data The STEP data buffer.
+   * @param wasmModule The wasm module.
+   * @param settings Loader settings (ON_PROGRESS / ON_MODEL_INFO honored).
+   * @return {Promise<IfcApiProxyAP214>} The constructed proxy.
+   */
+  public static async createDeferred(
+      modelID: number,
+      data: Uint8Array,
+      wasmModule: any,
+      settings?: Loadersettings ): Promise<IfcApiProxyAP214> {
+
+    const loadState = await IfcApiProxyAP214.parseColumnarAndExtractAsync(
+        modelID, data, new ConwayGeometry(wasmModule), settings, true)
+
+    return new IfcApiProxyAP214(modelID, data, wasmModule, settings, loadState)
+  }
+
+  /**
    * Streamed twin of parseAndExtractAsync: cooperative columnar index
    * build (periodic event-loop yields, absolute byte-cursor progress),
    * then the model adopts the columns directly — no per-record object
@@ -387,7 +444,8 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
       modelID: number,
       data: Uint8Array,
       conwaywasm: ConwayGeometry,
-      settings?: Loadersettings ): Promise<Ap214ProxyLoadState> {
+      settings?: Loadersettings,
+      deferGeometry: boolean = false ): Promise<Ap214ProxyLoadState> {
 
     const tracker = IfcApiProxyAP214.makeTracker(settings)
 
@@ -443,6 +501,26 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
     statistics?.setParseTime(parseEndTime - parseStartTime)
 
     const conwayGeometry = new AP214GeometryExtraction(conwaywasm, model)
+
+    // Deferred mode (createDeferred): build the assembly tree and the
+    // ordered unit list but execute nothing — the batch pump populates
+    // the scene progressively. `scene` is the same object the deferred
+    // capture walks, so meshes appear to consumers as units extract.
+    if (deferGeometry) {
+
+      conwayGeometry.prepareDemandExtraction()
+
+      return {
+        conwaywasm,
+        deferred: true,
+        allTimeStart,
+        stepHeader,
+        model,
+        scene: conwayGeometry.scene,
+        conwayGeometry,
+        geometryTimeInMs: 0,
+      }
+    }
 
     // Heartbeat only: the AP214 thunk-tree extraction has no flat
     // product loop to tick from yet.
@@ -1090,7 +1168,248 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
    * @param modelID
    * @param meshCallback
    */
+  /**
+   * Deferred-mode unit pump (STEP demand parity phase 2; conway
+   * extension consumed through ExtractGeometryBatch): execute the next
+   * `batchSize` assembly-tree units and emit THIS BATCH's meshes as
+   * per-entity DELTA FlatMeshes — the AP214 twin of the IFC proxy's
+   * pump, same delta contract. On a fully-extracted model this is a
+   * no-op returning remaining 0.
+   *
+   * @param batchSize Max units to execute this call (min 1).
+   * @param meshCallback Receives each newly-captured delta mesh.
+   * @return {object} `{extracted, remaining}` — units executed this
+   * call and units still pending.
+   */
+  extractGeometryBatch(
+      batchSize: number,
+      meshCallback?: (mesh: FlatMesh) => void ): {extracted: number, remaining: number} {
+
+    if (!this.deferredMode_) {
+      return {extracted: 0, remaining: 0}
+    }
+
+    const extraction = this.conwayGeometry_
+
+    const extracted = extraction.extractDemandUnitBatch(batchSize)
+    const remaining = extraction.demandUnitCount - extraction.demandUnitCursor
+
+    if (remaining === 0 && !this.demandFinished_) {
+      this.demandFinished_ = true
+      extraction.finishDemandExtraction()
+    }
+
+    if (meshCallback !== void 0) {
+      this.streamNewMeshes_(meshCallback)
+    }
+
+    return {extracted, remaining}
+  }
+
+  /**
+   * Walk the scene and emit every not-yet-captured placed instance as
+   * per-entity DELTA FlatMeshes — the incremental core of
+   * streamAllMeshes with identical placed-geometry math (bare
+   * coordination x nativeTransform composition, occurrence paths),
+   * processed in walk order exactly once per instance. The shared
+   * meshMap accumulates each entity's FULL vector so getFlatMesh stays
+   * whole-model correct; the derived coordination matrix is remembered
+   * across calls (demandCoordination_) without leaking through
+   * getCoordinationMatrix (classic identity contract).
+   *
+   * @param meshCallback Receives one delta FlatMesh per entity that
+   * gained instances this call.
+   */
+  private streamNewMeshes_(
+      meshCallback: (mesh: FlatMesh) => void ): void {
+
+    const [model, scene, meshMap, geometryMaterialTransformMap] = this.model
+
+    let coordinationMatrix = this.demandCoordination_ ?? glmatrix.mat4.create()
+    const seenThisPass = new Map<number, number>()
+    const deltas = new Map<number, PlacedGeometry[]>()
+    const deltaExpressIDs = new Map<number, number>()
+
+    // eslint-disable-next-line no-unused-vars
+    for (const [_, nativeTransform, geometry, material, entity, occurrencePath]
+      of scene.walkWithOccurrence()) {
+
+      if (entity?.localID === void 0 || entity.expressID === void 0) {
+        continue
+      }
+
+      const walkIndex = seenThisPass.get(entity.localID) ?? 0
+      seenThisPass.set(entity.localID, walkIndex + 1)
+
+      if (walkIndex < (this.demandCapturedCounts_.get(entity.localID) ?? 0)) {
+        continue
+      }
+
+      this.demandCapturedCounts_.set(entity.localID, walkIndex + 1)
+
+      if (geometry.type !== CanonicalMeshType.BUFFER_GEOMETRY || geometry.temporary) {
+        continue
+      }
+
+      const material_: CanonicalMaterial = material ?? {
+        name: '',
+        // eslint-disable-next-line no-magic-numbers
+        baseColor: [0.8, 0.8, 0.8, 1],
+        // eslint-disable-next-line no-magic-numbers
+        legacyColor: [0.8, 0.8, 0.8, 1],
+        doubleSided: true,
+        blend: 0,
+      }
+
+      let nativePt: Vector3
+      if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
+        nativePt = geometry.geometry.getPoint(0)
+      }
+
+      const expressID = model.getElementByLocalID(geometry.localID)?.expressID as number
+
+      const geometryTransform = nativeTransform?.getValues()
+      let newMatrix: glmatrix.mat4
+
+      if (geometryTransform !== void 0) {
+        newMatrix = glmatrix.mat4.fromValues(
+            ...(geometryTransform as unknown as
+              Parameters<typeof glmatrix.mat4.fromValues>))
+      } else {
+        newMatrix = glmatrix.mat4.create()
+      }
+
+      if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
+
+        const transformedPt: glmatrix.vec4 = glmatrix.vec4.create()
+        glmatrix.vec4.transformMat4(
+            transformedPt,
+            [nativePt!.x, nativePt!.y, nativePt!.z, 1],
+            newMatrix)
+
+        coordinationMatrix = glmatrix.mat4.create()
+        glmatrix.mat4.fromTranslation(coordinationMatrix,
+            [-transformedPt[0], -transformedPt[1], -transformedPt[2]])
+
+        const scaleMatrix = glmatrix.mat4.create()
+        const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
+            this.linearScalingFactor,
+            this.linearScalingFactor)
+
+        glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
+        glmatrix.mat4.multiply(coordinationMatrix, this.NormalizeMat, coordinationMatrix)
+        glmatrix.mat4.multiply(coordinationMatrix, scaleMatrix, coordinationMatrix)
+
+        this.demandCoordination_ = coordinationMatrix
+        this._isCoordinated = true
+      }
+
+      // Bare composition — no per-leaf recenter (issue #308: AP214
+      // instances share one geometry buffer), matching streamAllMeshes.
+      const newTransform = glmatrix.mat4.create()
+      glmatrix.mat4.multiply(newTransform, coordinationMatrix, newMatrix)
+
+      const newTransformArr = Array.from(newTransform)
+
+      geometryMaterialTransformMap.set(expressID,
+          [geometry.geometry, material_, newTransformArr])
+
+      const color = {
+        x: material_.legacyColor[0],
+        y: material_.legacyColor[1],
+        z: material_.legacyColor[2],
+        w: material_.legacyColor[3],
+      }
+
+      const placed: PlacedGeometry = {
+        color,
+        geometryExpressID: expressID,
+        flatTransformation: newTransformArr,
+        occurrencePath,
+      }
+
+      let mesh = meshMap.get(entity.localID)
+
+      if (mesh === void 0) {
+
+        const placedArray = new Array<PlacedGeometry>()
+        const placedVector: Vector<PlacedGeometry> = {
+          get: (index: number) => placedArray[index] ?? placed,
+          size: () => placedArray.length,
+          push: (parameter: PlacedGeometry) => {
+            placedArray.push(parameter)
+          },
+        }
+        const flatMesh: FlatMesh = {
+          geometries: placedVector,
+          expressID: entity.expressID,
+        }
+
+        mesh = [placedVector, flatMesh]
+        meshMap.set(entity.localID, mesh)
+      }
+
+      mesh[0].push(placed)
+      mesh[1].geometries = mesh[0]
+
+      let delta = deltas.get(entity.localID)
+      if (delta === void 0) {
+        delta = []
+        deltas.set(entity.localID, delta)
+        deltaExpressIDs.set(entity.localID, entity.expressID)
+      }
+      delta.push(placed)
+    }
+
+    const vectorFlatMesh = this.model[4]
+
+    for (const [localID, placedList] of deltas) {
+
+      const placedVector: Vector<PlacedGeometry> = {
+        get: (index: number) => placedList[index] ?? placedList[0],
+        size: () => placedList.length,
+        push: (parameter: PlacedGeometry) => {
+          placedList.push(parameter)
+        },
+      }
+      const deltaMesh: FlatMesh = {
+        geometries: placedVector,
+        expressID: deltaExpressIDs.get(localID)!,
+      }
+
+      vectorFlatMesh.push(deltaMesh)
+      meshCallback(deltaMesh)
+    }
+  }
+
+  /**
+   *
+   * @param meshCallback
+   */
   streamAllMeshes( meshCallback: (mesh: FlatMesh) => void) {
+
+    // Deferred models: pump any remainder to completion and serve the
+    // accumulated full per-entity meshes — re-running the classic walk
+    // would push every instance a second time (mirrors the IFC proxy).
+    if (this.deferredMode_) {
+
+      const noCallback = void 0
+
+      while (this.extractGeometryBatch(
+          DEFERRED_DRAIN_BATCH_AP214, noCallback).remaining > 0) {
+        // draining
+      }
+      this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
+
+      const [, , meshMap, , vectorFlatMesh] = this.model
+
+      meshMap.forEach((mesh) => {
+        vectorFlatMesh.push(mesh[1])
+        meshCallback(mesh[1])
+      })
+
+      return
+    }
 
     const [model,
       scene,

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -32,6 +32,18 @@ import { ProgressTracker } from '../../core/progress'
 import { formatModelLine } from '../../core/progress_log'
 import { extractModelInfo } from '../../loaders/loading_utilities'
 import { StepHeader } from '../../step/parsing/step_parser'
+import { BufferByteSource } from '../../step/parsing/byte_source'
+import { ColumnarIndexSink } from '../../step/parsing/columnar_index'
+import {
+  buildIndexStreamingAsync,
+} from '../../step/parsing/streaming_index_builder'
+import EntityTypesAP214 from '../../AP214E3_2010/AP214E3_2010_gen/entity_types_ap214.gen'
+
+/* Moving-window size for the streamed columnar parse (matches the IFC
+ * proxy; the window bounds parse-time scratch, not the source buffer,
+ * which the model keeps resident here). */
+// eslint-disable-next-line no-magic-numbers
+const STREAMED_PARSE_POOL_BYTES = 1024 * 1024
 
 /**
  * Everything parse/extraction produces that the proxy constructor's tail
@@ -327,6 +339,140 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
         modelID, data, new ConwayGeometry(wasmModule), settings)
 
     return new IfcApiProxyAP214(modelID, data, wasmModule, settings, loadState)
+  }
+
+  /**
+   * Streamed columnar construction (conway extension, used by
+   * OpenModelStreamed): the data parse runs through the streaming
+   * columnar indexer over a moving window instead of the per-record
+   * object parse, so the index is columnar from birth — the AP214 twin
+   * of IfcApiProxyIfc.createStreamed (STEP demand parity phase 1).
+   * Geometry extraction stays the classic whole-model thunk-tree walk;
+   * the deferred pump and preview channel follow in later phases.
+   * Throws when the streamed parse is anything but COMPLETE — the
+   * factory falls back to the classic open.
+   *
+   * @param modelID The model ID being opened.
+   * @param data The STEP data buffer.
+   * @param wasmModule The wasm module.
+   * @param settings Loader settings (ON_PROGRESS / ON_MODEL_INFO honored).
+   * @return {Promise<IfcApiProxyAP214>} The constructed proxy.
+   */
+  public static async createStreamed(
+      modelID: number,
+      data: Uint8Array,
+      wasmModule: any,
+      settings?: Loadersettings ): Promise<IfcApiProxyAP214> {
+
+    const loadState = await IfcApiProxyAP214.parseColumnarAndExtractAsync(
+        modelID, data, new ConwayGeometry(wasmModule), settings)
+
+    return new IfcApiProxyAP214(modelID, data, wasmModule, settings, loadState)
+  }
+
+  /**
+   * Streamed twin of parseAndExtractAsync: cooperative columnar index
+   * build (periodic event-loop yields, absolute byte-cursor progress),
+   * then the model adopts the columns directly — no per-record object
+   * phase. Mirrors IfcApiProxyIfc.parseColumnarAndExtractAsync minus
+   * the deferred branch.
+   *
+   * @param modelID The model ID being opened.
+   * @param data The STEP data buffer.
+   * @param conwaywasm The conway geometry wasm wrapper.
+   * @param settings Loader settings (ON_PROGRESS / ON_MODEL_INFO honored).
+   * @return {Promise<Ap214ProxyLoadState>} Everything the constructor tail needs.
+   */
+  private static async parseColumnarAndExtractAsync(
+      modelID: number,
+      data: Uint8Array,
+      conwaywasm: ConwayGeometry,
+      settings?: Loadersettings ): Promise<Ap214ProxyLoadState> {
+
+    const tracker = IfcApiProxyAP214.makeTracker(settings)
+
+    const allTimeStart = Date.now()
+    const parser = AP214StepParser.Instance
+    const bufferInput = new ParsingBuffer(data)
+
+    tracker?.beginPhase('headerParse', 'bytes', data.length)
+
+    // Header parsed standalone first so the model line fires before the
+    // full parse (the columnar build re-reads the tiny header
+    // internally; the cost is negligible).
+    const [stepHeader, result0] = parser.parseHeader(bufferInput)
+
+    Logger.createStatistics(modelID)
+
+    const statistics = Logger.getStatistics(modelID)
+
+    IfcApiProxyAP214.reportHeaderParseResult(result0, bufferInput, modelID)
+
+    const modelInfo = extractModelInfo(stepHeader, data.length)
+
+    Logger.info(formatModelLine(modelInfo))
+    settings?.ON_MODEL_INFO?.(modelInfo)
+
+    tracker?.beginPhase('dataParse', 'bytes', data.length)
+
+    const parseTick = tracker !== void 0 ?
+      (cursorBytes: number) => tracker.update(cursorBytes) : void 0
+
+    const parseStartTime = Date.now()
+
+    const sink = new ColumnarIndexSink<EntityTypesAP214>()
+
+    const { result } = await buildIndexStreamingAsync(
+        new BufferByteSource(data), parser, STREAMED_PARSE_POOL_BYTES,
+        void 0, sink, parseTick)
+
+    const columns = sink.finalize()
+
+    const parseEndTime = Date.now()
+
+    tracker?.endPhase(data.length)
+
+    if (result !== ParseResult.COMPLETE) {
+      Logger.warning(`[OpenModelStreamed]: streamed parse result ${result}`)
+      statistics?.setLoadStatus('PARSE_FAIL')
+      throw new Error( 'Streamed parse did not complete' )
+    }
+
+    const model = new AP214StepModel(data, columns)
+
+    statistics?.setParseTime(parseEndTime - parseStartTime)
+
+    const conwayGeometry = new AP214GeometryExtraction(conwaywasm, model)
+
+    // Heartbeat only: the AP214 thunk-tree extraction has no flat
+    // product loop to tick from yet.
+    tracker?.beginPhase('geometry', 'products')
+
+    const startTime = Date.now()
+    const [extractionResult, scene] =
+      conwayGeometry.extractAP214GeometryData()
+
+    const endTime = Date.now()
+
+    tracker?.endPhase()
+
+    if (extractionResult !== ExtractResult.COMPLETE) {
+      Logger.error('[OpenModelStreamed]: Error extracting geometry, exiting...')
+      statistics?.setLoadStatus('FAIL')
+      throw new Error( 'Couldn\'t extract model' )
+    }
+
+    statistics?.setGeometryTypeCounts(conwayGeometry.geometryTypeCounts)
+
+    return {
+      conwaywasm,
+      allTimeStart,
+      stepHeader,
+      model,
+      scene,
+      conwayGeometry,
+      geometryTimeInMs: endTime - startTime,
+    }
   }
 
   /**


### PR DESCRIPTION
Brings STEP (AP214, with the AP203/AP242 fall-throughs) up to the IFC demand path's parity — phases 1+2 of the plan (epic #390; requested after Share #1614's burn-in showed STEP loading classically). Phase 3 (parse-time preview channel generalization) follows separately.

## Phase 1 — streamed columnar open

`OpenModelStreamed` serves AP214 through the streaming columnar indexer: index columnar from birth, no per-record object phase, cooperative parse, internal fallback to the classic open on any streamed-parse failure. `AP214ModelGeometry.add` gains the same float-mirror freeze as `IfcModelGeometry.add` (#426).

## Phase 2 — deferred assembly-tree unit pump

`extractAP214GeometryData`'s monolithic thunk-tree walk is refactored into **prepare / execute / finish**, with the classic path running through the same units — parity by construction:

- `prepareDemandExtraction()` builds the assembly tree exactly as before but captures root executions as an ordered **unit list**. Childless roots are one unit; roots with children are flattened one level (one unit per immediate child, then the root's own items, matching the thunk body's order) — so single-root assemblies (Arty) still pump progressively per part. `makeThunk` gains an internal slice parameter; recursion untouched. The deferred SDR-site executions are safe to reorder: those roots are childless by construction.
- `extractDemandUnitBatch(n)` executes the next n units, finalizing staged face tessellation per batch; `finishDemandExtraction()` runs the classic tail (temporaries, point buffer, memoization restore).
- Proxy: `createDeferred` + `ExtractGeometryBatch` for AP214 — the unit pump plus the watermark delta capture (per-entity localID watermarks over `walkWithOccurrence`, classic bare coordination × nativeTransform math, occurrence paths preserved, coordination remembered internally without leaking through `GetCoordinationMatrix`). Deferred `StreamAllMeshes` drains the pump. Factory routes STEP `DEFER_GEOMETRY` to `createDeferred`.

**Share needs zero changes** — its demand branch feature-detects the pump, so STEP models materialize progressively the moment this releases.

## Tests

- Streamed-vs-classic exact parity (instances, transforms, byte-identical `GetGeometry` vertex content) on real-part fixtures (nema-23, gear).
- Small-batch (2-unit) pump-to-completion equals classic exactly: entity sets, per-entity instance multisets, transforms.
- No-pump `StreamAllMeshes` drain parity.
- 295/295 across compat, AP214, ifc, step, and core suites; STEP regression corpus digests are the CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz