### PR TITLE
Run the rel-aggregates master-voids pass in the deferred geometry pump

### DIFF
--- a/data/aggregate_master_voids.ifc
+++ b/data/aggregate_master_voids.ifc
@@ -1,0 +1,50 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('aggregate_master_voids.ifc','2026-07-23T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+/* Minimal synthetic model exercising the rel-aggregates master-voids
+   second pass: an IfcElementAssembly (no own representation) carries an
+   IfcRelVoidsElement opening, and aggregates an IfcBuildingElementPart
+   whose box body must be CUT by that opening on the whole-model walk's
+   second product pass (and, for parity, by the deferred demand pump). */
+#1=IFCPROJECT('0hF0kSTOX3ovkcpuOhkPrX',$,'AggregateMasterVoids',$,$,$,$,(#20),#10);
+#10=IFCUNITASSIGNMENT((#11));
+#11=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#20=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-05,#21,$);
+#21=IFCAXIS2PLACEMENT3D(#22,$,$);
+#22=IFCCARTESIANPOINT((0.,0.,0.));
+#23=IFCDIRECTION((0.,0.,1.));
+#24=IFCDIRECTION((1.,0.,0.));
+/* Assembly: relating object of both the rel-voids and the aggregate. */
+#100=IFCELEMENTASSEMBLY('1hF0kSTOX3ovkcpuOhkPrX',$,'Assembly',$,$,#101,$,$,$,.NOTDEFINED.);
+#101=IFCLOCALPLACEMENT($,#21);
+/* Part: 1m x 1m x 1m box, spanning (0,0,0)..(1,1,1). */
+#200=IFCBUILDINGELEMENTPART('2hF0kSTOX3ovkcpuOhkPrX',$,'Part',$,$,#201,#210,$,$);
+#201=IFCLOCALPLACEMENT(#101,#21);
+#210=IFCPRODUCTDEFINITIONSHAPE($,$,(#211));
+#211=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#212));
+#212=IFCEXTRUDEDAREASOLID(#213,#216,#23,1.);
+#213=IFCRECTANGLEPROFILEDEF(.AREA.,$,#214,1.,1.);
+#214=IFCAXIS2PLACEMENT2D(#215,$);
+#215=IFCCARTESIANPOINT((0.5,0.5));
+#216=IFCAXIS2PLACEMENT3D(#22,$,$);
+/* Opening: 0.4m x 0.4m column through the part, z from -0.5 to 1.5. */
+#300=IFCOPENINGELEMENT('3hF0kSTOX3ovkcpuOhkPrX',$,'Opening',$,$,#301,#310,$,$);
+#301=IFCLOCALPLACEMENT(#101,#21);
+#310=IFCPRODUCTDEFINITIONSHAPE($,$,(#311));
+#311=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#312));
+#312=IFCEXTRUDEDAREASOLID(#313,#316,#23,2.);
+#313=IFCRECTANGLEPROFILEDEF(.AREA.,$,#314,0.4,0.4);
+#314=IFCAXIS2PLACEMENT2D(#315,$);
+#315=IFCCARTESIANPOINT((0.5,0.5));
+#316=IFCAXIS2PLACEMENT3D(#317,$,$);
+#317=IFCCARTESIANPOINT((0.,0.,-0.5));
+/* The opening voids the ASSEMBLY (the relating object), not the part. */
+#400=IFCRELVOIDSELEMENT('4hF0kSTOX3ovkcpuOhkPrX',$,$,$,#100,#300);
+/* The assembly aggregates the part. */
+#500=IFCRELAGGREGATES('5hF0kSTOX3ovkcpuOhkPrX',$,$,$,#100,(#200));
+ENDSEC;
+END-ISO-10303-21;

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -244,6 +244,87 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     expect( api3.ReleaseModelGeometry( 9999 ) ).toBe( false )
   }, 240000 )
 
+  test( 'pump applies the rel-aggregates master-voids pass (cut parity)', async () => {
+
+    // Classic's whole-model walk follows its product loop with a second
+    // pass re-extracting every IfcRelAggregates related product with
+    // the RELATING object's rel-voids, REPLACING the canonical mesh
+    // under the same localID — aggregate parts whose parent carries
+    // openings end up cut. A pump that only ran the per-product pass
+    // served the UNCUT content classic never exposes (field reports:
+    // wrong shapes + flicker on faceset-heavy vyzn models). The
+    // synthetic fixture is an assembly voided by an opening,
+    // aggregating a box part the opening must cut.
+    //
+    // Fresh IfcAPI (CloseModel poisons later opens — see the content
+    // parity test's note).
+    const api4 = new IfcAPI()
+    await api4.Init()
+
+    const fixture = new Uint8Array(
+        fs.readFileSync( 'data/aggregate_master_voids.ifc' ) )
+
+    const classicID = api4.OpenModel( fixture, SETTINGS )
+    const classicInstances: number[] = []
+
+    api4.StreamAllMeshes( classicID, ( mesh ) => {
+      for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+        classicInstances.push( mesh.geometries.get( where ).geometryExpressID )
+      }
+    } )
+
+    // The second pass re-extracts the part: two placed instances of the
+    // (cut) part geometry — the fixture must exercise the seam at all.
+    expect( classicInstances.length ).toBe( 2 )
+
+    const deferredID = await api4.OpenModelStreamed(
+        fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+    const pumpedInstances: number[] = []
+
+    for ( ; ; ) {
+
+      const { extracted, remaining } = api4.ExtractGeometryBatch(
+          deferredID, 1, ( mesh ) => {
+            for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+              pumpedInstances.push(
+                  mesh.geometries.get( where ).geometryExpressID )
+            }
+          } )
+
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+
+    // Instance parity: the pump must emit the re-extracted instance too.
+    expect( pumpedInstances.sort() ).toEqual( classicInstances.sort() )
+
+    // Content parity: GetGeometry must serve the CUT part, byte-identical
+    // to classic (the uncut box has strictly fewer vertices).
+    for ( const geometryID of new Set( classicInstances ) ) {
+
+      const classicGeometry = api4.GetGeometry( classicID, geometryID )
+      const deferredGeometry = api4.GetGeometry( deferredID, geometryID )
+
+      const classicSize = classicGeometry.GetVertexDataSize()
+
+      expect( classicSize ).toBeGreaterThan( 0 )
+      expect( deferredGeometry.GetVertexDataSize() ).toBe( classicSize )
+      expect( deferredGeometry.GetIndexDataSize() )
+          .toBe( classicGeometry.GetIndexDataSize() )
+
+      const classicVertices =
+        api4.GetVertexArray( classicGeometry.GetVertexData(), classicSize )
+      const deferredVertices =
+        api4.GetVertexArray( deferredGeometry.GetVertexData(), classicSize )
+
+      expect( deferredVertices ).toEqual( classicVertices )
+    }
+
+    api4.CloseModel( classicID )
+    api4.CloseModel( deferredID )
+  }, 240000 )
+
   test( 'ExtractGeometryBatch is a safe no-op on non-deferred models', async () => {
 
     const modelID = await api.OpenModelStreamed( buffer, SETTINGS )

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -118,6 +118,18 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   private demandCursor_ = 0
 
   /**
+   * Has the pump run the rel-aggregates master-voids pass? Classic's
+   * whole-model walk follows its product loop with a second pass that
+   * re-extracts every IfcRelAggregates related product using the
+   * relating object's rel-voids (extractRelAggregatesGeometry), which
+   * REPLACES the canonical mesh under the same localID — aggregate
+   * parts whose parent carries openings end up cut. The pump must run
+   * that same pass once after its last product batch or GetGeometry
+   * serves the uncut content classic never exposes.
+   */
+  private demandAggregatesDone_ = false
+
+  /**
    * Coordination matrix the deferred capture derived (or adopted from
    * the parse-time preview channel). Kept OFF the model tuple's slot 5
    * deliberately: classic streamAllMeshes derives its coordination into
@@ -1478,6 +1490,19 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       if (this.conwayGeometry_.extractProductGeometryByLocalID(localID)) {
         ++extracted
       }
+    }
+
+    // Classic parity: once the product walk completes, run the
+    // whole-model walk's second (rel-aggregates master-voids) pass in
+    // the SAME call, so this call's delta capture already emits the
+    // re-extracted instances and the GetGeometry map's last writer for
+    // every replaced mesh matches classic exactly (see
+    // demandAggregatesDone_).
+    if (this.demandCursor_ >= this.demandProducts_.length &&
+        !this.demandAggregatesDone_) {
+
+      this.demandAggregatesDone_ = true
+      this.conwayGeometry_.extractRelAggregatesGeometry()
     }
 
     if (meshCallback !== void 0) {

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -6019,10 +6019,12 @@ export class IfcGeometryExtraction {
    * path's entry (Phase B2). Requires {@link prepareDemandExtraction} (or a
    * prior whole-model walk) so the shared maps exist.
    *
-   * Note: products that are targets of IfcRelAggregates whose relating
-   * object carries rel-voids get those master voids only on the whole-model
-   * walk; the demand path extracts the product's own voids. The parity gate
-   * for this seam is the whole-model digest CI.
+   * Note: this extracts a single product with its OWN voids. Products that
+   * are targets of IfcRelAggregates whose relating object carries rel-voids
+   * additionally need the whole-model walk's second pass
+   * ({@link extractRelAggregatesGeometry}) — the demand pump runs it once
+   * after the last product batch so pumped extractions converge to the
+   * classic walk exactly.
    *
    * @param localID The product's local ID.
    * @return {boolean} True if the local ID was an IfcProduct and was
@@ -6041,6 +6043,78 @@ export class IfcGeometryExtraction {
     this.extractProductGeometry( element )
 
     return true
+  }
+
+  /**
+   * The whole-model walk's SECOND product pass, shared with the demand
+   * pump: for every IfcRelAggregates, re-extract the related products
+   * with the relating object's rel-voids as a master override. This
+   * re-extraction REPLACES the canonical mesh cached under each
+   * representation item's localID (the scene resolves geometry by
+   * localID at walk time), so aggregate parts whose parent carries
+   * openings end up CUT — a demand pump that only ran the per-product
+   * pass would leave them uncut and serve different GetGeometry content
+   * than the classic walk (the vyzn romana/DOWA scatter). Call exactly
+   * once, after every product has been extracted.
+   */
+  public extractRelAggregatesGeometry(): void {
+
+    const relAggregates = this.model.types(IfcRelAggregates)
+
+    for ( const relAggregate of relAggregates ) {
+
+      this.extractRelAggregateGeometry_( relAggregate )
+    }
+  }
+
+  /**
+   * Extract one IfcRelAggregates' related products with the relating
+   * object's ("master") rel-voids — the shared per-item body of the
+   * whole-model walk's rel-aggregates loop and
+   * {@link extractRelAggregatesGeometry}.
+   *
+   * @param relAggregate The rel-aggregates relationship to process.
+   */
+  private extractRelAggregateGeometry_( relAggregate: IfcRelAggregates ): void {
+
+    try {
+
+      // Note, this is required because the relating object
+      // can be where the rel-void is applied, so we
+      // used this as a top level over-ride for a rel-void.
+      // for all objects in the aggregate - CS
+      const relatingObject = relAggregate.RelatingObject
+
+      const masterRelVoids =
+        relatingObject instanceof IfcProduct ?
+          this.extractRelVoids( relatingObject ) :
+          void 0
+
+      const relatedObjects = relAggregate.RelatedObjects
+
+      for ( const productRepresentation of relatedObjects ) {
+
+        if ( productRepresentation instanceof IfcProduct ) {
+
+          this.extractProductGeometry( productRepresentation, masterRelVoids )
+        }
+      }
+
+      if ( masterRelVoids !== void 0 ) {
+        masterRelVoids[ 0 ].delete()
+      }
+    } catch (ex) {
+      if (ex instanceof Error) {
+        if (MATERIAL_RELATED_OBJECTS_PERMISSIVE) {
+          Logger.error('Error processing relAggregate\n\t' +
+            `error: ${ex.message}\n\t express ID: #${relAggregate.expressID}`)
+        } else {
+          throw ex
+        }
+      } else {
+        Logger.error('Unknown exception processing IfcRelAssociateMaterials.')
+      }
+    }
   }
 
   /**
@@ -6368,44 +6442,7 @@ export class IfcGeometryExtraction {
 
         yield [++completedItems, totalItems]
 
-        try {
-
-          // Note, this is required because the relating object
-          // can be where the rel-void is applied, so we
-          // used this as a top level over-ride for a rel-void.
-          // for all objects in the aggregate - CS
-          const relatingObject = relAggregate.RelatingObject
-
-          const masterRelVoids =
-            relatingObject instanceof IfcProduct ?
-              this.extractRelVoids( relatingObject ) :
-              void 0
-
-          const relatedObjects = relAggregate.RelatedObjects
-
-          for ( const productRepresentation of relatedObjects ) {
-
-            if ( productRepresentation instanceof IfcProduct ) {
-
-              this.extractProductGeometry( productRepresentation, masterRelVoids )
-            }
-          }
-
-          if ( masterRelVoids !== void 0 ) {
-            masterRelVoids[ 0 ].delete()
-          }
-        } catch (ex) {
-          if (ex instanceof Error) {
-            if (MATERIAL_RELATED_OBJECTS_PERMISSIVE) {
-              Logger.error('Error processing relAggregate\n\t' +
-                `error: ${ex.message}\n\t express ID: #${relAggregate.expressID}`)
-            } else {
-              throw ex
-            }
-          } else {
-            Logger.error('Unknown exception processing IfcRelAssociateMaterials.')
-          }
-        }
+        this.extractRelAggregateGeometry_( relAggregate )
       }
 
       if ( RegressionCaptureState.memoization !== MemoizationCapture.FULL ) {


### PR DESCRIPTION
Fixes janky/wrong geometry on the demand path for models with voided assemblies (field reports on Swiss vyzn IFCs — romana, DOWA).

## Root cause (verified, not float precision)

Classic `OpenModel` + `StreamAllMeshes` runs a **second pass over `IfcRelAggregates`** (`extractIFCGeometryDataIncremental`): every aggregated product is re-extracted with the *relating* (parent) object's rel-voids applied as a master override. That re-extraction **replaces the canonical mesh cached under the same localID** and adds a second placed instance — so an assembly's parts that inherit the parent's openings render **cut**, twice-placed.

The deferred pump (`OpenModelStreamed {DEFER_GEOMETRY}` + `ExtractGeometryBatch`) only ran the per-product pass, so `GetGeometry` served the **uncut** single-instance mesh classic never exposes. In Share this bakes the wrong shape wherever those products are instanced → janky layout, and the wrong overlapping pieces flicker while orbiting (read as "jitter"). expressID↔localID is 1:1, so this is not aliasing — it's a missing extraction pass.

On romana (private): 3 of 651 geometries diverged; e.g. #1330 classic 672 verts / 231 tris (cut, re-extracted at scene-walk idx 819) vs deferred 438/138 (uncut).

## Fix

- **`ifc_geometry_extraction.ts`** — hoist the rel-aggregates loop body into `extractRelAggregateGeometry_()` + public `extractRelAggregatesGeometry()`; the classic incremental walk calls the shared body verbatim (yield cadence unchanged).
- **`ifc_api_proxy_ifc.ts`** — `extractGeometryBatch` runs `extractRelAggregatesGeometry()` exactly once, in the call that consumes the last product, before `streamNewMeshes_`, so that batch's delta capture emits the re-extracted instances and the served-geometry map converges to classic. Delta semantics unchanged (the second instances are ordinary new instances past the watermarks).
- **AP214** — no change: its pump and classic path are one code path by construction.
- **Preview channel** — no change: throwaway by contract (openings excluded from preview; the durable pump replaces it).

## Verification

- Parity probe on romana: `contentDiff=3 → 0` (651/651 ids identical; deferredMissing=0, classicMissing=0). Independently re-confirmed.
- New public synthetic fixture `data/aggregate_master_voids.ifc` (authored from scratch — no private-model content) + test in `ifc_api_deferred_open.test.ts` asserting instance-set + byte-identical `GetGeometry` parity; **verified to fail with the fix disabled** (deferred 144/36 uncut vs classic 384/144 cut, missing instance).
- Suites green: compat/web-ifc + AP214 + ifc extraction (deferred/preview/streamed/extraction 24 tests in the focused run; full compat 60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_