### PR TITLE
Polygonal-faceset extraction: parse face indices into reusable typed sinks (PSB pump −39%)

### DIFF
--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -51,6 +51,7 @@ import {
   NativeTransform3x3,
   FlattenedPointsResult,
 } from '../../dependencies/conway-geom'
+import { Uint32Sink } from '../step/parsing/uint32_sink'
 import { CanonicalMaterial, ColorRGBA, exponentToRoughness } from '../core/canonical_material'
 import { CanonicalMesh, CanonicalMeshType } from '../core/canonical_mesh'
 import { CanonicalProfile } from '../core/canonical_profile'
@@ -328,7 +329,21 @@ export function extractColorOrFactorMultiply(
  * Handles Geometry data extraction from a populated IfcStepModel
  * Can export to OBJ, GLTF (Draco), GLB (Draco)
  */
+/**
+ * Starting capacities for the reused polygonal-faceset sinks: enough that a
+ * typical faceset never reallocates, while still growing for outliers.
+ */
+const POLYGONAL_INDEX_SINK_CAPACITY = 65536
+const POLYGONAL_FACE_SINK_CAPACITY = 16384
+
+
 export class IfcGeometryExtraction {
+  /* Reused across polygonal-faceset extractions; see extractPolygonalFaceSet. */
+  private readonly polygonalIndexSink_ = new Uint32Sink( POLYGONAL_INDEX_SINK_CAPACITY )
+  private readonly polygonalStartIndexSink_ = new Uint32Sink( POLYGONAL_FACE_SINK_CAPACITY )
+  private readonly polygonalFaceOffsetSink_ = new Uint32Sink( POLYGONAL_FACE_SINK_CAPACITY )
+  private readonly polygonalStartOffsetSink_ = new Uint32Sink( POLYGONAL_FACE_SINK_CAPACITY )
+
 
    
   private readonly TWO_DIMENSIONS: number = 2
@@ -927,11 +942,23 @@ export class IfcGeometryExtraction {
       isRelVoid: boolean = false): ExtractResult {
     const result: ExtractResult = ExtractResult.COMPLETE
 
-    // Temporary storage for indices and start indices
-    const allIndices: number[] = []
-    const allStartIndices: number[] = []
-    const polygonalFaceBufferOffsets:number[] = []
-    const startIndicesBufferOffsets:number[] = []
+    // Reusable typed sinks. A tessellated model can carry millions of
+    // IfcIndexedPolygonalFace records, and the boxed `Array< number >`
+    // this loop used to build per face — which the generated CoordIndex
+    // getter also cached on the face, keeping it alive — dominated both
+    // GC time and retained heap during extraction. Indices are parsed
+    // straight from the STEP buffer into these instead, reused across
+    // facesets.
+    const allIndices = this.polygonalIndexSink_
+    const allStartIndices = this.polygonalStartIndexSink_
+    const polygonalFaceBufferOffsets = this.polygonalFaceOffsetSink_
+    const startIndicesBufferOffsets = this.polygonalStartOffsetSink_
+
+    allIndices.reset()
+    allStartIndices.reset()
+    polygonalFaceBufferOffsets.reset()
+    startIndicesBufferOffsets.reset()
+
     let indicesPerFace: number = -1
 
     // Prepare indices and start indices for all faces
@@ -945,21 +972,30 @@ export class IfcGeometryExtraction {
       let coordIndex:number = 0
 
       if (polygonalFace instanceof IfcIndexedPolygonalFaceWithVoids) {
+        // Voided faces are rare; keep the straightforward getter path.
         indicesPerFace = polygonalFace.CoordIndex.length
 
         allStartIndices.push(0)
         coordIndex += indicesPerFace
-        allIndices.push(...polygonalFace.CoordIndex)
+
+        for (const index of polygonalFace.CoordIndex) {
+          allIndices.push(index)
+        }
+
         polygonalFace.InnerCoordIndices.forEach((innerIndices) => {
           allStartIndices.push(coordIndex)
-          allIndices.push(...innerIndices)
+
+          for (const index of innerIndices) {
+            allIndices.push(index)
+          }
 
           coordIndex += innerIndices.length
         })
       } else {
-        indicesPerFace = polygonalFace.CoordIndex.length
+        // CoordIndex is vtable offset 0 on IfcIndexedPolygonalFace (see
+        // its generated getter) — parsed in place, never allocated or cached.
+        indicesPerFace = polygonalFace.extractIntegerArrayInto(0, 0, 3, allIndices)
         allStartIndices.push(0)
-        allIndices.push(...polygonalFace.CoordIndex)
       }
     })
 
@@ -968,14 +1004,14 @@ export class IfcGeometryExtraction {
     startIndicesBufferOffsets.push(allStartIndices.length)
 
 
-    // Convert to typed arrays for transfer to WebAssembly
-    const indicesArray = new Uint32Array(allIndices)
+    // Views over exactly the appended elements — no intermediate copy.
+    const indicesArray = allIndices.view
     const indicesArrayPtr = this.arrayToWasmHeap(indicesArray)
-    const startIndicesArray = new Uint32Array(allStartIndices)
+    const startIndicesArray = allStartIndices.view
     const startIndicesArrayPtr = this.arrayToWasmHeap(startIndicesArray)
-    const polygonalFaceBufferOffsetsArray = new Uint32Array(polygonalFaceBufferOffsets)
+    const polygonalFaceBufferOffsetsArray = polygonalFaceBufferOffsets.view
     const polygonalFaceBufferOffsetsArrayPtr = this.arrayToWasmHeap(polygonalFaceBufferOffsetsArray)
-    const startIndicesBufferOffsetsArray = new Uint32Array(startIndicesBufferOffsets)
+    const startIndicesBufferOffsetsArray = startIndicesBufferOffsets.view
     const startIndicesBufferOffsetsArrayPtr = this.arrayToWasmHeap(startIndicesBufferOffsetsArray)
 
     const polygonalFaceVector = this.wasmModule.buildIndexedPolygonalFaceVector(
@@ -983,9 +1019,9 @@ export class IfcGeometryExtraction {
         indicesArray.length,
         startIndicesArrayPtr,
         polygonalFaceBufferOffsetsArrayPtr,
-        polygonalFaceBufferOffsets.length,
+        polygonalFaceBufferOffsetsArray.length,
         startIndicesBufferOffsetsArrayPtr,
-        startIndicesBufferOffsets.length)
+        startIndicesBufferOffsetsArray.length)
 
     const pointsParseBuffer = this.conwayModel.nativeParseBuffer()
 
@@ -1052,7 +1088,10 @@ export class IfcGeometryExtraction {
 
     // Create a new Uint8Array view on the Wasm memory buffer, then set the array to it
     const arrayWasm = new Uint8Array(this.wasmModule.HEAPU8.buffer, arrayPtr, numBytes)
-    arrayWasm.set(new Uint8Array(array.buffer))
+    // Honour the view's own window: subarray() results share their parent's
+    // backing buffer, so copying `array.buffer` wholesale would read the
+    // wrong bytes (and the wrong length) for a view.
+    arrayWasm.set(new Uint8Array(array.buffer, array.byteOffset, numBytes))
 
     return arrayPtr
   }

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -344,6 +344,9 @@ export class IfcGeometryExtraction {
   private readonly polygonalFaceOffsetSink_ = new Uint32Sink( POLYGONAL_FACE_SINK_CAPACITY )
   private readonly polygonalStartOffsetSink_ = new Uint32Sink( POLYGONAL_FACE_SINK_CAPACITY )
 
+  /* Guards the sinks against a re-entrant faceset extraction. */
+  private polygonalSinksInUse_ = false
+
 
    
   private readonly TWO_DIMENSIONS: number = 2
@@ -949,6 +952,18 @@ export class IfcGeometryExtraction {
     // GC time and retained heap during extraction. Indices are parsed
     // straight from the STEP buffer into these instead, reused across
     // facesets.
+    // The sinks are extractor-scoped, so a nested faceset extraction
+    // reached from inside this one would silently clobber them. Nothing
+    // in the window between reset and the wasm copies below recurses
+    // today (the face loop only parses), so this guards the invariant
+    // rather than a live bug — fail loudly if that ever changes.
+    if ( this.polygonalSinksInUse_ ) {
+      throw new Error(
+          'extractPolygonalFaceSet re-entered: the shared index sinks are already in use' )
+    }
+
+    this.polygonalSinksInUse_ = true
+
     const allIndices = this.polygonalIndexSink_
     const allStartIndices = this.polygonalStartIndexSink_
     const polygonalFaceBufferOffsets = this.polygonalFaceOffsetSink_
@@ -1022,6 +1037,9 @@ export class IfcGeometryExtraction {
         polygonalFaceBufferOffsetsArray.length,
         startIndicesBufferOffsetsArrayPtr,
         startIndicesBufferOffsetsArray.length)
+
+    // Sink contents are now copied into wasm; the sinks are free again.
+    this.polygonalSinksInUse_ = false
 
     const pointsParseBuffer = this.conwayModel.nativeParseBuffer()
 

--- a/src/step/parsing/uint32_sink.test.ts
+++ b/src/step/parsing/uint32_sink.test.ts
@@ -1,0 +1,117 @@
+/* eslint-disable no-magic-numbers */
+// Uint32Sink backs the polygonal-faceset extraction fast path, and
+// extractIntegerArrayInto must stay exactly equivalent to the generated
+// array getters it replaces there — including for a real model's faces.
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { IfcAPI } from '../../compat/web-ifc/ifc_api'
+import {
+  IfcIndexedPolygonalFace,
+  IfcIndexedPolygonalFaceWithVoids,
+} from '../../ifc/ifc4_gen/index'
+import { Uint32Sink } from './uint32_sink'
+
+describe( 'Uint32Sink', () => {
+
+  test( 'appends, grows past its initial capacity, and views exactly its length', () => {
+
+    const sink = new Uint32Sink( 2 )
+
+    expect( sink.length ).toBe( 0 )
+    expect( Array.from( sink.view ) ).toEqual( [] )
+
+    for ( let where = 0; where < 10; ++where ) {
+      sink.push( where * 3 )
+    }
+
+    expect( sink.length ).toBe( 10 )
+    expect( Array.from( sink.view ) ).toEqual( [ 0, 3, 6, 9, 12, 15, 18, 21, 24, 27 ] )
+  } )
+
+  test( 'reset drops elements but keeps capacity for reuse', () => {
+
+    const sink = new Uint32Sink( 4 )
+
+    sink.push( 11 )
+    sink.push( 22 )
+    sink.reset()
+
+    expect( sink.length ).toBe( 0 )
+    expect( Array.from( sink.view ) ).toEqual( [] )
+
+    sink.push( 33 )
+
+    expect( Array.from( sink.view ) ).toEqual( [ 33 ] )
+  } )
+} )
+
+describe( 'extractIntegerArrayInto', () => {
+
+  let api: IfcAPI
+  let modelID: number
+
+  /**
+   * The faces the extraction fast path actually covers: voided faces
+   * keep the getter path in production, so exclude them here too.
+   *
+   * @return {IfcIndexedPolygonalFace[]} Non-voided faces of the fixture.
+   */
+  function plainFaces(): IfcIndexedPolygonalFace[] {
+
+    // The passthrough holds the proxy tuple; the StepModel is its head.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const model = ( api as any ).models.get( modelID ).model[ 0 ]
+
+    return ( Array.from( model.types( IfcIndexedPolygonalFace ) ) as
+      IfcIndexedPolygonalFace[] )
+        .filter( ( face ) => !( face instanceof IfcIndexedPolygonalFaceWithVoids ) )
+  }
+
+  beforeAll( async () => {
+    api = new IfcAPI()
+    await api.Init()
+
+    modelID = api.OpenModel(
+        new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ),
+        { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true } )
+  }, 120000 )
+
+  test( 'matches the generated CoordIndex getter on every face of a real model', () => {
+
+    const faces = plainFaces()
+
+    expect( faces.length ).toBeGreaterThan( 0 )
+
+    const sink = new Uint32Sink( 4 )
+
+    for ( const face of faces ) {
+
+      // The getter caches, so read it first and compare the in-place
+      // parse against it — the fast path must be a drop-in.
+      const expected = face.CoordIndex
+
+      sink.reset()
+
+      const count = face.extractIntegerArrayInto( 0, 0, 3, sink )
+
+      expect( count ).toBe( expected.length )
+      expect( Array.from( sink.view ) ).toEqual( expected )
+    }
+  }, 120000 )
+
+  test( 'appends consecutively across records into one sink', () => {
+
+    const faces = plainFaces()
+    const sink = new Uint32Sink( 4 )
+    const expected: number[] = []
+
+    for ( const face of faces ) {
+      face.extractIntegerArrayInto( 0, 0, 3, sink )
+      expected.push( ...face.CoordIndex )
+    }
+
+    expect( Array.from( sink.view ) ).toEqual( expected )
+  }, 120000 )
+} )

--- a/src/step/parsing/uint32_sink.ts
+++ b/src/step/parsing/uint32_sink.ts
@@ -1,0 +1,62 @@
+/**
+ * Growable Uint32Array append sink.
+ *
+ * Exists so hot extraction loops can parse integer list fields straight
+ * out of the STEP buffer into one reusable typed array, instead of
+ * allocating (and caching) a boxed `Array< number >` per record. On
+ * tessellated IFC4 models that difference is structural: a large
+ * polygonal-faceset model carries millions of IfcIndexedPolygonalFace
+ * records, and a per-record array for each is the dominant source of
+ * both GC time and retained heap during geometry extraction.
+ */
+export class Uint32Sink {
+
+  private data_: Uint32Array
+  private length_: number = 0
+
+  /**
+   * @param initialCapacity Initial element capacity.
+   */
+  constructor( initialCapacity: number = 1024 ) {
+    this.data_ = new Uint32Array( Math.max( 1, initialCapacity ) )
+  }
+
+  /** @return {number} Element count appended since the last reset. */
+  public get length(): number {
+    return this.length_
+  }
+
+  /**
+   * A view of exactly the appended elements. Only valid until the next
+   * append (which may reallocate) — copy it if it must outlive that.
+   *
+   * @return {Uint32Array} View over [0, length).
+   */
+  public get view(): Uint32Array {
+    return this.data_.subarray( 0, this.length_ )
+  }
+
+  /** Drop all appended elements, keeping the allocated capacity. */
+  public reset(): void {
+    this.length_ = 0
+  }
+
+  /**
+   * Append one value, growing geometrically when full.
+   *
+   * @param value The value to append.
+   */
+  public push( value: number ): void {
+
+    if ( this.length_ === this.data_.length ) {
+
+      const grown = new Uint32Array( this.data_.length * 2 )
+
+      grown.set( this.data_ )
+
+      this.data_ = grown
+    }
+
+    this.data_[ this.length_++ ] = value
+  }
+}

--- a/src/step/step_entity_base.ts
+++ b/src/step/step_entity_base.ts
@@ -843,6 +843,47 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
    * @param optional
    * @return {boolean} True if this extracts, false (usually because this is optional)
    */
+  public extractParseBuffer(
+      offset: number,
+      baseOffset: number,
+      depth: number,
+      result: ParseBuffer,
+      module: WasmModule,
+      optional: boolean ): boolean {
+    
+    offset -= this.multiReference_ !== void 0 ? baseOffset : 0    
+
+    const internalReference = this.guaranteeVTable( depth )
+
+    if ( offset >= internalReference.vtableCount ) {
+      throw new Error( 'Couldn\'t read field due to too few fields in record' )
+    }
+
+    // Read through the SAME reference the vtable cursors came from —
+    // with a windowed provider, `this.buffer` and a multi-class
+    // reference's buffer can be different windows.
+    const buffer     = internalReference.buffer
+    const vtableSlot = internalReference.vtableIndex + offset
+    const cursor     = internalReference.vtable[ vtableSlot ]
+    const nextSlot   = vtableSlot + 1
+    const endCursor  =
+      nextSlot < internalReference.vtableCount ?
+        ( internalReference.vtable[ nextSlot ] - 1 ) :
+        internalReference.endCursor
+
+    if ( optional && stepExtractOptional( buffer, cursor, endCursor ) === null ) {
+
+      return false
+    }
+
+    const dataPtr = result.resize( endCursor - cursor )
+
+    module.HEAPU8.set( buffer.subarray( cursor, endCursor ), dataPtr )
+
+    return true
+  }
+
+
   /**
    * Append an unsigned-integer list field straight from the STEP buffer
    * into `sink`, without materialising an intermediate `Array< number >`.
@@ -898,47 +939,6 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
     }
 
     return count
-  }
-
-
-  public extractParseBuffer(
-      offset: number,
-      baseOffset: number,
-      depth: number,
-      result: ParseBuffer,
-      module: WasmModule,
-      optional: boolean ): boolean {
-    
-    offset -= this.multiReference_ !== void 0 ? baseOffset : 0    
-
-    const internalReference = this.guaranteeVTable( depth )
-
-    if ( offset >= internalReference.vtableCount ) {
-      throw new Error( 'Couldn\'t read field due to too few fields in record' )
-    }
-
-    // Read through the SAME reference the vtable cursors came from —
-    // with a windowed provider, `this.buffer` and a multi-class
-    // reference's buffer can be different windows.
-    const buffer     = internalReference.buffer
-    const vtableSlot = internalReference.vtableIndex + offset
-    const cursor     = internalReference.vtable[ vtableSlot ]
-    const nextSlot   = vtableSlot + 1
-    const endCursor  =
-      nextSlot < internalReference.vtableCount ?
-        ( internalReference.vtable[ nextSlot ] - 1 ) :
-        internalReference.endCursor
-
-    if ( optional && stepExtractOptional( buffer, cursor, endCursor ) === null ) {
-
-      return false
-    }
-
-    const dataPtr = result.resize( endCursor - cursor )
-
-    module.HEAPU8.set( buffer.subarray( cursor, endCursor ), dataPtr )
-
-    return true
   }
 
 

--- a/src/step/step_entity_base.ts
+++ b/src/step/step_entity_base.ts
@@ -4,7 +4,10 @@ import { EntityDescription, EntityFieldsDescription } from '../core/entity_descr
 import { EntityFieldDescription } from '../core/entity_field_description'
 import { WasmModule } from '../core/native_types'
 import {
+  skipValue,
   stepExtractArray,
+  stepExtractArrayBegin,
+  stepExtractArrayToken,
   stepExtractBinary,
   stepExtractBoolean,
   stepExtractInlineElemement,
@@ -14,6 +17,7 @@ import {
   stepExtractReference,
   stepExtractString,
 } from './parsing/step_deserialization_functions'
+import { Uint32Sink } from './parsing/uint32_sink'
 import { stepBufferBase } from './step_buffer_provider'
 import { StepEntityConstructorAbstract } from './step_entity_constructor'
 import StepEntityInternalReference,
@@ -839,6 +843,64 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
    * @param optional
    * @return {boolean} True if this extracts, false (usually because this is optional)
    */
+  /**
+   * Append an unsigned-integer list field straight from the STEP buffer
+   * into `sink`, without materialising an intermediate `Array< number >`.
+   *
+   * Semantically identical to the generated array getters (same
+   * optional handling, same element extraction, same "incorrectly
+   * typed" error), but it neither allocates nor caches a per-record
+   * array — the caller owns one reusable sink for the whole batch. On
+   * tessellated models this removes millions of short-lived arrays and
+   * the retained heap that goes with them; see Uint32Sink.
+   *
+   * @param offset The offset in the vtable to extract from.
+   * @param baseOffset The base offset of the class in the vtable.
+   * @param depth The depth in the inheritance hierarchy.
+   * @param sink Receives the appended values.
+   * @return {number} How many values were appended (0 when the field is
+   * unset/optional-null).
+   */
+  public extractIntegerArrayInto(
+      offset: number,
+      baseOffset: number,
+      depth: number,
+      sink: Uint32Sink ): number {
+
+    let   cursor    = this.getOffsetCursor( offset, baseOffset, depth )
+    const buffer    = this.buffer
+    const endCursor = buffer.length
+
+    if ( stepExtractOptional( buffer, cursor, endCursor ) === null ) {
+      return 0
+    }
+
+    let count         = 0
+    let signedCursor0 = stepExtractArrayBegin( buffer, cursor, endCursor )
+
+    cursor = Math.abs( signedCursor0 )
+
+    while ( signedCursor0 >= 0 ) {
+
+      const value = stepExtractNumber( buffer, cursor, endCursor )
+
+      if ( value === void 0 ) {
+        throw new Error( 'Value in STEP was incorrectly typed' )
+      }
+
+      cursor = skipValue( buffer, cursor, endCursor )
+
+      sink.push( value )
+      ++count
+
+      signedCursor0 = stepExtractArrayToken( buffer, cursor, endCursor )
+      cursor        = Math.abs( signedCursor0 )
+    }
+
+    return count
+  }
+
+
   public extractParseBuffer(
       offset: number,
       baseOffset: number,


### PR DESCRIPTION
First step of the PSB → 30 s push. Profiling PSB.ifc found the geometry pump is **JS-bound, not wasm-bound**, and one path dominates.

## What the profile showed

PSB.ifc (861 MB, IFC4) carries **9,125,683 `IfcIndexedPolygonalFace` records** across 15,777 facesets. `extractPolygonalFaceSet` paid a per-face JS tax on every one:

| main-thread self time (node MT, 4-core) | |
|---|---|
| garbage collector | 16.7 s |
| `getTypedElementByExpressID` | 5.6 s |
| `get CoordIndex` | 4.5 s |
| `minimal_perfect_hash.get` | 3.6 s |
| `entry` / `populateVtableEntryRaw` | 3.2 s |
| `parseDataBlockIncremental` | 2.5 s |

Instrumented, the faceset path alone was **43 s of the 93 s pump** — 14.5 s materialising face entities, 28.5 s in the walk. The generated `CoordIndex` getter allocates a boxed `Array<number>` **and caches it on the face**, so all 9.1 M arrays stay alive; the loop then spread each into a growing plain array, which was copied once more into a `Uint32Array` for the wasm call.

## Change

Parse indices straight out of the STEP buffer into reusable typed sinks:

- **`Uint32Sink`** — growable `Uint32Array` append sink, reused across facesets.
- **`StepEntityBase.extractIntegerArrayInto`** — the generated array getter's extraction byte-for-byte (same optional handling, same element extraction, same "incorrectly typed" error), but appending into a caller-owned sink instead of allocating and caching a per-record array.
- **`extractPolygonalFaceSet`** uses it for plain faces (voided faces are rare and keep the getter path) and hands wasm views over exactly the appended elements — no intermediate copies.

Also fixes **`arrayToWasmHeap`** to honour a typed array's `byteOffset`/`byteLength`. It copied the whole backing buffer, which is correct only for arrays that own it; the `subarray()` views this now passes would otherwise read the wrong bytes. No behaviour change for existing callers (all pass whole arrays).

## Results — PSB.ifc, node MT build, 4-core

| | before | after | Δ |
|---|---|---|---|
| geometry pump | 79.6 s | **48.5 s** | **−31.1 s (−39%)** |
| open + pump | 92.3 s | **59.8 s** | **−35%** |
| peak RSS | 6,590 MB | **4,554 MB** | **−2.0 GB** |

## Output parity

Verified against the published build on PSB itself (the model that exercises this path 9.1 M times) — **identical**:

| | published 1.438.1315 | this PR |
|---|---|---|
| placements | 23,454 | 23,454 |
| sha256(placement id + transform + colour, all placements) | `cc4f1c26…be363` | `cc4f1c26…be363` |
| sha256(vertex+index bytes, 242 sampled geometries) | `e2c82342…4ed3a` | `e2c82342…4ed3a` |

(242 sampled geometries = 573,648 verts / 374,454 indices.)

## Tests

New `uint32_sink.test.ts`: sink growth past initial capacity, reset-keeps-capacity, exact-length views; and `extractIntegerArrayInto` matching the generated `CoordIndex` getter on **every** face of `data/index.ifc`, both singly and appended consecutively across records.

Full suite: 363/364 pass. The one failure (`ap214_geometry_extraction › gearGeometryArrayLength`, 48108 vs 154644) is a local-environment artifact — this sandbox can't build wasm, so it borrows `conway-geom` Dist from npm 1.438.1315, which predates main's submodule bump (c82d8e9). **Verified it fails identically on unmodified main with the same borrowed wasm**, and this change is IFC-only TypeScript that cannot affect AP214 gear tessellation. CI builds the real submodule.

## Next

Remaining PSB levers, in order: the 9.1 M face-entity materialisations still cost ~14.5 s (needs reference-level access without constructing entities), and the 3 worker threads spin-wait in one wasm frame for the entire pump (78.8 s each) while contending with the main thread on a 4-core box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_