### PR TITLE
Revolution, extrusion, cylinder + cone surface fidelity: round shafts, correct compressor drum (conway-geom#149)

### DIFF
--- a/src/AP214E3_2010/ap214_geometry_extraction.test.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.test.ts
@@ -149,7 +149,10 @@ describe('AP214 Geometry Extraction', () => {
   })
 
   test('tubeGeometryArrayLength()', () => {
-    const testParameter:number = 9108
+    // Dropped from 9108 with conway-geom#153: cylindrical faces CDT their
+    // trim loops in a (theta, z) unwrap instead of refining earcut chords
+    // until the triangle budget ran out.
+    const testParameter:number = 828
     expect(getTubeMeshSize()).toBe(testParameter)
 
   })

--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -3328,13 +3328,28 @@ export class AP214GeometryExtraction {
    */
   extractSurfaceOfLinearExtrusion(from: surface_of_linear_extrusion, nativeSurface: SurfaceObject) {
 
-    const profile = this.extractProfile( from.swept_curve )
+    // AP214's swept_curve is a bare curve, not a profile_def, so it goes
+    // through extractCurve + createNativeIfcProfile like the revolution
+    // path does. extractProfile() never fills nativeProfile for bare
+    // curves, which silently dropped every linear-extrusion face (1,370
+    // faces on the Jetenginestep compressor shaft alone).
+    const nativeCurve = this.extractCurve( from.swept_curve )
 
-    if (profile?.nativeProfile === void 0) {
+    if ( nativeCurve === void 0 ) {
 
       Logger.warning('Couldn\'t get curve profile for linear extrusion surface')
       return
     }
+
+    const parameters: ParamsCreateNativeIfcProfile = {
+      curve: nativeCurve,
+      holes: this.nativeVectorCurve(),
+      isConvex: false,
+      isComposite: false,
+      profiles: this.nativeVectorProfile(),
+    }
+
+    const nativeProfile = this.conwayModel.createNativeIfcProfile(parameters)
 
     const extrusionAxis = from.extrusion_axis
     const depth = extrusionAxis.magnitude
@@ -3348,7 +3363,7 @@ export class AP214GeometryExtraction {
         y: directionCoords[1],
         z: directionCoords[2],
       },
-      profile: profile?.nativeProfile,
+      profile: nativeProfile,
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the Jetenginestep turbine&#39;s remaining geometry complaints from bldrs-ai/test-models#47 — the faceted shaft/spinner (revolution surfaces), the corrupt compressor central shaft (linear-extrusion surfaces), the degenerate blade/join/shaft rings between compressor sections (cylindrical + conical surfaces), and the fuel-manifold tube around the accessory hub (toroidal surfaces).

### Revolution surfaces (conway-geom#150, #151 — closes conway-geom#149)

- Adaptive ring count (64 segments/turn instead of fixed 10) + the shared adaptive on-surface refinement.
- Boundary loops CDT-trimmed in (θ, profile-arclength) with exact hole nesting; swept-grid fallback on any degeneracy.

### Linear-extrusion surfaces (this repo + conway-geom#152)

- **Extractor fix (this repo)**: `extractSurfaceOfLinearExtrusion` used `extractProfile()`, which never fills `nativeProfile` for AP214&#39;s bare swept curves — every `surface_of_linear_extrusion` face (1,370 on the jet compressor alone) silently fell into the flat `TriangulateBounds` fallback. Now routed through `extractCurve` + `createNativeIfcProfile`.
- **`TriangulateExtrusion` rewrite (conway-geom#152)**: exact developable unwrap — (profile-arclength, axial-distance) CDT with hole nesting, closed-profile periodicity, scale-aware refinement floor, `TriangulateBounds` fallback on every degeneracy path.

### Cylindrical + conical surfaces (conway-geom#153)

- Legacy earcut projections (annulus-by-max-z for cylinders; axial z-dropping projection for cones) produced chord triangles that the budgeted refinement inflated into lumpy shelves on the compressor&#39;s rings. Both now unwrap trim loops into (θ, z) and CDT with exact hole nesting via the shared `unwrap_detail::triangulateUnwrappedLoops()`; cone generator line least-squares fitted from boundary samples; apex cones bail to the legacy fan path.
- Removing the refine-until-budget waste drops the jet 4.90M → 3.49M triangles (driver_board 3.74M → 0.39M); tube test golden 9108 → 828.

### Toroidal surfaces (conway-geom#154)

- The fuel manifold is a thin torus (R=538, r=17.5) split into half-tube segments whose rectangle rails both sit on the z=0 equators. Boundary-only CDT chorded the tube diametrically, and closest-point refinement structurally cannot lift z≈0 chords back onto the arc — the budget subdivided a flat creased ribbon in place (visible in prod around the hub forward of the combustion chamber).
- Trimmed torus faces now seed interior Steiner points on the analytic (θ, φ) grid before CDT (all three layouts), with boundary-only retry if CDT rejects the seeded input; toroidal refinement gains the same scale-aware deflection floor as the other unwraps.

## Validation

- Jet: all 148 placements identical at every step; compressor drum rings smooth (drum 826k → 392k tris); manifold tube renders as a round pipe from every angle; model total 3.47M tris.
- 10-model corpus: error signatures identical throughout; torus-heavy models gain legitimate rounding where blend fillets were under-tessellated chords (nist_ftc_08 30k → 101k); washer unchanged.

The visual-diff comment is the review artifact: check the jet row for the round shaft, rebuilt compressor section, smooth inter-section rings, and the round manifold tube.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7