### PR TITLE
Extract aggregate parts once, in the rel-aggregates pass (content-final delivery)

### DIFF
--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -273,21 +273,32 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
       }
     } )
 
-    // The second pass re-extracts the part: two placed instances of the
-    // (cut) part geometry — the fixture must exercise the seam at all.
-    expect( classicInstances.length ).toBe( 2 )
+    // Aggregate targets are extracted ONLY by the second pass now
+    // (aggregateTargetLocalIDs): exactly ONE placed instance of the cut
+    // part. (Historically 2 — the first-pass uncut node plus the
+    // pass-two re-extraction node coinciding, a duplicate that
+    // z-fought and, on the pump, delivered stale uncut content.)
+    expect( classicInstances.length ).toBe( 1 )
 
     const deferredID = await api4.OpenModelStreamed(
         fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
     const pumpedInstances: number[] = []
+    const pumpedTrisAtDelivery: number[] = []
 
     for ( ; ; ) {
 
       const { extracted, remaining } = api4.ExtractGeometryBatch(
           deferredID, 1, ( mesh ) => {
             for ( let where = 0; where < mesh.geometries.size(); ++where ) {
-              pumpedInstances.push(
-                  mesh.geometries.get( where ).geometryExpressID )
+              const geometryID =
+                mesh.geometries.get( where ).geometryExpressID
+              pumpedInstances.push( geometryID )
+              // Content-at-delivery: what an incremental consumer
+              // copies the moment the instance is emitted.
+              const geometry = api4.GetGeometry( deferredID, geometryID )
+              pumpedTrisAtDelivery.push(
+                  // eslint-disable-next-line no-magic-numbers
+                  ( geometry.GetIndexDataSize() / 3 ) | 0 )
             }
           } )
 
@@ -296,8 +307,22 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
       }
     }
 
-    // Instance parity: the pump must emit the re-extracted instance too.
+    // Instance parity: same single cut instance as classic.
     expect( pumpedInstances.sort() ).toEqual( classicInstances.sort() )
+
+    // The #1640 invariant (Share bldrs-ai/Share#1640): the content an
+    // incremental consumer copies AT DELIVERY equals the final content
+    // — the pump must never mutate a geometry after emitting instances
+    // that reference it.
+    for ( let where = 0; where < pumpedInstances.length; ++where ) {
+
+      const finalGeometry =
+        api4.GetGeometry( deferredID, pumpedInstances[ where ] )
+
+      expect( pumpedTrisAtDelivery[ where ] )
+          // eslint-disable-next-line no-magic-numbers
+          .toBe( ( finalGeometry.GetIndexDataSize() / 3 ) | 0 )
+    }
 
     // Content parity: GetGeometry must serve the CUT part, byte-identical
     // to classic (the uncut box has strictly fewer vertices).

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -45,7 +45,7 @@ import Memory from '../../memory/memory'
 import { FromRawLineData } from './ifc2x4_helper'
 import { shimIfcEntityMap, shimIfcEntityReverseMap } from './shim_schema_mapping'
 import { EntityTypesIfcCount } from '../../ifc/ifc4_gen/entity_types_ifc.gen'
-import { IfcProduct, IfcRoot } from '../../ifc/ifc4_gen'
+import { IfcProduct, IfcRelAggregates, IfcRoot } from '../../ifc/ifc4_gen'
 import { CanonicalMeshType } from '../../index'
 
 // Batch size used when a whole-model consumer (streamAllMeshes) drains
