### PR TITLE
visual-diff: suppress no-op rows below a pixel-diff threshold

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -709,7 +709,8 @@ jobs:
           node scripts/visual_diff_report.cjs \
             --models abs_models.txt \
             --base engines/base --cand engines/cand \
-            --out vdout --max 24
+            --out vdout --max 24 \
+            --diff-threshold 0.0005
 
       - name: Publish images to assets branch
         id: assets

--- a/scripts/render_glb.cjs
+++ b/scripts/render_glb.cjs
@@ -328,6 +328,50 @@ function renderToPixels(tris, bounds, size) {
   return pixels
 }
 
+/**
+ * Per-pixel difference between two equal-size RGB buffers.
+ *
+ * The rasterizer is deterministic and anti-aliasing-free, so identical
+ * geometry rendered under the shared pair camera yields byte-identical
+ * pixels — a truly-unchanged pair reports changedPixels === 0. Any real
+ * geometry difference (including a bounds-moving spike, which the shared
+ * union camera amplifies) lights up pixels here. Callers threshold on
+ * changedFraction to suppress no-op rows.
+ *
+ * @param {Buffer} a RGB bytes (before)
+ * @param {Buffer} b RGB bytes (after), same length as a
+ * @returns {{changedPixels:number,totalPixels:number,changedFraction:number,maxDelta:number}}
+ */
+function diffPixels(a, b) {
+  if (a.length !== b.length) {
+    // Different geometry can't change the raster dimensions (size is
+    // fixed), so a length mismatch is a bug, not a diff — surface it as
+    // maximally-changed rather than silently comparing a prefix.
+    return { changedPixels: -1, totalPixels: 0, changedFraction: 1, maxDelta: 255 }
+  }
+  const totalPixels = a.length / 3
+  let changedPixels = 0
+  let maxDelta = 0
+  for (let i = 0; i < a.length; i += 3) {
+    const d = Math.max(
+        Math.abs(a[i] - b[i]),
+        Math.abs(a[i + 1] - b[i + 1]),
+        Math.abs(a[i + 2] - b[i + 2]))
+    if (d > 0) {
+      ++changedPixels
+    }
+    if (d > maxDelta) {
+      maxDelta = d
+    }
+  }
+  return {
+    changedPixels,
+    totalPixels,
+    changedFraction: totalPixels > 0 ? changedPixels / totalPixels : 0,
+    maxDelta,
+  }
+}
+
 // ---------------------------------------------------------------------------
 // PNG encoding (RGB8, filter 0, zlib) — no dependencies
 // ---------------------------------------------------------------------------
@@ -422,8 +466,14 @@ function main() {
     const after = loadTriangles(afterGlb)
     const bounds = unionBounds(
         projectedBounds(before, basis), projectedBounds(after, basis))
-    writePng(`${outPrefix}-before.png`, renderToPixels(before, bounds, size), size)
-    writePng(`${outPrefix}-after.png`, renderToPixels(after, bounds, size), size)
+    const beforePixels = renderToPixels(before, bounds, size)
+    const afterPixels = renderToPixels(after, bounds, size)
+    writePng(`${outPrefix}-before.png`, beforePixels, size)
+    writePng(`${outPrefix}-after.png`, afterPixels, size)
+    // The pair's diff metric on stdout (single JSON line) — the caller
+    // thresholds on it to drop no-op rows. Kept as the only stdout
+    // output so a caller can parse it directly.
+    process.stdout.write(JSON.stringify(diffPixels(beforePixels, afterPixels)) + '\n')
   } else {
     const [glbPath, outPath] = args
     const tris = loadTriangles(glbPath)
@@ -431,4 +481,10 @@ function main() {
   }
 }
 
-main()
+// Run as a CLI, but stay require()-able so diffPixels can be unit-tested
+// without executing main().
+if (require.main === module) {
+  main()
+}
+
+module.exports = { diffPixels }

--- a/scripts/visual_diff_report.cjs
+++ b/scripts/visual_diff_report.cjs
@@ -36,6 +36,13 @@ function parseArgs() {
     opts[args[i].replace(/^--/, '')] = args[i + 1]
   }
   opts.max = parseInt(opts.max, 10)
