### PR TITLE
Widen .claude/settings.json: PR-activity, git, dev-loop reads

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,7 +35,17 @@
       "mcp__github__list_releases",
       "mcp__Claude_Code_Remote__send_later",
       "mcp__Claude_Code_Remote__delete_trigger",
-      "mcp__Claude_Code_Remote__list_triggers"
+      "mcp__Claude_Code_Remote__list_triggers",
+      "mcp__Claude_Code_Remote__subscribe_pr_activity",
+      "mcp__Claude_Code_Remote__unsubscribe_pr_activity",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git fetch:*)",
+      "Bash(yarn lint:*)",
+      "Bash(yarn test:*)",
+      "Bash(yarn build-incremental:*)"
     ]
   }
 }


### PR DESCRIPTION
Part of a consistent `.claude/settings.json` allow-list across the bldrs repos (Share, conway, conway-geom, test-models, test-models-private) so the assistant's PR-babysitting + review workflow stops prompting on safe, read-only actions.

Extends conway's **existing** allow-list (the read-only GitHub set + CCR triggers, unchanged) and the SessionStart hook (untouched) with:

- **PR activity**: `subscribe_pr_activity` / `unsubscribe_pr_activity` (new)
- **Read-only git**: `status`, `diff`, `log`, `show`, `fetch`
- **Dev-loop** (CLAUDE.md "run tests, don't ask first"): `yarn lint`, `yarn test`, `yarn build-incremental`

Every mutating action still prompts: opening / merging PRs, commenting, reviewing, pushing, wasm builds, and any Bash not on the list. Precommit (lint + jest) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7)_