@@ -118,16 +118,21 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   private demandCursor_ = 0
 
   /**
-   * Has the pump run the rel-aggregates master-voids pass? Classic's
-   * whole-model walk follows its product loop with a second pass that
-   * re-extracts every IfcRelAggregates related product using the
-   * relating object's rel-voids (extractRelAggregatesGeometry), which
-   * REPLACES the canonical mesh under the same localID — aggregate
-   * parts whose parent carries openings end up cut. The pump must run
-   * that same pass once after its last product batch or GetGeometry
-   * serves the uncut content classic never exposes.
+   * Deferred-mode rel-aggregates worklist, pumped batch-by-batch AFTER
+   * the product cursor completes. Classic's whole-model walk follows
+   * its product loop with a second pass extracting every
+   * IfcRelAggregates related product using the relating object's
+   * rel-voids. Aggregate-target products are EXCLUDED from
+   * demandProducts_ (see aggregateTargetLocalIDs) so this pass is their
+   * first and only extraction — content is final when their instances
+   * are captured, and no placement is ever appended over an
+   * already-delivered one (the ILNA missing-facades / 388_4
+   * duplicate-placement class).
    */
-  private demandAggregatesDone_ = false
+  private demandAggregates_?: IfcRelAggregates[]
+
+  /** Cursor into demandAggregates_ — items before it are extracted. */
+  private demandAggregatesCursor_ = 0
 
   /**
    * Coordination matrix the deferred capture derived (or adopted from
@@ -1403,7 +1408,9 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     if (this.deferredMode_ &&
         this.demandProducts_ !== void 0 &&
-        this.demandCursor_ < this.demandProducts_.length) {
+        (this.demandCursor_ < this.demandProducts_.length ||
+          this.demandAggregatesCursor_ <
+            (this.demandAggregates_?.length ?? 0))) {
       Logger.warning(
           '[ReleaseModelGeometry]: deferred pump not drained — not releasing')
       return false
@@ -1467,18 +1474,41 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     if (this.demandProducts_ === void 0) {
 
+      // Aggregate-target products are extracted ONLY by the
+      // rel-aggregates pass below (with the relating object's master
+      // rel-voids), never by the per-product pass: extracting them here
+      // first would emit their instances with the uncut/placeholder
+      // content and the pass's later replacement would never reach an
+      // incremental consumer (it copies at delivery), while the pass's
+      // second scene instance would draw over the first (see
+      // aggregateTargetLocalIDs).
+      const aggregateTargets = this.conwayGeometry_.aggregateTargetLocalIDs()
+
       const products: number[] = []
 
       for (const product of this.model[0].types(IfcProduct)) {
+
+        if (aggregateTargets.has(product.localID)) {
+          continue
+        }
         products.push(product.localID)
       }
 
+      const aggregates: IfcRelAggregates[] = []
+
+      for (const relAggregate of this.model[0].types(IfcRelAggregates)) {
+        aggregates.push(relAggregate)
+      }
+
       this.demandProducts_ = products
+      this.demandAggregates_ = aggregates
       this.demandCursor_ = 0
+      this.demandAggregatesCursor_ = 0
     }
 
+    const budget = Math.max(batchSize, 1)
     const end = Math.min(
-        this.demandCursor_ + Math.max(batchSize, 1),
+        this.demandCursor_ + budget,
         this.demandProducts_.length)
 
     let extracted = 0
@@ -1492,17 +1522,27 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       }
     }
 
-    // Classic parity: once the product walk completes, run the
-    // whole-model walk's second (rel-aggregates master-voids) pass in
-    // the SAME call, so this call's delta capture already emits the
-    // re-extracted instances and the GetGeometry map's last writer for
-    // every replaced mesh matches classic exactly (see
-    // demandAggregatesDone_).
-    if (this.demandCursor_ >= this.demandProducts_.length &&
-        !this.demandAggregatesDone_) {
+    // Classic parity: once the product walk completes, pump the
+    // whole-model walk's second (rel-aggregates master-voids) pass with
+    // the same per-call budget — batch-by-batch, not as one end-of-load
+    // stall — so aggregate parts stream in cut, exactly once, with
+    // final content (see demandAggregates_).
+    const aggregates = this.demandAggregates_ ?? []
 
-      this.demandAggregatesDone_ = true
-      this.conwayGeometry_.extractRelAggregatesGeometry()
+    if (this.demandCursor_ >= this.demandProducts_.length &&
+        this.demandAggregatesCursor_ < aggregates.length) {
+
+      const aggregatesEnd = Math.min(
+          this.demandAggregatesCursor_ + (budget - extracted),
+          aggregates.length)
+
+      for (; this.demandAggregatesCursor_ < aggregatesEnd;
+        ++this.demandAggregatesCursor_) {
+
+        this.conwayGeometry_.extractRelAggregateGeometry(
+            aggregates[this.demandAggregatesCursor_])
+        ++extracted
+      }
     }
 
     if (meshCallback !== void 0) {
@@ -1511,7 +1551,8 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     return {
       extracted,
-      remaining: this.demandProducts_.length - this.demandCursor_,
+      remaining: (this.demandProducts_.length - this.demandCursor_) +
+        (aggregates.length - this.demandAggregatesCursor_),
     }
   }
 

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -5922,6 +5922,59 @@ export class IfcGeometryExtraction {
   // walk can both trigger it without duplicating work.
   private extractionMapsPrepared_ = false
 
+  // Lazy cache for aggregateTargetLocalIDs().
+  private aggregateTargetLocalIDs_?: Set<number>
+
+  /**
+   * Local IDs of every IfcProduct that is a RelatedObject of any
+   * IfcRelAggregates — the exact set the rel-aggregates pass
+   * ({@link extractRelAggregateGeometry}) re-extracts with the relating
+   * object's master rel-voids.
+   *
+   * Both product walks SKIP these in their first pass and extract them
+   * only in the aggregates pass, for two invariants consumers rely on:
+   *   1. one scene instance per placement (the first-pass node plus the
+   *      re-extraction node used to coincide exactly — a duplicate draw
+   *      that z-fights), and
+   *   2. a part's canonical mesh content is never REPLACED after its
+   *      instances were already emitted — incremental consumers copy
+   *      content at delivery time, so a first-pass emission served the
+   *      uncut (or empty) content and the later replacement never
+   *      reached the screen (the ILNA missing-facades class).
+   *
+   * @return {Set<number>} product localIDs deferred to the aggregates
+   * pass; empty for models without IfcRelAggregates.
+   */
+  public aggregateTargetLocalIDs(): Set<number> {
+
+    if ( this.aggregateTargetLocalIDs_ !== void 0 ) {
+      return this.aggregateTargetLocalIDs_
+    }
+
+    const targets = new Set<number>()
+
+    for ( const relAggregate of this.model.types( IfcRelAggregates ) ) {
+
+      try {
+
+        for ( const related of relAggregate.RelatedObjects ) {
+
+          if ( related instanceof IfcProduct ) {
+            targets.add( related.localID )
+          }
+        }
+      } catch {
+        // Malformed relationship rows are tolerated exactly like the
+        // aggregates pass itself tolerates them (permissive catch) —
+        // their targets simply stay in the first-pass walk.
+      }
+    }
+
+    this.aggregateTargetLocalIDs_ = targets
+
+    return targets
+  }
+
   /**
    * One-time extraction setup shared by the whole-model walk and the
    * per-product demand path (Phase B2): linear scaling factor and the
@@ -6063,7 +6116,7 @@ export class IfcGeometryExtraction {
 
     for ( const relAggregate of relAggregates ) {
 
-      this.extractRelAggregateGeometry_( relAggregate )
+      this.extractRelAggregateGeometry( relAggregate )
     }
   }
 
@@ -6071,11 +6124,13 @@ export class IfcGeometryExtraction {
    * Extract one IfcRelAggregates' related products with the relating
    * object's ("master") rel-voids — the shared per-item body of the
    * whole-model walk's rel-aggregates loop and
-   * {@link extractRelAggregatesGeometry}.
+   * {@link extractRelAggregatesGeometry}. Public so the deferred pump
+   * can run the pass incrementally (batch-budgeted) instead of as one
+   * end-of-load stall.
    *
    * @param relAggregate The rel-aggregates relationship to process.
    */
