### PR TITLE
CI: full regression once per rc; PRs run a smoke subset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,9 +227,13 @@ jobs:
           path: tierA-goldens/*.csv
 
   # ---------------------------------------------------------------------------
-  # Regression: consumes build's WASM cache (no rebuild). Posts results to PR.
-  # Kept on a separate job (vs steps in build) so its 5-10 min runtime doesn't
-  # block the build-job status from showing once the fast feedback finishes.
+  # Regression (SMOKE subset): consumes build's WASM cache (no rebuild), runs
+  # the digest batch over regression/smoke_models.txt only, gates on failures,
+  # posts results to the PR, and packs the npm tarball the perf jobs consume.
+  # The FULL public+private corpus runs once per release candidate in
+  # rc-regression.yml (rc-* tag) — its baseline-PR diff is the release's
+  # regression report. Kept on a separate job (vs steps in build) so its
+  # runtime doesn't block the build-job status once fast feedback finishes.
   # ---------------------------------------------------------------------------
   run-ifc-regression:
     needs: build
@@ -340,19 +344,61 @@ jobs:
           git -C test-models fetch --depth 1 origin "$SHA"
           git -C test-models checkout "$SHA"
 
+      # This job runs the SMOKE subset only (regression/smoke_models.txt) —
+      # the full public+private corpus runs once per release candidate in
+      # rc-regression.yml, whose baseline-PR diff is the release's regression
+      # report. The batch CLI only has an EXCLUDE regex, so build one that
+      # excludes every model file whose basename is NOT in the smoke list.
+      # The regex must only ever match model FILES (extension-anchored):
+      # the batch's directory walk applies the same regex to directories,
+      # and a broader pattern would stop recursion entirely.
+      - name: Build smoke-subset exclude regex
+        id: smoke
+        run: |
+          python3 - <<'EOF'
+          import os, re
+          names = [l.strip() for l in open('regression/smoke_models.txt')
+                   if l.strip() and not l.strip().startswith('#')]
+          assert names, 'smoke_models.txt selected no models'
+          alts = '|'.join(re.escape(n) for n in names)
+          regex = (rf"^(?!.*/(?:{alts})$)"
+                   r".*\.(?:[iI][fF][cC]|[sS][tT][eE][pP]|[sS][tT][pP])$")
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            fh.write(f'regex={regex}\n')
+          print(f'{len(names)} smoke models; exclude regex: {regex}')
+          EOF
+
       # Perf CSV lands OUTSIDE the diffed test_models folder so machine-specific
       # timings don't show up as "changes" against test-models's checked-in
       # baselines. The aggregate is uploaded as a workflow artifact below and
-      # summarised in the PR comment.
-      - name: Run IFC Regression Batch Script
+      # summarised in the PR comment. NOTE these timings come from a --parallel
+      # run (models contend), so they're a smoke signal only — the clean
+      # per-model perf record is the rc-gated perf-three-* jobs.
+      - name: Run IFC Regression Batch Script (smoke subset)
+        env:
+          SMOKE_EXCLUDE: ${{ steps.smoke.outputs.regex }}
         run: |
           node --experimental-specifier-resolution=node ./compiled/src/ifc/ifc_regression_batch_main.js \
-            -e "sp-.*\.ifc" \
+            -e "$SMOKE_EXCLUDE" \
             -t ${{ steps.tmsha.outputs.sha }} \
             --perf "${GITHUB_WORKSPACE}/perf.csv" \
             test-models \
             test-models/regression/test_models \
             --parallel --mem-utilization 90
+
+      # Hard gate: a smoke model that fails to parse/extract blocks the PR.
+      # Digest CHANGES stay informational (intended geometry changes are
+      # reviewed via the visual diff and blessed at the rc), but a crash is
+      # never intended.
+      - name: Fail on smoke regression failures
+        run: |
+          FAILED=test-models/regression/test_models/failed.csv
+          if [ -f "$FAILED" ] && [ "$(wc -l < "$FAILED")" -gt 1 ]; then
+            echo "::error::Smoke regression failures:"
+            cat "$FAILED"
+            exit 1
+          fi
+          echo "No smoke failures."
 
       - name: Gather Regression Results
         id: regression_results