+  // Minimum fraction of pixels that must differ between the before/after
+  // render for a row to be shown. The digest gate and the visual-diff base
+  // (published npm) use different baselines, so a flagged model can render
+  // identically here — this drops those no-op rows. Default 0.05% (~205px
+  // at 640^2); tune via --diff-threshold.
+  opts.diffThreshold = opts['diff-threshold'] !== undefined ?
+    parseFloat(opts['diff-threshold']) : 0.0005
   // The exporter children run with cwd set to a scratch dir, so a relative
   // --base/--cand (as the workflow passes) would make Node resolve the CLI
   // entry point against the scratch dir and die with ERR_MODULE_NOT_FOUND.
@@ -45,6 +52,34 @@ function parseArgs() {
     }
   }
   return opts
+}
+
+/**
+ * Parse render_glb.cjs's pair diff metric (a single JSON line on stdout).
+ * Returns null when no parseable metric is present — an older render, or a
+ * crash — so the caller falls back to SHOWING the row: a metrics glitch
+ * must never silently hide a real diff.
+ *
+ * @param {string} stdout render_glb.cjs --pair stdout
+ * @return {{changedFraction:number,maxDelta:number}|null}
+ */
+function parseMetric(stdout) {
+  const lines = String(stdout).trim().split('\n').filter(Boolean)
+  for (let i = lines.length - 1; i >= 0; --i) {
+    const line = lines[i].trim()
+    if (!line.startsWith('{')) {
+      continue
+    }
+    try {
+      const parsed = JSON.parse(line)
+      if (typeof parsed.changedFraction === 'number') {
+        return parsed
+      }
+    } catch {
+      // Not the metric line; keep scanning older output.
+    }
+  }
+  return null
 }
 
 /** Model file → the CLI entry point (relative to a package root) for it. */
@@ -113,6 +148,9 @@ function main() {
 
   const renderScript = path.join(__dirname, 'render_glb.cjs')
   const rows = []
+  // Models whose shared-camera render differed below the threshold — shown
+  // as a tally, not rows, so the comment carries only reviewable diffs.
+  const unchanged = []
   const skipped = models.length > opts.max ? models.slice(opts.max) : []
   const selected = models.slice(0, opts.max)
 
@@ -129,7 +167,7 @@ function main() {
       const why = (base.diagnostic || cand.diagnostic || '')
           .replace(/\|/g, '\\|').slice(0, 200)
       rows.push(`| \`${name}\` | _no geometry from both engines_` +
-          `${why ? ` — \`${why}\`` : ''} | |`)
+          `${why ? ` — \`${why}\`` : ''} | | — |`)
       fs.rmSync(work, { recursive: true, force: true })
       continue
     }
@@ -158,14 +196,29 @@ function main() {
 
     if (base.glbs.length > 0 && cand.glbs.length > 0) {
       try {
-        execFileSync(process.execPath, [
+        const renderOut = execFileSync(process.execPath, [
           renderScript, '--pair', base.glbs.join(','), cand.glbs.join(','),
           path.join(opts.out, slug),
         ], { stdio: 'pipe', timeout: 5 * 60 * 1000 })
-        rows.push(
-            `| \`${name}\` ` +
-            `| ![before](RAW_URL_BASE/${slug}-before.png) ` +
-            `| ![after](RAW_URL_BASE/${slug}-after.png) |`)
+
+        const metric = parseMetric(renderOut.toString())
+        // Suppress no-op rows: the render base is the published package, so
+        // a digest-flagged model can render identically here (the change
+        // already shipped). A missing/garbled metric (older render, crash)
+        // falls back to SHOWING the row — never hide a real diff on a glitch.
+        if (metric && metric.changedFraction < opts.diffThreshold) {
+          fs.rmSync(path.join(opts.out, `${slug}-before.png`), { force: true })
+          fs.rmSync(path.join(opts.out, `${slug}-after.png`), { force: true })
+          unchanged.push(name)
+        } else {
+          const badge = metric ?
+            `${(metric.changedFraction * 100).toFixed(2)}% (Δmax ${metric.maxDelta})` : 'n/a'
+          rows.push(
+              `| \`${name}\` ` +
+              `| ![before](RAW_URL_BASE/${slug}-before.png) ` +
+              `| ![after](RAW_URL_BASE/${slug}-after.png) ` +
+              `| ${badge} |`)
+        }
         fs.rmSync(work, { recursive: true, force: true })
         continue
       } catch (err) {
@@ -178,21 +231,39 @@ function main() {
       }
     }
 
+    // Independently-framed fallback (pair render failed): the two cameras
+    // are no longer shared, so the images aren't pixel-comparable and the
+    // threshold doesn't apply — always shown.
     rows.push(
         `| \`${name}\` ` +
         `| ${renderSingle(base, 'base', 'before')} ` +
-        `| ${renderSingle(cand, 'candidate', 'after')} |`)
+        `| ${renderSingle(cand, 'candidate', 'after')} | n/a |`)
     fs.rmSync(work, { recursive: true, force: true })
   }
 
-  let report = '| model | base (main) | candidate (this PR) |\n| --- | --- | --- |\n'
+  let report = '| model | base (main) | candidate (this PR) | Δ pixels |\n' +
+      '| --- | --- | --- | --- |\n'
   report += rows.join('\n') + '\n'
+  if (unchanged.length > 0) {
+    report += `\n_${unchanged.length} digest-changed model(s) rendered below the ` +
+        `${(opts.diffThreshold * 100).toFixed(2)}% pixel-diff threshold ` +
+        `(no visible change vs the base engine; not shown): ` +
+        `${unchanged.join(', ')}_\n`
+  }
   if (skipped.length > 0) {
     report += `\n_${skipped.length} more changed model(s) not rendered ` +
         `(cap ${opts.max}): ${skipped.map((m) => path.basename(m)).join(', ')}_\n`
   }
   fs.writeFileSync(path.join(opts.out, 'report.md'), report)
-  process.stderr.write(`visual-diff: wrote ${rows.length} row(s)\n`)
+  process.stderr.write(
+      `visual-diff: wrote ${rows.length} row(s), ` +
+      `${unchanged.length} below threshold\n`)
 }
 
-main()
+// Run as a CLI, but stay require()-able so parseMetric can be unit-tested
+// without executing main().
+if (require.main === module) {
+  main()
+}
+
+module.exports = { parseMetric }


### PR DESCRIPTION
## Summary

The visual-diff comment has been listing models that render **pixel-identical** between base and candidate (e.g. `Snowdon…IFC4` in PR #440's triage: diff bbox `None`, max channel delta `0`). This adds a pixel-diff threshold so only rows with a real visible difference are shown.

## Root cause

Two different baselines are in play:
- The **digest-changed set** (what gates the render) is computed vs the pinned `test-models` baseline.
- The **visual-diff render base** is the published `@bldrs-ai/conway` npm package.

A model flagged by the digest gate can still render identically here when its geometry change already shipped to npm, or when the PR is TS-only. Those rows are noise, not reviewable diffs.

This PR fixes the *symptom* (the noise). The upstream fix — re-blessing the drifted `test-models` digest baseline so the changed-set itself shrinks — is a separate `test-models` change to revisit once this lands and it's clear what genuine diffs remain.

## What changed

- **`scripts/render_glb.cjs`** — `--pair` mode now emits a single-line JSON diff metric (`changedPixels`, `changedFraction`, `maxDelta`) computed from the two in-memory pixel buffers. The rasterizer is deterministic and anti-aliasing-free, so identical geometry under the shared pair camera yields byte-identical pixels → `changedFraction` 0; any real difference (including a bounds-moving spike the union camera amplifies) lights up pixels.
- **`scripts/visual_diff_report.cjs`** — thresholds on that metric (`--diff-threshold`, default **0.05%**). Below-threshold pairs are dropped from the table (and their PNGs removed so the `visual-diff-assets` branch doesn't carry them) and tallied in a summary line. Shown rows gain a **`Δ pixels`** column with the magnitude. A missing/garbled metric (older render, crash) falls back to **showing** the row — a metrics glitch must never hide a real diff. The independently-framed single-render fallback isn't pixel-comparable and is always shown (`n/a`).
- **`.github/workflows/build.yml`** — passes `--diff-threshold 0.0005` so the knob is visible/tunable in CI.

## Testing

- Unit tests on the two new exported helpers: `diffPixels` (identical → 0; one-pixel delta; length-mismatch guard) and `parseMetric` (extracts the JSON line, `null` on non-JSON).
- End-to-end `--pair` render on synthetic single-triangle GLBs: identical → `changedFraction 0` (suppressed); one vertex nudged → `2.03%`, `Δmax 181` (shown).
- Both scripts stay `require()`-able (`main` guarded on `require.main === module`) so the helpers are testable without executing the CLI.

## Note on CI for this PR

This is a scripts/workflow-only change, so it produces **no digest-changed models** — the `visual-diff` job is gated on `visual_diff_count != 0` and will therefore **skip** on this PR. The new path is validated locally (above) and will exercise on the next PR that actually moves geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyCxwn1wc35pkBiM9VC64V

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyCxwn1wc35pkBiM9VC64V)_