### PR TITLE
Add a checked-in model-diagnostics harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,12 @@ isolate*.log
 scripts/*.csv
 scripts/app.json
 scripts/test_runs/
+# Blanket-ignore script output directories (perf runs write per-model dumps
+# next to the scripts), then re-include the ones holding checked-in tooling.
+# The directory itself has to be re-included, not just its files — git does
+# not descend into an excluded directory looking for negations.
 scripts/*/
+!scripts/debug/
 benchmarks/*private
 
 #external

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,69 @@
-Do not try and run yarn setup again. It has already been run in the environment setup. 
+# AGENTS.md
 
+Conway — IFC/STEP CAD engine: a TypeScript schema/extraction layer over
+the [conway-geom](https://github.com/bldrs-ai/conway-geom) C++/wasm core,
+consumed by [Share](https://github.com/bldrs-ai/Share).
 
-To build, run yarn build-codex-MT. To test, run yarn test. If only making changes to the typescript code in conway, you can run yarn build-incremental. If making changes to conway-geom, you need to run a full yarn build-codex-MT. 
+## Build and test
 
-Run chmod +x on scripts/build-codex.sh before trying to call yarn build-codex-MT.
+Do not try and run `yarn setup` again. It has already been run in the
+environment setup.
 
+To build, run `yarn build-codex-MT`. To test, run `yarn test`. If only
+making changes to the TypeScript code in conway, you can run `yarn
+build-incremental`. If making changes to conway-geom, you need to run a
+full `yarn build-codex-MT`.
 
-This repo uses yarn 1.22.22. 
+Run `chmod +x` on `scripts/build-codex.sh` before trying to call `yarn
+build-codex-MT`.
+
+`yarn build-codex-MT` takes roughly 90 seconds. When iterating on
+conway-geom, stage a set of edits and evaluate them in one build rather
+than rebuilding per edit.
+
+This repo uses yarn 1.22.22.
+
+## Debugging a bad model
+
+When a model renders wrong — spikes, missing parts, exploded assemblies —
+**start with `scripts/debug/model_report.mjs`, not with a new tracer.** It
+loads the model through the normal loader with probes at four levels of
+the geometry pipeline, and names the entities responsible:
+
+```
+node scripts/debug/model_report.mjs Right_Hand.step
+```
+
+Full guide, a worked example against a real defect
+(`EDGE_CURVE.same_sense`, conway#444), and how to read the numbers:
+[scripts/debug/README.md](scripts/debug/README.md).
+
+Two rules from that page are worth repeating here, because ignoring them
+is what made that investigation slow:
+
+- **A probe that never fires looks exactly like a clean model.** Validate
+  any new instrumentation against a case you know is non-zero before
+  believing a null result from it.
+- **Never hold a `HEAPF32` view across extraction.** Wasm memory growth
+  detaches the buffer and the held view silently reads zeroes. Read
+  vertices via `getPoint()` and curve points via `get3d()`.
+
+Check `scripts/` before building tooling — see
+[scripts/README.md](scripts/README.md) for what is already there.
+
+## Where to read more
+
+| Topic | Doc |
+|---|---|
+| Debugging one model's geometry; render and diff tooling | [scripts/debug/README.md](scripts/debug/README.md) |
+| What is in `scripts/`, and performance testing | [scripts/README.md](scripts/README.md) |
+| Geometry-quality signals, and which ones Share should surface to users | [design/new/model-diagnostics.md](design/new/model-diagnostics.md) |
+| Regression corpus, digest CSVs, smoke subset vs RC pass | [regression/README.md](regression/README.md), [design/new/step-regression.md](design/new/step-regression.md) |
+| STEP support: schemas, coverage, known gaps | [design/new/step-support.md](design/new/step-support.md) |
+| STEP product structure and metadata (the AP242 wrinkle, NIST) | [design/new/step-metadata-nist.md](design/new/step-metadata-nist.md) |
+| Native GLB export from the CLI | [design/new/glb-native-export.md](design/new/glb-native-export.md) |
+| Memory residency, streaming and federated loading | [design/new/memory-residency.md](design/new/memory-residency.md), [design/new/streaming-federated-loader.md](design/new/streaming-federated-loader.md) |
+| emsdk version, wasm build environment | [design/new/web-build-environment.md](design/new/web-build-environment.md), [design/new/emsdk-upgrade-scalable-allocator.md](design/new/emsdk-upgrade-scalable-allocator.md) |
+
+Add a row here when you write a doc future assistants should find — this
+table is the index, not the filesystem.

--- a/design/new/model-diagnostics.md
+++ b/design/new/model-diagnostics.md
@@ -1,0 +1,174 @@
+# Model diagnostics
+
+Status: living doc. Tooling shipped (`scripts/debug/model_report.mjs`);
+the Share-facing items in §4 are candidates, not commitments.
+
+Two audiences want the same underlying measurements:
+
+- **us**, debugging why one model renders wrong, offline, at any cost in
+  time — that is `scripts/debug/model_report.mjs`
+  ([guide](../../scripts/debug/README.md));
+- **users**, who want to know whether the thing on their screen is what
+  they exported, live, at near-zero cost.
+
+This doc is the inventory that connects them: what can be measured, what
+each signal means, what it costs, and which ones are worth surfacing in
+Share.
+
+
+## 1. Why this exists
+
+The AmazingHand STEP investigation (conway#444) is the motivating case. A
+0.17 m robot-hand assembly rendered as an exploded mess of half-metre
+spikes. From the user's side the entire signal was "it's hilariously
+misshapen" plus a screenshot. From our side it took about thirty minutes
+of ad-hoc instrumentation to reach "561 of 2541 edges have
+`same_sense = .F.`, and those are the ones producing 0.7 m curves".
+
+Every number in that sentence was measurable in under two seconds. None
+of it was reachable without writing code first. That gap — measurable but
+not measured — is what both the tooling and the Share candidates below
+are aimed at.
+
+A secondary point the same investigation made: **model defects cluster**.
+One bad model surfaced five distinct engine defects (arc complement
+selection, CDT constraint handling, absolute-vs-relative deflection
+thresholds, a colour-extraction fallback, and non-UTF-8 header strings).
+A diagnostic that reports several weak signals at once is more useful
+than one that reports a single strong one, because the correlations are
+what identify the mechanism.
+
+
+## 2. The signals
+
+Measured against the whole model, so they carry across formats and scales.
+"Cost" is what it takes to compute during a normal load.
+
+| Signal | Means | Cost |
+|---|---|---|
+| **Extent outliers** — meshes whose local bounds far exceed the median mesh | Geometry flung away from where it belongs: bad curve interpretation, bad transform, bad unit scale | Near-free; bounds are walked anyway |
+| **Empty products** — products that produced no geometry | Unsupported representation, or a silently swallowed extraction failure | Free (a counter) |
+| **Warning/error churn** — engine diagnostics, counted by message | Per-entity failures. Churn *between versions* of the same model is a regression signal in its own right | Free; already collected |
+| **Degenerate loops** — under 3 points, or consecutive points below the coordinate quantum | Triangulation-failure candidates. Often the proximate cause when a face is missing rather than misplaced | Cheap; one pass over loop points |
+| **Curve extent outliers** — curves whose points leave the part | The earliest place a placement defect is visible, and the only one that names the curve entity and its trim state | Cheap, but only on the advanced-BREP path |
+| **Face vertex attribution** — vertices one face contributed, and how far out | Bridges curve and mesh: which face turned a bad curve into bad triangles | Requires immediate (non-staged) faces; changes triangle ordering |
+| **Model extent vs. schema expectation** | Unit-scale error — the mm/m confusion class of bug | Free once bounds exist |
+| **Geometry-type breakdown** | Which representations a model leans on; which engine paths a defect could be in | Free; already in the statistics line |
+
+### Reading them
+
+The baseline is always the **median**, never the mean: the thing being
+detected is a handful of runaway entities among thousands of sound ones,
+and a mean lets them hide themselves. p90 alongside the median is the
+calibration — when p90 sits near the outlier threshold the model
+legitimately has mixed-scale parts and any flag is weak evidence.
+
+The stages are deliberately redundant, and **the narrowest dirty stage is
+the diagnosis**: dirty at `mesh` but clean at `curve` means tessellation,
+CSG or transform; dirty already at `curve` means curve interpretation
+upstream of all of that.
+
+
+## 3. Where they come from
+
+Four seams, in pipeline order. The first three are per-schema or shared
+extraction points; the last is a post-load walk.
+
+| Seam | Shared by | Yields |
+|---|---|---|
+| `extractCurve` (AP214, IFC) | per-schema, same signature | curve extent, entity type, trim state |
+| `ConwayGeometry.getLoop` | IFC + STEP | loop extent, point spacing |
+| `ConwayGeometry.addFaceToGeometry` | IFC + STEP | per-face vertex contribution |
+| `Scene.walk()` | IFC + STEP | per-mesh bounds, attributed to the product entity |
+
+That `getLoop` and `addFaceToGeometry` sit **below** the schema layer is
+what makes one probe cover both formats — worth preserving. Instrumenting
+`extractAdvancedFace` instead misses faces that carry their own styled
+geometry, which is one of the two false-negative readings the AmazingHand
+investigation lost time to.
+
+
+## 4. What Share could surface
+
+Ranked by value per unit of work. Nothing here is committed; the point is
+that the measurements already exist and the surfaces mostly do too.
+
+### 4.1 Model-health lines in the load report — cheapest, do first
+
+Share's load report ([Share
+`design/new/load-log-format.md`](https://github.com/bldrs-ai/Share/blob/main/design/new/load-log-format.md))
+already renders one "Warnings & errors" summary line and an engine
+statistics line with the geometry-type breakdown. Extent outliers, empty
+products and degenerate-loop counts belong on the same footing:
+
+```
+Health: 3 parts outside model bounds (max 33x median), 12 products with no geometry
+```
+
+The canonical formatter is conway's `src/core/progress_log.ts`, which
+Share deep-imports, so the line renders byte-identical in the CLI, the
+console, the snackbar expando and the copyable "i" report with no
+Share-side work beyond the pin. That shared-formatter property is the
+reason to put it there rather than inventing a Share-side panel.
+
+### 4.2 Attach the diagnostic to a bug report — highest leverage for us
+
+The "i" report is already copy-to-clipboard and already reaches Sentry as
+load context. Extending it with the machine-readable diagnostic
+(`model_report.mjs --json` is the shape) turns "it looks wrong" plus a
+screenshot into a report naming the express IDs. That is the single
+change that would most reduce the cost of the next AmazingHand: the
+thirty minutes went to *reproducing and localizing*, not to fixing.
+
+Needs care on privacy — express IDs and part names are model content.
+Opt-in per report, not automatic telemetry.
+
+### 4.3 Robust auto-framing — a user-visible win with no engine fix
+
+Today one runaway part drags the scene bounds and the default camera
+frames the spike instead of the model; the hand appeared as a tiny blob
+in a large empty view. Framing on a **percentile** of part bounds rather
+than the absolute union would have shown a recognizable (if broken) hand.
+
+This is worth doing on its own merits: it improves every malformed model,
+including ones whose defects we have not found yet, and it is independent
+of any diagnostic UI.
+
+### 4.4 Navigate to flagged parts
+
+Share already has NavTree selection, per-occurrence picking and
+permalink cameras. A flagged express ID in the report becomes a link that
+selects and frames that part. Small increment on 4.1 + existing
+selection, and it is what turns a diagnostic into something a *user* can
+act on ("this bracket didn't import — here it is").
+
+### 4.5 Not obviously worth it yet
+
+- A dedicated "model quality" panel or score. The signals are advisory
+  and mixed-scale models produce honest false positives; a score invites
+  the reading that a number means something absolute.
+- Live per-face diagnostics. The `face` stage needs immediate rather
+  than staged faces, so it is not free on a normal load.
+
+
+## 5. Open questions
+
+- **Thresholds across an assembly with genuinely mixed part scales.** 8x
+  median is a debugging default a human calibrates with p90; a
+  user-facing line needs something that does not cry wolf on a site plan
+  next to a door handle. Percentile-of-parts rather than
+  multiple-of-median is the likely answer, untested.
+- **Attribution below the product level.** Curve and face signals name
+  entities; the mesh stage names products. Bridging them (which product
+  owns a bad curve) currently means reading the STEP file.
+- **Should health signals gate the regression digests?** Extent-outlier
+  counts are more stable than triangle counts and would catch a class of
+  defect the digests currently only catch as a visual diff.
+
+
+## See also
+
+- [scripts/debug/README.md](../../scripts/debug/README.md) — the tool, a
+  worked example, and how to read the numbers
+- [step-regression.md](step-regression.md) — corpus, digests, smoke subset
+- [step-support.md](step-support.md) — schema coverage and known gaps

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,7 +1,33 @@
+# scripts/
+
+Check this index before writing new tooling — most of what a geometry or
+performance investigation needs already exists here.
+
+| Script | Use |
+|---|---|
+| [`debug/model_report.mjs`](debug/README.md) | Why does *this* model look wrong — probes the geometry pipeline and names the entities responsible |
+| `render_glb.cjs` | GLB → PNG with a pure-JS software rasterizer. No browser, no native deps, bit-deterministic across machines. `--pair` renders before/after with one shared camera |
+| `visual_diff_report.cjs` | Per-model before/after image comparison for a PR's regression run |
+| `gen_delta_csv.cjs`, `run_gen_deltas.cjs` | Digest CSV deltas between two conway versions |
+| `benchmark.cjs` | Timing sweep over a model corpus |
+| `generate_flame_graph.cjs` | Flame graph from a `yarn cli-profile` run |
+| `stream_corpus_sweep.mjs` | Streaming-loader sweep across the corpus |
+| `step_nonproduct_survey.py` | Survey of non-product STEP entity usage across the corpus |
+| `setup-emsdk.sh`, `build-codex.sh`, `build-gha.sh` | Toolchain and build drivers |
+| `code-gen.cjs`, `gen-web-ifc-types.cjs` | Schema code generation |
+| `extract-wasm-dependencies.cjs`, `fetch-prebuilt-wasm.cjs`, `fd-patch.cjs` | Build plumbing |
+| `firestore_*.py`, `upload_to_firestore.py`, `updateVersion.mjs` | Release and corpus-data plumbing |
+
+Scripts here are not covered by `yarn lint`, which runs over `src` only.
+
 # Performance Test
 
 This document provides detailed instructions on how to set up and run the
 performance tests for the project.
+
+> Note: the `performance_test.sh` driver below is no longer in this
+> directory; the surrounding setup (headless-three cross-linking, the
+> `benchmarks/` output layout) still describes how performance runs work.
 
 ## Prerequisites
 

--- a/scripts/debug/README.md
+++ b/scripts/debug/README.md
@@ -1,0 +1,207 @@
+# Model debugging
+
+Tools for the question *"why does this model look wrong?"* — as distinct
+from *"did this change break anything?"*, which is what the regression
+digests and visual diffs in [../README.md](../README.md) answer.
+
+Start here before writing a one-off tracer. The reason this directory
+exists is that the AmazingHand STEP investigation (conway#444) burned
+most of its wall clock on throwaway instrumentation that was rebuilt from
+zero, twice attached to the wrong seam, and never survived the session.
+
+| Tool | Answers |
+|---|---|
+| [`model_report.mjs`](model_report.mjs) | Which entities produced bad geometry, and at which stage of the pipeline |
+| [`../render_glb.cjs`](../render_glb.cjs) | What does the output actually look like (zero-dependency software rasterizer, deterministic, pair mode for before/after) |
+| [`../visual_diff_report.cjs`](../visual_diff_report.cjs) | Which regression models changed appearance in this PR |
+| The STEP / IFC CLI mains | Query entities by express ID, and export GLB/GLTF/OBJ to feed the renderer |
+
+
+## Quick start
+
+Needs a built tree — the tools import from `compiled/`, not `src/`:
+
+```
+yarn build-incremental              # TypeScript only
+yarn build-codex-MT                 # if conway-geom (C++/wasm) changed
+```
+
+Then:
+
+```
+node scripts/debug/model_report.mjs Right_Hand.step
+node scripts/debug/model_report.mjs haus.ifc --stage mesh --top 40
+node scripts/debug/model_report.mjs part.step --limit 0.25 --json | jq .
+```
+
+To see it, export a GLB and rasterize it. The CLI mains take the model
+directly; `yarn cli` / `yarn step` are the same entry points bundled, and
+need `yarn bundle-examples` first.
+
+```
+STEP=compiled/src/AP214E3_2010/ap214_command_line_main.js   # IFC: compiled/src/ifc/ifc_command_line_main.js
+
+node $STEP Right_Hand.step -g          # writes Right_Hand_test0.glb (+ gltf, draco) to cwd
+node scripts/render_glb.cjs Right_Hand_test0.glb hand.png
+```
+
+Large models split across several chunk files (`..._test0.glb`,
+`..._test1.glb`, ...); pass them comma-separated, because rendering only
+the first chunk silently drops the rest of the model.
+
+`render_glb.cjs` also takes `--pair before.glb after.glb outPrefix`, which
+frames both sides with one camera on the union of their bounds — the only
+way a stray spike reads as an obvious difference rather than two
+individually auto-fit, incomparable images.
+
+
+## The four stages
+
+`model_report.mjs` loads the model through the normal `ConwayModelLoader`
+path — so IFC and STEP behave exactly as they do in Share — with probes at
+four levels, and reports entities whose output is an outlier against the
+rest of the model.
+
+| Stage | Seam | Sees |
+|---|---|---|
+| `curve` | `extractCurve` (AP214 + IFC) | Per-curve point extent, express ID, entity type, whether it was trimmed |
+| `loop` | `ConwayGeometry.getLoop` | Per-loop extent, point-spacing histogram, wrap duplicates, sub-3-point loops |
+| `face` | `ConwayGeometry.addFaceToGeometry` | Vertices one face contributed, and how far out they landed |
+| `mesh` | scene walk after load | Per-mesh local bounds, attributed to the product entity |
+
+They are deliberately redundant, and that redundancy is the diagnostic:
+the *narrowest dirty stage* is where the defect lives.
+
+- `mesh` dirty, `curve` clean → tessellation, CSG or transform.
+- `curve` already dirty → curve or geometry interpretation, upstream of
+  tessellation. Look at the entity types and the `trimmed` column.
+- `loop` clean on extent but showing gaps orders of magnitude below the
+  loop's own size → a triangulation-robustness problem, not a placement
+  problem.
+
+The `face` stage forces `CONWAY_DISABLE_STAGED_FACES=1`, because staged
+faces defer their work to a later batch where a per-call vertex delta is
+always zero. That makes runs including `face` slightly slower and changes
+triangle *ordering* (not content) versus a default run.
+
+
+## Worked example: the AmazingHand `same_sense` bug
+
+Pollen Robotics' `Right_Hand.step` — a 0.17 m Onshape AP242 export —
+rendered as an exploded mess of half-metre spikes. With the defect
+reintroduced, the whole diagnosis is one command:
+
+```
+$ node scripts/debug/model_report.mjs Right_Hand.step --quiet --top 4
+
+# Right_Hand.step
+  3.58 MB, loaded in 2134 ms, curve,loop,face,mesh
+
+## curve
+  2541 calls, 2541 measured, median 0.0522, p90 0.0950, threshold 0.4176 (8x median)
+        0.7178  expressID=76 entity=ellipse points=24 trimmed=true
+        0.7178  expressID=77 entity=ellipse points=24 trimmed=true
+        0.7178  expressID=78 entity=ellipse points=24 trimmed=true
+        0.7178  expressID=79 entity=ellipse points=24 trimmed=true
+  ... 11 more above threshold
+
+## loop
+  1570 calls, 1570 measured, median 0.0502, p90 0.0950, threshold 0.4018 (8x median)
+  point gaps: <1e-8 0, <1e-7 0, <1e-6 6, <1e-5 0, rest 49698
+  wrap-duplicate loops: 1522, under 3 points: 48
+        0.7178  points=95 minGap=0.0001 wrapDuplicate=true
+  ... 19 more above threshold
+
+## mesh
+  29 calls, 29 measured, median 0.0218, p90 0.4623, threshold 0.1748 (8x median)
+        0.7178  expressID=19722 entity=manifold_solid_brep vertices=1697 triangles=3320
+  ... 4 more above threshold
+```
+
+Read it in this order:
+
+1. **The dirt reaches the earliest stage.** `curve` is already dirty, so
+   nothing downstream — tessellation, CSG, transforms — is the cause.
+2. **The spread says it is a defect, not a big part.** Median 0.052, p90
+   0.095, offenders at 0.718: the honest population is tight and the
+   outliers sit 13× above p90. Compare a mesh stage where median 0.02 and
+   p90 0.46 overlap the threshold — there, large parts are normal and the
+   flags need corroborating.
+3. **The columns name the mechanism.** Every offender is a trimmed conic
+   (`entity=ellipse`/`circle`, `trimmed=true`, 24 points). Trimmed conics
+   going long is the signature of walking the *complement* arc.
+4. Open those express IDs in the file —
+
+   ```
+   $ node compiled/src/AP214E3_2010/ap214_command_line_main.js Right_Hand.step -e 76 -f expressID type
+   |expressID|type|
+   |---|---|
+   |#76|ELLIPSE|
+   ```
+
+   — and the `EDGE_CURVE` referencing them has `same_sense = .F.`, which
+   the extractor was ignoring, so it swept the arc the wrong way around a
+   circle far larger than the part.
+
+Fixed, the same command reports `no outliers` at every stage in ~1.5 s.
+
+The historical value here is the contrast: this took about thirty minutes
+of face-level then curve-level ad-hoc tracing, including two false "0
+outliers" readings from probes attached to a seam the model did not take.
+
+
+## Reading the numbers
+
+- **The baseline is the median**, not the mean — a handful of runaway
+  entities drags a mean up far enough to hide itself. `--factor` (default
+  8) sets how far above the median counts as an outlier; `--limit` sets an
+  absolute threshold instead, which is the right call when you already
+  know the model's true size.
+- **p90 is the calibration column.** If p90 sits near the threshold, the
+  model legitimately has parts of mixed scale and the flags are weak
+  evidence — raise `--factor`. If p90 hugs the median, anything flagged is
+  real.
+- **The `mesh` stage is the noisiest** of the four for exactly that
+  reason: an assembly with one large housing and forty small fasteners
+  will flag the housing every time. It is still the only stage that can
+  name the *product* a defect belongs to.
+- **`wrap-duplicate loops` is usually not a finding.** Most exporters
+  repeat the start point as the last point. It is reported because when
+  combined with sub-micron gaps it identifies triangulation-failure
+  candidates.
+- **A `## conway diagnostics` section** appears when the load logged
+  warnings or errors, counted by message. Error churn between two runs of
+  the same model is itself a regression signal.
+
+
+## Rules this tooling encodes
+
+Four things cost real time on conway#444. Each has a countermeasure here;
+they apply to any new instrumentation you write, not just to this script.
+
+1. **A probe that never fires looks exactly like a clean model.** Every
+   stage prints its `fired` count, `model_report.mjs` refuses to run at
+   all if a seam it wraps has been renamed, and it exits 2 when a stage
+   you named on `--stage` produced nothing. Before believing a null
+   result from *any* new probe, run it against a case you know is
+   non-zero.
+2. **Never hold a `HEAPF32` view across extraction.** Wasm memory growth
+   detaches the buffer and a held view silently reads zeroes — one of the
+   two false negatives above. Read vertices through `getPoint()` and
+   curve points through `get3d()`.
+3. **Check `scripts/` before building tooling.** `render_glb.cjs` already
+   existed and was rebuilt from scratch as a Playwright + three.js
+   harness over about four iterations, for a worse result: the existing
+   one needs no browser and is bit-deterministic across machines.
+4. **Batch C++ edits per rebuild.** `yarn build-codex-MT` is ~90 s.
+   Staging a set of hypotheses and evaluating them in one build beats a
+   rebuild per edit, and the TypeScript-only path (`yarn
+   build-incremental`) is far cheaper when the change is above the wasm
+   boundary.
+
+A fifth is worth stating even though this script can't enforce it: when
+verifying a fix, re-run the *whole* corpus subset, not just the model that
+motivated it. The finer curve sampling that fixed the hand pushed a
+cylinder unwrap into a different CDT path and produced a metre-long
+sliver on an unrelated model, caught only because the regression smoke
+subset was re-run.

--- a/scripts/debug/model_report.mjs
+++ b/scripts/debug/model_report.mjs
@@ -1,0 +1,774 @@
+#!/usr/bin/env node
+/**
+ * Geometry diagnostics for one model: which entities produced bad output.
+ *
+ * This is the "why does this model look wrong?" tool. It loads a model
+ * through the normal ConwayModelLoader path (so IFC and STEP behave
+ * exactly as they do in Share) with probes installed at four levels of
+ * the geometry pipeline, and reports the entities whose output is an
+ * outlier against the rest of the model:
+ *
+ *   curve  extractCurve      per-curve point extent      (AP214 + IFC)
+ *   loop   getLoop           per-loop extent + point spacing
+ *   face   addFaceToGeometry vertices a single face contributed
+ *   mesh   scene walk        per-mesh local bounds, attributed to entities
+ *
+ * The stages are deliberately redundant: they bracket the pipeline, so
+ * comparing them localises a defect. A model whose `mesh` stage shows a
+ * runaway part but whose `curve` stage is clean has a tessellation or
+ * transform bug; one where `curve` is already dirty has a curve/geometry
+ * interpretation bug upstream of tessellation. Running them together and
+ * reading the narrowest dirty stage is the fast path — that is how the
+ * AmazingHand `EDGE_CURVE.same_sense` defect was found (see README.md
+ * §"Worked example").
+ *
+ * ## Two hazards this tool exists to remove
+ *
+ * 1. **A probe that never fires looks exactly like a clean model.** Every
+ *    stage reports its `fired` count and the run exits non-zero if a
+ *    requested probe never fired. During the AmazingHand investigation,
+ *    ad-hoc tracers twice reported "0 outliers" because they were
+ *    attached to a seam the model did not take — hours attributed to the
+ *    wrong subsystem. A zero here is only meaningful next to a non-zero
+ *    `fired`.
+ *
+ * 2. **Reading wasm memory directly goes stale.** Vertex data is read
+ *    through `getPoint()` / `get3d()`, never through a cached `HEAPF32`
+ *    view: wasm memory growth during extraction detaches the old buffer
+ *    and a held view silently reads zeroes.
+ *
+ * Usage:
+ *   node scripts/debug/model_report.mjs <model> [options]
+ *
+ *   --stage <list>   comma-separated: curve,loop,face,mesh (default all)
+ *   --limit <n>      absolute outlier threshold, in model units
+ *   --factor <n>     outlier = value > factor x median (default 8)
+ *   --top <n>        rows printed per stage (default 15)
+ *   --json           machine-readable output on stdout
+ *   --csg-depth <n>  maximum CSG depth (default 20)
+ *   --quiet          suppress conway's own log output
+ *
+ * Examples:
+ *   node scripts/debug/model_report.mjs Right_Hand.step
+ *   node scripts/debug/model_report.mjs haus.ifc --stage mesh --top 40
+ *   node scripts/debug/model_report.mjs part.step --limit 0.25 --json
+ *
+ * Requires a built tree (`yarn build-incremental`, or `yarn build-codex-MT`
+ * if conway-geom changed) — it imports from `compiled/`, not `src/`.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const REPO_ROOT = new URL('../../', import.meta.url)
+
+/** Default multiple of the median above which a value is called an outlier. */
+const DEFAULT_FACTOR = 8
+
+/** Rows printed per stage before truncation. */
+const DEFAULT_TOP = 15
+
+/** Point-spacing histogram buckets, in model units, ascending. */
+const GAP_BUCKETS = [1e-8, 1e-7, 1e-6, 1e-5]
+
+const ALL_STAGES = ['curve', 'loop', 'face', 'mesh']
+
+const EXIT_PROBE_DEAD = 2
+const EXIT_USAGE = 1
+
+/**
+ * Where the human-readable report goes.
+ *
+ * Under --json it moves to stderr so stdout carries nothing but the JSON
+ * document and the run can be piped straight into jq.
+ */
+let say = console.log
+
+
+/**
+ * Parse argv into an options object.
+ *
+ * @param {string[]} argv Arguments after the node binary and script path
+ * @return {object} Parsed options, or {help: true}
+ */
+function parseArgs(argv) {
+  const options = {
+    stages: ALL_STAGES,
+    stagesExplicit: false,
+    limit: undefined,
+    factor: DEFAULT_FACTOR,
+    top: DEFAULT_TOP,
+    json: false,
+    csgDepth: 20,
+    quiet: false,
+    model: undefined,
+  }
+
+  for (let i = 0; i < argv.length; ++i) {
+    const arg = argv[i]
+
+    switch (arg) {
+      case '--stage':
+        options.stages = argv[++i].split(',').map((s) => s.trim()).filter(Boolean)
+        options.stagesExplicit = true
+        break
+      case '--limit':
+        options.limit = Number(argv[++i])
+        break
+      case '--factor':
+        options.factor = Number(argv[++i])
+        break
+      case '--top':
+        options.top = Number(argv[++i])
+        break
+      case '--csg-depth':
+        options.csgDepth = Number(argv[++i])
+        break
+      case '--json':
+        options.json = true
+        break
+      case '--quiet':
+        options.quiet = true
+        break
+      case '-h':
+      case '--help':
+        return {help: true}
+      default:
+        if (arg.startsWith('-')) {
+          throw new Error(`unknown option: ${arg}`)
+        }
+        options.model = arg
+    }
+  }
+
+  const unknown = options.stages.filter((s) => !ALL_STAGES.includes(s))
+
+  if (unknown.length > 0) {
+    throw new Error(`unknown stage(s): ${unknown.join(', ')} (want ${ALL_STAGES.join('|')})`)
+  }
+
+  return options
+}
+
+
+/**
+ * A stage's accumulated observations.
+ *
+ * Keeps every magnitude (for the median) but only the largest `capacity`
+ * records, so a million-curve model costs an array of doubles rather than
+ * a million objects.
+ */
+class Stage {
+
+  /**
+   * @param {string} name Stage name, as passed to --stage
+   * @param {number} capacity How many top records to retain
+   */
+  constructor(name, capacity) {
+    this.name = name
+    this.capacity = capacity
+    this.fired = 0
+    this.values = []
+    this.top = []
+    this.extra = {}
+  }
+
+  /**
+   * Record one observation.
+   *
+   * @param {number} value The magnitude this observation is ranked by
+   * @param {Function} describe Called only if the record is retained, to
+   * avoid building a description object per observation
+   */
+  record(value, describe) {
+    if (!Number.isFinite(value)) {
+      return
+    }
+
+    this.values.push(value)
+
+    const worst = this.top[this.top.length - 1]
+
+    if (this.top.length >= this.capacity && worst !== undefined && value <= worst.value) {
+      return
+    }
+
+    this.top.push({value, ...describe()})
+    this.top.sort((a, b) => b.value - a.value)
+    this.top.length = Math.min(this.top.length, this.capacity)
+  }
+
+  /**
+   * The observation at a given quantile, or 0 if nothing was observed.
+   *
+   * The median (0.5) is the baseline outliers are measured against: mean
+   * rather than median would let a handful of runaway entities drag the
+   * baseline up far enough to hide themselves. p90 is reported alongside
+   * it purely so a reader can see how wide the honest spread is before
+   * deciding whether a flagged row is a defect or just the big part.
+   *
+   * @param {number} quantile In [0, 1]
+   * @return {number} The magnitude at that quantile
+   */
+  quantile(quantile) {
+    if (this.values.length === 0) {
+      return 0
+    }
+
+    this.sorted ??= [...this.values].sort((a, b) => a - b)
+
+    return this.sorted[Math.min(this.sorted.length - 1,
+        Math.floor(this.sorted.length * quantile))]
+  }
+}
+
+
+/**
+ * Largest absolute coordinate over a curve's points.
+ *
+ * Magnitude rather than a proper bounding box: the failure being looked
+ * for is geometry flung away from the origin, and one number per entity
+ * keeps the comparison across thousands of entities readable.
+ *
+ * @param {object} curve A conway-geom CurveObject
+ * @return {number} The largest |x|, |y| or |z| over its 3D points
+ */
+function curveExtent(curve) {
+  const count = curve.getPointsSize()
+  let extent = 0
+
+  for (let i = 0; i < count; ++i) {
+    const point = curve.get3d(i)
+
+    extent = Math.max(extent, Math.abs(point.x), Math.abs(point.y), Math.abs(point.z))
+  }
+
+  return extent
+}
+
+
+/**
+ * Point-spacing statistics for one loop.
+ *
+ * Near-coincident consecutive points are what drive the constrained
+ * Delaunay triangulation into self-intersecting-constraint territory, so
+ * a loop whose minimum gap is orders of magnitude below its own extent is
+ * a tessellation-failure candidate even when its coordinates look sane.
+ *
+ * @param {object} curve A conway-geom CurveObject holding the loop
+ * @return {object} {points, extent, minGap, gaps, wrapDuplicate}
+ */
+function loopSpacing(curve) {
+  const count = curve.getPointsSize()
+  const gaps = new Array(GAP_BUCKETS.length + 1).fill(0)
+  let extent = 0
+  let minGap = Infinity
+  let previous
+  let first
+
+  for (let i = 0; i < count; ++i) {
+    const point = curve.get3d(i)
+
+    extent = Math.max(extent, Math.abs(point.x), Math.abs(point.y), Math.abs(point.z))
+
+    if (i === 0) {
+      first = {x: point.x, y: point.y, z: point.z}
+    } else {
+      const gap = Math.hypot(point.x - previous.x, point.y - previous.y, point.z - previous.z)
+
+      minGap = Math.min(minGap, gap)
+
+      const bucket = GAP_BUCKETS.findIndex((edge) => gap < edge)
+
+      gaps[bucket < 0 ? GAP_BUCKETS.length : bucket] += 1
+    }
+
+    previous = {x: point.x, y: point.y, z: point.z}
+  }
+
+  // A loop that repeats its start point as its last point double-counts a
+  // vertex in the triangulation; harmless in some paths, a degeneracy in
+  // others, and worth seeing either way.
+  const wrapDuplicate = count > 2 && first !== undefined &&
+    Math.hypot(previous.x - first.x, previous.y - first.y, previous.z - first.z) < GAP_BUCKETS[0]
+
+  return {points: count, extent, minGap: count > 1 ? minGap : 0, gaps, wrapDuplicate}
+}
+
+
+/**
+ * Largest absolute coordinate over a half-open range of a geometry's vertices.
+ *
+ * @param {object} geometry A conway-geom GeometryObject
+ * @param {number} from First vertex index, inclusive
+ * @param {number} to Last vertex index, exclusive
+ * @return {number} The largest |x|, |y| or |z| over those vertices
+ */
+function vertexExtent(geometry, from, to) {
+  let extent = 0
+
+  for (let i = from; i < to; ++i) {
+    const point = geometry.getPoint(i)
+
+    extent = Math.max(extent, Math.abs(point.x), Math.abs(point.y), Math.abs(point.z))
+  }
+
+  return extent
+}
+
+
+/**
+ * Describe an entity for a report row.
+ *
+ * @param {object|undefined} entity A conway Entity, or undefined
+ * @return {object} {expressID, entity} with undefined fields elided
+ */
+function describeEntity(entity) {
+  return {
+    expressID: entity?.expressID,
+    entity: entity?.constructor?.name,
+  }
+}
+
+
+/**
+ * Wrap a prototype method, leaving the original callable through `next`.
+ *
+ * @param {Function|undefined} Klass The class whose prototype to patch
+ * @param {string} method The method name
+ * @param {Function} wrap Receives (next, args, self) and returns the result
+ * @return {boolean} True if the method existed and was patched
+ */
+function patch(Klass, method, wrap) {
+  const original = Klass?.prototype?.[method]
+
+  if (typeof original !== 'function') {
+    return false
+  }
+
+  Klass.prototype[method] = function(...args) {
+    return wrap((...forwarded) => original.apply(this, forwarded), args, this)
+  }
+
+  return true
+}
+
+
+/**
+ * Install the curve probe on both schema extractors.
+ *
+ * Curves are memoized per entity, so extractCurve is called far more
+ * often than there are distinct curves; observations are deduplicated by
+ * express ID to keep the median honest.
+ *
+ * @param {Stage} stage The stage to record into
+ * @param {object} classes {AP214GeometryExtraction, IfcGeometryExtraction}
+ * @return {number} How many extractor classes were patched
+ */
+function installCurveProbe(stage, classes) {
+  const seen = new Set()
+  let patched = 0
+
+  const wrap = (next, args) => {
+    const curve = next(...args)
+
+    stage.fired += 1
+
+    const from = args[0]
+
+    if (curve === undefined || typeof curve.getPointsSize !== 'function' ||
+        seen.has(from?.expressID)) {
+      return curve
+    }
+
+    seen.add(from?.expressID)
+
+    const trims = args[3]
+
+    stage.record(curveExtent(curve), () => ({
+      ...describeEntity(from),
+      points: curve.getPointsSize(),
+      trimmed: trims?.exist === true,
+    }))
+
+    return curve
+  }
+
+  for (const Klass of [classes.AP214GeometryExtraction, classes.IfcGeometryExtraction]) {
+    patched += patch(Klass, 'extractCurve', wrap) ? 1 : 0
+  }
+
+  return patched
+}
+
+
+/**
+ * Install the loop probe on the shared conway-geom wrapper.
+ *
+ * `getLoop` is below the schema layer, so one probe covers IFC and STEP.
+ *
+ * @param {Stage} stage The stage to record into
+ * @param {Function} ConwayGeometry The conway-geom wrapper class
+ * @return {number} How many methods were patched
+ */
+function installLoopProbe(stage, ConwayGeometry) {
+  stage.extra.gaps = new Array(GAP_BUCKETS.length + 1).fill(0)
+  stage.extra.wrapDuplicates = 0
+  stage.extra.degenerate = 0
+
+  return patch(ConwayGeometry, 'getLoop', (next, args) => {
+    const curve = next(...args)
+
+    stage.fired += 1
+
+    if (curve === undefined || typeof curve.getPointsSize !== 'function') {
+      return curve
+    }
+
+    const spacing = loopSpacing(curve)
+
+    for (let i = 0; i < spacing.gaps.length; ++i) {
+      stage.extra.gaps[i] += spacing.gaps[i]
+    }
+
+    if (spacing.wrapDuplicate) {
+      stage.extra.wrapDuplicates += 1
+    }
+
+    if (spacing.points < 3) {
+      stage.extra.degenerate += 1
+    }
+
+    // Ranked by extent, not by gap: a loop is worth looking at first when
+    // it is in the wrong place, and the gap columns then say whether it is
+    // also a triangulation risk.
+    stage.record(spacing.extent, () => ({
+      points: spacing.points,
+      minGap: spacing.minGap,
+      wrapDuplicate: spacing.wrapDuplicate,
+    }))
+
+    return curve
+  }) ? 1 : 0
+}
+
+
+/**
+ * Install the face probe on the shared conway-geom wrapper.
+ *
+ * Measures the vertices a single face contributed, by vertex count delta
+ * around the call. That only works when faces are added immediately —
+ * AP214's staged-face path defers the work to a later batch, where the
+ * delta is zero — so the caller sets CONWAY_DISABLE_STAGED_FACES=1 before
+ * the load (see `main`).
+ *
+ * @param {Stage} stage The stage to record into
+ * @param {Function} ConwayGeometry The conway-geom wrapper class
+ * @return {number} How many methods were patched
+ */
+function installFaceProbe(stage, ConwayGeometry) {
+  let patched = 0
+
+  const wrap = (next, args) => {
+    const geometry = args[1]
+    const before = geometry?.getVertexCount?.() ?? 0
+    const result = next(...args)
+
+    stage.fired += 1
+
+    const after = geometry?.getVertexCount?.() ?? 0
+
+    if (after > before) {
+      stage.record(vertexExtent(geometry, before, after), () => ({
+        vertices: after - before,
+      }))
+    }
+
+    return result
+  }
+
+  for (const method of ['addFaceToGeometry', 'addFaceToGeometrySimple']) {
+    patched += patch(ConwayGeometry, method, wrap) ? 1 : 0
+  }
+
+  return patched
+}
+
+
+/**
+ * Walk the built scene and record per-mesh local bounds.
+ *
+ * Runs after the load rather than as a probe, and is the only stage that
+ * can name the product a defect belongs to — the earlier stages see
+ * curves and faces, not parts.
+ *
+ * @param {Stage} stage The stage to record into
+ * @param {object} model The loaded Model
+ * @param {object} scene The built Scene
+ */
+function collectMeshes(stage, model, scene) {
+  if (typeof scene?.walk !== 'function') {
+    return
+  }
+
+  const seen = new Set()
+
+  for (const walked of scene.walk()) {
+    const mesh = walked[2]
+    const geometry = mesh?.geometry
+
+    if (typeof geometry?.getVertexCount !== 'function' || seen.has(mesh.localID)) {
+      continue
+    }
+
+    seen.add(mesh.localID)
+    stage.fired += 1
+
+    const count = geometry.getVertexCount()
+
+    if (count === 0) {
+      continue
+    }
+
+    stage.record(vertexExtent(geometry, 0, count), () => ({
+      ...describeEntity(model.getElementByLocalID?.(mesh.localID)),
+      vertices: count,
+      triangles: geometry.getTriangleCount?.(),
+    }))
+  }
+}
+
+
+/**
+ * Format a number for a report column.
+ *
+ * @param {number} value The value
+ * @return {string} Fixed notation for human-scale values, exponential otherwise
+ */
+function fmt(value) {
+  if (value === 0) {
+    return '0'
+  }
+
+  return Math.abs(value) >= 1e-4 && Math.abs(value) < 1e6 ?
+    value.toFixed(4) :
+    value.toExponential(2)
+}
+
+
+/**
+ * Print one stage's findings.
+ *
+ * @param {Stage} stage The stage
+ * @param {object} options Parsed CLI options
+ * @return {object} A summary suitable for --json
+ */
+function reportStage(stage, options) {
+  const median = stage.quantile(0.5)
+  const p90 = stage.quantile(0.9)
+  const threshold = options.limit ?? median * options.factor
+  const outliers = stage.top.filter((row) => row.value > threshold)
+
+  say(`\n## ${stage.name}`)
+
+  if (stage.fired === 0) {
+    say('  PROBE NEVER FIRED — this stage says nothing about the model.')
+    say('  Expected when the model uses no geometry of this kind (an IFC of')
+    say('  extrusions and polygonal face sets reaches neither loop nor face);')
+    say('  a defect when it does. Do not read this as "clean".')
+
+    return {name: stage.name, fired: 0, dead: true}
+  }
+
+  say(
+      `  ${stage.fired} calls, ${stage.values.length} measured, ` +
+      `median ${fmt(median)}, p90 ${fmt(p90)}, threshold ${fmt(threshold)}` +
+      `${options.limit === undefined ? ` (${options.factor}x median)` : ' (--limit)'}`)
+
+  if (stage.name === 'loop') {
+    const labels = GAP_BUCKETS.map((edge) => `<${edge.toExponential(0)}`).concat('rest')
+
+    say(`  point gaps: ${
+      labels.map((label, i) => `${label} ${stage.extra.gaps[i]}`).join(', ')}`)
+    say(
+        `  wrap-duplicate loops: ${stage.extra.wrapDuplicates}, ` +
+        `under 3 points: ${stage.extra.degenerate}`)
+  }
+
+  if (outliers.length === 0) {
+    say('  no outliers')
+  }
+
+  for (const row of outliers.slice(0, options.top)) {
+    const {value, ...rest} = row
+    const detail = Object.entries(rest)
+      .filter(([, v]) => v !== undefined && v !== false)
+      .map(([k, v]) => `${k}=${typeof v === 'number' && !Number.isInteger(v) ? fmt(v) : v}`)
+      .join(' ')
+
+    say(`  ${fmt(value).padStart(12)}  ${detail}`)
+  }
+
+  if (outliers.length > options.top) {
+    say(`  ... ${outliers.length - options.top} more above threshold`)
+  }
+
+  return {
+    name: stage.name,
+    fired: stage.fired,
+    measured: stage.values.length,
+    median,
+    p90,
+    threshold,
+    outliers: outliers.slice(0, options.top),
+    extra: stage.extra,
+  }
+}
+
+
+/**
+ * Load the model and report.
+ *
+ * @return {Promise<number>} Process exit code
+ */
+async function main() {
+  let options
+
+  try {
+    options = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    console.error(`${error.message}\n`)
+    console.error('run with --help for usage')
+
+    return EXIT_USAGE
+  }
+
+  // Usage text is the file's own header comment: one copy, so the flags
+  // documented and the flags parsed cannot drift apart.
+  if (options.help || options.model === undefined) {
+    const header = fs.readFileSync(new URL(import.meta.url), 'utf8')
+      .split('\n */')[0]
+      .split('\n')
+      .slice(2)
+      .map((line) => line.replace(/^\s*\* ?/, ''))
+
+    console.error(header.join('\n'))
+
+    return options.help ? 0 : EXIT_USAGE
+  }
+
+  say = options.json ? console.error : console.log
+
+  // Must be set before the extraction object is constructed, which happens
+  // inside the load: AP214 reads it once, at construction.
+  if (options.stages.includes('face')) {
+    process.env.CONWAY_DISABLE_STAGED_FACES = '1'
+  }
+
+  const compiled = (rel) => import(new URL(`compiled/${rel}`, REPO_ROOT).href)
+
+  const [
+    {ConwayGeometry},
+    {AP214GeometryExtraction},
+    {IfcGeometryExtraction},
+    {ConwayModelLoader},
+    {default: Logger},
+    {default: Environment},
+  ] = await Promise.all([
+    compiled('dependencies/conway-geom/index.js'),
+    compiled('src/AP214E3_2010/ap214_geometry_extraction.js'),
+    compiled('src/ifc/ifc_geometry_extraction.js'),
+    compiled('src/loaders/conway_model_loader.js'),
+    compiled('src/logging/logger.js'),
+    compiled('src/utilities/environment.js'),
+  ])
+
+  Environment.checkEnvironment()
+  Logger.initializeWasmCallbacks()
+
+  // Conway's own warnings and errors are a diagnostic in their own right —
+  // "Error extracting fill area style color" was one of five defects the
+  // AmazingHand model surfaced — but they repeat per entity, so they are
+  // counted by message rather than echoed.
+  const messages = new Map()
+
+  Logger.setSink((level, message) => {
+    if (level === 'warning' || level === 'error') {
+      const key = `${level}: ${message.split('\n')[0].slice(0, 120)}`
+
+      messages.set(key, (messages.get(key) ?? 0) + 1)
+    }
+
+    if (!options.quiet) {
+      console.error(message)
+    }
+  })
+
+  const stages = new Map(
+      options.stages.map((name) => [name, new Stage(name, Math.max(options.top * 4, 40))]))
+
+  const probesInstalled = {
+    curve: stages.has('curve') ?
+      installCurveProbe(stages.get('curve'), {AP214GeometryExtraction, IfcGeometryExtraction}) : 0,
+    loop: stages.has('loop') ? installLoopProbe(stages.get('loop'), ConwayGeometry) : 0,
+    face: stages.has('face') ? installFaceProbe(stages.get('face'), ConwayGeometry) : 0,
+  }
+
+  for (const [name, count] of Object.entries(probesInstalled)) {
+    if (stages.has(name) && count === 0) {
+      console.error(
+          `\nFATAL: could not install the '${name}' probe — the method it wraps no longer ` +
+          'exists. Fix scripts/debug/model_report.mjs before trusting any result.')
+
+      return EXIT_PROBE_DEAD
+    }
+  }
+
+  const data = new Uint8Array(fs.readFileSync(options.model))
+  const started = Date.now()
+  const [model, scene] = await ConwayModelLoader.loadModelWithScene(data, true, options.csgDepth, 0)
+  const elapsed = Date.now() - started
+
+  if (stages.has('mesh')) {
+    collectMeshes(stages.get('mesh'), model, scene)
+  }
+
+  say(`\n# ${path.basename(options.model)}`)
+  say(
+      `  ${(data.length / 1024 / 1024).toFixed(2)} MB, loaded in ${elapsed} ms, ` +
+      `${options.stages.join(',')}`)
+
+  const reports = [...stages.values()].map((stage) => reportStage(stage, options))
+
+  if (messages.size > 0) {
+    say('\n## conway diagnostics')
+
+    for (const [message, count] of [...messages].sort((a, b) => b[1] - a[1]).slice(0, options.top)) {
+      say(`  ${String(count).padStart(6)}x  ${message}`)
+    }
+  }
+
+  const dead = reports.filter((report) => report.dead)
+
+  if (options.json) {
+    console.log(`\n${JSON.stringify({model: options.model, elapsed, reports,
+      diagnostics: Object.fromEntries(messages)}, null, 1)}`)
+  }
+
+  // Non-zero only when the run learned nothing it was asked to learn: a
+  // stage named on --stage that produced no observations, or a default run
+  // where every stage was silent. Under the default all-stages run a silent
+  // stage is routine (see reportStage), and failing the process for it would
+  // train the reader to ignore the exit code.
+  if (dead.length > 0 && (options.stagesExplicit || dead.length === reports.length)) {
+    say(
+        `\nExiting ${EXIT_PROBE_DEAD}: ${dead.map((d) => d.name).join(', ')} never fired. ` +
+        'A stage that never fired is not a clean result.')
+
+    return EXIT_PROBE_DEAD
+  }
+
+  return 0
+}
+
+process.exitCode = await main()

--- a/scripts/debug/model_report.mjs
+++ b/scripts/debug/model_report.mjs
@@ -25,12 +25,14 @@
  * ## Two hazards this tool exists to remove
  *
  * 1. **A probe that never fires looks exactly like a clean model.** Every
- *    stage reports its `fired` count and the run exits non-zero if a
- *    requested probe never fired. During the AmazingHand investigation,
- *    ad-hoc tracers twice reported "0 outliers" because they were
- *    attached to a seam the model did not take — hours attributed to the
- *    wrong subsystem. A zero here is only meaningful next to a non-zero
- *    `fired`.
+ *    stage reports its `fired` count, and a silent stage says so instead
+ *    of reporting "no outliers". The run exits 2 when a stage named on
+ *    --stage was silent, or when every stage was; under the default
+ *    all-stages run a single silent stage is routine and does not fail
+ *    the process. During the AmazingHand investigation, ad-hoc tracers
+ *    twice reported "0 outliers" because they were attached to a seam
+ *    the model did not take — hours attributed to the wrong subsystem. A
+ *    zero here is only meaningful next to a non-zero `fired`.
  *
  * 2. **Reading wasm memory directly goes stale.** Vertex data is read
  *    through `getPoint()` / `get3d()`, never through a cached `HEAPF32`
@@ -104,6 +106,21 @@ function parseArgs(argv) {
     model: undefined,
   }
 
+  // A mistyped numeric option must not degrade into a quiet wrong answer:
+  // `--limit x` would otherwise make every `value > NaN` comparison false
+  // and report "no outliers" with every probe firing — a false clean
+  // result arriving through the argument parser, which is the one failure
+  // mode this tool exists to rule out.
+  const number = (flag, raw) => {
+    const parsed = Number(raw)
+
+    if (!Number.isFinite(parsed)) {
+      throw new Error(`${flag} needs a number, got: ${raw ?? '(nothing)'}`)
+    }
+
+    return parsed
+  }
+
   for (let i = 0; i < argv.length; ++i) {
     const arg = argv[i]
 
@@ -113,16 +130,16 @@ function parseArgs(argv) {
         options.stagesExplicit = true
         break
       case '--limit':
-        options.limit = Number(argv[++i])
+        options.limit = number(arg, argv[++i])
         break
       case '--factor':
-        options.factor = Number(argv[++i])
+        options.factor = number(arg, argv[++i])
         break
       case '--top':
-        options.top = Number(argv[++i])
+        options.top = number(arg, argv[++i])
         break
       case '--csg-depth':
-        options.csgDepth = Number(argv[++i])
+        options.csgDepth = number(arg, argv[++i])
         break
       case '--json':
         options.json = true
@@ -186,6 +203,7 @@ class Stage {
     }
 
     this.values.push(value)
+    this.sorted = undefined
 
     const worst = this.top[this.top.length - 1]
 
@@ -215,10 +233,36 @@ class Stage {
       return 0
     }
 
+    // Invalidated by record(); every observation is in before anything is
+    // reported today, but a caller that interleaved the two would otherwise
+    // get a stale baseline with no sign that anything was wrong.
     this.sorted ??= [...this.values].sort((a, b) => a - b)
 
     return this.sorted[Math.min(this.sorted.length - 1,
         Math.floor(this.sorted.length * quantile))]
+  }
+
+  /**
+   * How many observations exceed a threshold.
+   *
+   * Counted over every observation, not over the retained `top` records:
+   * `top` is capped, so counting there would silently cap the reported
+   * blast radius of a defect at `capacity` — understating a model with
+   * hundreds of runaway faces as if it had sixty.
+   *
+   * @param {number} threshold The outlier threshold
+   * @return {number} The number of observations strictly above it
+   */
+  countAbove(threshold) {
+    let count = 0
+
+    for (const value of this.values) {
+      if (value > threshold) {
+        count += 1
+      }
+    }
+
+    return count
   }
 }
 
@@ -567,7 +611,8 @@ function reportStage(stage, options) {
   const median = stage.quantile(0.5)
   const p90 = stage.quantile(0.9)
   const threshold = options.limit ?? median * options.factor
-  const outliers = stage.top.filter((row) => row.value > threshold)
+  const outlierCount = stage.countAbove(threshold)
+  const rows = stage.top.filter((row) => row.value > threshold)
 
   say(`\n## ${stage.name}`)
 
@@ -595,11 +640,11 @@ function reportStage(stage, options) {
         `under 3 points: ${stage.extra.degenerate}`)
   }
 
-  if (outliers.length === 0) {
+  if (outlierCount === 0) {
     say('  no outliers')
   }
 
-  for (const row of outliers.slice(0, options.top)) {
+  for (const row of rows.slice(0, options.top)) {
     const {value, ...rest} = row
     const detail = Object.entries(rest)
       .filter(([, v]) => v !== undefined && v !== false)
@@ -609,8 +654,15 @@ function reportStage(stage, options) {
     say(`  ${fmt(value).padStart(12)}  ${detail}`)
   }
 
-  if (outliers.length > options.top) {
-    say(`  ... ${outliers.length - options.top} more above threshold`)
+  const shown = Math.min(rows.length, options.top)
+
+  if (outlierCount > shown) {
+    say(`  ... ${outlierCount - shown} more above threshold` +
+      // Beyond `capacity` the rows themselves were never retained, so
+      // --top cannot show them; only the count is recoverable. Say which
+      // limit is biting rather than letting the reader assume --top.
+      `${outlierCount > stage.capacity ? ' (only the count survives past ' +
+        `${stage.capacity} retained rows — raise --top to retain more)` : ''}`)
   }
 
   return {
@@ -620,7 +672,8 @@ function reportStage(stage, options) {
     median,
     p90,
     threshold,
-    outliers: outliers.slice(0, options.top),
+    outlierCount,
+    outliers: rows.slice(0, options.top),
     extra: stage.extra,
   }
 }
@@ -741,10 +794,17 @@ async function main() {
   const reports = [...stages.values()].map((stage) => reportStage(stage, options))
 
   if (messages.size > 0) {
-    say('\n## conway diagnostics')
+    const ranked = [...messages].sort((a, b) => b[1] - a[1])
+    const total = ranked.reduce((sum, [, count]) => sum + count, 0)
 
-    for (const [message, count] of [...messages].sort((a, b) => b[1] - a[1]).slice(0, options.top)) {
+    say(`\n## conway diagnostics (${total} messages, ${messages.size} distinct)`)
+
+    for (const [message, count] of ranked.slice(0, options.top)) {
       say(`  ${String(count).padStart(6)}x  ${message}`)
+    }
+
+    if (ranked.length > options.top) {
+      say(`  ... ${ranked.length - options.top} more distinct messages`)
     }
   }
 


### PR DESCRIPTION
Docs and tooling only — no engine changes, no behaviour change to any load.

## Why

Debugging a malformed model has meant writing a throwaway tracer each time. The AmazingHand STEP investigation (#444) spent most of its wall clock on instrumentation that was rebuilt from zero, twice attached to a seam the model did not take, and did not survive the session. Two of the three most expensive mistakes there were tooling mistakes, not analysis mistakes.

## What

**`scripts/debug/model_report.mjs`** loads a model through the normal `ConwayModelLoader` path — so IFC and STEP behave exactly as they do in Share — with probes at four levels of the geometry pipeline, and ranks entities by how far their output falls outside the model's own median.

| Stage | Seam | Yields |
|---|---|---|
| `curve` | `extractCurve` (AP214 + IFC) | curve extent, entity type, trim state |
| `loop` | `ConwayGeometry.getLoop` | loop extent, point-spacing histogram, wrap duplicates |
| `face` | `ConwayGeometry.addFaceToGeometry` | vertices one face contributed, and how far out |
| `mesh` | `Scene.walk()` | per-mesh bounds, attributed to the product entity |

`getLoop` and `addFaceToGeometry` sit below the schema layer, so one probe covers both formats. That also avoids `extractAdvancedFace`, which misses faces carrying their own styled geometry — one of the two false-negative readings that cost time on #444.

The stages are deliberately redundant, and the redundancy is the diagnostic: the narrowest dirty stage is where the defect lives. Dirty at `mesh` but clean at `curve` means tessellation, CSG or transform; dirty already at `curve` means curve interpretation upstream of all of it.

The whole `same_sense` diagnosis is now one command. With the fix reverted in the compiled tree:

```
$ node scripts/debug/model_report.mjs Right_Hand.step --quiet --top 4

## curve
  2541 calls, 2541 measured, median 0.0522, p90 0.0950, threshold 0.4176 (8x median)
        0.7178  expressID=76 entity=ellipse points=24 trimmed=true
        0.7178  expressID=77 entity=ellipse points=24 trimmed=true
  ... 13 more above threshold
```

Trimmed conics at 13× p90, with express IDs to open in the file. That took about thirty minutes of ad-hoc tracing the first time.

## Two traps designed out rather than documented

1. **A probe that never fires looks exactly like a clean model.** Every stage prints its `fired` count; the tool refuses to run at all if a seam it wraps has been renamed; and it exits 2 when a stage named on `--stage` produced nothing. Under a default all-stages run a silent stage is reported loudly but does not fail the process, because an IFC of extrusions and polygonal face sets legitimately reaches neither `loop` nor `face`.
2. **A held `HEAPF32` view goes stale.** Wasm memory growth during extraction detaches the buffer and the view silently reads zeroes — the other false negative. Vertices are read via `getPoint()`, curve points via `get3d()`.

## Verification

- Clean (`no outliers`, every probe firing) on current main for `a-gear.step`, `Right_Hand.step`, `supercap.step` — the last also confirming the CDT error churn from #444 is gone.
- Dirty, with the entity-level attribution above, against a build with `same_sense` reverted in `compiled/`.
- Both probe-failure paths exercised: a renamed seam (exit 2, refuses to run) and an installed-but-never-fired probe (exit 2 when explicitly requested).
- `Momentum.ifc`, where `loop` and `face` correctly report never firing and the run still exits 0.
- The documented export → render chain end to end: CLI `-g` → `render_glb.cjs` → PNG.

## Discoverability

- `AGENTS.md` gains a "Debugging a bad model" section and a doc index table.
- `scripts/README.md` gains an index of what is already in `scripts/`. This is how I confirmed `render_glb.cjs` — zero-dependency, deterministic, with a `--pair` mode — had been sitting there the whole time it was being rebuilt during #444 as a worse Playwright + three.js harness. The perf section also documents a `performance_test.sh` that is no longer in the tree; noted rather than fixed.
- `design/new/model-diagnostics.md` inventories the signals, what each means and what it costs, and ranks which are worth surfacing to users in Share — health lines in the load report (reusing `progress_log.ts`, which Share deep-imports), attaching the diagnostic to a bug report, and outlier-robust auto-framing.
- `.gitignore`'s `scripts/*/` was swallowing the new directory; the negation re-includes it.

## Open question

`8x median` is a debugging default that a human calibrates against the p90 column. A user-facing health line needs something that will not cry wolf on a site plan next to a door handle — percentile-of-parts rather than multiple-of-median is the likely answer, and is untested.

Related: bldrs-ai/Share#1715 adds the router row pointing here.