@@ -580,9 +626,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ## Regression Results (IFC + STEP)
+            ## Regression Results (smoke subset, IFC + STEP)
 
-            **Models:** `test-models` @ `${{ steps.tmsha.outputs.sha }}` (ref `${{ env.TEST_MODELS_REF }}`)
+            **Models:** smoke subset (`regression/smoke_models.txt`) of `test-models` @ `${{ steps.tmsha.outputs.sha }}` (ref `${{ env.TEST_MODELS_REF }}`).
+            The full public+private corpus runs once per release candidate (`rc-*` tag, see `rc-regression.yml`).
 
             **Failed.csv:**
             ${{ steps.regression_results.outputs.failed_output }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -417,6 +417,18 @@ jobs:
           from collections import Counter
 
           sha, name, empty_msg, mode = sys.argv[1:5]
+          # Optional 5th arg: a smoke_models.txt path. The run only regenerates
+          # that subset, so baseline rows for models OUTSIDE it would all count
+          # as "resolved" (they weren't retested — on the first smoke run that
+          # was 602 phantom resolved errors). Scope both sides to the subset so
+          # the diff is apples-to-apples.
+          scope_path = sys.argv[5] if len(sys.argv) > 5 else ""
+          scope = set()
+          if scope_path:
+              scope = {
+                  l.strip() for l in open(scope_path)
+                  if l.strip() and not l.strip().startswith("#")
+              }
 
           def parse(text):
               rows = list(csv.reader(io.StringIO(text)))
@@ -458,6 +470,13 @@ jobs:
           has_baseline = baseline_run.returncode == 0
           baseline = parse(baseline_run.stdout)[1] if has_baseline else []
 
+          scoped_note = ""
+          if scope and "file" in header:
+              fi = header.index("file")
+              baseline = [r for r in baseline if len(r) > fi and r[fi] in scope]
+              current = [r for r in current if len(r) > fi and r[fi] in scope]
+              scoped_note = ", scoped to the smoke subset"
+
           current_counts, baseline_counts = Counter(current), Counter(baseline)
           added = list((current_counts - baseline_counts).elements())
           resolved = list((baseline_counts - current_counts).elements())
@@ -467,7 +486,7 @@ jobs:
           if not current:
               lines.append(empty_msg)
           else:
-              lines.append(f"**{len(current)}** row(s) (baseline **{len(baseline)}**).")
+              lines.append(f"**{len(current)}** row(s) (baseline **{len(baseline)}**{scoped_note}).")
 
           if not has_baseline:
               lines.append(f"_No {name} at the pinned test-models commit - every row counts as new._")
@@ -497,14 +516,16 @@ jobs:
           EOF
 
           if FAILED_OUTPUT=$(python /tmp/regression_summary.py \
-              "${{ steps.tmsha.outputs.sha }}" failed.csv "No failures :white_check_mark:" full); then
+              "${{ steps.tmsha.outputs.sha }}" failed.csv "No failures :white_check_mark:" full \
+              "${GITHUB_WORKSPACE}/regression/smoke_models.txt"); then
             :
           else
             FAILED_OUTPUT="Failed to summarize failed.csv (see job log)."
           fi
 
           if ERRORS_OUTPUT=$(python /tmp/regression_summary.py \
-              "${{ steps.tmsha.outputs.sha }}" errors.csv "No errors found." diff); then
+              "${{ steps.tmsha.outputs.sha }}" errors.csv "No errors found." diff \
+              "${GITHUB_WORKSPACE}/regression/smoke_models.txt"); then
             :
           else
             ERRORS_OUTPUT="Failed to summarize errors.csv (see job log)."

--- a/.github/workflows/rc-regression.yml
+++ b/.github/workflows/rc-regression.yml
@@ -1,44 +1,47 @@
-name: Re-bless regression baselines
+name: RC regression (full corpus + baseline bless)
 
-# Regenerate the committed digest baselines in the test-models repos with
-# conway's PINNED toolchain and open a PR in each repo with the result.
+# The once-per-release full regression pass. Pushing an `rc-*` tag runs the
+# digest batch over the ENTIRE public and private corpora with conway's
+# PINNED toolchain, gates on failures, and opens a baseline PR in each
+# test-models repo whose diff IS the release's regression report:
 #
-# WHY THIS EXISTS
-# The digest baselines live in the test-models repos at
-# `regression/test_models/*.csv`. Every PR's `run-ifc-regression` job diffs
-# freshly-regenerated digests against those committed baselines. When the
-# engine changes but the baseline isn't refreshed, the baseline drifts and
-# every PR shows the same phantom "changed" models (the noise the visual-diff
-# threshold in build.yml papers over). This workflow refreshes the baseline
-# so the changed-set once again means "this PR moved geometry".
+#   - failed.csv rows            -> this workflow goes RED, the rc is bad.
+#   - digest/errors churn        -> shows up as the baseline PR diff; review
+#                                   it (with the per-PR visual evidence that
+#                                   motivated the change) and MERGE to bless.
+#   - merging the baseline PRs   -> baselines now track this release exactly,
+#                                   so per-PR smoke diffs mean "this PR moved
+#                                   geometry", not accumulated drift.
+#
+# Per-PR CI (build.yml run-ifc-regression) runs only the smoke subset in
+# regression/smoke_models.txt — this workflow is where the whole corpus gets
+# tested, once per blessed release candidate.
 #
 # WHY IT MIRRORS run-ifc-regression's BUILD
-# The blessed digests MUST be byte-reproducible by a future PR's
-# `run-ifc-regression`, or the baseline drifts again immediately. That job
-# builds conway from source and restores the WASM Dist from a cache keyed on
-# the conway-geom submodule SHA. This workflow restores the SAME cache (same
-# key) and runs the SAME batch CLI, so its digests are identical to what any
-# later run at that submodule SHA produces. Do NOT switch this to install the
-# published npm package instead — that can lag main's conway-geom SHA and
-# reintroduce drift.
+# The blessed digests MUST be byte-reproducible by a later PR's smoke run, or
+# the baseline drifts again immediately. That job builds conway from source
+# and restores the WASM Dist from a cache keyed on the conway-geom submodule
+# SHA. This workflow restores the SAME cache (same key) and runs the SAME
+# batch CLI. Do NOT switch this to install the published npm package instead —
+# it can lag main's conway-geom SHA and reintroduce drift.
 #
-# MANUAL ONLY: re-blessing is a deliberate human action. Cut it when main is
-# stable, review the resulting per-repo PR (the diff IS the churn), and merge.
-#
-# NOTE: the "Run workflow" button only appears once this file is on the
-# default branch (main) — merge the PR that adds it first.
-#
-# PREREQUISITE — secret `REBLESS_TOKEN`
-# A PAT or GitHub App token with `contents: write` + `pull_requests: write` on
-# BOTH bldrs-ai/test-models and bldrs-ai/test-models-private. The default
-# GITHUB_TOKEN is scoped to conway only and cannot push to those repos. Until
-# this secret is set the workflow fails fast on the first step.
+# PREREQUISITE — secret `REBLESS_TOKEN` (stored in conway's repo secrets):
+# a PAT/App token with `contents: write` + `pull_requests: write` on BOTH
+# bldrs-ai/test-models and bldrs-ai/test-models-private. GITHUB_TOKEN is
+# conway-scoped and cannot push to those repos. Also requires LFS bandwidth
+# budget on the test-models org — this workflow materializes the full model
+# set fresh, once per rc.
 
 on:
+  push:
+    tags:
+      - 'rc-*'
+  # On-demand runs (e.g. re-bless after fixing one model, or public-only)
+  # without cutting a new tag.
   workflow_dispatch:
     inputs:
       targets:
-        description: 'Which baselines to re-bless'
+        description: 'Which corpora to run'
         type: choice
         options: [both, public, private]
         default: both
@@ -70,7 +73,8 @@ jobs:
       - name: Pick target repos
         id: pick
         env:
-          TARGETS: ${{ github.event.inputs.targets }}
+          # Empty on rc-* tag pushes (no dispatch inputs) -> both corpora.
+          TARGETS: ${{ github.event.inputs.targets || 'both' }}
         run: |
           PUBLIC='{"name":"public","repo":"bldrs-ai/test-models"}'
           PRIVATE='{"name":"private","repo":"bldrs-ai/test-models-private"}'
@@ -205,6 +209,19 @@ jobs:
             models/regression/test_models \
             --parallel --mem-utilization 90
 
+      # Hard gate: any model that failed to parse/extract makes this rc RED.
+      # Digest/errors churn is NOT gated here — it lands in the baseline PR
+      # diff below, where a human reviews and blesses it.
+      - name: Fail on regression failures
+        run: |
+          FAILED=models/regression/test_models/failed.csv
+          if [ -f "$FAILED" ] && [ "$(wc -l < "$FAILED")" -gt 1 ]; then
+            echo "::error::${{ matrix.target.repo }} has regression failures — this rc is bad:"
+            cat "$FAILED"
+            exit 1
+          fi
+          echo "No failures."
+
       # The batch always writes regression/test_models/changes.csv via a git
       # diff whose pathspec is relative to the model folder, so under this
       # layout it resolves to nothing and the file comes out empty. It's a
@@ -237,17 +254,18 @@ jobs:
           add-paths: regression/test_models
           branch: rebless/${{ github.run_id }}
           base: main
-          commit-message: "Re-bless regression baselines (conway ${{ github.sha }})"
-          title: "Re-bless regression baselines"
+          commit-message: "Bless regression baselines (conway ${{ github.ref_name }} @ ${{ github.sha }})"
+          title: "Bless regression baselines: conway ${{ github.ref_name }}"
           body: |
-            Regenerated digest baselines under `regression/test_models/` using
-            conway's pinned toolchain at
-            [`${{ github.repository }}@${{ github.sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
-            (run [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})).
+            Full-corpus digest regression for conway **`${{ github.ref_name }}`**
+            ([`${{ github.repository }}@${{ github.sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }}),
+            run [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})).
 
-            The diff below is the baseline drift being blessed. Every changed
-            digest reflects the current engine's output for that model; merging
-            makes it the new comparison point for future `run-ifc-regression`
-            runs, so their changed-set again means "this PR moved geometry".
+            **This diff is the release candidate's regression report.** Every
+            changed digest is a model whose geometry differs from the last
+            blessed baseline. No failures were detected (the generating
+            workflow gates on `failed.csv`). Review the churn and merge to
+            bless — from then on, per-PR smoke diffs in conway mean "this PR
+            moved geometry", not accumulated drift.
 
-            Generated by conway's `rebless-regression` workflow.
+            Generated by conway's `rc-regression` workflow.

--- a/regression/README.md
+++ b/regression/README.md
@@ -2,6 +2,14 @@
 
 Conway has a built in regression testing framework that is designed to be run as a batch process for release checking, but also supports spot and verbose output to track down where regressions are.
 
+### CI tiering
+
+CI runs the framework at three escalating scopes, so full-corpus cost is paid once per release instead of per push:
+
+1. **Every PR / merge** — unit tests plus the in-repo `data/` goldens (Tier A in `build.yml`), and the digest batch over the **smoke subset** in `regression/smoke_models.txt`. A smoke model that fails to parse blocks the PR; digest *changes* are informational and reviewed via the visual diff.
+2. **Release candidate (`rc-*` tag)** — `rc-regression.yml` runs the batch over the **entire public and private corpora**, goes red on any failure, and opens a baseline PR in each test-models repo. That PR's diff is the release's regression report; merging it blesses the baselines so they track releases exactly.
+3. **Perf** — the headless-three benchmarks also run per `rc-*` tag (`perf-three-*` in `build.yml`); timings from the parallel smoke batch are contended and only a coarse signal.
+
  ### Individual models
 
 Conway can run produce regression dump output, designed to be diffed against the dumps of previous versions. This is done by the individual regression testing console application, which has a manifest digest mode (which produces a CSV hash manifest of all the curve, profile and mesh components of an IFC file) and a verbose mode (produces OBJ files for all the same components in a directory).

--- a/regression/smoke_models.txt
+++ b/regression/smoke_models.txt
@@ -1,0 +1,26 @@
+# PR-time regression smoke subset.
+#
+# One model filename per line (basename with extension, matched against the
+# test-models tree; lines starting with '#' are ignored). Every PR's
+# run-ifc-regression job runs the digest batch over ONLY these models — the
+# full public+private corpus runs once per release candidate (rc-* tag) in
+# rc-regression.yml, whose baseline-PR diff is the release's regression
+# report.
+#
+# Curation intent: small/fast models, a spread of schemas and exporters,
+# both IFC and STEP, plus one chronically error-producing model (supercap)
+# so error-churn regressions surface at PR time too. Each entry must have a
+# committed baseline CSV in test-models regression/test_models/. Slow models
+# (SKYLARK, Snowdon, Arty_Z7, Jetenginestep, DSA2, nist_ftc_08...) are
+# deliberately excluded — they belong to the RC pass.
+index.ifc
+duplex.ifc
+AC20-FZK-Haus.ifc
+ISSUE_005_haus.ifc
+ISSUE_021_Mini Project.ifc
+MB-Khaya.ifc
+nist_ctc_01_asme1_rd.stp
+nist_ctc_02_asme1_rc.stp
+create-a-tube.step
+supercap.step
+driver board.step


### PR DESCRIPTION
## Summary

Implements the tiered testing model: **full public+private corpus once per blessed release candidate; a small always-on smoke gate on every PR; baseline blessing folded into the release itself.** Goal: faster/cheaper iterations, with breaks on non-smoke models surfacing at RC time (an accepted trade).

## The tiers

| When | Runs | Gates? |
|---|---|---|
| Every PR / merge | unit tests + Tier-A `data/` goldens + digest batch over the **smoke subset** (`regression/smoke_models.txt`) | **yes** — smoke `failed.csv` rows block; digest *changes* stay informational (reviewed via visual diff) |
| `rc-*` tag | `rc-regression.yml`: digest batch over the **entire public and private corpora** + baseline PR per repo; plus the existing `perf-three-*` H3 benchmarks | **yes** — any `failed.csv` row turns the rc red; digest churn lands in the baseline PR diff for human bless |

## Changes

**`build.yml` (`run-ifc-regression`)**
- Batch now runs over `regression/smoke_models.txt` only — 11 small models (schema/exporter spread, IFC+STEP, plus `supercap.step` as an error-churn canary; slow models deliberately excluded). The batch CLI only has an *exclude* regex, so a step builds a negative-lookahead regex from the list; it's extension-anchored so it can only match model **files** — the batch applies the same regex to directories during its walk, and a broader pattern would halt recursion.
- New hard gate: rows in `failed.csv` fail the job.
- Tarball/perf/visual-diff plumbing unchanged; PR comment labeled as smoke scope. Smoke perf timings are flagged as contended (`--parallel`) — the clean per-model perf record is the rc-gated `perf-three-*` jobs.

**`rebless-regression.yml` → `rc-regression.yml`**
- Also triggers on `rc-*` tag pushes now (dispatch retained; `targets` defaults to `both` on tag pushes).
- Hard gate per corpus: `failed.csv` rows make the rc red.
- The baseline PR is reframed as **the release's regression report** — title/body carry the rc tag; merging it *is* the bless. Baselines then track releases exactly, so per-PR smoke diffs mean "this PR moved geometry", not accumulated drift.

**`regression/README.md`** documents the tiering; **`regression/smoke_models.txt`** is the curated list (edit it to tune the PR gate).

## Verification

- Both workflows YAML-validated.
- The smoke exclude regex was verified by **simulating the batch's directory walk over the real test-models tree**: all 11 smoke models kept (12 files — `index.ifc` exists at two paths, a pre-existing corpus quirk), 89 other model files excluded, directory recursion unaffected.
- The rc path still requires the LFS bandwidth bump before its first successful run (unchanged prerequisite from #442), and `REBLESS_TOKEN` in conway's secrets (already set).

## Expected effect

Per-PR large-runner time drops from ~13 min (full batch + visual diff over a drifted changed-set) to roughly the build + a ~1-minute smoke batch; the full corpus cost is paid once per `rc-*` tag. First real exercise: the next rc you cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyCxwn1wc35pkBiM9VC64V

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyCxwn1wc35pkBiM9VC64V)_