### PR TITLE
Large-model demand fixes: quiet IFC preview logging + float64 coordinate-to-origin (georeferencing jitter)

### DIFF
--- a/src/compat/web-ifc/coordination_f64.test.ts
+++ b/src/compat/web-ifc/coordination_f64.test.ts
@@ -1,0 +1,135 @@
+/* eslint-disable no-magic-numbers */
+import { describe, expect, test } from '@jest/globals'
+import * as glmatrix from 'gl-matrix'
+import {
+  composeTransformF64,
+  deriveCoordinationF64,
+  mat4MultiplyF64,
+} from './coordination_f64'
+
+// The Z-up -> Y-up normalize matrix the proxies pass in (column-major).
+const NORMALIZE_MAT: number[] = [
+  1, 0, 0, 0,
+  0, 0, -1, 0,
+  0, 1, 0, 0,
+  0, 0, 0, 1,
+]
+
+/**
+ * A pseudo-random but deterministic 4x4 (no Math.random — stable runs).
+ *
+ * @param seed Any integer seed.
+ * @return {number[]} 16 column-major components in [-1, 1).
+ */
+function pseudoMat( seed: number ): number[] {
+  const out = new Array<number>( 16 )
+  let state = seed
+  for ( let i = 0; i < 16; ++i ) {
+    // xorshift-ish; deterministic.
+    state = ( state * 1103515245 + 12345 ) & 0x7fffffff
+    out[ i ] = ( state / 0x7fffffff ) * 2 - 1
+  }
+  return out
+}
+
+describe( 'coordination_f64', () => {
+
+  test( 'mat4MultiplyF64 matches gl-matrix multiply for arbitrary inputs', () => {
+    for ( let seed = 1; seed <= 8; ++seed ) {
+      const a = pseudoMat( seed )
+      const b = pseudoMat( seed * 31 + 7 )
+      const mine = mat4MultiplyF64( a, b )
+      const ref = glmatrix.mat4.create()
+      glmatrix.mat4.multiply(
+          ref,
+          a as unknown as glmatrix.mat4,
+          b as unknown as glmatrix.mat4 )
+      for ( let i = 0; i < 16; ++i ) {
+        // float32 gl-matrix vs float64 mine: agree to float32 precision.
+        expect( mine[ i ] ).toBeCloseTo( ref[ i ], 4 )
+      }
+    }
+  } )
+
+  test( 'recentres a LV95-magnitude reference exactly where float32 mis-lands it', () => {
+    // The georeferencing jitter mechanism: the recentre translation
+    // negates a reference point at Swiss LV95 magnitude (~2.6M easting).
+    // Stored in a Float32Array it quantizes to the ~0.31 m grid (float32
+    // ULP at 2.6M), so the reference lands cm-to-dm off the origin — a
+    // per-model positional error baked into every emitted transform. The
+    // float64 recentre lands it exactly.
+    const identity = glmatrix.mat4.create() // placement; world via the point
+    const ref = { x: 2_600_000.31, y: 1_200_000.17, z: 412.5 }
+
+    /**
+     * Apply a column-major 4x4 to a point.
+     *
+     * @param m 16-element matrix.
+     * @param p The point.
+     * @return {number} The transformed point's distance from origin.
+     */
+    const originDist = ( m: ArrayLike<number> ) => Math.hypot(
+        m[ 0 ] * ref.x + m[ 4 ] * ref.y + m[ 8 ] * ref.z + m[ 12 ],
+        m[ 1 ] * ref.x + m[ 5 ] * ref.y + m[ 9 ] * ref.z + m[ 13 ],
+        m[ 2 ] * ref.x + m[ 6 ] * ref.y + m[ 10 ] * ref.z + m[ 14 ] )
+
+    // float64 recentre (the fix).
+    const distF64 = originDist( deriveCoordinationF64( identity, ref, NORMALIZE_MAT, 1 ) )
+
+    // Old float32 gl-matrix recentre: the translation is stored in a
+    // Float32Array, quantizing the -2.6M component.
+    const tp = glmatrix.vec4.create()
+    glmatrix.vec4.transformMat4( tp, [ ref.x, ref.y, ref.z, 1 ], identity )
+    const coordF32 = glmatrix.mat4.create()
+    glmatrix.mat4.fromTranslation( coordF32, [ -tp[ 0 ], -tp[ 1 ], -tp[ 2 ] ] )
+    glmatrix.mat4.multiply( coordF32, NORMALIZE_MAT as unknown as glmatrix.mat4, coordF32 )
+    const distF32 = originDist( coordF32 )
+
+    // float64 lands sub-micron; float32 is off by cm+.
+    expect( distF64 ).toBeLessThan( 1e-6 )
+    expect( distF32 ).toBeGreaterThan( 1e-2 )
+  } )
+
+  test( 'near origin float64 and float32 agree (fixtures unaffected)', () => {
+    const placement = pseudoMat( 99 )
+    // Keep it a valid affine-ish transform near origin.
+    placement[ 12 ] = 3; placement[ 13 ] = -2; placement[ 14 ] = 5
+    placement[ 3 ] = 0; placement[ 7 ] = 0; placement[ 11 ] = 0; placement[ 15 ] = 1
+    const point = { x: 0.5, y: 0.25, z: -0.75 }
+
+    const f64 = deriveCoordinationF64( placement, point, NORMALIZE_MAT, 1 )
+    const composed = composeTransformF64( f64, placement, { x: 0.1, y: 0.2, z: 0.3 } )
+    expect( composed ).toHaveLength( 16 )
+    // Sanity: finite, bounded.
+    for ( const v of composed ) {
+      expect( Number.isFinite( v ) ).toBe( true )
+    }
+  } )
+
+  test( 'flushes non-finite and float32-underflow garbage to zero (reopen parity)', () => {
+    // A degenerate/reopened-model placement whose getValues() returns
+    // subnormal garbage + a NaN. The old Float32Array path zeroed the
+    // subnormals; we zero those AND NaN/Inf so parity holds and no NaN
+    // leaks into a transform.
+    const garbage = [
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      1.29e-304, NaN, Infinity, 1,
+    ]
+    const out = composeTransformF64(
+        [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 ], garbage )
+    expect( out[ 12 ] ).toBe( 0 ) // subnormal -> 0
+    expect( out[ 13 ] ).toBe( 0 ) // NaN -> 0
+    expect( out[ 14 ] ).toBe( 0 ) // Infinity -> 0
+    for ( const v of out ) {
+      expect( Number.isFinite( v ) ).toBe( true )
+    }
+  } )
+
+  test( 'undefined placement is treated as identity', () => {
+    const coord = [ 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1 ]
+    const out = composeTransformF64( coord, void 0 )
+    expect( Array.from( out ) ).toEqual( coord )
+  } )
+} )

