### PR TITLE
AP214: quiet recoverable per-record errors in preview prefix extractions

### DIFF
--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -270,6 +270,15 @@ export class AP214GeometryExtraction {
    * or the maximum level for CSG memoization if it is not.
    * @param lowMemoryMode Whether to enable low memory mode for geometry extraction.
    */
+  /** When true, per-record recoverable errors (dangling styled items,
+   * child-representation failures, stack mismatches) are not logged.
+   * Set by the parse-time preview channel's throwaway PREFIX
+   * extractions, where truncated-tail records make those errors
+   * expected by construction — several generations over a large STEP
+   * file otherwise flood the load report with thousands of warnings
+   * (Arty: 5k+). Durable extractions keep full logging. */
+  public quietRecoverableLogging: boolean
+
   constructor(
     private readonly conwayModel: ConwayGeometry,
     public readonly model: AP214StepModel,
@@ -278,6 +287,7 @@ export class AP214GeometryExtraction {
     private readonly lowMemoryMode: boolean = false ) {
 
     this.csgMemoization = !this.lowMemoryMode
+    this.quietRecoverableLogging = false
 
     this.materials = model.materials
     this.scene = new AP214SceneBuilder(model, conwayModel, this.materials)
@@ -3982,7 +3992,9 @@ export class AP214GeometryExtraction {
           styledItemMap.set( styledItem.item.localID, styledItem.localID )
         }
       } catch (error) {
-        Logger.error(`Error populating styled item map for item ${styledItem.localID}: ${error}`)
+        if ( !this.quietRecoverableLogging ) {
+          Logger.error(`Error populating styled item map for item ${styledItem.localID}: ${error}`)
+        }
       }
     }
     
@@ -3993,7 +4005,9 @@ export class AP214GeometryExtraction {
           styledItemMap.set( overridingStyledItem.item.localID, overridingStyledItem.localID )
         }
       } catch (error) {
-        Logger.error(`Error populating styled item map for item ${overridingStyledItem.localID}: ${error}`)
+        if ( !this.quietRecoverableLogging ) {
+          Logger.error(`Error populating styled item map for item ${overridingStyledItem.localID}: ${error}`)
+        }
       }
     }
   }
@@ -4204,7 +4218,9 @@ export class AP214GeometryExtraction {
             try {
               mappedChild.thunk!( childOwningLocalID, childTransform )
             } catch ( ex ) {
-              if ( ex instanceof Error ) {
+              if ( this.quietRecoverableLogging ) {
+                // Preview prefix: dangling children are expected — skip quietly.
+              } else if ( ex instanceof Error ) {
                 Logger.error( `Error processing child shape_representation: \n\t${ex.name}\n\t${ex.message}\n\texpressID: #${this.model.getExpressIDByLocalID( childLocalID )}` )
               } else {
                 Logger.error( `Unknown exception processing child shape_representation (${ex}) expressID: #${this.model.getExpressIDByLocalID( childLocalID )}` )
@@ -4217,7 +4233,8 @@ export class AP214GeometryExtraction {
               this.scene.popTransform()
             }
 
-            if( this.scene.stackLength !== enterChildStackDepth || this.scene.currentParent !== enterChildParent ) {
+            if( ( this.scene.stackLength !== enterChildStackDepth ||
+                this.scene.currentParent !== enterChildParent ) && !this.quietRecoverableLogging ) {
               Logger.error( `Stack length mismatch after processing child shape_representation ${this.scene.currentParent} ${enterChildParent} expressID: #${representation.expressID}` )
             }
           }
@@ -4262,7 +4279,8 @@ export class AP214GeometryExtraction {
           this.scene.popTransform()
         }
 
-        if( this.scene.stackLength !== entryTransformDepth || this.scene.currentParent !== currentParent ) {
+        if( ( this.scene.stackLength !== entryTransformDepth ||
+            this.scene.currentParent !== currentParent ) && !this.quietRecoverableLogging ) {
           Logger.error( `Stack length mismatch after processing shape_representation  ${this.scene.currentParent} ${currentParent} expressID: #${representation.expressID}` )
         }
       }
@@ -4711,7 +4729,10 @@ export class AP214GeometryExtraction {
         units[ this.demandCursor_ ]()
         ++executed
       } catch ( ex ) {
-        if ( ex instanceof Error ) {
+        if ( this.quietRecoverableLogging ) {
+          // Preview prefix: failing units are expected — retried on a
+          // richer generation, and the durable extraction re-runs all.
+        } else if ( ex instanceof Error ) {
           Logger.error( `Error processing demand unit: \n\t${ex.name}\n\t${ex.message}` )
         } else {
           Logger.error( `Unknown exception processing demand unit (${ex})` )

--- a/src/compat/web-ifc/streamed_preview_channel.ts
+++ b/src/compat/web-ifc/streamed_preview_channel.ts
@@ -274,6 +274,11 @@ export function ap214PreviewAdapter(): PreviewSchemaAdapter {
 
       const extraction = new AP214GeometryExtraction( conwaywasm, model )
 
+      // Prefix extractions hit dangling records by construction —
+      // don't let their expected per-record errors flood the report
+      // (Arty: 5k+ styled-item warnings across generations).
+      extraction.quietRecoverableLogging = true
+
       extraction.prepareDemandExtraction()
 
       if ( extraction.demandUnitCount === 0 ) {


### PR DESCRIPTION
The preview channel's throwaway prefix extractions hit dangling records by construction (truncated tail mid-parse), and their caught per-record errors — styled-item map population, child `shape_representation` failures, stack mismatches, failing demand units — logged at error level. Several generations over a real STEP file flooded the Share load report with **5k+ warnings** (Arty, spotted in the v1.431 field report).

New `AP214GeometryExtraction.quietRecoverableLogging`, set only by the AP214 preview adapter: the same errors stay caught-and-skipped, just unlogged. Durable extractions keep full logging.

Verified on Arty_Z7.stp: a pure durable run logs zero of these either way; a preview-channel run went 5k+ → 0 across three consecutive probe runs, with pump output unchanged (49 delta meshes). Channel + AP214 suites green (50 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_