### PR TITLE
STEP preview channel: private complex entries, fail-soft prefix prep, retry semantics

### DIFF
--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -4323,9 +4323,22 @@ export class AP214GeometryExtraction {
       for ( const contextDependentShapeRepresentation of
         contextDependentShapeRepresentations ) {
 
-        const assembly = contextDependentShapeRepresentation.represented_product_relation
+        // Per-record containment: reference getters throw on
+        // malformed/dangling records (a mid-parse PREFIX model — the
+        // preview channel's snapshots — always has a truncated tail).
+        // One bad edge record skips, it must not abort the whole
+        // preparation.
+        let assembly
+        let shapeRelationship
+
+        try {
+          assembly = contextDependentShapeRepresentation.represented_product_relation
+          shapeRelationship = contextDependentShapeRepresentation.representation_relation
+        } catch {
+          continue
+        }
+
         const owningLocalID = assembly.localID
-        const shapeRelationship = contextDependentShapeRepresentation.representation_relation
         shapeRepresentationRelationshipsSeen.add( shapeRelationship.localID )
 
         /* Exporters disagree on the rep_1/rep_2 order of an assembly
@@ -4340,8 +4353,16 @@ export class AP214GeometryExtraction {
          * SDR-bound product definition against them, and keep the legacy
          * (child, parent) reading when the match is ambiguous/unresolvable.
          */
-        let sourceShape = shapeRelationship.rep_1
-        let targetShape = shapeRelationship.rep_2
+        let sourceShape
+        let targetShape
+
+        try {
+          sourceShape = shapeRelationship.rep_1
+          targetShape = shapeRelationship.rep_2
+        } catch {
+          continue
+        }
+
         let orientationFlipped = false
 
         try {
@@ -4366,8 +4387,17 @@ export class AP214GeometryExtraction {
           // Malformed NAUO/PDS reference — keep the legacy orientation.
         }
 
-        const [transform, isContinue] = this.doTransforms(
-            shapeRelationship, sourceShape, targetShape, owningLocalID, orientationFlipped)
+        let transform
+        let isContinue
+
+        try {
+          [transform, isContinue] = this.doTransforms(
+              shapeRelationship, sourceShape, targetShape, owningLocalID, orientationFlipped)
+        } catch {
+          // Malformed transform record (prefix truncation) — skip the edge.
+          continue
+        }
+
         if (isContinue) {
           continue
         }
@@ -4412,10 +4442,23 @@ export class AP214GeometryExtraction {
          * source and rep_2 is the target, whereas in
          * context_dependent_shape_representation, the relationship is inverted.
          */
-        const sourceShape = shapeRelationship.rep_2
-        const targetShape = shapeRelationship.rep_1
-        
-        const [transform, isContinue] = this.doTransforms(shapeRelationship, sourceShape, targetShape, owningLocalID)
+        let sourceShape
+        let targetShape
+        let transform
+        let isContinue
+
+        try {
+          sourceShape = shapeRelationship.rep_2
+          targetShape = shapeRelationship.rep_1;
+
+          [transform, isContinue] =
+            this.doTransforms(shapeRelationship, sourceShape, targetShape, owningLocalID)
+        } catch {
+          // Malformed relationship/transform record (prefix truncation)
+          // — skip the edge.
+          continue
+        }
+
         if (isContinue) {
           continue
         }
@@ -4449,14 +4492,25 @@ export class AP214GeometryExtraction {
       const shapeDefinitions = model.types( shape_definition_representation )
       
       for ( const shapeDefinitionRepresentation of shapeDefinitions ) {
-        const shapeRepresentation = shapeDefinitionRepresentation.used_representation
-        if ( !( shapeRepresentation instanceof shape_representation ) ) {
+
+        let shapeRepresentation
+        let definition
+
+        try {
+          shapeRepresentation = shapeDefinitionRepresentation.used_representation
+
+          if ( !( shapeRepresentation instanceof shape_representation ) ) {
+            continue
+          }
+
+          definition = shapeDefinitionRepresentation.definition
+        } catch {
+          // Malformed SDR record (prefix truncation) — skip it.
           continue
         }
 
         //this.scene.clearParentStack()
 
-        const definition = shapeDefinitionRepresentation.definition
         const owningElementLocalID = definition.localID
         let treeNode = treeMap.get( shapeRepresentation.localID )
         const hasMappedNode = treeNode !== void 0
@@ -4475,17 +4529,22 @@ export class AP214GeometryExtraction {
 
         if ( !hasMappedNode ) {
           mappedTreeNode.processed = true
-            
-          const sourceShapeContext = 
-            shapeRepresentation.context_of_items.findVariant( global_unit_assigned_context )?.units?.
-            find( unit => unit.findVariant( length_unit ) )?.findVariant( length_unit ) as length_unit | undefined
 
           let scaleTransform : NativeTransform4x4 | undefined = void 0
 
-          if ( sourceShapeContext !== void 0 ) {
-            const sourceUnitInM = ( this.convertToMetres( sourceShapeContext ) ?? 1.0 )
-            scaleTransform =
-              this.uniformScaleAffine( this.identity3DNativeMatrix, 1.0 / sourceUnitInM )
+          try {
+            const sourceShapeContext =
+              shapeRepresentation.context_of_items.findVariant( global_unit_assigned_context )?.units?.
+              find( unit => unit.findVariant( length_unit ) )?.findVariant( length_unit ) as length_unit | undefined
+
+            if ( sourceShapeContext !== void 0 ) {
+              const sourceUnitInM = ( this.convertToMetres( sourceShapeContext ) ?? 1.0 )
+              scaleTransform =
+                this.uniformScaleAffine( this.identity3DNativeMatrix, 1.0 / sourceUnitInM )
+            }
+          } catch {
+            // Malformed unit context (prefix truncation) — no unit scale.
+            scaleTransform = void 0
           }
 
           // not an assembly mapped item — capture as a pending root
@@ -4530,17 +4589,22 @@ export class AP214GeometryExtraction {
       for ( const [sourceID, mappedNode] of treeMap.entries() ) {
         if ( ( mappedNode.parents ?? 0 ) === 0 && mappedNode.thunk !== void 0 && mappedNode.processed !== true ) {
 
-          const shapeRepresentation = this.model.getTypedElementByLocalID( sourceID, shape_representation )! as shape_representation
-          const sourceShapeContext = 
-            shapeRepresentation.context_of_items.findVariant( global_unit_assigned_context )?.units?.
-            find( unit => unit.findVariant( length_unit ) )?.findVariant( length_unit ) as length_unit | undefined
-
           let scaleTransform : NativeTransform4x4 | undefined = void 0
 
-          if ( sourceShapeContext !== void 0 ) {
-            const sourceUnitInM = ( this.convertToMetres( sourceShapeContext ) ?? 1.0 )
-            scaleTransform =
-              this.uniformScaleAffine( this.identity3DNativeMatrix, 1.0 / sourceUnitInM )
+          try {
+            const shapeRepresentation = this.model.getTypedElementByLocalID( sourceID, shape_representation )! as shape_representation
+            const sourceShapeContext =
+              shapeRepresentation.context_of_items.findVariant( global_unit_assigned_context )?.units?.
+              find( unit => unit.findVariant( length_unit ) )?.findVariant( length_unit ) as length_unit | undefined
+
+            if ( sourceShapeContext !== void 0 ) {
+              const sourceUnitInM = ( this.convertToMetres( sourceShapeContext ) ?? 1.0 )
+              scaleTransform =
+                this.uniformScaleAffine( this.identity3DNativeMatrix, 1.0 / sourceUnitInM )
+            }
+          } catch {
+            // Malformed unit context (prefix truncation) — no unit scale.
+            scaleTransform = void 0
           }
 
           pendingRoots.push( { node: mappedNode, scaleTransform } )

--- a/src/compat/web-ifc/ifc_api_preview_channel.test.ts
+++ b/src/compat/web-ifc/ifc_api_preview_channel.test.ts
@@ -277,4 +277,138 @@ describe( 'StreamedPreviewChannel', () => {
     api.CloseModel( classicID )
     api.CloseModel( deferredID )
   }, 240000 )
+
+  test( 'a throwing prefix build retires the attempt, not the channel', () => {
+
+    // Mid-parse prefixes can be structurally incomplete and the adapter's
+    // generation build can THROW (AP214's assembly-tree prep does on
+    // dangling references — this killed the whole STEP preview). The
+    // channel must swallow the attempt and succeed on a later, larger
+    // prefix. The sink is complete here, so growth is simulated by
+    // inflating the reported record count past the retry gate.
+    const sink = buildSink()
+    const realRecords = sink.topLevelCount
+
+    let reportedRecords = realRecords
+    const growingSink = {
+      get topLevelCount() {
+        return reportedRecords
+      },
+      snapshot: () => sink.snapshot(),
+    } as unknown as ColumnarIndexSink<number>
+
+    let buildAttempts = 0
+    const inner = ifcPreviewAdapter()
+    const flakyAdapter = {
+      buildGeneration: (
+          source: Uint8Array,
+          wasm: ConwayGeometry,
+          columns: StepIndexColumns<number> ) => {
+        if ( buildAttempts++ === 0 ) {
+          throw new Error( 'structurally incomplete prefix' )
+        }
+        return inner.buildGeneration( source, wasm, columns )
+      },
+    }
+
+    const payloads: PreviewMeshPayload[] = []
+
+    const channel = new StreamedPreviewChannel(
+        data, conwayGeometry, growingSink, flakyAdapter, true,
+        ( mesh ) => payloads.push( mesh ), void 0, void 0, 1 )
+
+    // First drain: the build throws — no payloads, but the channel
+    // survives the attempt.
+    channel.drainForTest()
+
+    expect( buildAttempts ).toBe( 1 )
+    expect( payloads.length ).toBe( 0 )
+
+    // Same record count: the failure gate must hold the retry.
+    channel.drainForTest()
+    expect( buildAttempts ).toBe( 1 )
+
+    // The index "grows" past the gate: the retry builds and drains fully.
+    reportedRecords = realRecords * 4
+    channel.drainForTest()
+
+    expect( buildAttempts ).toBe( 2 )
+    expect( payloads.length ).toBeGreaterThan( 0 )
+  }, 240000 )
+
+  test( 'retryEmptyUnits re-runs empty units on later generations', () => {
+
+    // AP214-style schema: the unit list is fixed up front but the
+    // geometry units reference arrives later in the file. The channel
+    // must re-run units that captured nothing against each richer
+    // generation, and stop retrying a unit once it captures.
+    const UNIT_COUNT = 3
+    const runsPerGeneration: number[][] = []
+
+    let reportedRecords = 2048
+    const fakeSink = {
+      get topLevelCount() {
+        return reportedRecords
+      },
+      snapshot: () => ( {} ),
+    } as unknown as ColumnarIndexSink<number>
+
+    const disposed: number[] = []
+
+    const makeGeneration = ( generationIndex: number ) => {
+      const runs: number[] = []
+      runsPerGeneration.push( runs )
+      return {
+        // Empty scene: units "execute" but never capture, so no unit
+        // ever completes and every generation re-runs all of them.
+        scene: { *walk() { /* no instances */ } },
+        unitCount: UNIT_COUNT,
+        linearScalingFactor: 1,
+        runUnits: ( from: number ) => {
+          runs.push( from )
+          return 1
+        },
+        geometryExpressID: () => void 0,
+        recenter: false,
+        dispose: () => disposed.push( generationIndex ),
+      }
+    }
+
+    let generationIndex = 0
+    const adapter = {
+      retryEmptyUnits: true,
+      buildGeneration: () => makeGeneration( generationIndex++ ),
+    }
+
+    const channel = new StreamedPreviewChannel(
+        data, conwayGeometry, fakeSink, adapter, false,
+        () => { /* no payloads expected */ }, void 0, void 0, 1 )
+
+    const forceTick = () => {
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      ( channel as any ).lastInlineTick_ = 0;
+      ( channel as any ).tickIntervalMs_ = 0
+      /* eslint-enable @typescript-eslint/no-explicit-any */
+      channel.maybeTickInline()
+    }
+
+    // Generation 1: all units run once (none capture).
+    forceTick()
+    expect( runsPerGeneration[ 0 ] ).toEqual( [ 0, 1, 2 ] )
+
+    // Same record count: growth-gated, no rebuild, no re-runs.
+    forceTick()
+    expect( runsPerGeneration.length ).toBe( 1 )
+    expect( runsPerGeneration[ 0 ] ).toEqual( [ 0, 1, 2 ] )
+
+    // Records double: a fresh generation re-runs every empty unit and
+    // the outgoing generation is disposed.
+    reportedRecords *= 4
+    forceTick()
+    expect( runsPerGeneration.length ).toBe( 2 )
+    expect( runsPerGeneration[ 1 ] ).toEqual( [ 0, 1, 2 ] )
+    expect( disposed ).toContain( 0 )
+
+    channel.stop()
+  }, 240000 )
 } )

--- a/src/compat/web-ifc/streamed_preview_channel.ts
+++ b/src/compat/web-ifc/streamed_preview_channel.ts
@@ -132,6 +132,20 @@ export interface PreviewPrefixGeneration {
 export interface PreviewSchemaAdapter {
 
   /**
+   * Retry semantics for schemas whose unit list is FIXED up front while
+   * the geometry those units reference arrives throughout the file
+   * (AP214: the assembly tree sits at the head, solids follow). Without
+   * this, the first generation "consumes" every unit against a prefix
+   * that has no geometry yet and later, richer generations report no
+   * new units — the channel then never emits anything. With it, the
+   * channel re-runs units that emitted no instances against each new
+   * generation, and marks a unit done only once it captures something.
+   * Leave unset for schemas whose units keep appearing with the parse
+   * (IFC products) — re-running those would be quadratic for no gain.
+   */
+  readonly retryEmptyUnits?: boolean
+
+  /**
    * Build a generation over the given prefix columns.
    *
    * @param data The (fully resident) source buffer.
@@ -252,6 +266,7 @@ function releaseModelGeometry(
  */
 export function ap214PreviewAdapter(): PreviewSchemaAdapter {
   return {
+    retryEmptyUnits: true,
     buildGeneration( data, conwaywasm, columns ) {
 
       const model = new AP214StepModel(
@@ -327,6 +342,14 @@ export class StreamedPreviewChannel {
    * notes). */
   private unitOrdinal_ = 0
 
+  /** Retry mode (adapter.retryEmptyUnits): ordinals that captured ≥ 1
+   * instance — done for good, skipped on later generations. */
+  private readonly completedUnits_ = new Set<number>()
+
+  /** Retry mode: scan position within the CURRENT generation (resets to
+   * 0 on every new generation so empty units get re-run). */
+  private retryScan_ = 0
+
   /** Geometry expressIDs whose payload has been emitted (cross-generation
    * dedup for mapped/shared geometry). */
   private readonly emittedGeometry_ = new Set<number>()
@@ -337,6 +360,11 @@ export class StreamedPreviewChannel {
   }
 
   private lastSnapshotRecords_ = 0
+
+  /** Records at the last snapshot whose generation build THREW (a
+   * structurally incomplete prefix) — gates retries to index growth so a
+   * throwing prefix build can't hot-loop every tick. */
+  private lastFailedSnapshotRecords_ = 0
 
   /**
    * @param data The (fully resident) source buffer the parse is indexing.
@@ -473,6 +501,33 @@ export class StreamedPreviewChannel {
     const active = this.generation_!
     const { generation } = active
 
+    if (this.adapter.retryEmptyUnits === true) {
+
+      // Retry mode: scan the fixed unit list, skipping units that
+      // already captured instances on an earlier (or this) generation.
+      // Capture runs per unit so completion can be attributed — unit
+      // counts here are small by construction (assembly roots).
+      while (this.retryScan_ < generation.unitCount &&
+          this.emittedUnits_ < this.maxUnits &&
+          Date.now() < deadline) {
+
+        const ordinal = this.retryScan_++
+
+        if (this.completedUnits_.has(ordinal)) {
+          continue
+        }
+
+        const executed = generation.runUnits(ordinal, 1)
+
+        if (executed > 0 && this.captureNewInstances_() > 0) {
+          this.completedUnits_.add(ordinal)
+          ++this.emittedUnits_
+        }
+      }
+
+      return
+    }
+
     let extractedThisTick = 0
 
     while (this.unitOrdinal_ < generation.unitCount &&
@@ -501,7 +556,7 @@ export class StreamedPreviewChannel {
 
     const active = this.generation_
 
-    if (active !== void 0 && this.unitOrdinal_ < active.generation.unitCount) {
+    if (active !== void 0 && this.hasPendingUnits_(active.generation)) {
       return true
     }
 
@@ -516,26 +571,62 @@ export class StreamedPreviewChannel {
       return false
     }
 
-    const columns = this.sink.snapshot()
-    const generation =
-      this.adapter.buildGeneration(this.data, this.conwaywasm, columns)
+    if (records < this.lastFailedSnapshotRecords_ * GENERATION_GROWTH_FACTOR) {
+      return false
+    }
 
+    const columns = this.sink.snapshot()
+
+    let generation: PreviewPrefixGeneration | undefined
+
+    try {
+      generation =
+        this.adapter.buildGeneration(this.data, this.conwaywasm, columns)
+    } catch {
+      // A mid-parse prefix can be structurally incomplete — dangling
+      // references throw schema-typed errors (AP214's assembly-tree
+      // prep especially; a bad prefix killed the whole STEP preview
+      // before this catch). That retires THIS attempt, not the
+      // channel: the growth gate above retries once the index has
+      // grown enough for a materially different prefix.
+      this.lastFailedSnapshotRecords_ = records
+      return false
+    }
+
+    this.lastFailedSnapshotRecords_ = 0
     this.lastSnapshotRecords_ = records
+
+    if (generation === void 0) {
+      // Prefix grew but cannot build yet — wait for more records.
+      return false
+    }
+
+    const newGenerationPending = this.adapter.retryEmptyUnits === true ?
+      generation.unitCount > 0 &&
+        this.completedUnits_.size < generation.unitCount :
+      generation.unitCount > this.unitOrdinal_
+
+    if (!newGenerationPending) {
+      // Nothing this prefix can add — free it and wait for more records.
+      // (The active generation, if any, keeps its scan state untouched.)
+      try {
+        generation.dispose()
+      } catch {
+        // Never let a free break the open.
+      }
+      return false
+    }
+
+    // Retry mode: a fresh generation re-runs every not-yet-captured unit.
+    this.retryScan_ = 0
 
     // The outgoing generation's instances are all captured (a
     // generation is only replaced once exhausted + captured) — free its
     // native scenes before adopting the new one.
-    if (generation !== void 0 && generation.unitCount > this.unitOrdinal_) {
-      try {
-        active?.generation.dispose()
-      } catch {
-        // Never let a free break the open.
-      }
-    }
-
-    if (generation === void 0 || generation.unitCount <= this.unitOrdinal_) {
-      // Prefix grew but produced no new units — wait for more records.
-      return false
+    try {
+      active?.generation.dispose()
+    } catch {
+      // Never let a free break the open.
     }
 
     this.generation_ = {
@@ -547,14 +638,35 @@ export class StreamedPreviewChannel {
   }
 
   /**
+   * Does the given generation still have units this channel would run —
+   * retry mode: not-yet-captured ordinals ahead of the scan; classic
+   * mode: ordinals beyond the global forward-only cursor.
+   *
+   * @param generation The generation to check.
+   * @return {boolean} True when a tick can make progress on it.
+   */
+  private hasPendingUnits_(generation: PreviewPrefixGeneration): boolean {
+
+    if (this.adapter.retryEmptyUnits === true) {
+      return this.retryScan_ < generation.unitCount &&
+        this.completedUnits_.size < generation.unitCount
+    }
+
+    return this.unitOrdinal_ < generation.unitCount
+  }
+
+  /**
    * Walk the current generation's scene and emit every not-yet-captured
    * placed instance as a payload — the preview twin of the durable delta
    * captures, with the same placed-geometry math per schema (recentering
    * for IFC, bare composition for AP214) so preview and durable
    * placements coincide, but copying geometry OUT of the wasm heap
    * instead of retaining native references.
+   *
+   * @return {number} Instances emitted by this pass (retry mode uses
+   * this to attribute unit completion).
    */
-  private captureNewInstances_(): void {
+  private captureNewInstances_(): number {
 
     const active = this.generation_!
     const { generation, capturedCounts } = active
@@ -562,6 +674,8 @@ export class StreamedPreviewChannel {
 
     const linearScalingFactor = generation.linearScalingFactor
     const seenThisPass = new Map<number, number>()
+
+    let emitted = 0
 
     type WalkTuple = [
       unknown,
@@ -723,11 +837,14 @@ export class StreamedPreviewChannel {
       }
 
       this.onMesh(payload)
+      ++emitted
 
       if (this.emittedBytes_ >= this.maxBytes) {
-        return
+        return emitted
       }
     }
+
+    return emitted
   }
 
   /**

--- a/src/step/parsing/columnar_index.ts
+++ b/src/step/parsing/columnar_index.ts
@@ -242,7 +242,8 @@ implements StepIndexSink<TypeIDType> {
 
     for ( const [ localID, entry ] of this.retained_ ) {
       if ( entry.multiMapping !== void 0 ) {
-        ( complexEntries ??= new Map() ).set( localID, entry )
+        ( complexEntries ??= new Map() ).set(
+            localID, cloneIndexEntry( entry ) as StepIndexEntry<TypeIDType> )
       }
     }
 
@@ -257,6 +258,54 @@ implements StepIndexSink<TypeIDType> {
       expressIdsSorted: this.expressIdsSorted_,
     }
   }
+}
+
+
+/**
+ * Clone an index entry (and its multiMapping sub-entries, which models
+ * also stamp) down to the persistent index fields.
+ *
+ * Models materialise complex entries by writing lazy parse state —
+ * vtable views, buffer references, entity instances — onto the entry
+ * objects IN PLACE (see StepModelBase.invalidate, which clears exactly
+ * those fields). Handing every snapshot/finalize the same retained
+ * object therefore let one model poison every other model built over
+ * the same sink: a throwaway prefix model (parse-time preview channel)
+ * stamped its own vtable views, and the durable model's short-circuit
+ * (`vtableIndex !== undefined`) then read stale views — "Value in STEP
+ * was incorrectly typed" on AP214's complex-instance transforms.
+ * Cloning per assembly keeps each model's lazy state private.
+ * `inlineEntities` stays shared: inline records are unfolded into
+ * column scalars above and their objects are never stamped.
+ *
+ * @param entry The retained entry to clone.
+ * @return {StepIndexEntryBase} A fresh holder with persistent fields only.
+ */
+function cloneIndexEntry<TypeIDType>(
+    entry: StepIndexEntryBase<TypeIDType> ): StepIndexEntryBase<TypeIDType> {
+
+  const clone: StepIndexEntryBase<TypeIDType> = {
+    address: entry.address,
+    length: entry.length,
+  }
+
+  if ( entry.typeID !== void 0 ) {
+    clone.typeID = entry.typeID
+  }
+
+  if ( entry.expressID !== void 0 ) {
+    clone.expressID = entry.expressID
+  }
+
+  if ( entry.inlineEntities !== void 0 ) {
+    clone.inlineEntities = entry.inlineEntities
+  }
+
+  if ( entry.multiMapping !== void 0 ) {
+    clone.multiMapping = entry.multiMapping.map( cloneIndexEntry )
+  }
+
+  return clone
 }
 
 


### PR DESCRIPTION
The parse-time preview channel emitted **nothing** for AP214/STEP models and — worse — could corrupt the durable deferred open. Root-caused on Arty_Z7.stp (58MB), three fixes:

## 1. Snapshot state pollution (correctness)

`ColumnarIndexSink.assemble_` handed every snapshot **and** the finalize the *same* retained complex (multi-mapping) entry objects. Models stamp lazy parse state (vtable views, buffer references, entities) onto complex entries in place — so a throwaway prefix model built over a snapshot poisoned the durable model built over `finalize()`: the durable short-circuit (`vtableIndex !== undefined`) read stale vtable views and threw `"Value in STEP was incorrectly typed"` on AP214's complex-instance transforms. On Arty the durable pump went **49 → 0 meshes** once prefix builds ran. IFC was immune only because IFC files carry no complex instances.

Fix: clone retained complex entries (and their `multiMapping` sub-entries) per assembly, down to the persistent index fields.

## 2. Fail-soft prefix preparation

A mid-parse prefix always has a truncated tail, and `prepareDemandExtraction`'s edge/root loops (CDSR, `shape_representation_relationship`, SDR, unit-context derivation) used throwing reference getters unguarded — one dangling record aborted the entire preparation, and the channel's fatal tick catch then killed the whole STEP preview on tick #1 (this is why STEP never showed parse-time preview). Now: per-record containment (skip the bad edge), and the channel treats a throwing generation build as a failed *attempt* with growth-gated retry instead of channel death. On a complete model nothing throws, so durable behavior/digests are unchanged.

## 3. Retry semantics for fixed-unit-list schemas

AP214's assembly tree sits at the file head while geometry arrives throughout the file — running each unit once against the first viable prefix consumed the whole unit list before any geometry existed, and later generations reported "no new units" forever. New `PreviewSchemaAdapter.retryEmptyUnits` (set by the AP214 adapter): the channel re-runs units that captured no instances against each richer generation, with per-unit capture attribution, marking a unit done only once it emits. Also fixes a leak where rejected new generations were dropped undisposed.

## Verification

- Arty_Z7.stp: durable pump parity restored with 8 prefix builds interleaved mid-parse (55 units / 6816 scene nodes — identical to a no-snapshot run); prefix generations build successfully from ~65k records (previously: every build threw); open time back to ~1.8s (was 17.5s with the naive retry).
- IFC unchanged: Schependomlaan 462 payloads, first at 54ms; full-drain classic parity test still byte-exact.
- New tests: throwing prefix build retires the attempt not the channel (growth-gated retry); `retryEmptyUnits` re-runs empty units on later generations and disposes replaced generations.
- Suites green: preview channel (6), deferred/streamed opens (14), step/parsing (72), AP214 (38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_