--- a/src/compat/web-ifc/coordination_f64.ts
+++ b/src/compat/web-ifc/coordination_f64.ts
@@ -1,0 +1,191 @@
+/**
+ * Float64 coordinate-to-origin (COORDINATE_TO_ORIGIN) math.
+ *
+ * gl-matrix's `mat4`/`vec4` are backed by `Float32Array`
+ * (`ARRAY_TYPE = Float32Array` in gl-matrix/common.js), so the recentre
+ * derivation — which subtracts a large world reference point
+ * (`transformedPt = placement * nativePoint`, on the order of 1e5 m for a
+ * Swiss/CHE georeferenced IFC, up to ~2.6e6 m in LV95 easting/northing) —
+ * loses precision: float32 ULP is ~7.6 mm at 100 km and ~60 mm at 2.6 M m.
+ * Baked into the emitted FlatMesh transform that quantization forms a
+ * spatial grid that reads as rotational jitter when the camera is zoomed
+ * to detail.
+ *
+ * The native placement crosses the wasm boundary as `glm::dmat4` and the
+ * reference point as `glm::dvec3` — both full float64 (see
+ * conway-api.cpp `getMatrixValues4x4` / the `glmdVec3` value object), so
+ * `nativeTransform.getValues()` and `geometry.getPoint()` deliver doubles.
+ * Feeding those doubles straight through a double-precision composition
+ * (rather than gl-matrix's float32 path, and without the intermediate
+ * `mat4.fromValues` truncation to `Float32Array`) fully recovers the
+ * precision for georeferenced models.
+ *
+ * All layout/multiply conventions match gl-matrix exactly (column-major,
+ * `out = a * b`), so near-origin models — where float32 and float64 agree
+ * to well under a micron — stay bit-comparable across the
+ * classic / deferred / preview paths that share this recentre.
+ */
+
+const IDENTITY: readonly number[] =
+  [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+
+/**
+ * Smallest positive magnitude representable in single precision
+ * (2 ** -149, the smallest float32 subnormal). The previous code path
+ * built the placement with gl-matrix `mat4.fromValues(...)` — a
+ * `Float32Array` — so any transform component below this magnitude was
+ * stored as exactly zero. Valid geometry never produces a non-zero
+ * component this small (positions are metres/kilometres, rotation and
+ * scale terms are O(1) or exactly zero), so the only inputs it affects
+ * are denormal garbage from degenerate/uninitialised native transforms
+ * (e.g. a released-then-reopened model whose `getValues()` returns
+ * subnormals). Flushing those to zero here keeps the classic, deferred
+ * and preview paths bit-identical on such inputs — matching the old
+ * Float32Array behaviour — while leaving every valid value at full
+ * double precision.
+ */
+const FLOAT32_MIN_SUBNORMAL = 2 ** -149
+
+/**
+ * Flush non-finite and float32-underflow garbage to zero; pass every
+ * valid value through untouched at full double precision.
+ *
+ * @param v A transform component.
+ * @return {number} v, or 0 if it is non-finite or below float32 range.
+ */
+function flushGarbage(v: number): number {
+  return Number.isFinite(v) &&
+    (v === 0 || Math.abs(v) >= FLOAT32_MIN_SUBNORMAL) ? v : 0
+}
+
+/**
+ * Copy 16 matrix components into a fresh `number[]`, flushing float32
+ * underflow / non-finite garbage to zero (see FLOAT32_MIN_SUBNORMAL).
+ *
+ * @param m A 16-element matrix.
+ * @return {number[]} The sanitized copy.
+ */
+function sanitize16(m: ArrayLike<number>): number[] {
+  const out = new Array<number>(16)
+  for (let i = 0; i < 16; ++i) {
+    out[i] = flushGarbage(m[i])
+  }
+  return out
+}
+
+/**
+ * A 3D point with double-precision components, as delivered by
+ * conway-geom's `getPoint` / `normalize` (glm::dvec3 across the boundary).
+ */
+export interface Point3Like {
+  x: number
+  y: number
+  z: number
+}
+
+/**
+ * Multiply two column-major 4x4 matrices in float64.
+ *
+ * Computes `out = a * b`, the identical formula (and operand order) to
+ * gl-matrix `mat4.multiply(out, a, b)`, but retaining double precision.
+ *
+ * @param a Left matrix (16 elements, column-major).
+ * @param b Right matrix (16 elements, column-major).
+ * @return {number[]} The product as a fresh 16-element `number[]`.
+ */
+export function mat4MultiplyF64(
+    a: ArrayLike<number>, b: ArrayLike<number>): number[] {
+
+  const a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3]
+  const a10 = a[4], a11 = a[5], a12 = a[6], a13 = a[7]
+  const a20 = a[8], a21 = a[9], a22 = a[10], a23 = a[11]
+  const a30 = a[12], a31 = a[13], a32 = a[14], a33 = a[15]
+
+  const out = new Array<number>(16)
+
+  for (let i = 0; i < 4; ++i) {
+    const b0 = b[i * 4], b1 = b[i * 4 + 1], b2 = b[i * 4 + 2], b3 = b[i * 4 + 3]
+    out[i * 4] = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30
+    out[i * 4 + 1] = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31
+    out[i * 4 + 2] = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32
+    out[i * 4 + 3] = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33
+  }
+
+  return out
+}
+
+/**
+ * Derive the coordination (recentre) matrix in float64, matching the
+ * gl-matrix op sequence exactly:
+ * `scale * NormalizeMat * translate(-(placement * point))`.
+ *
+ * @param placement The native placement (16 elements, column-major
+ * float64 from `getValues()`); `undefined` is treated as identity.
+ * @param point The world reference point (`getPoint(0)`), float64.
+ * @param normalizeMat The Z-up -> Y-up normalize matrix (16 elements).
+ * @param scaleFactor The linear scaling factor.
+ * @return {number[]} The coordination matrix as a 16-element `number[]`.
+ */
+export function deriveCoordinationF64(
+    placement: ArrayLike<number> | undefined,
+    point: Point3Like,
+    normalizeMat: ArrayLike<number>,
+    scaleFactor: number): number[] {
+
+  const p = placement !== undefined ? sanitize16(placement) : IDENTITY
+  const { x, y, z } = point
+
+  // transformedPt = placement * (x, y, z, 1)
+  const tx = p[0] * x + p[4] * y + p[8] * z + p[12]
+  const ty = p[1] * x + p[5] * y + p[9] * z + p[13]
+  const tz = p[2] * x + p[6] * y + p[10] * z + p[14]
+
+  // translate(-transformedPt)
+  const translate = IDENTITY.slice()
+  translate[12] = -tx
+  translate[13] = -ty
+  translate[14] = -tz
+
+  // scale(scaleFactor)
+  const scale = [
+    scaleFactor, 0, 0, 0,
+    0, scaleFactor, 0, 0,
+    0, 0, scaleFactor, 0,
+    0, 0, 0, 1,
+  ]
+
+  // scale * (NormalizeMat * translate)
+  return mat4MultiplyF64(scale, mat4MultiplyF64(normalizeMat, translate))
+}
+
+/**
+ * Compose the emitted world transform in float64:
+ * `coordination * placement [ * translate(geomCenter) ]`.
+ *
+ * @param coordination The coordination matrix (16 elements).
+ * @param placement The native placement (16 elements, column-major
+ * float64 from `getValues()`); `undefined` is treated as identity.
+ * @param geomCenter The per-leaf normalize centre; omit for the bare
+ * composition used by the AP214 shared-buffer path (issue #308).
+ * @return {number[]} The flat transform as a 16-element `number[]`,
+ * ready to hand back as a FlatMesh `flatTransformation`.
+ */
+export function composeTransformF64(
+    coordination: ArrayLike<number>,
+    placement: ArrayLike<number> | undefined,
+    geomCenter?: Point3Like): number[] {
+
+  let out = placement !== undefined ?
+    mat4MultiplyF64(coordination, sanitize16(placement)) :
+    Array.from(coordination as ArrayLike<number>)
+
+  if (geomCenter !== undefined) {
+    const gm = IDENTITY.slice()
+    gm[12] = geomCenter.x
+    gm[13] = geomCenter.y
+    gm[14] = geomCenter.z
+    out = mat4MultiplyF64(out, gm)
+  }
+
+  return out
+}

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -16,6 +16,7 @@ import {
 import { StepExternalByteStore } from '../../step/step_buffer_provider'
 import { IfcApiModelPassthrough } from './ifc_api_model_passthrough'
 import * as glmatrix from 'gl-matrix'
+import { composeTransformF64, deriveCoordinationF64 } from './coordination_f64'
 import Logger from '../../logging/logger'
 import ParsingBuffer from '../../parsing/parsing_buffer'
 import { ExtractResult } from '../../index'
@@ -70,7 +71,7 @@ interface Ap214ProxyLoadState {
   deferred?: boolean
   /** Coordination matrix the parse-time preview channel derived —
    * adopted by the durable capture so both share one frame. */
-  previewCoordinationMatrix?: glmatrix.mat4
+  previewCoordinationMatrix?: number[]
   allTimeStart: number
   stepHeader: StepHeader
   model: AP214StepModel
@@ -114,7 +115,7 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
    * multi-call memory only — getCoordinationMatrix keeps the classic
    * identity contract (see the IFC proxy's demandCoordination_ note).
    */
-  private demandCoordination_?: glmatrix.mat4
+  private demandCoordination_?: number[]
 
   _isCoordinated: boolean = false
   linearScalingFactor: number = 1
@@ -1328,7 +1329,8 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
 
     const [model, scene, meshMap, geometryMaterialTransformMap] = this.model
 
-    let coordinationMatrix = this.demandCoordination_ ?? glmatrix.mat4.create()
+    let coordinationMatrix: ArrayLike<number> =
+      this.demandCoordination_ ?? glmatrix.mat4.create()
     const seenThisPass = new Map<number, number>()
     const deltas = new Map<number, PlacedGeometry[]>()
     const deltaExpressIDs = new Map<number, number>()
@@ -1371,48 +1373,24 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
 
       const expressID = model.getElementByLocalID(geometry.localID)?.expressID as number
 
+      // Full-precision float64 placement straight from the wasm boundary
+      // (glm::dmat4) — never truncated through a gl-matrix Float32Array;
+      // the recentre math runs in double precision (see coordination_f64).
       const geometryTransform = nativeTransform?.getValues()
-      let newMatrix: glmatrix.mat4
-
-      if (geometryTransform !== void 0) {
-        newMatrix = glmatrix.mat4.fromValues(
-            ...(geometryTransform as unknown as
-              Parameters<typeof glmatrix.mat4.fromValues>))
-      } else {
-        newMatrix = glmatrix.mat4.create()
-      }
 
       if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
 
-        const transformedPt: glmatrix.vec4 = glmatrix.vec4.create()
-        glmatrix.vec4.transformMat4(
-            transformedPt,
-            [nativePt!.x, nativePt!.y, nativePt!.z, 1],
-            newMatrix)
+        const derived = deriveCoordinationF64(
+            geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)
 
-        coordinationMatrix = glmatrix.mat4.create()
-        glmatrix.mat4.fromTranslation(coordinationMatrix,
-            [-transformedPt[0], -transformedPt[1], -transformedPt[2]])
-
-        const scaleMatrix = glmatrix.mat4.create()
-        const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-            this.linearScalingFactor,
-            this.linearScalingFactor)
-
-        glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-        glmatrix.mat4.multiply(coordinationMatrix, this.NormalizeMat, coordinationMatrix)
-        glmatrix.mat4.multiply(coordinationMatrix, scaleMatrix, coordinationMatrix)
-
-        this.demandCoordination_ = coordinationMatrix
+        coordinationMatrix = derived
+        this.demandCoordination_ = derived
         this._isCoordinated = true
       }
 
       // Bare composition — no per-leaf recenter (issue #308: AP214
       // instances share one geometry buffer), matching streamAllMeshes.
-      const newTransform = glmatrix.mat4.create()
-      glmatrix.mat4.multiply(newTransform, coordinationMatrix, newMatrix)
-
-      const newTransformArr = Array.from(newTransform)
+      const newTransformArr = composeTransformF64(coordinationMatrix, geometryTransform)
 
       geometryMaterialTransformMap.set(expressID,
           [geometry.geometry, material_, newTransformArr])
@@ -1534,7 +1512,7 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
       geometryMaterialTransformMap,
       vectorFlatMesh] = this.model
 
