### PR TITLE
STEP small-model fidelity: same_sense, trims, colours, scale-relative tessellation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -574,9 +574,14 @@ jobs:
 
       # The batch run above left regenerated digest CSVs in the test-models
       # working tree; any tracked CSV that differs from the pinned commit is a
-      # model whose geometry changed under this PR's engine. Model paths are
-      # recorded relative to the test-models root so the visual-diff job (a
-      # different workspace) can re-anchor them.
+      # model whose geometry changed under this PR's engine, and any UNTRACKED
+      # digest CSV is a model newly added to the smoke subset (no committed
+      # baseline yet — `git diff` can't see it, which is how new smoke models
+      # used to miss their visual diff entirely). New models are marked with a
+      # tab-separated `new` field; the report always shows their rows, since a
+      # first-time model must be eyeballed before its digest gets blessed.
+      # Model paths are recorded relative to the test-models root so the
+      # visual-diff job (a different workspace) can re-anchor them.
       - name: Collect digest-changed models for visual diff
         id: vdiff
         run: |
@@ -586,14 +591,24 @@ jobs:
           out = subprocess.run(
               ['git', 'diff', '--name-only', sha, '--', 'regression/test_models'],
               cwd=root, capture_output=True, text=True, check=True).stdout
+          untracked = subprocess.run(
+              ['git', 'ls-files', '--others', '--exclude-standard', '--',
+               'regression/test_models'],
+              cwd=root, capture_output=True, text=True, check=True).stdout
           # Per-run report files churn on every run (env-specific paths,
           # counters) — only per-model digest CSVs identify changed geometry.
           meta = {'errors.csv', 'failed.csv', 'main.csv', 'changes.csv'}
-          stems = set()
-          for line in out.splitlines():
-              base = os.path.basename(line)
-              if base.endswith('.csv') and base not in meta:
-                  stems.add(base[:-4])
+
+          def digest_stems(listing):
+              stems = set()
+              for line in listing.splitlines():
+                  base = os.path.basename(line)
+                  if base.endswith('.csv') and base not in meta:
+                      stems.add(base[:-4])
+              return stems
+
+          new_stems = digest_stems(untracked)
+          stems = digest_stems(out) | new_stems
           models, found = [], set()
           for top in ('ifc', 'step'):
               for dirpath, _, files in os.walk(os.path.join(root, top)):
@@ -602,11 +617,12 @@ jobs:
                       if (stem in stems and stem not in found and
                               ext.lower() in ('.ifc', '.step', '.stp')):
                           found.add(stem)
+                          rel = os.path.relpath(os.path.join(dirpath, f), root)
                           models.append(
-                              os.path.relpath(os.path.join(dirpath, f), root))
+                              f'{rel}\tnew' if stem in new_stems else rel)
           with open('changed_models.txt', 'w') as fh:
               fh.write('\n'.join(sorted(models)) + ('\n' if models else ''))
-          print(f'{len(models)} digest-changed model(s)')
+          print(f'{len(models)} digest-changed/new model(s)')
           for m in models:
               print(f'  {m}')
           with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
@@ -818,7 +834,7 @@ jobs:
           RAW="https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.assets.outputs.sha }}/${{ steps.assets.outputs.dest }}"
           sed "s|RAW_URL_BASE|$RAW|g" vdout/report.md > report_final.md
           {
-            echo "## Visual Diff (digest-changed models)"
+            echo "## Visual Diff (digest-changed & new models)"
             echo ""
             echo "Base: published \`@bldrs-ai/conway\` (main). Candidate: this PR's build."
             echo "Each row shares one camera framed on the union of both bounds — scale differences are real."

--- a/regression/smoke_models.txt
+++ b/regression/smoke_models.txt
@@ -24,3 +24,9 @@ nist_ctc_02_asme1_rc.stp
 create-a-tube.step
 supercap.step
 driver board.step
+# Metre-unit Onshape AP242 assembly (rational B-splines, same_sense=.F.
+# edges, pre-defined colours) — the exporter family the
+# step-small-model-fidelity fixes target; ~2s end-to-end. No committed
+# baseline yet: first smoke run's digest lands as new and gets blessed
+# with the next baseline PR.
+Right_Hand.step

--- a/scripts/visual_diff_report.cjs
+++ b/scripts/visual_diff_report.cjs
@@ -14,7 +14,10 @@
  *   visual_diff_report.cjs --models <changed_models.txt> \
  *     --base <package root> --cand <package root> --out <dir> [--max N]
  *
- * <changed_models.txt>: one absolute model path per line.
+ * <changed_models.txt>: one absolute model path per line, optionally
+ * followed by a tab and `new` for models whose digest has no committed
+ * baseline yet (first appearance in the smoke subset) — their rows are
+ * always shown, never threshold-suppressed.
  * <package root>: a directory containing compiled/src/... (an unpacked npm
  * package or a built working tree).
  *
@@ -142,8 +145,17 @@ function slugify(name) {
 
 function main() {
   const opts = parseArgs()
+  // Each line is `<model path>` or `<model path>\tnew` — the workflow marks
+  // models whose digest CSV is untracked (first appearance in the smoke
+  // subset, no committed baseline). New models bypass the below-threshold
+  // suppression: a first-time model must be eyeballed before its digest is
+  // blessed, even when both engines render it identically.
   const models = fs.readFileSync(opts.models, 'utf8')
       .split('\n').map((l) => l.trim()).filter(Boolean)
+      .map((line) => {
+        const [file, marker] = line.split('\t')
+        return { file, isNew: marker === 'new' }
+      })
   fs.mkdirSync(opts.out, { recursive: true })
 
   const renderScript = path.join(__dirname, 'render_glb.cjs')
@@ -154,8 +166,9 @@ function main() {
   const skipped = models.length > opts.max ? models.slice(opts.max) : []
   const selected = models.slice(0, opts.max)
 
-  for (const model of selected) {
+  for (const { file: model, isNew } of selected) {
     const name = path.basename(model)
+    const nameCell = isNew ? `\`${name}\` _(new)_` : `\`${name}\``
     const slug = slugify(name)
     const work = fs.mkdtempSync(path.join(os.tmpdir(), `vdiff-${slug}-`))
     process.stderr.write(`visual-diff: ${name}\n`)
@@ -166,7 +179,7 @@ function main() {
     if (base.glbs.length === 0 && cand.glbs.length === 0) {
       const why = (base.diagnostic || cand.diagnostic || '')
           .replace(/\|/g, '\\|').slice(0, 200)
-      rows.push(`| \`${name}\` | _no geometry from both engines_` +
+      rows.push(`| ${nameCell} | _no geometry from both engines_` +
           `${why ? ` — \`${why}\`` : ''} | | — |`)
       fs.rmSync(work, { recursive: true, force: true })
       continue
@@ -206,7 +219,8 @@ function main() {
         // a digest-flagged model can render identically here (the change
         // already shipped). A missing/garbled metric (older render, crash)
         // falls back to SHOWING the row — never hide a real diff on a glitch.
-        if (metric && metric.changedFraction < opts.diffThreshold) {
+        // New smoke models are never suppressed (see the models parse above).
+        if (!isNew && metric && metric.changedFraction < opts.diffThreshold) {
           fs.rmSync(path.join(opts.out, `${slug}-before.png`), { force: true })
           fs.rmSync(path.join(opts.out, `${slug}-after.png`), { force: true })
           unchanged.push(name)
@@ -214,7 +228,7 @@ function main() {
           const badge = metric ?
             `${(metric.changedFraction * 100).toFixed(2)}% (Δmax ${metric.maxDelta})` : 'n/a'
           rows.push(
-              `| \`${name}\` ` +
+              `| ${nameCell} ` +
               `| ![before](RAW_URL_BASE/${slug}-before.png) ` +
               `| ![after](RAW_URL_BASE/${slug}-after.png) ` +
               `| ${badge} |`)
@@ -235,7 +249,7 @@ function main() {
     // are no longer shared, so the images aren't pixel-comparable and the
     // threshold doesn't apply — always shown.
     rows.push(
-        `| \`${name}\` ` +
+        `| ${nameCell} ` +
         `| ${renderSingle(base, 'base', 'before')} ` +
         `| ${renderSingle(cand, 'candidate', 'after')} | n/a |`)
     fs.rmSync(work, { recursive: true, force: true })
@@ -252,7 +266,7 @@ function main() {
   }
   if (skipped.length > 0) {
     report += `\n_${skipped.length} more changed model(s) not rendered ` +
-        `(cap ${opts.max}): ${skipped.map((m) => path.basename(m)).join(', ')}_\n`
+        `(cap ${opts.max}): ${skipped.map((m) => path.basename(m.file)).join(', ')}_\n`
   }
   fs.writeFileSync(path.join(opts.out, 'report.md'), report)
   process.stderr.write(

--- a/src/AP214E3_2010/ap214_geometry_extraction.test.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.test.ts
@@ -158,7 +158,12 @@ describe('AP214 Geometry Extraction', () => {
   })
 
   test('gearGeometryArrayLength()', () => {
-    const testParameter:number = 48108
+    // Raised from 48108 with the extent-relative deflection thresholds
+    // (conway-geom relativeCurveDeflectionSquared): the gear's involute
+    // flank splines are a few mm across, so the old absolute 1mm chord
+    // tolerance sampled them with ~3 chords per flank; 0.1%-of-extent
+    // tolerance resolves the involute curvature the profile actually has.
+    const testParameter:number = 154644
     expect(getGearMeshSize()).toBe(testParameter)
 
   })

--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -3087,17 +3087,40 @@ export class AP214GeometryExtraction {
               }
             }
 
+            // EDGE_CURVE.same_sense: does the edge's start→end direction agree
+            // with the basis curve's parametrisation? For same_sense=false the
+            // edge sweeps from edge_start to edge_end AGAINST the curve
+            // parameter. The native circle/ellipse trim (getAP214Circle) always
+            // sweeps the positive parametric arc from trim1 to trim2 (its
+            // senseAgreement=false path mis-negates the sweep), so ignoring
+            // same_sense selects the COMPLEMENT arc — e.g. Onshape AP242
+            // exports write near-straight edges as shallow arcs of large
+            // circles, and the complement is a ~340° loop that explodes the
+            // face boundary (Right_Hand.step spikes; the CDT "Intersecting
+            // constraint edges" cascade). Normalise instead of forwarding the
+            // flag: swap the trim ends so the positive sweep is the correct
+            // arc, leaving the extracted (memoised) curve running edge_end →
+            // edge_start; the orientation check below compensates.
+            const sameSense = edgeElement.same_sense
+
             const trimmingArguments: TrimmingArguments = {
               exist: !!((trimmingStart !== void 0 && trimmingEnd !== void 0)),
-              start: trimmingStart,
-              end: trimmingEnd,
+              start: sameSense ? trimmingStart : trimmingEnd,
+              end: sameSense ? trimmingEnd : trimmingStart,
             }
 
             const curve = this.extractCurve( edgeCurve, true, true, trimmingArguments )
 
             if (curve !== void 0) {
 
-              if ( !edge.orientation ) {
+              // The memoised curve runs edge_start→edge_end when same_sense
+              // held, edge_end→edge_start when the trims were swapped above
+              // (and, for untrimmed basis curves like full B-splines, native
+              // point order is parametric order — reversed relative to the
+              // edge exactly when same_sense is false). Traversal for this
+              // ORIENTED_EDGE must run with `orientation`, so invert on the
+              // XOR of the two flags rather than orientation alone.
+              if ( edge.orientation !== sameSense ) {
                 // reverse curve
                 // Logger.info("edge orientation == true, inverting curve")
                 const invertedCurve = curve.clone()

--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -73,6 +73,7 @@ import {
   cartesian_transformation_operator_2d,
   cartesian_transformation_operator_3d,
   circle,
+  colour,
   colour_rgb,
   composite_curve,
   composite_curve_segment,
@@ -112,6 +113,7 @@ import {
   placement, plane,
   poly_loop,
   polyline,
+  pre_defined_colour,
   presentation_layer_assignment,
   product,
   product_definition,
@@ -168,6 +170,20 @@ type Mutable<T> = { -readonly [P in keyof T]: T[P] }
  */
 export function extractColorRGBPremultiplied(from: colour_rgb, alpha: number = 1): ColorRGBA {
   return [from.red * alpha, from.green * alpha, from.blue * alpha, alpha]
+}
+
+// RGB values for the ISO 10303-46 pre-defined draughting colour names
+// (draughting_pre_defined_colour / pre_defined_colour), which carry a name
+// instead of components.
+const PRE_DEFINED_COLOUR_RGB: Record<string, [number, number, number]> = {
+  'red': [1, 0, 0],
+  'green': [0, 1, 0],
+  'blue': [0, 0, 1],
+  'yellow': [1, 1, 0],
+  'magenta': [1, 0, 1],
+  'cyan': [0, 1, 1],
+  'black': [0, 0, 0],
+  'white': [1, 1, 1],
 }
 
 /**
@@ -1216,23 +1232,48 @@ export class AP214GeometryExtraction {
             if ( fillAreaColor !== void 0 ) {
 
               try {
-                const fillColor = fillAreaColor.fill_colour
+                // `fill_colour` is the schema's colour select, but AP214
+                // gives pre_defined_colour TWO supertypes (colour AND
+                // pre_defined_item) and the single-inheritance generator
+                // kept only pre_defined_item — so the typed getter throws
+                // "incorrectly typed" for e.g.
+                // DRAUGHTING_PRE_DEFINED_COLOUR('white') (Onshape exports).
+                // Re-extract the same field (offset 1) under the type the
+                // generator did keep, and map the name to RGB.
+                let surfaceColor: ColorRGBA | undefined
 
-                if ( !(fillColor instanceof colour_rgb ) ) {
+                let fillColor: colour | undefined
+
+                try {
+                  fillColor = fillAreaColor.fill_colour
+                } catch {
+                  const preDefined = fillAreaColor.extractElement(
+                      1, 0, 0, true, pre_defined_colour )
+                  const rgb =
+                    PRE_DEFINED_COLOUR_RGB[ preDefined?.name?.toLowerCase() ?? '' ]
+
+                  if ( rgb !== void 0 ) {
+                    surfaceColor = [rgb[ 0 ], rgb[ 1 ], rgb[ 2 ], 1]
+                  }
+                }
+
+                if ( fillColor instanceof colour_rgb ) {
+                  surfaceColor = extractColorRGBPremultiplied(fillColor, 1)
+                }
+
+                if ( surfaceColor === void 0 ) {
 
                   continue
                 }
 
-                const surfaceColor = extractColorRGBPremultiplied(fillColor, 1)
-
                 newMaterial.baseColor   = surfaceColor
                 newMaterial.legacyColor = surfaceColor
-                newMaterial.roughness   = 1            
+                newMaterial.roughness   = 1
               }
               catch ( error ) {
                 Logger.warning(
-                    `Error extracting fill area style color for expressID: 
-                  #${from.expressID} - type: 
+                    `Error extracting fill area style color for expressID:
+                  #${from.expressID} - type:
                   ${EntityTypesAP214[style.type]} - error: ${error}`)
               }
             }
@@ -1506,11 +1547,22 @@ export class AP214GeometryExtraction {
 
     let stepCurve: CurveObject | undefined
 
-    stepCurve = this.curves.get( from.localID )
+    // Edge-supplied trims are specific to one EDGE_CURVE, but `from` is the
+    // shared basis curve — memoising a trimmed extraction under the basis
+    // curve's localID would hand the first edge's arc to every other edge
+    // sharing that curve. Trimmed extractions are memoised by the caller
+    // under the EDGE_CURVE's localID instead (see extractAdvancedFace);
+    // untrimmed extractions stay memoised here.
+    const hasEdgeTrims = trimmingArguments?.exist === true
 
-    if ( stepCurve !== void 0 ) {
-      
-      return stepCurve
+    if ( !hasEdgeTrims ) {
+
+      stepCurve = this.curves.get( from.localID )
+
+      if ( stepCurve !== void 0 ) {
+
+        return stepCurve
+      }
     }
 
       // console.log("[extractCurve]: curve express ID: "
@@ -1639,12 +1691,15 @@ export class AP214GeometryExtraction {
     } 
     
     if ( stepCurve === void 0 ) {
- 
+
       Logger.warning(`Unsupported Curve! Type: ${EntityTypesAP214[from.type]}`)
       return
     }
 
-    this.curves.add( from.localID, stepCurve )
+    if ( !hasEdgeTrims ) {
+
+      this.curves.add( from.localID, stepCurve )
+    }
 
     return stepCurve
   }
@@ -2977,6 +3032,12 @@ export class AP214GeometryExtraction {
 
    const bound3DVector = this.nativeBound3DVector()
 
+   // Loop curves are collected before bound creation so the outer-bound
+   // heuristic below can compare their extents across the whole face.
+   const loopCurves: CurveObject[] = []
+   const loopIsOuter: boolean[] = []
+   const loopOrientations: boolean[] = []
+
    for ( const bound of bounds ) {
 
       let vec3Array: StdVector< Vector3 >
@@ -3109,7 +3170,24 @@ export class AP214GeometryExtraction {
               end: sameSense ? trimmingEnd : trimmingStart,
             }
 
-            const curve = this.extractCurve( edgeCurve, true, true, trimmingArguments )
+            // Trimmed extractions are memoised under THIS edge's localID —
+            // not the basis curve's — so edges sharing one basis curve with
+            // different trims each get their own arc, while the second
+            // ORIENTED_EDGE user of this edge (the adjacent face) still
+            // reuses the extraction. extractCurve skips its basis-curve
+            // memo whenever edge trims exist (see hasEdgeTrims there); the
+            // shared this.curves container keeps ownership either way.
+            let curve = this.curves.get( edgeElement.localID )
+
+            if ( curve === void 0 ) {
+
+              curve = this.extractCurve( edgeCurve, true, true, trimmingArguments )
+
+              if ( curve !== void 0 && trimmingArguments.exist ) {
+
+                this.curves.add( edgeElement.localID, curve )
+              }
+            }
 
             if (curve !== void 0) {
 
@@ -3195,9 +3273,13 @@ export class AP214GeometryExtraction {
         }
       } else {
           Logger.warning(`Unsupported bound ${bound.bound}`)
-          // Free this iteration's edge-curve vector and the face's partial
-          // bound vector before bailing out, or they leak per bad face.
+          // Free this iteration's edge-curve vector, previously collected
+          // loop curves and the face's partial bound vector before bailing
+          // out, or they leak per bad face.
           nativeEdgeCurves.delete()
+          for ( const loopCurve of loopCurves ) {
+            loopCurve.delete()
+          }
           bound3DVector.delete()
           return
       }
@@ -3206,15 +3288,73 @@ export class AP214GeometryExtraction {
         points: vec3Array,
         edges: nativeEdgeCurves,
       }
-     
+
       // Logger.info("isEdgeLoop: " + (isEdgeLoop) ? "TRUE" : "FALSE")
       const curve: CurveObject = this.conwayModel.getLoop(parameters)
 
-      // create bound vector
+      loopCurves.push( curve )
+      loopIsOuter.push( bound.type === EntityTypesAP214.FACE_OUTER_BOUND )
+      loopOrientations.push( bound.orientation )
+
+      vec3Array.delete()
+      nativeEdgeCurves.delete()
+    }
+
+    // STEP allows a face's loops to all be plain FACE_BOUNDs; without a
+    // FACE_OUTER_BOUND the native triangulators would warn ("Expected outer
+    // bound, using fallback tesselation") and treat loops[0] as outer, which
+    // is only right by luck (Onshape AP242 exports order hole loops first on
+    // some faces). A face's outer loop strictly contains its holes, so tag
+    // the loop with the largest bounding-box diagonal as the outer one.
+    if ( loopCurves.length > 1 && !loopIsOuter.includes( true ) ) {
+
+      let largestIndex = 0
+      let largestDiagonal2 = -1
+
+      for ( let loopIndex = 0; loopIndex < loopCurves.length; ++loopIndex ) {
+
+        const loopCurve = loopCurves[ loopIndex ]
+        const pointCount = loopCurve.getPointsSize()
+
+        let minX = Infinity
+        let minY = Infinity
+        let minZ = Infinity
+        let maxX = -Infinity
+        let maxY = -Infinity
+        let maxZ = -Infinity
+
+        for ( let where = 0; where < pointCount; ++where ) {
+
+          const point = loopCurve.get3d( where )
+
+          minX = Math.min( minX, point.x )
+          minY = Math.min( minY, point.y )
+          minZ = Math.min( minZ, point.z )
+          maxX = Math.max( maxX, point.x )
+          maxY = Math.max( maxY, point.y )
+          maxZ = Math.max( maxZ, point.z )
+        }
+
+        const diagonal2 =
+          ( ( maxX - minX ) * ( maxX - minX ) ) +
+          ( ( maxY - minY ) * ( maxY - minY ) ) +
+          ( ( maxZ - minZ ) * ( maxZ - minZ ) )
+
+        if ( pointCount > 0 && diagonal2 > largestDiagonal2 ) {
+          largestDiagonal2 = diagonal2
+          largestIndex = loopIndex
+        }
+      }
+
+      loopIsOuter[ largestIndex ] = true
+    }
+
+    for ( let loopIndex = 0; loopIndex < loopCurves.length; ++loopIndex ) {
+
       const parametersCreateBounds3D: ParamsCreateBound3D = {
-        curve: curve,
-        orientation: bound.orientation,
-        type: (bound.type === EntityTypesAP214.FACE_OUTER_BOUND) ? 0 : 1,
+        curve: loopCurves[ loopIndex ],
+        orientation: loopOrientations[ loopIndex ],
+        type: loopIsOuter[ loopIndex ] ? 0 : 1,
       }
 
       const bound3D: Bound3DObject = this.conwayModel.createBound3D(parametersCreateBounds3D)
@@ -3225,9 +3365,7 @@ export class AP214GeometryExtraction {
       // bound wrapper are temporaries that must be freed to avoid leaking
       // native memory on every face bound.
       bound3D.delete()
-      curve.delete()
-      vec3Array.delete()
-      nativeEdgeCurves.delete()
+      loopCurves[ loopIndex ].delete()
     }
 
     const surface = from.face_geometry

--- a/src/step/parsing/decode_utf8.ts
+++ b/src/step/parsing/decode_utf8.ts
@@ -60,6 +60,38 @@ export function decodeUtf8(view: Uint8Array): string {
   return decoder.decode(decodeNeedsCopy(view.buffer) ? view.slice() : view)
 }
 
+const strictUtf8Decoder = new TextDecoder('utf-8', {fatal: true})
+
+/**
+ * Decode the raw byte run of a STEP string literal.
+ *
+ * ISO 10303-21 says raw (non-\X\-escaped) bytes are ISO 8859-1, but modern
+ * exporters routinely write UTF-8 (and some, like Onshape's ST-Developer,
+ * write outright invalid sequences). The lenient default decoder mapped every
+ * non-UTF-8 byte to U+FFFD, so a spec-conformant latin-1 'Küche' surfaced as
+ * 'K�che' in product names and titles. Decode as strict UTF-8 first (the
+ * common modern case, and unambiguous when it validates), and fall back to
+ * exact ISO 8859-1 (byte = code point, which cannot fail) when it doesn't.
+ *
+ * @param view The bytes of the string literal's raw run.
+ * @return The decoded string.
+ */
+export function decodeStepString(view: Uint8Array): string {
+  const bytes = decodeNeedsCopy(view.buffer) ? view.slice() : view
+
+  try {
+    return strictUtf8Decoder.decode(bytes)
+  } catch {
+    let result = ''
+
+    for (let where = 0; where < bytes.length; ++where) {
+      result += String.fromCharCode(bytes[where])
+    }
+
+    return result
+  }
+}
+
 let shimInstalled = false
 
 /**

--- a/src/step/parsing/step_string_parser.ts
+++ b/src/step/parsing/step_string_parser.ts
@@ -1,6 +1,6 @@
 import ParsingConstants from '../../parsing/parsing_constants'
 import ParsingDfa16Table from '../../parsing/parsing_dfa_16table'
-import { decodeUtf8, installResizableTextDecoderShim } from './decode_utf8'
+import { decodeStepString, installResizableTextDecoderShim } from './decode_utf8'
 
 // Emscripten 6's browser wasm heap is a resizable ArrayBuffer, on which strict
 // browsers' TextDecoder.decode() throws — including the glue's own UTF8ToString
@@ -123,7 +123,7 @@ export default class StepStringParser extends ParsingDfa16Table {
               result ??= ''
 
               if (cursor > reificationIndex) {
-                result += decodeUtf8(input.subarray(reificationIndex, cursor - 1))
+                result += decodeStepString(input.subarray(reificationIndex, cursor - 1))
               }
 
               result += '\''
@@ -133,7 +133,7 @@ export default class StepStringParser extends ParsingDfa16Table {
             } else {
               result ??= ''
 
-              result += decodeUtf8(input.subarray(reificationIndex, cursor))
+              result += decodeStepString(input.subarray(reificationIndex, cursor))
 
               return result
             }
@@ -171,7 +171,7 @@ export default class StepStringParser extends ParsingDfa16Table {
 
               if (nextChar2 !== BSLASH) {
                 result ??= ''
-                result += decodeUtf8(input.subarray(reificationIndex, cursor))
+                result += decodeStepString(input.subarray(reificationIndex, cursor))
                 cursor = nextCursor2 + 1
                 break
               }
@@ -189,7 +189,7 @@ export default class StepStringParser extends ParsingDfa16Table {
               }
 
               result ??= ''
-              result += decodeUtf8(input.subarray(reificationIndex, cursor))
+              result += decodeStepString(input.subarray(reificationIndex, cursor))
 
               codePage = nextChar3 - A
 
@@ -208,7 +208,7 @@ export default class StepStringParser extends ParsingDfa16Table {
 
               if (nextChar2 !== BSLASH) {
                 result ??= ''
-                result += decodeUtf8(input.subarray(reificationIndex, cursor))
+                result += decodeStepString(input.subarray(reificationIndex, cursor))
                 cursor = nextCursor2 + 1
                 break
               }
@@ -222,7 +222,7 @@ export default class StepStringParser extends ParsingDfa16Table {
               const nextChar3 = input[nextCursor3]
 
               result ??= ''
-              result += decodeUtf8(input.subarray(reificationIndex, cursor))
+              result += decodeStepString(input.subarray(reificationIndex, cursor))
 
               /* eslint-disable no-magic-numbers */
               if (nextChar3 < 0x7F) {
@@ -248,7 +248,7 @@ export default class StepStringParser extends ParsingDfa16Table {
               const nextChar2 = input[nextCursor2]
 
               result ??= ''
-              result += decodeUtf8(input.subarray(reificationIndex, cursor))
+              result += decodeStepString(input.subarray(reificationIndex, cursor))
 
               const hexParserTil0 = (count: number) => {
 


### PR DESCRIPTION
## Summary

Fixes the mangled rendering of metre-unit Onshape AP242 exports (the AmazingHand `Right_Hand.step` mirrored into test-models at `step/pollen-robotics/AmazingHand/`), which surfaced a family of unit-scale and STEP-semantics bugs. Before: exploded spike/ribbon geometry, 12 CDT exceptions, dropped faces, white materials, mojibake names. After: clean extraction with zero warnings, correct hand, and NIST AS1 regains its canonical part colours.

Pairs with conway-geom branch [`fix/step-small-model-fidelity`](https://github.com/bldrs-ai/conway-geom/tree/fix/step-small-model-fidelity) (4 commits, based on the previously pinned `28d316a`, no drift against conway-geom main in the touched files); the submodule pointer here adopts its head. **Dist wasm must be rebuilt from the submodule** — the prebuilt npm bundle predates these changes.

## Conway (TS) changes

- **Honor `EDGE_CURVE.same_sense`** in advanced-face edge extraction: `.F.` edges (561 of 2,541 in Right_Hand.step) selected the complement arc of their trimmed circles/ellipses — Onshape writes near-straight edges as shallow arcs of large circles, so complements were ~340° loops half a metre out of a 0.17 m model. Normalised by swapping trim ends and inverting on the XOR of `ORIENTED_EDGE.orientation` with `same_sense`.
- **Per-edge trim memoisation**: trimmed extractions memoise under the EDGE_CURVE's localID, not the shared basis curve's.
- **Pre-defined colour fallback**: AP214 gives `pre_defined_colour` two supertypes but the generator kept only `pre_defined_item`, so the typed `colour` getter threw and e.g. `DRAUGHTING_PRE_DEFINED_COLOUR('white')` fell back to the default material (AS1's green/red/blue parts rendered white). Re-extract under the kept type and map ISO 10303-46 colour names.
- **Outer-bound heuristic**: faces with only plain `FACE_BOUND`s (legal STEP) pick the largest-extent loop as outer instead of trusting loop order (also fixes the "No basis found for brep!" when a hole loop came first).
- **UTF-8 STEP strings with ISO 8859-1 fallback**: raw byte runs decoded strictly as UTF-8, falling back to exact latin-1 per ISO 10303-21 instead of mapping every non-UTF-8 byte to U+FFFD.
- **Smoke subset**: adds `Right_Hand.step` (~2s end-to-end) to `regression/smoke_models.txt` as the metre-unit Onshape AP242 representative. No committed baseline yet — the first smoke run's digest lands as new in this PR's diff and gets blessed with the next baseline PR.

## conway-geom changes (via submodule bump)

- `getAP214Circle`: `senseAgreement=false` mis-negated the sweep back to positive (walked the complement, then chord-stitched to trim2); arc sample counts now scale with arc length with a quantiser-relative chord floor, eliminating the micro-arc CDT "Intersecting constraint edges" cascade at its source.
- Face-tessellation CDT sites use `IntersectingConstraintEdges::TryResolve` — sliver-boundary faces triangulate instead of dropping to holes (CSG sites keep `NotAllowed`), with guards skipping triangles that touch resolve-inserted split vertices (those index past the consumers' input vertex arrays; unguarded this produced a metre-long ribbon).
- Refinement deflection thresholds are extent-relative (0.1% of feature size) for both surfaces and B-spline curves, replacing absolute constants that assumed millimetre numeric scale — metre-unit models refined to ~1mm true deviation (faceted fingertips) while mm-unit models over-refined.

## Expected regression-diff shifts

- Triangle counts move by design: small-feature models refine more (gear golden re-blessed 48,108 → 154,644 — involute flanks previously got ~3 chords each), huge-numeric-scale models refine less (AS1 output ~halves).
- AS1-family models gain their pre-defined colours.
- Previously-dropped sliver faces now emit geometry.

## Verification

- Full jest suite 360/360 across 72 suites (native NodeMT wasm rebuilt locally from the submodule via emsdk 6.0.2, matching CI's toolchain).
- Right_Hand.step: 0 runaway faces, 0 CDT exceptions/warnings, correct 0.28 m envelope, renders verified from multiple angles.
- zoo.dev a-gear and NIST as1-oc-214 extract and render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhouF3Ly73rKNcpaBzztFo

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhouF3Ly73rKNcpaBzztFo)_