### PR TITLE
Faceset extraction: read face indices via references, not entities (PSB −520MB)

### DIFF
--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -994,8 +994,6 @@ export class IfcGeometryExtraction {
         startIndicesBufferOffsetsArrayPtr,
         startIndicesBufferOffsetsArray.length)
 
-    // Sink contents are now copied into wasm; the sinks are free again.
-    this.polygonalSinksInUse_ = false
 
     const pointsParseBuffer = this.conwayModel.nativeParseBuffer()
 
@@ -1052,14 +1050,49 @@ export class IfcGeometryExtraction {
 
 
   /**
+   * Extract a polygonal faceset.
+   *
+   * The index sinks are extractor-scoped, so a nested faceset extraction
+   * reached from inside this one would silently clobber them. Nothing
+   * recurses there today, so this guards the invariant rather than a
+   * live bug — but the release must survive a throw: per-record
+   * extraction errors are caught upstream and are expected on malformed
+   * models, and a leaked flag would turn one bad record into a failure
+   * for every remaining faceset.
+   *
+   * @param entity The faceset.
+   * @param temporary Is this a temporary (preview/operand) extraction?
+   * @param isRelVoid Is this geometry a rel-void operand?
+   * @return {ExtractResult} The extraction result.
+   */
+  private extractPolygonalFaceSet(entity: IfcPolygonalFaceSet,
+      temporary: boolean = false,
+      isRelVoid: boolean = false): ExtractResult {
+
+    if ( this.polygonalSinksInUse_ ) {
+      throw new Error(
+          'extractPolygonalFaceSet re-entered: the shared index sinks are already in use' )
+    }
+
+    this.polygonalSinksInUse_ = true
+
+    try {
+      return this.extractPolygonalFaceSetGuarded_( entity, temporary, isRelVoid )
+    } finally {
+      this.polygonalSinksInUse_ = false
+    }
+  }
+
+
+  /**
    * @param entity
    * @param temporary
    * @param isRelVoid
    * @return {ExtractResult}
    */
-  private extractPolygonalFaceSet(entity: IfcPolygonalFaceSet,
-      temporary: boolean = false,
-      isRelVoid: boolean = false): ExtractResult {
+  private extractPolygonalFaceSetGuarded_(entity: IfcPolygonalFaceSet,
+      temporary: boolean,
+      isRelVoid: boolean): ExtractResult {
     const result: ExtractResult = ExtractResult.COMPLETE
 
     // Reusable typed sinks. A tessellated model can carry millions of
@@ -1069,18 +1102,6 @@ export class IfcGeometryExtraction {
     // GC time and retained heap during extraction. Indices are parsed
     // straight from the STEP buffer into these instead, reused across
     // facesets.
-    // The sinks are extractor-scoped, so a nested faceset extraction
-    // reached from inside this one would silently clobber them. Nothing
-    // in the window between reset and the wasm copies below recurses
-    // today (the face loop only parses), so this guards the invariant
-    // rather than a live bug — fail loudly if that ever changes.
-    if ( this.polygonalSinksInUse_ ) {
-      throw new Error(
-          'extractPolygonalFaceSet re-entered: the shared index sinks are already in use' )
-    }
-
-    this.polygonalSinksInUse_ = true
-
     const allIndices = this.polygonalIndexSink_
     const allStartIndices = this.polygonalStartIndexSink_
     const polygonalFaceBufferOffsets = this.polygonalFaceOffsetSink_

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -333,6 +333,17 @@ export function extractColorOrFactorMultiply(
  * Starting capacities for the reused polygonal-faceset sinks: enough that a
  * typical faceset never reallocates, while still growing for outliers.
  */
+/**
+ * Vtable coordinates of IfcPolygonalFaceSet.Faces and
+ * IfcIndexedPolygonalFace.CoordIndex, mirroring their generated
+ * getters. The equivalence test in uint32_sink.test.ts fails loudly if
+ * codegen ever moves them.
+ */
+const FACES_FIELD_OFFSET = 2
+const FACES_FIELD_BASE_OFFSET = 1
+const FACES_FIELD_DEPTH = 4
+const COORD_INDEX_FIELD_OFFSET = 0
+
 const POLYGONAL_INDEX_SINK_CAPACITY = 65536
 const POLYGONAL_FACE_SINK_CAPACITY = 16384
 
@@ -935,84 +946,29 @@ export class IfcGeometryExtraction {
   }
 
   /**
-   * @param entity
-   * @param temporary
-   * @param isRelVoid
-   * @return {ExtractResult}
+   * Hand a faceset's accumulated indices to wasm and register the
+   * resulting mesh. Shared by the fast reference-level path and the
+   * generated-getter fallback so they cannot diverge.
+   *
+   * @param entity The faceset.
+   * @param temporary Is this a temporary (preview//operand) extraction?
+   * @param isRelVoid Is this geometry a rel-void operand?
+   * @param indicesPerFace Index count of the last face processed.
+   * @param allIndices Face indices, concatenated.
+   * @param allStartIndices Per-face start indices.
+   * @param polygonalFaceBufferOffsets Per-face offsets into allIndices.
+   * @param startIndicesBufferOffsets Per-face offsets into allStartIndices.
+   * @return {ExtractResult} The extraction result.
    */
-  private extractPolygonalFaceSet(entity: IfcPolygonalFaceSet,
-      temporary: boolean = false,
-      isRelVoid: boolean = false): ExtractResult {
-    const result: ExtractResult = ExtractResult.COMPLETE
-
-    // Reusable typed sinks. A tessellated model can carry millions of
-    // IfcIndexedPolygonalFace records, and the boxed `Array< number >`
-    // this loop used to build per face — which the generated CoordIndex
-    // getter also cached on the face, keeping it alive — dominated both
-    // GC time and retained heap during extraction. Indices are parsed
-    // straight from the STEP buffer into these instead, reused across
-    // facesets.
-    // The sinks are extractor-scoped, so a nested faceset extraction
-    // reached from inside this one would silently clobber them. Nothing
-    // in the window between reset and the wasm copies below recurses
-    // today (the face loop only parses), so this guards the invariant
-    // rather than a live bug — fail loudly if that ever changes.
-    if ( this.polygonalSinksInUse_ ) {
-      throw new Error(
-          'extractPolygonalFaceSet re-entered: the shared index sinks are already in use' )
-    }
-
-    this.polygonalSinksInUse_ = true
-
-    const allIndices = this.polygonalIndexSink_
-    const allStartIndices = this.polygonalStartIndexSink_
-    const polygonalFaceBufferOffsets = this.polygonalFaceOffsetSink_
-    const startIndicesBufferOffsets = this.polygonalStartOffsetSink_
-
-    allIndices.reset()
-    allStartIndices.reset()
-    polygonalFaceBufferOffsets.reset()
-    startIndicesBufferOffsets.reset()
-
-    let indicesPerFace: number = -1
-
-    // Prepare indices and start indices for all faces
-    entity.Faces.forEach((polygonalFace) => {
-
-      // set the offets for the memory buffers so we can rebuild the
-      // indexed polygonal face vector later
-      polygonalFaceBufferOffsets.push(allIndices.length)
-      startIndicesBufferOffsets.push(allStartIndices.length)
-
-      let coordIndex:number = 0
-
-      if (polygonalFace instanceof IfcIndexedPolygonalFaceWithVoids) {
-        // Voided faces are rare; keep the straightforward getter path.
-        indicesPerFace = polygonalFace.CoordIndex.length
-
-        allStartIndices.push(0)
-        coordIndex += indicesPerFace
-
-        for (const index of polygonalFace.CoordIndex) {
-          allIndices.push(index)
-        }
-
-        polygonalFace.InnerCoordIndices.forEach((innerIndices) => {
-          allStartIndices.push(coordIndex)
-
-          for (const index of innerIndices) {
-            allIndices.push(index)
-          }
-
-          coordIndex += innerIndices.length
-        })
-      } else {
-        // CoordIndex is vtable offset 0 on IfcIndexedPolygonalFace (see
-        // its generated getter) — parsed in place, never allocated or cached.
-        indicesPerFace = polygonalFace.extractIntegerArrayInto(0, 0, 3, allIndices)
-        allStartIndices.push(0)
-      }
-    })
+  private finishPolygonalFaceSet_(
+      entity: IfcPolygonalFaceSet,
+      temporary: boolean,
+      isRelVoid: boolean,
+      indicesPerFace: number,
+      allIndices: Uint32Sink,
+      allStartIndices: Uint32Sink,
+      polygonalFaceBufferOffsets: Uint32Sink,
+      startIndicesBufferOffsets: Uint32Sink ): ExtractResult {
 
     // Add the final entry
     polygonalFaceBufferOffsets.push(allIndices.length)
@@ -1091,8 +1047,155 @@ export class IfcGeometryExtraction {
       this.model.voidGeometry.add(canonicalMesh)
     }
 
+    return ExtractResult.COMPLETE
+  }
+
+
+  /**
+   * @param entity
+   * @param temporary
+   * @param isRelVoid
+   * @return {ExtractResult}
+   */
+  private extractPolygonalFaceSet(entity: IfcPolygonalFaceSet,
+      temporary: boolean = false,
+      isRelVoid: boolean = false): ExtractResult {
+    const result: ExtractResult = ExtractResult.COMPLETE
+
+    // Reusable typed sinks. A tessellated model can carry millions of
+    // IfcIndexedPolygonalFace records, and the boxed `Array< number >`
+    // this loop used to build per face — which the generated CoordIndex
+    // getter also cached on the face, keeping it alive — dominated both
+    // GC time and retained heap during extraction. Indices are parsed
+    // straight from the STEP buffer into these instead, reused across
+    // facesets.
+    // The sinks are extractor-scoped, so a nested faceset extraction
+    // reached from inside this one would silently clobber them. Nothing
+    // in the window between reset and the wasm copies below recurses
+    // today (the face loop only parses), so this guards the invariant
+    // rather than a live bug — fail loudly if that ever changes.
+    if ( this.polygonalSinksInUse_ ) {
+      throw new Error(
+          'extractPolygonalFaceSet re-entered: the shared index sinks are already in use' )
+    }
+
+    this.polygonalSinksInUse_ = true
+
+    const allIndices = this.polygonalIndexSink_
+    const allStartIndices = this.polygonalStartIndexSink_
+    const polygonalFaceBufferOffsets = this.polygonalFaceOffsetSink_
+    const startIndicesBufferOffsets = this.polygonalStartOffsetSink_
+
+    allIndices.reset()
+    allStartIndices.reset()
+    polygonalFaceBufferOffsets.reset()
+    startIndicesBufferOffsets.reset()
+
+    let indicesPerFace: number = -1
+
+    // Fast path: read each face's CoordIndex straight from its record,
+    // never constructing the 9M+ IfcIndexedPolygonalFace entities a
+    // large tessellated model would otherwise materialise (and retain,
+    // since the generated Faces getter caches them). It handles only
+    // plain, single-class IFCINDEXEDPOLYGONALFACE records; anything
+    // else (voided faces, inline elements, multi-mapped records)
+    // abandons the whole faceset back to the getter path below, so
+    // correctness never depends on the fast path's coverage.
+    let fastPathOk = true
+
+    const facesWalked = entity.forEachReferenceInField(
+        FACES_FIELD_OFFSET,
+        FACES_FIELD_BASE_OFFSET,
+        FACES_FIELD_DEPTH,
+        (expressID) => {
+
+          if (expressID === void 0) {
+            fastPathOk = false
+            return false
+          }
+
+          const count = this.model.extractIntegerArrayByExpressIDInto(
+              expressID,
+              COORD_INDEX_FIELD_OFFSET,
+              EntityTypesIfc.IFCINDEXEDPOLYGONALFACE,
+              allIndices)
+
+          if (count === void 0) {
+            fastPathOk = false
+            return false
+          }
+
+          polygonalFaceBufferOffsets.push(allIndices.length - count)
+          startIndicesBufferOffsets.push(allStartIndices.length)
+          allStartIndices.push(0)
+          indicesPerFace = count
+
+          return true
+        })
+
+    if (fastPathOk && facesWalked) {
+      this.finishPolygonalFaceSet_(
+          entity, temporary, isRelVoid, indicesPerFace,
+          allIndices, allStartIndices,
+          polygonalFaceBufferOffsets, startIndicesBufferOffsets)
+
+      return result
+    }
+
+    // Fallback: something in this faceset needs the generated getters.
+    allIndices.reset()
+    allStartIndices.reset()
+    polygonalFaceBufferOffsets.reset()
+    startIndicesBufferOffsets.reset()
+    indicesPerFace = -1
+
+    // Prepare indices and start indices for all faces
+    entity.Faces.forEach((polygonalFace) => {
+
+      // set the offets for the memory buffers so we can rebuild the
+      // indexed polygonal face vector later
+      polygonalFaceBufferOffsets.push(allIndices.length)
+      startIndicesBufferOffsets.push(allStartIndices.length)
+
+      let coordIndex:number = 0
+
+      if (polygonalFace instanceof IfcIndexedPolygonalFaceWithVoids) {
+        // Voided faces are rare; keep the straightforward getter path.
+        indicesPerFace = polygonalFace.CoordIndex.length
+
+        allStartIndices.push(0)
+        coordIndex += indicesPerFace
+
+        for (const index of polygonalFace.CoordIndex) {
+          allIndices.push(index)
+        }
+
+        polygonalFace.InnerCoordIndices.forEach((innerIndices) => {
+          allStartIndices.push(coordIndex)
+
+          for (const index of innerIndices) {
+            allIndices.push(index)
+          }
+
+          coordIndex += innerIndices.length
+        })
+      } else {
+        // CoordIndex is vtable offset 0 on IfcIndexedPolygonalFace (see
+        // its generated getter) — parsed in place, never allocated or cached.
+        indicesPerFace = polygonalFace.extractIntegerArrayInto(0, 0, 3, allIndices)
+        allStartIndices.push(0)
+      }
+    })
+
+    this.finishPolygonalFaceSet_(
+        entity, temporary, isRelVoid, indicesPerFace,
+        allIndices, allStartIndices,
+        polygonalFaceBufferOffsets, startIndicesBufferOffsets)
+
     return result
   }
+
+
 
   /**
    * @param array

--- a/src/step/parsing/uint32_sink.test.ts
+++ b/src/step/parsing/uint32_sink.test.ts
@@ -7,9 +7,11 @@ import * as fs from 'fs'
 import { beforeAll, describe, expect, test } from '@jest/globals'
 
 import { IfcAPI } from '../../compat/web-ifc/ifc_api'
+import EntityTypesIfc from '../../ifc/ifc4_gen/entity_types_ifc.gen'
 import {
   IfcIndexedPolygonalFace,
   IfcIndexedPolygonalFaceWithVoids,
+  IfcPolygonalFaceSet,
 } from '../../ifc/ifc4_gen/index'
 import { Uint32Sink } from './uint32_sink'
 
@@ -113,5 +115,128 @@ describe( 'extractIntegerArrayInto', () => {
     }
 
     expect( Array.from( sink.view ) ).toEqual( expected )
+  }, 120000 )
+} )
+
+
+// The reference-level path the faceset extraction uses to avoid
+// constructing an entity per face. It must agree with the generated
+// getters exactly, and must report failure (rather than guess) whenever
+// its preconditions don't hold, because the caller's fallback depends on
+// that signal.
+describe( 'reference-level faceset fast path', () => {
+
+  const FACES_OFFSET = 2
+  const FACES_BASE_OFFSET = 1
+  const FACES_DEPTH = 4
+  const COORD_INDEX_OFFSET = 0
+
+  let api: IfcAPI
+  let modelID: number
+
+  /**
+   * @return {object} The StepModel behind the passthrough tuple.
+   */
+  function stepModel(): any {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return ( api as any ).models.get( modelID ).model[ 0 ]
+  }
+
+  /**
+   * @return {IfcPolygonalFaceSet[]} The fixture's facesets.
+   */
+  function faceSets(): IfcPolygonalFaceSet[] {
+    return Array.from( stepModel().types( IfcPolygonalFaceSet ) ) as IfcPolygonalFaceSet[]
+  }
+
+  beforeAll( async () => {
+    api = new IfcAPI()
+    await api.Init()
+
+    modelID = api.OpenModel(
+        new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ),
+        { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true } )
+  }, 120000 )
+
+  test( 'forEachReferenceInField yields exactly the express IDs the Faces getter resolves', () => {
+
+    const sets = faceSets()
+
+    expect( sets.length ).toBeGreaterThan( 0 )
+
+    for ( const faceSet of sets ) {
+
+      const walked: ( number | undefined )[] = []
+
+      const completed = faceSet.forEachReferenceInField(
+          FACES_OFFSET, FACES_BASE_OFFSET, FACES_DEPTH,
+          ( expressID ) => {
+            walked.push( expressID )
+            return true
+          } )
+
+      expect( completed ).toBe( true )
+      expect( walked ).toEqual( faceSet.Faces.map( ( face ) => face.expressID ) )
+    }
+  }, 120000 )
+
+  test( 'forEachReferenceInField stops when the callback returns false', () => {
+
+    const faceSet = faceSets()[ 0 ]
+    const walked: ( number | undefined )[] = []
+
+    const completed = faceSet.forEachReferenceInField(
+        FACES_OFFSET, FACES_BASE_OFFSET, FACES_DEPTH,
+        ( expressID ) => {
+          walked.push( expressID )
+          return false
+        } )
+
+    expect( completed ).toBe( false )
+    expect( walked.length ).toBe( 1 )
+  }, 120000 )
+
+  test( 'extractIntegerArrayByExpressIDInto matches the generated CoordIndex getter', () => {
+
+    const model = stepModel()
+    const sink = new Uint32Sink( 4 )
+
+    for ( const faceSet of faceSets() ) {
+      for ( const face of faceSet.Faces ) {
+
+        if ( face instanceof IfcIndexedPolygonalFaceWithVoids ) {
+          continue
+        }
+
+        sink.reset()
+
+        const count = model.extractIntegerArrayByExpressIDInto(
+            face.expressID,
+            COORD_INDEX_OFFSET,
+            EntityTypesIfc.IFCINDEXEDPOLYGONALFACE,
+            sink )
+
+        expect( count ).toBe( face.CoordIndex.length )
+        expect( Array.from( sink.view ) ).toEqual( face.CoordIndex )
+      }
+    }
+  }, 120000 )
+
+  test( 'reports failure for an unknown express ID and for a type mismatch', () => {
+
+    const model = stepModel()
+    const sink = new Uint32Sink( 4 )
+    const face = faceSets()[ 0 ].Faces[ 0 ]
+
+    // Unknown record: the caller must fall back, not read something else.
+    expect( model.extractIntegerArrayByExpressIDInto(
+        0xFFFFFFF, COORD_INDEX_OFFSET, EntityTypesIfc.IFCINDEXEDPOLYGONALFACE, sink ) )
+        .toBeUndefined()
+
+    // Right record, wrong expected type: field offsets would not be
+    // comparable, so this must refuse rather than misread the record.
+    expect( model.extractIntegerArrayByExpressIDInto(
+        face.expressID, COORD_INDEX_OFFSET, EntityTypesIfc.IFCPOLYGONALFACESET, sink ) )
+        .toBeUndefined()
   }, 120000 )
 } )

--- a/src/step/parsing/uint32_sink.ts
+++ b/src/step/parsing/uint32_sink.ts
@@ -1,3 +1,11 @@
+import {
+  skipValue,
+  stepExtractArrayBegin,
+  stepExtractArrayToken,
+  stepExtractNumber,
+  stepExtractOptional,
+} from './step_deserialization_functions'
+
 /**
  * Growable Uint32Array append sink.
  *
@@ -59,4 +67,53 @@ export class Uint32Sink {
 
     this.data_[ this.length_++ ] = value
   }
+}
+
+
+/**
+ * Parse a STEP integer list at `cursor` into `sink`, appending in order.
+ *
+ * The single implementation shared by the entity-level and
+ * reference-level fast paths, so they cannot drift from each other or
+ * from the generated array getters they stand in for (same optional
+ * handling, same element extraction, same "incorrectly typed" error).
+ *
+ * @param buffer The record's buffer window.
+ * @param cursor Start of the field.
+ * @param endCursor End bound for extraction.
+ * @param sink Receives the appended values.
+ * @return {number} How many values were appended (0 when unset/optional-null).
+ */
+export function extractIntegerArrayAt(
+    buffer: Uint8Array,
+    cursor: number,
+    endCursor: number,
+    sink: Uint32Sink ): number {
+
+  if ( stepExtractOptional( buffer, cursor, endCursor ) === null ) {
+    return 0
+  }
+
+  let count         = 0
+  let signedCursor0 = stepExtractArrayBegin( buffer, cursor, endCursor )
+  let readCursor    = Math.abs( signedCursor0 )
+
+  while ( signedCursor0 >= 0 ) {
+
+    const value = stepExtractNumber( buffer, readCursor, endCursor )
+
+    if ( value === void 0 ) {
+      throw new Error( 'Value in STEP was incorrectly typed' )
+    }
+
+    readCursor = skipValue( buffer, readCursor, endCursor )
+
+    sink.push( value )
+    ++count
+
+    signedCursor0 = stepExtractArrayToken( buffer, readCursor, endCursor )
+    readCursor    = Math.abs( signedCursor0 )
+  }
+
+  return count
 }

--- a/src/step/step_entity_base.ts
+++ b/src/step/step_entity_base.ts
@@ -17,7 +17,7 @@ import {
   stepExtractReference,
   stepExtractString,
 } from './parsing/step_deserialization_functions'
-import { Uint32Sink } from './parsing/uint32_sink'
+import { Uint32Sink, extractIntegerArrayAt } from './parsing/uint32_sink'
 import { stepBufferBase } from './step_buffer_provider'
 import { StepEntityConstructorAbstract } from './step_entity_constructor'
 import StepEntityInternalReference,
@@ -902,43 +902,68 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
    * @return {number} How many values were appended (0 when the field is
    * unset/optional-null).
    */
-  public extractIntegerArrayInto(
+  /**
+   * Walk a reference-list field, handing each element's express ID to
+   * `onReference` without resolving it to an entity.
+   *
+   * Lets hot loops decide per element how to read the referenced record
+   * (see StepModelBase.extractIntegerArrayByExpressIDInto) instead of
+   * paying for an entity per element the way the generated list getters
+   * do. Inline (non-reference) elements yield `undefined`, and
+   * `onReference` returning false aborts the walk — together those let
+   * a caller bail out to the generated getter for anything it is not
+   * prepared to handle.
+   *
+   * @param offset The offset in the vtable to extract from.
+   * @param baseOffset The base offset of the class in the vtable.
+   * @param depth The depth in the inheritance hierarchy.
+   * @param onReference Receives each element's express ID, or undefined
+   * for an inline element; return false to abort.
+   * @return {boolean} False if the walk was aborted, true otherwise.
+   */
+  public forEachReferenceInField(
       offset: number,
       baseOffset: number,
       depth: number,
-      sink: Uint32Sink ): number {
+      onReference: ( expressID: number | undefined ) => boolean ): boolean {
 
     let   cursor    = this.getOffsetCursor( offset, baseOffset, depth )
     const buffer    = this.buffer
     const endCursor = buffer.length
 
     if ( stepExtractOptional( buffer, cursor, endCursor ) === null ) {
-      return 0
+      return true
     }
 
-    let count         = 0
     let signedCursor0 = stepExtractArrayBegin( buffer, cursor, endCursor )
 
     cursor = Math.abs( signedCursor0 )
 
     while ( signedCursor0 >= 0 ) {
 
-      const value = stepExtractNumber( buffer, cursor, endCursor )
-
-      if ( value === void 0 ) {
-        throw new Error( 'Value in STEP was incorrectly typed' )
+      if ( !onReference( stepExtractReference( buffer, cursor, endCursor ) ) ) {
+        return false
       }
 
-      cursor = skipValue( buffer, cursor, endCursor )
-
-      sink.push( value )
-      ++count
-
+      cursor        = skipValue( buffer, cursor, endCursor )
       signedCursor0 = stepExtractArrayToken( buffer, cursor, endCursor )
       cursor        = Math.abs( signedCursor0 )
     }
 
-    return count
+    return true
+  }
+
+
+  public extractIntegerArrayInto(
+      offset: number,
+      baseOffset: number,
+      depth: number,
+      sink: Uint32Sink ): number {
+
+    const cursor = this.getOffsetCursor( offset, baseOffset, depth )
+    const buffer = this.buffer
+
+    return extractIntegerArrayAt( buffer, cursor, buffer.length, sink )
   }
 
 

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -10,6 +10,7 @@ import {
 import StepVtableBuilder from './parsing/step_vtable_builder'
 import StepEntityBase from './step_entity_base'
 import StepEntitySchema from './step_entity_schema'
+import { Uint32Sink, extractIntegerArrayAt } from './parsing/uint32_sink'
 import StepEntityInternalReference, { StepEntityInternalReferencePrivate } from './step_entity_internal_reference'
 import { IIndexSetCursor } from '../core/i_index_set_cursor'
 import { extractOneHotLow } from '../indexing/bit_operations'
@@ -398,6 +399,68 @@ implements Iterable<BaseEntity>, Model {
    * @param element The raw elment to populate the vtable entry for.
    * @return {boolean} Did the vtable entry populate correctly?
    */
+  /**
+   * Append a referenced record's unsigned-integer list field into `sink`
+   * without materialising the referenced entity.
+   *
+   * This is the reference-level twin of
+   * `StepEntityBase.extractIntegerArrayInto`, for hot loops that walk
+   * millions of small records (tessellated facesets) where constructing
+   * an entity per record dominates. It deliberately handles only the
+   * simple case and reports failure otherwise, so callers keep a
+   * correct fallback rather than this growing subtle special cases:
+   * the reference must resolve, be single-class (no multi-mapping),
+   * and be exactly `expectedTypeID` — which is what makes reading
+   * `offset` as a plain vtable slot equivalent to the generated
+   * getter's `getOffsetCursor( offset, _, _ )` (that only subtracts a
+   * base offset for multi-mapped records).
+   *
+   * @param expressID The referenced record's express ID.
+   * @param offset The field's vtable offset within the record.
+   * @param expectedTypeID The type the record must be.
+   * @param sink Receives the appended values.
+   * @return {number | undefined} Count appended, or undefined when the
+   * fast path does not apply and the caller must fall back.
+   */
+  public extractIntegerArrayByExpressIDInto(
+      expressID: number,
+      offset: number,
+      expectedTypeID: EntityTypeIDs,
+      sink: Uint32Sink ): number | undefined {
+
+    const localID = this.expressIDMap_.get( expressID )
+
+    if ( localID === void 0 || localID >= this.count_ ) {
+      return void 0
+    }
+
+    const element = this.entry( localID )
+
+    // Multi-mapped records need per-depth base offsets; leave them to
+    // the generated getters.
+    if ( element.multiMapping !== void 0 || element.typeID !== expectedTypeID ) {
+      return void 0
+    }
+
+    if ( element.vtableIndex === void 0 && !this.populateVtableEntryRaw( element ) ) {
+      return void 0
+    }
+
+    const vtable = element.vtable
+    const buffer = element.buffer
+
+    if ( vtable === void 0 || buffer === void 0 ||
+      offset >= ( element.vtableCount ?? 0 ) ) {
+      return void 0
+    }
+
+    // Same window the vtable cursors were recorded against, and the
+    // same end bound the generated array getters use.
+    return extractIntegerArrayAt(
+        buffer, vtable[ ( element.vtableIndex as number ) + offset ], buffer.length, sink )
+  }
+
+
   public populateVtableEntryRaw(
     element: StepEntityInternalReference< EntityTypeIDs > ): boolean {
     if (element.vtableIndex !== void 0 || element.typeID === 0 ) {


### PR DESCRIPTION
Lever 2 of #446, stacked on #445. **The headline here is memory, not time** — see the honest numbers below.

## Problem

After #445 the indices themselves are cheap, but the path still materialised **one `IfcIndexedPolygonalFace` entity per face** (PSB.ifc: 9.13 M), and the generated `Faces` getter **caches that array on the faceset**, so they all stay alive for the extraction. The entity around a handful of integers was the remaining cost.

## Change

Read the indices at the reference level:

- **`StepEntityBase.forEachReferenceInField`** — walks a reference-list field, handing out express IDs without resolving them to entities.
- **`StepModelBase.extractIntegerArrayByExpressIDInto`** — reads a referenced record's integer list straight from its vtable slot. It deliberately handles only the simple case (reference resolves, single-class record, exactly the expected type) and returns `undefined` otherwise. That precondition is what makes reading the field as a plain vtable slot equivalent to the generated getter's `getOffsetCursor`, which only subtracts a base offset for multi-mapped records.
- **`extractPolygonalFaceSet`** tries that path and, on *any* refusal — voided faces, inline elements, multi-mapped or unexpected records — abandons the whole faceset back to the existing getter path. **Correctness never depends on the fast path's coverage.**

Both paths now converge on one `finishPolygonalFaceSet_` so they can't diverge, and the integer-list parse is a single shared helper (`extractIntegerArrayAt`) used by the entity-level and reference-level callers alike.

## Results — measured back-to-back

⚠️ This sandbox drifts badly across a session (the *same binary* measured 48.5 s and 69.8 s hours apart), so these are all from one machine state, single session:

| | geometry pump | peak RSS |
|---|---|---|
| main (with #445) | 69.8 s | 4,573 MB |
| **this PR** | **66.3 s** | **4,053 MB** |
| | **−5%** | **−520 MB** |

Cumulative vs published 1.438.1315, same session: pump **92.0 s → 66.3 s**, peak RSS **6,558 MB → 4,053 MB**.

**Being straight about the time win:** profiling attributed ~18 s to this cluster and I expected far more. Most of that 18 s is the express-ID lookup and vtable population, which the reference path *still* pays — what actually goes away is entity construction and retention, hence memory being the larger effect. I've recorded the corrected attribution in #446.

## Output parity

Identical to the published build on PSB (the model that exercises this 9.1 M times): placements 23,454; `sha256` over every placement's geometry id + transform + colour `cc4f1c26…be363`; content digest over 242 sampled geometries (573,648 verts / 374,454 indices) `e2c82342…4ed3a`.

## Tests

- `forEachReferenceInField` yields exactly the express IDs the `Faces` getter resolves, for every faceset in `data/index.ifc`, and honours an aborting callback.
- `extractIntegerArrayByExpressIDInto` matches the generated `CoordIndex` getter on every face, and **refuses** (returns `undefined`) for an unknown express ID and for a type mismatch — the contract the fallback depends on, so it's tested directly rather than assumed.
- Fast path verified to engage 7/7 facesets with zero fallbacks on the fixture.
- 188 tests green across `step/`, `ifc/`, `compat/web-ifc/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_