-    let coordinationMatrix = this.model[5]
+    let coordinationMatrix: ArrayLike<number> = this.model[5]
 
     // eslint-disable-next-line no-unused-vars
     for (const [_, nativeTransform, geometry, material, entity, occurrencePath]
@@ -1564,95 +1542,27 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
         // create PlacedGeometry
         const expressID = model.getElementByLocalID(geometry.localID)?.expressID as number
 
+        // Full-precision float64 placement straight from the wasm boundary
+        // (glm::dmat4) — never truncated through a gl-matrix Float32Array;
+        // the recentre math runs in double precision (see coordination_f64).
         const geometryTransform = nativeTransform?.getValues()
-        let newMatrix: glmatrix.mat4 | undefined
-        if (geometryTransform !== void 0) {
-          newMatrix = glmatrix.mat4.fromValues(
-              geometryTransform[0],
-              geometryTransform[1],
-              geometryTransform[2],
-              geometryTransform[3],
-              geometryTransform[4],
-              geometryTransform[5],
-              geometryTransform[6],
-              geometryTransform[7],
-              geometryTransform[8],
-              geometryTransform[9],
-              geometryTransform[10],
-              geometryTransform[11],
-              geometryTransform[12],
-              geometryTransform[13],
-              geometryTransform[14],
-              geometryTransform[15],
-          )
-        } else {
-          // set to identity if no transform found
-          newMatrix = glmatrix.mat4.create()
-        }
 
         if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
-          // coordinate the geometry to the origin
-          const pt: number[] = [nativePt!.x, nativePt!.y, nativePt!.z]
-
-          // Transform the point by the matrix.
-          const transformedPt: glmatrix.vec4 = glmatrix.vec4.create()
-          glmatrix.vec4.transformMat4(transformedPt, [pt[0], pt[1], pt[2], 1], newMatrix!)
-
-          // Create the translation matrix.
-          coordinationMatrix = glmatrix.mat4.create()
-
-          glmatrix.mat4.fromTranslation(coordinationMatrix,
-              [-transformedPt[0], -transformedPt[1], -transformedPt[2]])
-
-          const scaleMatrix = glmatrix.mat4.create()
-
-          // Create a 3D vector for scaling factors
-          const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-              this.linearScalingFactor,
-              this.linearScalingFactor)
-
-          // Scale the matrix
-          glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-
-          glmatrix.mat4.multiply(coordinationMatrix,
-              this.NormalizeMat,
-              coordinationMatrix)
-          glmatrix.mat4.multiply(coordinationMatrix,
-              scaleMatrix,
-              coordinationMatrix)
-
+          coordinationMatrix = deriveCoordinationF64(
+              geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)
           this._isCoordinated = true
         }
 