-  private extractRelAggregateGeometry_( relAggregate: IfcRelAggregates ): void {
+  public extractRelAggregateGeometry( relAggregate: IfcRelAggregates ): void {
 
     try {
 
@@ -6429,9 +6484,19 @@ export class IfcGeometryExtraction {
         this.model.typeCount(IfcProduct) + this.model.typeCount(IfcRelAggregates)
       let completedItems = 0
 
+      // Products the aggregates pass re-extracts are SKIPPED here and
+      // extracted exactly once, below, with the master rel-voids — one
+      // scene instance per placement and no content replacement after
+      // emission (see aggregateTargetLocalIDs).
+      const aggregateTargets = this.aggregateTargetLocalIDs()
+
       for (const product of products) {
 
         yield [++completedItems, totalItems]
+
+        if ( aggregateTargets.has( product.localID ) ) {
+          continue
+        }
 
         this.extractProductGeometry(product)
       }
@@ -6442,7 +6507,7 @@ export class IfcGeometryExtraction {
 
         yield [++completedItems, totalItems]
 
-        this.extractRelAggregateGeometry_( relAggregate )
+        this.extractRelAggregateGeometry( relAggregate )
       }
 
       if ( RegressionCaptureState.memoization !== MemoizationCapture.FULL ) {


### PR DESCRIPTION
Fixes the demand-pump geometry loss reported in bldrs-ai/Share#1640 and the duplicate-placement z-fighting in bldrs-ai/Share#1635 — one root cause, one fix.

## Root cause

Products that are RelatedObjects of an IfcRelAggregates were extracted twice: once in the per-product pass (own voids only) and again in the rel-aggregates pass (relating object's master voids), which REPLACED the canonical mesh under the same localID and appended a second, coinciding scene instance. Two user-visible failures follow:

- Incremental consumers copy content at delivery, so the pump's first-pass emission served the uncut/placeholder content and the pass-two replacement never reached the screen. On ILNA (98 MB vyzn) the demand path lost 20–34% of triangles vs classic — whole facades (IfcBuildingElementPart) missing (Share#1640).
- The duplicated instance drew the part twice at the identical transform — 343 coincident z-fighting duplicates on 388_4, in classic and demand output (Share#1635).

## Fix

`aggregateTargetLocalIDs()` names the set the aggregates pass re-extracts; both walks now SKIP those products in the first pass, so their single extraction happens in the aggregates pass with final (master-cut) content before any instance is emitted. The deferred pump runs that pass batch-by-batch with the same per-call budget (no end-of-load stall) and reports it through extracted/remaining; ReleaseModelGeometry's drain guard covers the aggregates cursor.

Invariants established (asserted by the updated master-voids parity test):
1. One scene instance per placement (fixture: 2 → 1).
2. Geometry content never mutates after an instance referencing it is emitted — content at delivery == final content.
3. Classic and deferred walks converge to identical output.

## Verification

- Fixture (`data/aggregate_master_voids.ifc`): classic 1 placement of the cut part; pump delivers it with final content (48 tris at delivery == at end).
- Full jest suite green: 72/72 suites, 360/360 tests, including the classic↔pump exact-match parity test.
- Tier-A goldens (`data/block.csv`, `data/index.csv`): byte-identical — neither exercises the aggregates path.
- Real models (node build, classic vs demand):

| model | path | placements | triangles |
|---|---|---|---|
| ILNA (98 MB) | classic | 28,637 | 3,110,189 |
| ILNA | demand | 28,637 (parity) | 3,107,405 (0.09% MT boolean nondeterminism) |
| 388_4 | classic | 792 | 33,556 |
| 388_4 | demand | 792 (parity) | 33,556 (exact) |

Placement counts drop vs prior builds (ILNA 37,667 → 28,637; 388_4 1,135 → 792) because the removed placements were the coincident duplicates — same visible surface, drawn once. Regression digests for aggregate-bearing models will shift accordingly (fewer duplicate placements); renders identical-or-better. Downstream Share renders identically-or-better (its coincidence dedup in Share#1627 becomes a no-op backstop).

Closes bldrs-ai/Share#1640. Closes bldrs-ai/Share#1635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz