### PR TITLE
ReleaseModelGeometry: free native model geometry after the scene build

### DIFF
--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -836,6 +836,33 @@ export class IfcAPI {
   }
 
   /**
+   * Conway extension: free a model's native geometry once the consumer
+   * has built its own scene from the meshes — every canonical mesh the
+   * extraction produced plus the GetGeometry map. Subsequent
+   * GetGeometry calls return an empty dummy; placed transforms, the
+   * spatial structure and properties are untouched. Feature-detect with
+   * `typeof api.ReleaseModelGeometry === 'function'`.
+   *
+   * The wasm heap never shrinks, but freed pages are reused — repeated
+   * loads in one tab plateau instead of stacking whole model scenes.
+   * On a deferred model whose pump has not drained this is a safe
+   * no-op returning false.
+   *
+   * @param modelID handle retrieved by OpenModel/OpenModelStreamed
+   * @return {boolean} True when geometry was released.
+   */
+  ReleaseModelGeometry(modelID: number): boolean {
+
+    const result = this.models.get(modelID)
+
+    if (result?.releaseGeometry === void 0) {
+      return false
+    }
+
+    return result.releaseGeometry()
+  }
+
+  /**
    *
    * @param modelID
    * @param meshCallback

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -195,6 +195,55 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     api2.CloseModel( deferredID )
   }, 240000 )
 
+  test( 'ReleaseModelGeometry frees served geometry, keeps meshes, refuses undrained pumps', async () => {
+
+    // Fresh IfcAPI (CloseModel poisons later opens — see the content
+    // parity test's note).
+    const api3 = new IfcAPI()
+    await api3.Init()
+
+    // Undrained deferred pump: refuse (releasing would break the
+    // remaining extraction).
+    const deferredID = await api3.OpenModelStreamed(
+        buffer, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    api3.ExtractGeometryBatch( deferredID, 1 )
+
+    expect( api3.ReleaseModelGeometry( deferredID ) ).toBe( false )
+
+    // Classic model: release frees GetGeometry serving, keeps captured
+    // mesh data, double-release stays safe.
+    const classicID = api3.OpenModel( buffer, SETTINGS )
+    const geometryIDs: number[] = []
+    let meshes = 0
+
+    api3.StreamAllMeshes( classicID, ( mesh ) => {
+      ++meshes
+      for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+        geometryIDs.push( mesh.geometries.get( where ).geometryExpressID )
+      }
+    } )
+
+    expect( meshes ).toBeGreaterThan( 0 )
+    expect( api3.GetGeometry( classicID, geometryIDs[ 0 ] ).GetVertexDataSize() )
+        .toBeGreaterThan( 0 )
+
+    expect( api3.ReleaseModelGeometry( classicID ) ).toBe( true )
+
+    // Served geometry degrades to the empty dummy; mesh data survives.
+    expect( api3.GetGeometry( classicID, geometryIDs[ 0 ] ).GetVertexDataSize() )
+        .toBe( 0 )
+
+    let meshesAfter = 0
+    api3.StreamAllMeshes( classicID, () => {
+      ++meshesAfter
+    } )
+    expect( meshesAfter ).toBeGreaterThan( 0 )
+
+    expect( api3.ReleaseModelGeometry( classicID ) ).toBe( true )
+    expect( api3.ReleaseModelGeometry( 9999 ) ).toBe( false )
+  }, 240000 )
+
   test( 'ExtractGeometryBatch is a safe no-op on non-deferred models', async () => {
 
     const modelID = await api.OpenModelStreamed( buffer, SETTINGS )

--- a/src/compat/web-ifc/ifc_api_model_passthrough.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough.ts
@@ -15,6 +15,10 @@ export interface IfcApiModelPassthrough {
    * Deferred-mode batch pump (IFC proxies opened with DEFER_GEOMETRY) —
    * see IfcApiProxyIfc.extractGeometryBatch.
    */
+  /** Free the model's native geometry after the consumer's scene build
+   * (conway extension) — see the proxies' releaseGeometry. */
+  releaseGeometry?(): boolean
+
   extractGeometryBatch?(
     batchSize: number,
     meshCallback?: (mesh: FlatMesh) => void): {extracted: number, remaining: number}

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -1209,6 +1209,47 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
    * @param meshCallback
    */
   /**
+   * Free this model's native geometry (conway extension) — the AP214
+   * twin of the IFC proxy's releaseGeometry; see its note.
+   *
+   * @return {boolean} True when geometry was released.
+   */
+  releaseGeometry(): boolean {
+
+    if (this.deferredMode_ && !this.demandFinished_ &&
+        this.conwayGeometry_.demandUnitCursor < this.conwayGeometry_.demandUnitCount) {
+      Logger.warning(
+          '[ReleaseModelGeometry]: deferred pump not drained — not releasing')
+      return false
+    }
+
+    const model = this.model[0]
+    const localIDs: number[] = []
+
+    for (const mesh of model.geometry) {
+      localIDs.push((mesh as {localID: number}).localID)
+    }
+
+    for (const localID of localIDs) {
+      try {
+        model.geometry.delete(localID)
+      } catch {
+        // Never let a free break a loaded model.
+      }
+    }
+
+    this.model[3].clear()
+
+    this.released_ = true
+
+    return true
+  }
+
+  /** Native geometry freed (releaseGeometry) — scene walks would touch
+   * freed objects, so mesh serving degrades to the accumulated maps. */
+  private released_ = false
+
+  /**
    * Deferred-mode unit pump (STEP demand parity phase 2; conway
    * extension consumed through ExtractGeometryBatch): execute the next
    * `batchSize` assembly-tree units and emit THIS BATCH's meshes as
@@ -1269,6 +1310,12 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
    */
   private streamNewMeshes_(
       meshCallback: (mesh: FlatMesh) => void ): void {
+
+    // Released models: the scene's natives are freed — nothing new can
+    // exist to capture, and walking would touch freed objects.
+    if (this.released_) {
+      return
+    }
 
     const [model, scene, meshMap, geometryMaterialTransformMap] = this.model
 
@@ -1434,6 +1481,20 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
    * @param meshCallback
    */
   streamAllMeshes( meshCallback: (mesh: FlatMesh) => void) {
+
+    // Released models: the natives behind the scene are freed — serve
+    // the accumulated per-entity meshes instead of re-walking.
+    if (this.released_ && !this.deferredMode_) {
+
+      const [, , meshMap, , vectorFlatMesh] = this.model
+
+      meshMap.forEach((mesh) => {
+        vectorFlatMesh.push(mesh[1])
+        meshCallback(mesh[1])
+      })
+
+      return
+    }
 
     // Deferred models: pump any remainder to completion and serve the
     // accumulated full per-entity meshes — re-running the classic walk

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -1364,6 +1364,58 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   }
 
   /**
+   * Free this model's native geometry (conway extension): every
+   * canonical mesh the extraction produced plus the GetGeometry map.
+   * Call AFTER the consumer has built its own scene from the meshes —
+   * subsequent GetGeometry calls return an empty dummy. On a deferred
+   * model whose pump has not drained, this is a no-op (releasing would
+   * break the remaining extraction).
+   *
+   * The wasm heap never shrinks, but freed pages are reused: repeated
+   * loads in one tab plateau instead of stacking whole model scenes
+   * (the multi-load crash).
+   *
+   * @return {boolean} True when geometry was released.
+   */
+  releaseGeometry(): boolean {
+
+    if (this.deferredMode_ &&
+        this.demandProducts_ !== void 0 &&
+        this.demandCursor_ < this.demandProducts_.length) {
+      Logger.warning(
+          '[ReleaseModelGeometry]: deferred pump not drained — not releasing')
+      return false
+    }
+
+    const model = this.model[0]
+    const localIDs: number[] = []
+
+    for (const mesh of model.geometry) {
+      localIDs.push((mesh as {localID: number}).localID)
+    }
+
+    for (const localID of localIDs) {
+      try {
+        model.geometry.delete(localID)
+      } catch {
+        // Never let a free break a loaded model.
+      }
+    }
+
+    // The GetGeometry map holds references to the now-freed natives —
+    // clear it so lookups degrade to the dummy instead of touching them.
+    this.model[3].clear()
+
+    this.released_ = true
+
+    return true
+  }
+
+  /** Native geometry freed (releaseGeometry) — scene walks would touch
+   * freed objects, so mesh serving degrades to the accumulated maps. */
+  private released_ = false
+
+  /**
    * Deferred-mode batch pump (conway extension; Share demand/tiled
    * rendering slice A): extract the next `batchSize` products (file
    * order) through the per-product demand seam and emit THIS BATCH's
@@ -1450,6 +1502,12 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    */
   private streamNewMeshes_(
       meshCallback: (mesh: FlatMesh) => void ): void {
+
+    // Released models: the scene's natives are freed — nothing new can
+    // exist to capture, and walking would touch freed objects.
+    if (this.released_) {
+      return
+    }
 
     const [model, scene, meshMap, geometryMaterialTransformMap] = this.model
 
@@ -1628,6 +1686,20 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * @param meshCallback
    */
   streamAllMeshes( meshCallback: (mesh: FlatMesh) => void) {
+
+    // Released models: the natives behind the scene are freed — serve
+    // the accumulated per-entity meshes instead of re-walking.
+    if (this.released_ && !this.deferredMode_) {
+
+      const [, , meshMap, , vectorFlatMesh] = this.model
+
+      meshMap.forEach((mesh) => {
+        vectorFlatMesh.push(mesh[1])
+        meshCallback(mesh[1])
+      })
+
+      return
+    }
 
     // Deferred models: the delta capture has already populated (or will
     // populate) the shared meshMap — re-running the classic walk would

--- a/src/compat/web-ifc/streamed_preview_channel.ts
+++ b/src/compat/web-ifc/streamed_preview_channel.ts
@@ -109,6 +109,13 @@ export interface PreviewPrefixGeneration {
    * #308).
    */
   recenter: boolean
+
+  /**
+   * Free the generation's native geometry (payloads are copies, so a
+   * retired generation holds nothing anyone can reference). Called by
+   * the channel when a generation is replaced and at stop().
+   */
+  dispose(): void
 }
 
 /**
@@ -183,8 +190,37 @@ export function ifcPreviewAdapter(): PreviewSchemaAdapter {
         geometryExpressID: ( geometryLocalID ) =>
           model.getElementByLocalID( geometryLocalID )?.expressID,
         recenter: true,
+        dispose: () => {
+          releaseModelGeometry( model.geometry )
+        },
       }
     },
+  }
+}
+
+/**
+ * Free every buffer-geometry canonical mesh a model geometry cache
+ * holds (native embind objects), leaving the cache empty. Safe on an
+ * already-released cache.
+ *
+ * @param geometry The model geometry cache (iterable of canonical
+ * meshes with a delete(localID)).
+ */
+function releaseModelGeometry(
+    geometry: Iterable<{ localID: number }> & { delete( localID: number ): void } ): void {
+
+  const localIDs: number[] = []
+
+  for ( const mesh of geometry ) {
+    localIDs.push( mesh.localID )
+  }
+
+  for ( const localID of localIDs ) {
+    try {
+      geometry.delete( localID )
+    } catch {
+      // Never let a free break a load — leaked is better than crashed.
+    }
   }
 }
 
@@ -229,6 +265,9 @@ export function ap214PreviewAdapter(): PreviewSchemaAdapter {
         geometryExpressID: ( geometryLocalID ) =>
           model.getElementByLocalID( geometryLocalID )?.expressID,
         recenter: false,
+        dispose: () => {
+          releaseModelGeometry( model.geometry )
+        },
       }
     },
   }
@@ -328,6 +367,16 @@ export class StreamedPreviewChannel {
       clearTimeout(this.timer_)
       this.timer_ = void 0
     }
+
+    // Payloads are copies — a stopped channel's throwaway scenes hold
+    // nothing anyone can reference. Free them so repeated loads in one
+    // tab reuse the wasm pages instead of stacking preview scenes.
+    try {
+      this.generation_?.generation.dispose()
+    } catch {
+      // Never let a free break the open.
+    }
+    this.generation_ = void 0
   }
 
   /** True when a cap was hit and the channel retired itself early. */
@@ -421,6 +470,17 @@ export class StreamedPreviewChannel {
       this.adapter.buildGeneration(this.data, this.conwaywasm, columns)
 
     this.lastSnapshotRecords_ = records
+
+    // The outgoing generation's instances are all captured (a
+    // generation is only replaced once exhausted + captured) — free its
+    // native scenes before adopting the new one.
+    if (generation !== void 0 && generation.unitCount > this.unitOrdinal_) {
+      try {
+        active?.generation.dispose()
+      } catch {
+        // Never let a free break the open.
+      }
+    }
 
     if (generation === void 0 || generation.unitCount <= this.unitOrdinal_) {
       // Prefix grew but produced no new units — wait for more records.


### PR DESCRIPTION
Addresses the multi-load tab crash reported during #1614 burn-in ("loaded a couple times, then fiddling, then crash"): every load retained its full native geometry until page teardown — `closeModel` destroys the *shared* wasm processor so it can't serve as a per-model free — and a few loads in one tab (or one PSB-class model twice) exhausted the wasm heap.

## Surface

`ReleaseModelGeometry(modelID)` (feature-detect with `typeof`): frees every canonical mesh the extraction produced and clears the GetGeometry map. Placed transforms, accumulated meshes, spatial structure and properties all survive; `GetGeometry` degrades to the empty dummy. A deferred model whose pump has not drained refuses with `false` (releasing would break the remaining extraction).

## Early-free hardening

Per the burn-in guidance to watch for premature frees, released models **cannot** re-walk freed natives by construction:
- `StreamAllMeshes` on a released model serves the accumulated per-entity meshes instead of walking the scene.
- The deferred delta capture short-circuits on released models (covers post-release `ExtractGeometryBatch` calls and the drain path's straggler capture).
- Every free is individually guarded — a failed delete degrades to a leak, never a crash.

Also: the parse-time preview channel now disposes its throwaway prefix scenes when a generation is replaced and at `stop()` — payloads are copies, so a retired generation holds nothing anyone can reference.

## Measured

Schependomlaan ×3 deferred loads in one module: wasm heap **78 → 93 → 93 MB** with release (third load reuses freed pages entirely) vs **78 → 112 → 162 MB** without.

## Tests

Release contract pinned: undrained pump refuses; served geometry degrades to size-0 dummy; mesh data survives; double-release and unknown-model calls safe. 297/297 across all suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_