-        // extract color
-        const newTransform = glmatrix.mat4.create()
-
-        // Create a 4x4 identity matrix
-        const scaleMatrix = glmatrix.mat4.create()
-
-        // Create a 3D vector for scaling factors
-        const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-            this.linearScalingFactor,
-            this.linearScalingFactor)
-
-        // Scale the matrix
-        glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-
         // Compose the world transform from the engine's scene transform
-        // (newMatrix = nativeTransform). Geometry vertices stay in their
-        // source-unit local space; nativeTransform maps them to metre world
-        // space — the same bare composition the native consumer
-        // geometry_aggregator uses. The per-leaf geometry.normalize() recenter
-        // was removed: AP214 instances/mapped-items share one geometry buffer,
-        // so normalize() mutated it once and later instances lost their offset
-        // and collapsed toward the origin (issue #308 "port cluster"). The
-        // global coordinationMatrix still carries Y-up + COORDINATE_TO_ORIGIN.
-        if (newMatrix !== void 0) {
-          glmatrix.mat4.multiply(newTransform, coordinationMatrix, newMatrix)
-        } else {
-          glmatrix.mat4.copy(newTransform, coordinationMatrix)
-        }
-        const newTransformArr = Array.from(newTransform)
+        // (nativeTransform). Geometry vertices stay in their source-unit local
+        // space; nativeTransform maps them to metre world space — the same
+        // bare composition the native consumer geometry_aggregator uses. The
+        // per-leaf geometry.normalize() recenter was removed: AP214
+        // instances/mapped-items share one geometry buffer, so normalize()
+        // mutated it once and later instances lost their offset and collapsed
+        // toward the origin (issue #308 "port cluster"). The global
+        // coordinationMatrix still carries Y-up + COORDINATE_TO_ORIGIN.
+        const newTransformArr = composeTransformF64(coordinationMatrix, geometryTransform)
         geometryMaterialTransformMap.set(expressID,
             [geometry.geometry, material_, newTransformArr])
 
@@ -1765,7 +1675,7 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
       geometryMaterialTransformMap,
       vectorFlatMesh] = this.model
 
-    let coordinationMatrix = this.model[5]
+    let coordinationMatrix: ArrayLike<number> = this.model[5]
 
     // eslint-disable-next-line no-unused-vars
     for (const [_, nativeTransform, geometry, material, entity, occurrencePath]
@@ -1795,95 +1705,28 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
         // create PlacedGeometry
         const expressID = model.getElementByLocalID(geometry.localID)?.expressID as number
 
+        // Full-precision float64 placement straight from the wasm boundary
+        // (glm::dmat4) — never truncated through a gl-matrix Float32Array;
+        // the recentre math runs in double precision (see coordination_f64).
         const geometryTransform = nativeTransform?.getValues()
-        let newMatrix: glmatrix.mat4 | undefined
-        if (geometryTransform !== void 0) {
-          newMatrix = glmatrix.mat4.fromValues(
-              geometryTransform[0],
-              geometryTransform[1],
-              geometryTransform[2],
-              geometryTransform[3],
-              geometryTransform[4],
-              geometryTransform[5],
-              geometryTransform[6],
-              geometryTransform[7],
-              geometryTransform[8],
-              geometryTransform[9],
-              geometryTransform[10],
-              geometryTransform[11],
-              geometryTransform[12],
-              geometryTransform[13],
-              geometryTransform[14],
-              geometryTransform[15],
-          )
-        }
 
         if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
-          // coordinate the geometry to the origin
-          // Assuming geom.GetPoint(0) returns a glm::dvec3, i.e., a 3D vector.
-          // In TypeScript, you can represent it as number[] or Float64Array.
           Logger.info('Setting up coordinationMatrix')
-          const pt: number[] = [nativePt!.x, nativePt!.y, nativePt!.z]
-
-          // Transform the point by the matrix.
-          const transformedPt: glmatrix.vec4 = glmatrix.vec4.create()
-          glmatrix.vec4.transformMat4(transformedPt, [pt[0], pt[1], pt[2], 1], newMatrix!)
-
-          // Create the translation matrix.
-          coordinationMatrix = glmatrix.mat4.create()
-
-          glmatrix.mat4.fromTranslation(coordinationMatrix,
-              [-transformedPt[0], -transformedPt[1], -transformedPt[2]])
-
-          const scaleMatrix = glmatrix.mat4.create()
-
-          // Create a 3D vector for scaling factors
-          const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-              this.linearScalingFactor,
-              this.linearScalingFactor)
-
-          // Scale the matrix
-          glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-
-          glmatrix.mat4.multiply(coordinationMatrix,
-              this.NormalizeMat,
-              coordinationMatrix)
-          glmatrix.mat4.multiply(coordinationMatrix,
-              scaleMatrix,
-              coordinationMatrix)
-
+          coordinationMatrix = deriveCoordinationF64(
+              geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)
           this._isCoordinated = true
         }
 
-        // extract color
-        const newTransform = glmatrix.mat4.create()
-
-        // Create a 4x4 identity matrix
-        const scaleMatrix = glmatrix.mat4.create()
-
-        // Create a 3D vector for scaling factors
-        const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-            this.linearScalingFactor,
-            this.linearScalingFactor)
-
-        // Scale the matrix
-        glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-
         // Compose the world transform from the engine's scene transform
-        // (newMatrix = nativeTransform). Geometry vertices stay in their
-        // source-unit local space; nativeTransform maps them to metre world
-        // space — the same bare composition the native consumer
-        // geometry_aggregator uses. The per-leaf geometry.normalize() recenter
-        // was removed: AP214 instances/mapped-items share one geometry buffer,
-        // so normalize() mutated it once and later instances lost their offset
-        // and collapsed toward the origin (issue #308 "port cluster"). The
-        // global coordinationMatrix still carries Y-up + COORDINATE_TO_ORIGIN.
-        if (newMatrix !== void 0) {
-          glmatrix.mat4.multiply(newTransform, coordinationMatrix, newMatrix)
-        } else {
-          glmatrix.mat4.copy(newTransform, coordinationMatrix)
-        }
-        const newTransformArr = Array.from(newTransform)
+        // (nativeTransform). Geometry vertices stay in their source-unit local
+        // space; nativeTransform maps them to metre world space — the same
+        // bare composition the native consumer geometry_aggregator uses. The
+        // per-leaf geometry.normalize() recenter was removed: AP214
+        // instances/mapped-items share one geometry buffer, so normalize()
+        // mutated it once and later instances lost their offset and collapsed
+        // toward the origin (issue #308 "port cluster"). The global
+        // coordinationMatrix still carries Y-up + COORDINATE_TO_ORIGIN.
+        const newTransformArr = composeTransformF64(coordinationMatrix, geometryTransform)
         geometryMaterialTransformMap.set(expressID,
             [geometry.geometry, material_, newTransformArr])
 

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -19,6 +19,7 @@ import { StepExternalByteStore } from '../../step/step_buffer_provider'
 import { IfcApiModelPassthrough } from './ifc_api_model_passthrough'
 import { NodeValueHandle } from './properties_passthrough'
 import * as glmatrix from 'gl-matrix'
+import { composeTransformF64, deriveCoordinationF64 } from './coordination_f64'
 import { IfcProperties } from './ifc_properties'
 import Logger from '../../logging/logger'
 import { ProgressTracker } from '../../core/progress'
@@ -69,7 +70,7 @@ interface IfcProxyLoadState {
   deferred?: boolean
   /** Coordination matrix the parse-time preview channel derived (slice
    * A2) — adopted by the durable capture so both share one frame. */
-  previewCoordinationMatrix?: glmatrix.mat4
+  previewCoordinationMatrix?: number[]
   allTimeStart: number
   stepHeader: StepHeader
   model: IfcStepModel
@@ -126,7 +127,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * apply twice. This field is only the pump's internal multi-call
    * memory.
    */
-  private demandCoordination_?: glmatrix.mat4
+  private demandCoordination_?: number[]
 
   _isCoordinated: boolean = false
   linearScalingFactor: number = 1
@@ -1520,7 +1521,8 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     const [model, scene, meshMap, geometryMaterialTransformMap] = this.model
 
-    let coordinationMatrix = this.demandCoordination_ ?? glmatrix.mat4.create()
+    let coordinationMatrix: ArrayLike<number> =
+      this.demandCoordination_ ?? glmatrix.mat4.create()
     const seenThisPass = new Map<number, number>()
     const deltas = new Map<number, PlacedGeometry[]>()
 
@@ -1560,64 +1562,32 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         nativePt = geometry.geometry.getPoint(0)
       }
 
-      const geomCenter: glmatrix.vec3 = glmatrix.vec3.create()
+      // normalize() recenters the shared geometry buffer (side effect)
+      // and returns the local centre used to place it.
       const center = geometry.geometry.normalize()
-
-      geomCenter[0] = center.x
-      geomCenter[1] = center.y
-      geomCenter[2] = center.z
-
-      const translationMatrixGeomMin: glmatrix.mat4 = glmatrix.mat4.create()
-      glmatrix.mat4.fromTranslation(translationMatrixGeomMin, geomCenter)
 
       const expressID = model.getElementByLocalID(geometry.localID)?.expressID as number
 
+      // Full-precision float64 placement straight from the wasm boundary
+      // (glm::dmat4). NOT re-truncated through a gl-matrix Float32Array —
+      // the recentre math runs in double precision (see coordination_f64).
       const geometryTransform = nativeTransform?.getValues()
-      let newMatrix: glmatrix.mat4
-
-      if (geometryTransform !== void 0) {
-        newMatrix = glmatrix.mat4.fromValues(
-            ...(geometryTransform as unknown as Parameters<typeof glmatrix.mat4.fromValues>))
-      } else {
-        newMatrix = glmatrix.mat4.create()
-      }
 
       if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
 
-        const pt: number[] = [nativePt!.x, nativePt!.y, nativePt!.z]
-        const transformedPt: glmatrix.vec4 = glmatrix.vec4.create()
-        glmatrix.vec4.transformMat4(transformedPt, [pt[0], pt[1], pt[2], 1], newMatrix)
+        const derived = deriveCoordinationF64(
+            geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)
 
-        coordinationMatrix = glmatrix.mat4.create()
-        glmatrix.mat4.fromTranslation(coordinationMatrix,
-            [-transformedPt[0], -transformedPt[1], -transformedPt[2]])
-
-        const scaleMatrix = glmatrix.mat4.create()
-        const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-            this.linearScalingFactor,
-            this.linearScalingFactor)
-
-        glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-        glmatrix.mat4.multiply(coordinationMatrix, this.NormalizeMat, coordinationMatrix)
-        glmatrix.mat4.multiply(coordinationMatrix, scaleMatrix, coordinationMatrix)
+        coordinationMatrix = derived
 
         // Persist for every later batch (internal only — see
         // demandCoordination_'s identity-contract note).
-        this.demandCoordination_ = coordinationMatrix
+        this.demandCoordination_ = derived
         this._isCoordinated = true
       }
 
-      const newTransform = glmatrix.mat4.create()
-      const scaleMatrix = glmatrix.mat4.create()
-      const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-          this.linearScalingFactor,
-          this.linearScalingFactor)
-
-      glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-      glmatrix.mat4.multiply(newTransform, coordinationMatrix, newMatrix)
-      glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
-
-      const newTransformArr = Array.from(newTransform)
+      const newTransformArr =
+          composeTransformF64(coordinationMatrix, geometryTransform, center)
 
       geometryMaterialTransformMap.set(expressID,
           [geometry.geometry, material_, newTransformArr])
@@ -1740,7 +1710,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       geometryMaterialTransformMap,
       vectorFlatMesh] = this.model
 
-    let coordinationMatrix = this.model[5]
+    let coordinationMatrix: ArrayLike<number> = this.model[5]
 
     // eslint-disable-next-line no-unused-vars
     for (const [_, nativeTransform, geometry, material, entity] of scene.walk()) {
@@ -1766,105 +1736,26 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
           nativePt = geometry.geometry.getPoint(0)
         }
 
-        // extract center
-        const geomCenter: glmatrix.vec3 = glmatrix.vec3.create()
+        // normalize() recenters the geometry buffer (side effect) and
+        // returns the local centre used to place it.
         const center = geometry.geometry.normalize()
-
-
-        geomCenter[0] = center.x
-        geomCenter[1] = center.y
-        geomCenter[2] = center.z
-
-        // Create a translation matrix from geom.min
-        const translationMatrixGeomMin: glmatrix.mat4 = glmatrix.mat4.create()
-        glmatrix.mat4.fromTranslation(translationMatrixGeomMin, geomCenter)
 
         // create PlacedGeometry
         const expressID = model.getElementByLocalID(geometry.localID)?.expressID as number
 
+        // Full-precision float64 placement straight from the wasm boundary
+        // (glm::dmat4) — never truncated through a gl-matrix Float32Array;
+        // the recentre math runs in double precision (see coordination_f64).
         const geometryTransform = nativeTransform?.getValues()
-        let newMatrix: glmatrix.mat4 | undefined
-        if (geometryTransform !== void 0) {
-          newMatrix = glmatrix.mat4.fromValues(
-              geometryTransform[0],
-              geometryTransform[1],
-              geometryTransform[2],
-              geometryTransform[3],
-              geometryTransform[4],
-              geometryTransform[5],
-              geometryTransform[6],
-              geometryTransform[7],
-              geometryTransform[8],
-              geometryTransform[9],
-              geometryTransform[10],
-              geometryTransform[11],
-              geometryTransform[12],
-              geometryTransform[13],
-              geometryTransform[14],
-              geometryTransform[15],
-          )
-        } else {
-          // set to identity if no transform found
-          newMatrix = glmatrix.mat4.create()
-        }
 
         if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
-          // coordinate the geometry to the origin
-          const pt: number[] = [nativePt!.x, nativePt!.y, nativePt!.z]
-
-          // Transform the point by the matrix.
-          const transformedPt: glmatrix.vec4 = glmatrix.vec4.create()
-          glmatrix.vec4.transformMat4(transformedPt, [pt[0], pt[1], pt[2], 1], newMatrix!)
-
-          // Create the translation matrix.
-          coordinationMatrix = glmatrix.mat4.create()
-
-          glmatrix.mat4.fromTranslation(coordinationMatrix,
-              [-transformedPt[0], -transformedPt[1], -transformedPt[2]])
-
-          const scaleMatrix = glmatrix.mat4.create()
-
-          // Create a 3D vector for scaling factors
-          const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-              this.linearScalingFactor,
-              this.linearScalingFactor)
-
-          // Scale the matrix
-          glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-
-          glmatrix.mat4.multiply(coordinationMatrix,
-              this.NormalizeMat,
-              coordinationMatrix)
-          glmatrix.mat4.multiply(coordinationMatrix,
-              scaleMatrix,
-              coordinationMatrix)
-
+          coordinationMatrix = deriveCoordinationF64(
+              geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)
           this._isCoordinated = true
         }
 
-        // extract color
-        const newTransform = glmatrix.mat4.create()
-
-        // Create a 4x4 identity matrix
-        const scaleMatrix = glmatrix.mat4.create()
-
-        // Create a 3D vector for scaling factors
-        const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-            this.linearScalingFactor,
-            this.linearScalingFactor)
-
-        // Scale the matrix
-        glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-
-        // Perform the matrix multiplications
-        if (newMatrix !== void 0) {
-          glmatrix.mat4.multiply(newTransform, coordinationMatrix, newMatrix)
-          glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
-        } else {
-          glmatrix.mat4.multiply(newTransform, coordinationMatrix, newTransform)
-          glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
-        }
-        const newTransformArr = Array.from(newTransform)
+        const newTransformArr =
+            composeTransformF64(coordinationMatrix, geometryTransform, center)
         geometryMaterialTransformMap.set(expressID,
             [geometry.geometry, material_!, newTransformArr])
 
@@ -1966,7 +1857,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       geometryMaterialTransformMap,
       vectorFlatMesh] = this.model
 
-    let coordinationMatrix = this.model[5]
+    let coordinationMatrix: ArrayLike<number> = this.model[5]
 
     const conwayTypesArray: number[] = []
     types.forEach((type) => {
@@ -2009,108 +1900,27 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
           nativePt = geometry.geometry.getPoint(0)
         }
 
-        // extract center
-        const geomCenter: glmatrix.vec3 = glmatrix.vec3.create()
+        // normalize() recenters the geometry buffer (side effect) and
+        // returns the local centre used to place it.
         const center = geometry.geometry.normalize()
-
-
-        geomCenter[0] = center.x
-        geomCenter[1] = center.y
-        geomCenter[2] = center.z
-
-        // Create a translation matrix from geom.min
-        const translationMatrixGeomMin: glmatrix.mat4 = glmatrix.mat4.create()
-        glmatrix.mat4.fromTranslation(translationMatrixGeomMin, geomCenter)
 
         // create PlacedGeometry
         const expressID = model.getElementByLocalID(geometry.localID)?.expressID as number
 
+        // Full-precision float64 placement straight from the wasm boundary
+        // (glm::dmat4) — never truncated through a gl-matrix Float32Array;
+        // the recentre math runs in double precision (see coordination_f64).
         const geometryTransform = nativeTransform?.getValues()
-        let newMatrix: glmatrix.mat4 | undefined
-        if (geometryTransform !== void 0) {
-          newMatrix = glmatrix.mat4.fromValues(
-              geometryTransform[0],
-              geometryTransform[1],
-              geometryTransform[2],
-              geometryTransform[3],
-              geometryTransform[4],
-              geometryTransform[5],
-              geometryTransform[6],
-              geometryTransform[7],
-              geometryTransform[8],
-              geometryTransform[9],
-              geometryTransform[10],
-              geometryTransform[11],
-              geometryTransform[12],
-              geometryTransform[13],
-              geometryTransform[14],
-              geometryTransform[15],
-          )
-        }
 
         if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
-          // coordinate the geometry to the origin
-          // Assuming geom.GetPoint(0) returns a glm::dvec3, i.e., a 3D vector.
-          // In TypeScript, you can represent it as number[] or Float64Array.
           Logger.info('Setting up coordinationMatrix')
-
-
-          // const nativePt = geometry.geometry.GetPoint(0)
-          const pt: number[] = [nativePt!.x, nativePt!.y, nativePt!.z]
-
-          // Transform the point by the matrix.
-          const transformedPt: glmatrix.vec4 = glmatrix.vec4.create()
-          glmatrix.vec4.transformMat4(transformedPt, [pt[0], pt[1], pt[2], 1], newMatrix!)
-
-          // Create the translation matrix.
-          coordinationMatrix = glmatrix.mat4.create()
-
-          glmatrix.mat4.fromTranslation(coordinationMatrix,
-              [-transformedPt[0], -transformedPt[1], -transformedPt[2]])
-
-          const scaleMatrix = glmatrix.mat4.create()
-
-          // Create a 3D vector for scaling factors
-          const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-              this.linearScalingFactor,
-              this.linearScalingFactor)
-
-          // Scale the matrix
-          glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-
-          glmatrix.mat4.multiply(coordinationMatrix,
-              this.NormalizeMat,
-              coordinationMatrix)
-          glmatrix.mat4.multiply(coordinationMatrix,
-              scaleMatrix,
-              coordinationMatrix)
-
+          coordinationMatrix = deriveCoordinationF64(
+              geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)
           this._isCoordinated = true
         }
 
-        // extract color
-        const newTransform = glmatrix.mat4.create()
-
-        // Create a 4x4 identity matrix
-        const scaleMatrix = glmatrix.mat4.create()
-
-        // Create a 3D vector for scaling factors
-        const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-            this.linearScalingFactor,
-            this.linearScalingFactor)
-
-        // Scale the matrix
-        glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-
-        // Perform the matrix multiplications
-        if (newMatrix !== void 0) {
-          glmatrix.mat4.multiply(newTransform, coordinationMatrix, newMatrix)
-          glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
-        } else {
-          glmatrix.mat4.multiply(newTransform, coordinationMatrix, newTransform)
-          glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
-        }
-        const newTransformArr = Array.from(newTransform)
+        const newTransformArr =
+            composeTransformF64(coordinationMatrix, geometryTransform, center)
         geometryMaterialTransformMap.set(expressID,
             [geometry.geometry, material_!, newTransformArr])
 
@@ -2210,7 +2020,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       geometryMaterialTransformMap,
       vectorFlatMesh] = this.model
 
-    let coordinationMatrix = this.model[5]
+    let coordinationMatrix: ArrayLike<number> = this.model[5]
 
     // eslint-disable-next-line no-unused-vars
     for (const [_, nativeTransform, geometry, material, entity] of scene.walk()) {
@@ -2236,108 +2046,27 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
           nativePt = geometry.geometry.getPoint(0)
         }
 
-        // extract center
-        const geomCenter: glmatrix.vec3 = glmatrix.vec3.create()
+        // normalize() recenters the geometry buffer (side effect) and
+        // returns the local centre used to place it.
         const center = geometry.geometry.normalize()
-
-
-        geomCenter[0] = center.x
-        geomCenter[1] = center.y
-        geomCenter[2] = center.z
-
-        // Create a translation matrix from geom.min
-        const translationMatrixGeomMin: glmatrix.mat4 = glmatrix.mat4.create()
-        glmatrix.mat4.fromTranslation(translationMatrixGeomMin, geomCenter)
 
         // create PlacedGeometry
         const expressID = model.getElementByLocalID(geometry.localID)?.expressID as number
 
+        // Full-precision float64 placement straight from the wasm boundary
+        // (glm::dmat4) — never truncated through a gl-matrix Float32Array;
+        // the recentre math runs in double precision (see coordination_f64).
         const geometryTransform = nativeTransform?.getValues()
-        let newMatrix: glmatrix.mat4 | undefined
-        if (geometryTransform !== void 0) {
-          newMatrix = glmatrix.mat4.fromValues(
-              geometryTransform[0],
-              geometryTransform[1],
-              geometryTransform[2],
-              geometryTransform[3],
-              geometryTransform[4],
-              geometryTransform[5],
-              geometryTransform[6],
-              geometryTransform[7],
-              geometryTransform[8],
-              geometryTransform[9],
-              geometryTransform[10],
-              geometryTransform[11],
-              geometryTransform[12],
-              geometryTransform[13],
-              geometryTransform[14],
-              geometryTransform[15],
-          )
-        }
 
         if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
-          // coordinate the geometry to the origin
-          // Assuming geom.GetPoint(0) returns a glm::dvec3, i.e., a 3D vector.
-          // In TypeScript, you can represent it as number[] or Float64Array.
           Logger.info('Setting up coordinationMatrix')
-
-
-          const pt: number[] = [nativePt!.x, nativePt!.y, nativePt!.z]
-
-          // Transform the point by the matrix.
-          const transformedPt: glmatrix.vec4 = glmatrix.vec4.create()
-          glmatrix.vec4.transformMat4(transformedPt, [pt[0], pt[1], pt[2], 1], newMatrix!)
-
-          // Create the translation matrix.
-          coordinationMatrix = glmatrix.mat4.create()
-
-          glmatrix.mat4.fromTranslation(coordinationMatrix,
-              [-transformedPt[0], -transformedPt[1], -transformedPt[2]])
-
-          const scaleMatrix = glmatrix.mat4.create()
-
-          // Create a 3D vector for scaling factors
-          const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-              this.linearScalingFactor,
-              this.linearScalingFactor)
-
-          // Scale the matrix
-          glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-
-          glmatrix.mat4.multiply(coordinationMatrix,
-              this.NormalizeMat,
-              coordinationMatrix)
-          glmatrix.mat4.multiply(coordinationMatrix,
-              scaleMatrix,
-              coordinationMatrix)
-
+          coordinationMatrix = deriveCoordinationF64(
+              geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)
           this._isCoordinated = true
         }
 
-
-        // extract color
-        const newTransform = glmatrix.mat4.create()
-
-        // Create a 4x4 identity matrix
-        const scaleMatrix = glmatrix.mat4.create()
-
-        // Create a 3D vector for scaling factors
-        const scaleVec = glmatrix.vec3.fromValues(this.linearScalingFactor,
-            this.linearScalingFactor,
-            this.linearScalingFactor)
-
-        // Scale the matrix
-        glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-
-        // Perform the matrix multiplications
-        if (newMatrix !== void 0) {
-          glmatrix.mat4.multiply(newTransform, coordinationMatrix, newMatrix)
-          glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
-        } else {
-          glmatrix.mat4.multiply(newTransform, coordinationMatrix, newTransform)
-          glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
-        }
-        const newTransformArr = Array.from(newTransform)
+        const newTransformArr =
+            composeTransformF64(coordinationMatrix, geometryTransform, center)
         geometryMaterialTransformMap.set(expressID,
             [geometry.geometry, material_!, newTransformArr])
 

--- a/src/compat/web-ifc/streamed_preview_channel.ts
+++ b/src/compat/web-ifc/streamed_preview_channel.ts
@@ -191,6 +191,11 @@ export function ifcPreviewAdapter(): PreviewSchemaAdapter {
 
       const extraction = new IfcGeometryExtraction( conwaywasm, model )
 
+      // Prefix extractions hit representation items whose style/select
+      // references aren't parsed yet — expected on a truncated tail;
+      // don't flood the report (DOWA: 1164 styled-item errors).
+      extraction.quietRecoverableLogging = true
+
       // Preview-only preparation: skip the relationship sweeps whose
       // entity materialization dominates per-generation cost.
       extraction.prepareDemandExtraction( true )

--- a/src/compat/web-ifc/streamed_preview_channel.ts
+++ b/src/compat/web-ifc/streamed_preview_channel.ts
@@ -12,6 +12,7 @@ import { ColumnarIndexSink } from '../../step/parsing/columnar_index'
 import { cursorIterator } from '../../indexing/cursor_utilities'
 import { Vector3 } from '../../../dependencies/conway-geom'
 import * as glmatrix from 'gl-matrix'
+import { composeTransformF64, deriveCoordinationF64 } from './coordination_f64'
 
 /* eslint-disable no-magic-numbers */
 
@@ -340,7 +341,7 @@ export class StreamedPreviewChannel {
   /** Coordination matrix pinned from the first captured instance, exactly
    * the derivation the durable capture would perform — the proxy adopts it
    * so preview and durable placements share one frame. */
-  public coordinationMatrix?: glmatrix.mat4
+  public coordinationMatrix?: number[]
 
   private stopped_ = false
   private timer_?: ReturnType<typeof setTimeout>
@@ -743,73 +744,28 @@ export class StreamedPreviewChannel {
         nativePt = geometry.geometry.getPoint(0)
       }
 
-      const translationMatrixGeomMin: glmatrix.mat4 = glmatrix.mat4.create()
-
-      if (recenter) {
-        const geomCenter: glmatrix.vec3 = glmatrix.vec3.create()
-        const center = geometry.geometry.normalize()
-
-        geomCenter[0] = center.x
-        geomCenter[1] = center.y
-        geomCenter[2] = center.z
-
-        glmatrix.mat4.fromTranslation(translationMatrixGeomMin, geomCenter)
-      }
+      // normalize() recenters the geometry buffer (side effect) and returns
+      // the local centre; only the per-leaf recenter path (IFC) applies it —
+      // AP214 shares one buffer and composes bare (issue #308).
+      const center = recenter ? geometry.geometry.normalize() : undefined
 
       const geometryExpressID =
         generation.geometryExpressID(geometry.localID) as number
 
+      // Full-precision float64 placement straight from the wasm boundary
+      // (glm::dmat4) — never truncated through a gl-matrix Float32Array;
+      // the recentre math runs in double precision (see coordination_f64).
       const geometryTransform = nativeTransform?.getValues()
-      let newMatrix: glmatrix.mat4
-
-      if (geometryTransform !== void 0) {
-        newMatrix = glmatrix.mat4.fromValues(
-            ...(geometryTransform as unknown as
-              Parameters<typeof glmatrix.mat4.fromValues>))
-      } else {
-        newMatrix = glmatrix.mat4.create()
-      }
 
       if (this.coordinationMatrix === void 0 && this.coordinateToOrigin) {
-
-        const transformedPt: glmatrix.vec4 = glmatrix.vec4.create()
-        glmatrix.vec4.transformMat4(
-            transformedPt,
-            [nativePt!.x, nativePt!.y, nativePt!.z, 1],
-            newMatrix)
-
-        const coordinationMatrix = glmatrix.mat4.create()
-        glmatrix.mat4.fromTranslation(coordinationMatrix,
-            [-transformedPt[0], -transformedPt[1], -transformedPt[2]])
-
-        const scaleMatrix = glmatrix.mat4.create()
-        const scaleVec = glmatrix.vec3.fromValues(
-            linearScalingFactor, linearScalingFactor, linearScalingFactor)
-
-        glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-        glmatrix.mat4.multiply(coordinationMatrix, NORMALIZE_MAT, coordinationMatrix)
-        glmatrix.mat4.multiply(coordinationMatrix, scaleMatrix, coordinationMatrix)
-
-        this.coordinationMatrix = coordinationMatrix
+        this.coordinationMatrix = deriveCoordinationF64(
+            geometryTransform, nativePt!, NORMALIZE_MAT, linearScalingFactor)
       }
 
       const coordination = this.coordinationMatrix ?? glmatrix.mat4.create()
 
-      const newTransform = glmatrix.mat4.create()
-
-      if (recenter) {
-        const scaleMatrix = glmatrix.mat4.create()
-        const scaleVec = glmatrix.vec3.fromValues(
-            linearScalingFactor, linearScalingFactor, linearScalingFactor)
-
-        glmatrix.mat4.scale(scaleMatrix, scaleMatrix, scaleVec)
-        glmatrix.mat4.multiply(newTransform, coordination, newMatrix)
-        glmatrix.mat4.multiply(newTransform, newTransform, translationMatrixGeomMin)
-      } else {
-        // Bare composition — no per-leaf recenter (AP214 instances share
-        // one geometry buffer, issue #308), matching its durable capture.
-        glmatrix.mat4.multiply(newTransform, coordination, newMatrix)
-      }
+      const newTransform =
+          composeTransformF64(coordination, geometryTransform, center)
 
       const payload: PreviewMeshPayload = {
         expressID: entity.expressID,

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -391,6 +391,15 @@ export class IfcGeometryExtraction {
    * or the maximum level for CSG memoization if it is not.
    * @param lowMemoryMode Whether to enable low memory mode for geometry extraction.
    */
+  /** When true, per-record recoverable extraction errors (a
+   * representation item whose style/select references aren't populated
+   * yet) are not logged. Set by the parse-time preview channel's
+   * throwaway PREFIX extractions, where a truncated-tail prefix makes
+   * those errors expected by construction — a large IFC otherwise
+   * floods the load report with thousands of them (DOWA: 1164). The
+   * durable extraction keeps full logging. Mirrors AP214's flag. */
+  public quietRecoverableLogging!: boolean
+
   constructor(
     private readonly conwayModel: ConwayGeometry,
     public readonly model: IfcStepModel,
@@ -399,6 +408,7 @@ export class IfcGeometryExtraction {
     private readonly lowMemoryMode: boolean = false ) {
 
     this.csgMemoization = !this.lowMemoryMode
+    this.quietRecoverableLogging = false
 
     this.materials = model.materials
     this.scene = new IfcSceneBuilder(model, conwayModel, this.materials)
@@ -6130,7 +6140,9 @@ export class IfcGeometryExtraction {
               }
             } catch ( error ) {
 
-              if ( error instanceof Error ) {
+              if ( this.quietRecoverableLogging ) {
+                // Preview prefix: expected on a truncated tail — skip.
+              } else if ( error instanceof Error ) {
 
                 Logger.error( `Error extracting representation item\n\t${error.message}\n\tExpress ID: #${item.expressID}`)
               } else {
@@ -6199,7 +6211,9 @@ export class IfcGeometryExtraction {
               }
             } catch ( error ) {
 
-              if ( error instanceof Error ) {
+              if ( this.quietRecoverableLogging ) {
+                // Preview prefix: expected on a truncated tail — skip.
+              } else if ( error instanceof Error ) {
 
                 Logger.error( `Error extracting representation item\n\t${error.message}\n\t${error.stack}\n\tExpress ID: #${item.localID}`)
               } else {


### PR DESCRIPTION
Two fixes for large-model loads, surfaced on a 398MB georeferenced Swiss ArchiCAD IFC (DOWA).

## 1. Quiet recoverable per-record errors in IFC preview prefix extractions

The parse-time preview channel's throwaway prefix extractions hit representation items whose styled-item/select references aren't parsed yet (`"Value in select must be populated"` from `extractStyledItem`) — expected on a truncated mid-parse tail. These logged at error level and flooded the Share load report (**1164** styled-item errors on DOWA). New `IfcGeometryExtraction.quietRecoverableLogging`, set only by the IFC preview adapter — the exact analog of the AP214 flag from #434. Durable extractions keep full logging.

## 2. Coordinate-to-origin in float64 (fixes georeferencing jitter)

The model jittered during rotation when zoomed in — float32 precision loss in the `COORDINATE_TO_ORIGIN` recentre. gl-matrix's `mat4`/`vec4` are `Float32Array`, and the coordination subtracts a large world reference point (`placement × firstPoint`, ~1e5 m for a Swiss/CHE model), then `mat4.fromValues` re-truncates the placement. Measured error baked into the emitted transform:

| placement magnitude | float32 error |
|---|---|
| near origin (~6 m) | 0.0002 mm |
| ~10 km | 0.44 mm |
| ~100 km (CHE georef) | ~12 mm |
| ~2.6M m (CH LV95) | ~281 mm |

The native placement (`getValues` → `glm::dmat4`) and reference point (`getPoint` → `glm::dvec3`) are **full float64 at the wasm boundary** — so a JS-only fix fully recovers precision, no conway-geom change needed. New `coordination_f64.ts` helper (plain `number[]` double 4×4 multiply / coordination derivation / composition, column-major, bit-matching gl-matrix conventions) routes the coordination derivation + final transform composition in **every** placed-geometry path: IFC (`streamNewMeshes_`, `streamAllMeshes`, `streamAllMeshesWithTypes`, `loadAllGeometry`), AP214 (three equivalents, bare composition per #308), and the preview channel (`captureNewInstances_`). Coordination state (`demandCoordination_`, `previewCoordinationMatrix`) is now `number[]` so full-double precision persists across deferred batches and the preview→durable handoff. Geometry buffers untouched. This is an **all-paths** georeferencing fix (classic merged and demand batched alike), not demand-specific.

## Tests

Full `compat/web-ifc` + `AP214E3_2010` suites: **92/92**. Deferred==classic and preview==durable parity preserved (float32/float64 agree to sub-micron near origin; the fix diverges only at large coordinates). Near-origin fixtures unchanged, so CI visual-diff passes as-is — a re-bless would only be needed if a georeferenced model were added to the regression suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz