### PR TITLE
RC regression: pass on the private corpus + stop the batch hanging CI

### DIFF
--- a/.github/workflows/rc-regression.yml
+++ b/.github/workflows/rc-regression.yml
@@ -103,7 +103,13 @@ jobs:
     # Same heavy runner as run-ifc-regression: the batch drives the MT WASM
     # engine over ~100 models with --parallel and reserves multi-GB shared.
     runs-on: ubuntu-22.04-8vcpu-32gb-300gbssd
-    timeout-minutes: 90
+    # ~3x a healthy run (build from the warm WASM cache + LFS checkout +
+    # concurrency-2 regen land well under 30 min). Caps quota burn if the
+    # batch ever wedges again instead of letting it ride the old 90-min
+    # ceiling. The batch also self-exits and per-model work is timeout-bounded;
+    # this is the outer backstop. A cold WASM-cache build can approach this —
+    # bump it if a legitimate rebuild is ever cancelled here.
+    timeout-minutes: 45
     steps:
       # --- Build conway from source (identical to run-ifc-regression) ---
       - name: Checkout conway

--- a/.github/workflows/rc-regression.yml
+++ b/.github/workflows/rc-regression.yml
@@ -5,7 +5,12 @@ name: RC regression (full corpus + baseline bless)
 # PINNED toolchain, gates on failures, and opens a baseline PR in each
 # test-models repo whose diff IS the release's regression report:
 #
-#   - failed.csv rows            -> this workflow goes RED, the rc is bad.
+#   - NEW failed.csv rows        -> this workflow goes RED, the rc is bad. A
+#                                   model already failing in the committed
+#                                   baseline (a known-failer that still loads
+#                                   in prod, or a not-yet-fixed input) does NOT
+#                                   block the rc — otherwise no rc could ever go
+#                                   green while any known-failer exists.
 #   - digest/errors churn        -> shows up as the baseline PR diff; review
 #                                   it (with the per-PR visual evidence that
 #                                   motivated the change) and MERGE to bless.
@@ -209,18 +214,93 @@ jobs:
             models/regression/test_models \
             --parallel --mem-utilization 90
 
-      # Hard gate: any model that failed to parse/extract makes this rc RED.
-      # Digest/errors churn is NOT gated here — it lands in the baseline PR
-      # diff below, where a human reviews and blesses it.
-      - name: Fail on regression failures
+      # Hard gate: fail the rc only on NEW parse/extract failures — models that
+      # were NOT already failing in the committed baseline. Pre-existing,
+      # already-blessed failures (a model that crashes here but loads in prod,
+      # or a known-bad input we haven't fixed yet) must NOT block every future
+      # rc; gating on failed.csv being non-empty means no rc can ever go green
+      # while any known-failer exists.
+      #
+      # The baseline is the failed.csv committed at the target repo's HEAD — the
+      # regeneration above overwrote the working copy in place, so `git show
+      # HEAD:` still yields the pre-run committed set. The diff is keyed on the
+      # `file` column, so a model is simply "failing" or not: robust to a
+      # known-failer's exact exit code/signal wobbling between runs (e.g. an OOM
+      # kill, which surfaces as an empty code/signal here). A brand-new failing
+      # model reds the rc; resolved failures are reported (and drop out of
+      # failed.csv in the baseline PR below) but never gate. Digest/errors churn
+      # is likewise not gated here — it lands in the baseline PR diff, where a
+      # human reviews and blesses it.
+      - name: Fail on NEW regression failures
         run: |
-          FAILED=models/regression/test_models/failed.csv
-          if [ -f "$FAILED" ] && [ "$(wc -l < "$FAILED")" -gt 1 ]; then
-            echo "::error::${{ matrix.target.repo }} has regression failures — this rc is bad:"
-            cat "$FAILED"
-            exit 1
-          fi
-          echo "No failures."
+          cd models/regression/test_models
+          python3 - "${{ matrix.target.repo }}" <<'EOF'
+          import csv, io, subprocess, sys
+          from collections import Counter
+
+          repo = sys.argv[1]
+
+          def read_csv(text):
+              rows = list(csv.reader(io.StringIO(text)))
+              if not rows:
+                  return [], []
+              return rows[0], [r for r in rows[1:] if r]
+
+          # Current (freshly regenerated) failed.csv.
+          try:
+              with open("failed.csv", newline="") as f:
+                  cur_header, current = read_csv(f.read())
+          except FileNotFoundError:
+              cur_header, current = [], []
+
+          # Committed baseline at the target repo's HEAD.
+          base_run = subprocess.run(
+              ["git", "-C", "../..", "show", "HEAD:regression/test_models/failed.csv"],
+              capture_output=True, text=True)
+          has_baseline = base_run.returncode == 0
+          base_header, baseline = read_csv(base_run.stdout) if has_baseline else ([], [])
+
+          def file_of(row, header):
+              if header and "file" in header:
+                  idx = header.index("file")
+                  return row[idx] if len(row) > idx else ""
+              return row[0] if row else ""
+
+          # Keep a representative full row per failing file for readable output.
+          cur_rows = {}
+          for r in current:
+              cur_rows.setdefault(file_of(r, cur_header), r)
+
+          cur_files = Counter(file_of(r, cur_header) for r in current)
+          base_files = Counter(file_of(r, base_header) for r in baseline)
+
+          new_failures = sorted((cur_files - base_files).elements())
+          resolved = sorted((base_files - cur_files).elements())
+          preexisting = sorted((cur_files & base_files).elements())
+
+          print(f"Failing models in {repo} — current: {len(list(cur_files.elements()))}, "
+                f"baseline: {len(list(base_files.elements()))}")
+          if not has_baseline:
+              print("  (no failed.csv at the target repo's HEAD — every failure counts as new)")
+          print(f"  pre-existing (blessed): {len(preexisting)}")
+          print(f"  resolved since baseline: {len(resolved)}")
+          print(f"  NEW: {len(new_failures)}")
+
+          if resolved:
+              print("\nResolved (no longer failing — drops from failed.csv on bless):")
+              for name in resolved:
+                  print(f"  - {name}")
+
+          if new_failures:
+              print(f"\n::error::{repo} has NEW regression failures "
+                    "(not in the blessed baseline) — this rc is bad.")
+              print("New failures (file,code,signal):")
+              for name in new_failures:
+                  print("  " + ",".join(cur_rows.get(name, [name])))
+              sys.exit(1)
+
+          print("\nNo new failures. Pre-existing known-failers do not block the rc.")
+          EOF
 
       # The batch always writes regression/test_models/changes.csv via a git
       # diff whose pathspec is relative to the model folder, so under this
@@ -263,9 +343,12 @@ jobs:
 
             **This diff is the release candidate's regression report.** Every
             changed digest is a model whose geometry differs from the last
-            blessed baseline. No failures were detected (the generating
-            workflow gates on `failed.csv`). Review the churn and merge to
-            bless — from then on, per-PR smoke diffs in conway mean "this PR
-            moved geometry", not accumulated drift.
+            blessed baseline. No NEW parse/extract failures were detected (the
+            generating workflow gates on failures added vs the committed
+            `failed.csv`; pre-existing known-failers do not block the rc, and
+            any that this run resolved drop out of `failed.csv` in this diff).
+            Review the churn and merge to bless — from then on, per-PR smoke
+            diffs in conway mean "this PR moved geometry", not accumulated
+            drift.
 
             Generated by conway's `rc-regression` workflow.

--- a/.github/workflows/rc-regression.yml
+++ b/.github/workflows/rc-regression.yml
@@ -204,12 +204,26 @@ jobs:
       # points the batch's changes summary at the current committed baseline.
       # NOT --dryrun: dryrun git-checkouts the output folder back, discarding
       # the regeneration — we want it to persist so the PR carries it.
+      #
+      # --concurrency 2 (down from the os.cpus() default): each child is itself
+      # multi-threaded, so one child per core heavily oversubscribes the CPUs.
+      # The largest models' wall-clock then balloons to several times their
+      # standalone time — the biggest private model parses + fully extracts in
+      # ~80s alone but blew past the old 150s per-model timeout under that
+      # contention, landing in failed.csv as a bogus timeout (empty
+      # code/signal), not a real crash. Two children at a time keep the cores
+      # busy without starving the big models; --timeout 600000 (10 min) is
+      # insurance on top of that. Both stay well inside the 90-min job budget.
+      # Digests are deterministic regardless of concurrency, so this changes
+      # only reliability, not the blessed output.
       - name: Regenerate baseline digests
         run: |
           node --experimental-specifier-resolution=node \
             ./compiled/src/ifc/ifc_regression_batch_main.js \
             -e "sp-.*\.ifc" \
             -t HEAD \
+            --concurrency 2 \
+            --timeout 600000 \
             models \
             models/regression/test_models \
             --parallel --mem-utilization 90

--- a/.github/workflows/rc-regression.yml
+++ b/.github/workflows/rc-regression.yml
@@ -103,13 +103,14 @@ jobs:
     # Same heavy runner as run-ifc-regression: the batch drives the MT WASM
     # engine over ~100 models with --parallel and reserves multi-GB shared.
     runs-on: ubuntu-22.04-8vcpu-32gb-300gbssd
-    # ~3x a healthy run (build from the warm WASM cache + LFS checkout +
-    # concurrency-2 regen land well under 30 min). Caps quota burn if the
-    # batch ever wedges again instead of letting it ride the old 90-min
-    # ceiling. The batch also self-exits and per-model work is timeout-bounded;
-    # this is the outer backstop. A cold WASM-cache build can approach this —
-    # bump it if a legitimate rebuild is ever cancelled here.
-    timeout-minutes: 45
+    # Outer backstop against a wedged run (down from an old 90). A healthy run
+    # is build-from-warm-cache + LFS checkout + concurrency-2 regen + the
+    # serial perf pass over the tracked models, comfortably under ~40 min; 60
+    # leaves headroom (incl. a cold WASM-cache rebuild) while still cancelling
+    # a hang far sooner than the old ceiling. The batch also self-exits and
+    # per-model work is timeout-bounded, so this rarely fires. Bump it if a
+    # legitimate cold rebuild is ever cancelled here.
+    timeout-minutes: 60
     steps:
       # --- Build conway from source (identical to run-ifc-regression) ---
       - name: Checkout conway
@@ -321,6 +322,71 @@ jobs:
 
           print("\nNo new failures. Pre-existing known-failers do not block the rc.")
           EOF
+
+      # Steady conway-native perf: re-run ONLY the tracked models
+      # (regression/perf_models.txt) through the batch at --concurrency 1 —
+      # one child at a time, full cores each — so parse/geometry/total + RSS
+      # are steady run-over-run. The parallel regen above oversubscribes the
+      # cores (os.cpus() multi-threaded children), which is fine for the
+      # deterministic digests but makes its timings noise. This is conway-
+      # native load timing, distinct from the headless-three perf-three-*
+      # jobs (end-to-end render path).
+      #
+      # Output goes to a throwaway temp folder so this re-extraction never
+      # touches the blessed baseline the regen just produced; only perf.csv is
+      # harvested. The batch CLI only excludes, so (as in build.yml's smoke
+      # job) build a regex that excludes every model NOT in the perf set. A
+      # given corpus only matches its own entries; the rest are simply absent.
+      - name: Build perf-set exclude regex
+        id: perfset
+        run: |
+          python3 - <<'EOF'
+          import os, re
+          names = [l.strip() for l in open('regression/perf_models.txt')
+                   if l.strip() and not l.strip().startswith('#')]
+          alts = '|'.join(re.escape(n) for n in names)
+          regex = (rf"^(?!.*/(?:{alts})$)"
+                   r".*\.(?:[iI][fF][cC]|[sS][tT][eE][pP]|[sS][tT][pP])$")
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            fh.write(f'regex={regex}\n')
+          print(f'{len(names)} tracked perf models; exclude-others regex: {regex}')
+          EOF
+
+      # The batch's built-in runDiff runs `git diff -- <outputFolder>` with cwd
+      # inside the models repo; a pathspec OUTSIDE that repo is a fatal git
+      # error, so the throwaway output MUST live inside models. Keep it OUT of
+      # regression/test_models so it can't leak into the bless PR (whose commit
+      # is add-paths-scoped to that folder) and drop it afterwards.
+      - name: Steady conway-native perf (tracked models, serial)
+        env:
+          PERF_EXCLUDE: ${{ steps.perfset.outputs.regex }}
+        run: |
+          rm -rf models/.perf-tmp
+          node --experimental-specifier-resolution=node \
+            ./compiled/src/ifc/ifc_regression_batch_main.js \
+            -e "$PERF_EXCLUDE" \
+            --concurrency 1 \
+            --timeout 600000 \
+            --perf "${RUNNER_TEMP}/perf-serial.csv" \
+            models \
+            models/.perf-tmp \
+            --parallel --mem-utilization 90
+          rm -rf models/.perf-tmp
+          echo "### Steady conway-native perf (${{ matrix.target.repo }}, serial)" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "${RUNNER_TEMP}/perf-serial.csv" ]; then
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            cat "${RUNNER_TEMP}/perf-serial.csv" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "_No perf rows produced (no tracked models present in this corpus)._" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload steady perf CSV
+        if: hashFiles(format('{0}/perf-serial.csv', runner.temp)) != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-serial-${{ matrix.target.name }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/perf-serial.csv
 
       # The batch always writes regression/test_models/changes.csv via a git
       # diff whose pathspec is relative to the model folder, so under this

--- a/regression/perf_models.txt
+++ b/regression/perf_models.txt
@@ -1,0 +1,30 @@
+# Steady conway-native perf-tracking set.
+#
+# One model filename per line (basename with extension, matched against the
+# test-models tree; lines starting with '#' are ignored).
+#
+# The rc-regression rebless job, AFTER its parallel digest regen, re-runs
+# ONLY these models through the batch at --concurrency 1 (one child at a
+# time, full cores each) with --perf, so the emitted parse/geometry/total +
+# RSS numbers are steady run-over-run — the parallel regen's timings are
+# noise because os.cpus() multi-threaded children oversubscribe the cores.
+#
+# This is conway-NATIVE load timing (parse + geometry extraction), distinct
+# from the headless-three perf-three-* jobs, which measure the end-to-end
+# render path (GL + scene build) on top of conway.
+#
+# Curation intent: the largest / slowest models across both corpora — the
+# ones whose load time we actually track (PSB -> 30s, the 0.11.800
+# comparison). A given rebless run only matches the entries present in its
+# target repo (public vs private); the rest are simply absent and skipped.
+# Keep this list SHORT: each model runs serially, adding its full standalone
+# runtime to the job.
+
+# --- public (bldrs-ai/test-models) ---
+SKYLARK250_design-kit_blocks_detailed.ifc
+Snowdon Towers Sample Architectural_IFC2x3.ifc
+Arty_Z7.stp
+DSA2.step
+
+# --- private (bldrs-ai/test-models-private) ---
+PSB.ifc

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -5922,15 +5922,47 @@ export class IfcGeometryExtraction {
   }
 
   /**
+   * Handle an error raised while building the cross-product extraction
+   * maps. Each map sweep reads references off relationship entities
+   * (materials, styled items, rel-voids); a single malformed reference in
+   * a large real-world model (STEP where an entity reference is expected)
+   * must not abort the whole model's extraction. Both the whole-model walk
+   * and the demand path depend on map prep being tolerant here — the
+   * browser demand pump swallows per-batch extraction throws, so a model
+   * that renders in prod would otherwise hard-fail the headless regression
+   * batch. Honours the strict-mode escape hatch so a strict run still
+   * surfaces the error.
+   *
+   * @param context Short label for the relationship being processed.
+   * @param expressID The offending record's express ID (may be undefined).
+   * @param ex The caught value.
+   */
+  private handleMapPrepError_(
+      context: string, expressID: number | undefined, ex: unknown ): void {
+    if (ex instanceof Error) {
+      if (MATERIAL_RELATED_OBJECTS_PERMISSIVE) {
+        Logger.error(`Error processing ${context} expressID: ${expressID}, error: ${ex.message}`)
+      } else {
+        throw ex
+      }
+    } else {
+      Logger.error(`Unknown exception processing ${context}.`)
+    }
+  }
+
+  /**
    *
    */
   populateStyledItemsMap() {
     const styledItems = this.model.types(IfcStyledItem)
 
     for (const styledItem of styledItems) {
-
-      if (styledItem.Item !== null) {
-        this.materials.styledItemMap.set(styledItem.Item.localID, styledItem.localID)
+      try {
+        if (styledItem.Item !== null) {
+          this.materials.styledItemMap.set(styledItem.Item.localID, styledItem.localID)
+        }
+      } catch (ex) {
+        this.handleMapPrepError_('IfcStyledItem', styledItem.expressID, ex)
       }
     }
   }
@@ -5943,14 +5975,18 @@ export class IfcGeometryExtraction {
     const materialDefinitionRepresentations = this.model.types(IfcMaterialDefinitionRepresentation)
 
     for (const materialDefinitionRep of materialDefinitionRepresentations) {
-
-      for (const representation of materialDefinitionRep.Representations) {
-        for (let itemIndex = 0; itemIndex < representation.Items.length; ++itemIndex) {
-          // save mapping of IfcMaterial --> IfcStyledItem
-          this.materials.materialDefinitionsMap.set(
-              materialDefinitionRep.RepresentedMaterial.localID,
-              representation.Items[itemIndex].localID)
+      try {
+        for (const representation of materialDefinitionRep.Representations) {
+          for (let itemIndex = 0; itemIndex < representation.Items.length; ++itemIndex) {
+            // save mapping of IfcMaterial --> IfcStyledItem
+            this.materials.materialDefinitionsMap.set(
+                materialDefinitionRep.RepresentedMaterial.localID,
+                representation.Items[itemIndex].localID)
+          }
         }
+      } catch (ex) {
+        this.handleMapPrepError_(
+            'IfcMaterialDefinitionRepresentation', materialDefinitionRep.expressID, ex)
       }
     }
   }
@@ -5962,19 +5998,23 @@ export class IfcGeometryExtraction {
     // populate relvoids map
     const relVoids = this.model.types(IfcRelVoidsElement)
     for (const relVoid of relVoids) {
-      // map product --> relvoids opening elements
-      const geometryLocalIDArray =
-        this.productToVoidGeometryMap.get(relVoid.RelatingBuildingElement.localID)
+      try {
+        // map product --> relvoids opening elements
+        const geometryLocalIDArray =
+          this.productToVoidGeometryMap.get(relVoid.RelatingBuildingElement.localID)
 
-      if (geometryLocalIDArray === void 0) {
-        const localIDArray: number[] = []
-        localIDArray.push(relVoid.RelatedOpeningElement.localID)
-        this.productToVoidGeometryMap.set(relVoid.RelatingBuildingElement.localID, localIDArray)
-      } else {
-        // append to it
-        geometryLocalIDArray.push(relVoid.RelatedOpeningElement.localID)
-        this.productToVoidGeometryMap.set(
-            relVoid.RelatingBuildingElement.localID, geometryLocalIDArray)
+        if (geometryLocalIDArray === void 0) {
+          const localIDArray: number[] = []
+          localIDArray.push(relVoid.RelatedOpeningElement.localID)
+          this.productToVoidGeometryMap.set(relVoid.RelatingBuildingElement.localID, localIDArray)
+        } else {
+          // append to it
+          geometryLocalIDArray.push(relVoid.RelatedOpeningElement.localID)
+          this.productToVoidGeometryMap.set(
+              relVoid.RelatingBuildingElement.localID, geometryLocalIDArray)
+        }
+      } catch (ex) {
+        this.handleMapPrepError_('IfcRelVoidsElement', relVoid.expressID, ex)
       }
     }
   }
@@ -6176,8 +6216,15 @@ export class IfcGeometryExtraction {
     const relAssociatesMaterials = this.model.types(IfcRelAssociatesMaterial)
 
     for (const relAssociateMaterial of relAssociatesMaterials) {
-      const relatingMaterial = relAssociateMaterial.RelatingMaterial
       try {
+        // Read RelatingMaterial INSIDE the guard: a malformed material
+        // reference (e.g. a value where an entity ref is expected) throws
+        // "Value in STEP was incorrectly typed", and pulling this read above
+        // the try let one bad relationship abort the whole model's extraction
+        // instead of being tolerated like every other malformed relationship
+        // here. The rel-aggregates loop below already reads its RelatingObject
+        // inside its own try for exactly this reason.
+        const relatingMaterial = relAssociateMaterial.RelatingMaterial
         const relatedObjects = relAssociateMaterial.RelatedObjects
         for (const relatedObject of relatedObjects) {
           const product = relatedObject
@@ -6198,16 +6245,10 @@ export class IfcGeometryExtraction {
           }
         }
       } catch (ex) {
-        if (ex instanceof Error) {
-          if (MATERIAL_RELATED_OBJECTS_PERMISSIVE) {
-            Logger.error('Error processing relatingMaterial expressID: ' +
-              `${relatingMaterial.expressID}, error: ${ex.message}`)
-          } else {
-            throw ex
-          }
-        } else {
-          Logger.error('Unknown exception processing IfcRelAssociateMaterials.')
-        }
+        // Reference the relationship record, not RelatingMaterial: the
+        // latter may be exactly what threw and would be undefined here.
+        this.handleMapPrepError_(
+            'IfcRelAssociatesMaterial', relAssociateMaterial.expressID, ex)
       }
     }
 
@@ -6679,7 +6720,28 @@ export class IfcGeometryExtraction {
           continue
         }
 
-        this.extractProductGeometry(product)
+        try {
+          this.extractProductGeometry(product)
+        } catch (ex) {
+          // A single malformed product must not abort the whole model. A
+          // reference field carrying a value where an entity is expected
+          // throws "Value in STEP was incorrectly typed" deep in material/
+          // representation extraction; the rel-aggregates pass below already
+          // tolerates this per-relationship, and the browser demand pump
+          // swallows per-product throws, so a model that renders in prod
+          // would otherwise hard-fail the headless regression batch. Skip
+          // the offending product and continue; strict mode re-throws.
+          if (ex instanceof Error) {
+            if (MATERIAL_RELATED_OBJECTS_PERMISSIVE) {
+              Logger.error(`Error extracting product expressID: ${product.expressID}, ` +
+                `error: ${ex.message}`)
+            } else {
+              throw ex
+            }
+          } else {
+            Logger.error('Unknown exception extracting product.')
+          }
+        }
       }
 
       const relAggregates = this.model.types(IfcRelAggregates)

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -58,8 +58,17 @@ async function safeExecWithCancellation(
 
     // Set up the timeout promise.
     const timeoutHandle = setTimeout(() => {
-      // Timeout occurred: kill the child process.
-      child.kill()
+      // Timeout occurred: SIGKILL (not the default SIGTERM) so a child stuck
+      // in a wasm compute loop is force-killed. A model exceeding the timeout
+      // is not expected once batch concurrency is bounded — this is a safety
+      // net. The explicit process.exit at the end of the run guarantees the
+      // batch still terminates promptly even if a killed child leaves a
+      // grandchild behind holding an open pipe.
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        // Already gone.
+      }
       resolve({
         type: 'Failed',
         name: 'TimeoutError',
@@ -767,6 +776,14 @@ const args = yargs(process.argv.slice(SKIP_PARAMS))
           const overallEnd = Date.now()
           const totalSec = ((overallEnd - overallStart) / divisor).toFixed(fixedPoint)
           console.log(`\nAll tasks completed. Total runtime: ${totalSec} seconds.`)
+
+          // All work is done and every CSV is written. Exit explicitly rather
+          // than waiting for the event loop to drain: a child that had to be
+          // force-killed (or any lingering wasm worker handle) can otherwise
+          // keep this process alive long after the run, hanging the CI step
+          // for the rest of the job timeout. console.log to a pipe is
+          // synchronous on Linux, so the line above is already flushed.
+          process.exit(0)
         },
     )
     .help().argv

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -426,6 +426,7 @@ function getSystemMemoryUsagePercent(): number {
  * @param failedLines
  * @param memUtilization
  * @param maxTimeout
+ * @param concurrency Max children processed at once (>= 1).
  * @param perfDir If set, the child writes its perf CSV here as <basename>.perf.csv.
  */
 async function processIFCFilesInParallel(
@@ -436,10 +437,11 @@ async function processIFCFilesInParallel(
     failedLines: string[],
     memUtilization: number,
     maxTimeout:number,
+    concurrency: number,
     perfDir?: string,
 ): Promise<void> {
-  const concurrencyLimit = os.cpus().length
-  console.log(`Concurrency: ${concurrencyLimit} threads - Max Timeout: ${maxTimeout} ms`)
+  const concurrencyLimit = Math.max(1, concurrency)
+  console.log(`Concurrency: ${concurrencyLimit} children - Max Timeout: ${maxTimeout} ms`)
 
   const limit = pLimit(concurrencyLimit)
   const taskTimeout = 2000
@@ -610,11 +612,23 @@ const args = yargs(process.argv.slice(SKIP_PARAMS))
           })
           // only relevant if parallel is enabled
           yargs2.option('mem-utilization', {
-             
+
             describe: 'Memory utilization threshold percentage for parallel processing (1-100, default: 95)',
             type: 'number',
             alias: 'm',
             default: 95,
+          })
+          // only relevant if parallel is enabled
+          yargs2.option('concurrency', {
+            describe:
+              'Max IFC files processed at once in parallel mode. Each child ' +
+              'is itself multi-threaded, so os.cpus() children heavily ' +
+              'oversubscribe the cores: the largest models\' wall-clock then ' +
+              'balloons (spurious timeouts) and per-model perf numbers become ' +
+              'noise. Lower this for steady timings. Default: CPU core count.',
+            type: 'number',
+            alias: 'j',
+            default: 0,
           })
           // Validate mem-utilization only if parallel mode is active
           yargs2.check((argv) => {
@@ -668,6 +682,10 @@ const args = yargs(process.argv.slice(SKIP_PARAMS))
           const doParallel = (argv['parallel'] as boolean) ?? false // <--- read the parallel flag
           const memUtilization = (argv['mem-utilization'] as number)
           const maxTimeout = (argv['timeout'] as number)
+          // 0 (the default) means "auto": one child per core.
+          const concurrencyArg = (argv['concurrency'] as number)
+          const concurrency =
+            concurrencyArg && concurrencyArg > 0 ? Math.floor(concurrencyArg) : os.cpus().length
           const perfOutputPath = ((argv['perf'] as string) ?? '').trim()
 
           if (changes.length === 0) {
@@ -712,6 +730,7 @@ const args = yargs(process.argv.slice(SKIP_PARAMS))
                 failedLines,
                 memUtilization,
                 maxTimeout,
+                concurrency,
                 perfTmpDir,
             )
           } else {


### PR DESCRIPTION
Makes the RC regression pass cleanly on the private corpus, stops it from wedging the runner, and adds steady conway-native perf. Five commits.

## 1. Gate on NEW failures only, not any failure (`rc-regression.yml`)
The gate reddened the rc **whenever `failed.csv` had any row**, so no rc could go green while any known-failer existed. Two private models were blessed as failing during pipeline bring-up though they load in prod (`PSB.ifc`, the Bauprojekt model). The gate now diffs the regenerated `failed.csv` against the one committed at the target repo's `HEAD` (keyed on the `file` column) and fails **only on newly-failing models**; resolved ones are reported and drop out on bless. Mirrors `build.yml`'s new-vs-baseline diff. Verified across identical / new / resolved / signal-wobble / no-baseline / all-clean scenarios.

## 2. Bauprojekt: tolerate malformed relationship refs per-record (`ifc_geometry_extraction.ts`)
Hard-failed with `Value in STEP was incorrectly typed` though it renders in prod — ~12 malformed refs across material / material-def / rel-void / product records. Extraction was inconsistently permissive: `RelatingMaterial` was read *outside* its guard, the three map populators had none, and the whole-model product loop had none (unlike the rel-aggregates loop beside it). Now all tolerate a malformed record per-record via a shared `handleMapPrepError_`, honouring the `MATERIAL_RELATED_OBJECTS_PERMISSIVE` strict escape hatch. Bauprojekt: exit 1 → exit 0, stable 31-row digest (12 tolerated, 2 products skipped, matching prod). Clean models byte-identical (guards inert unless a read throws).

## 3. PSB: bound batch concurrency instead of oversubscribing cores (`ifc_regression_batch_main.ts` + `rc-regression.yml`)
PSB's failure was the `TimeoutError` path (empty `code`/`signal`), not a crash. The batch ran one child per core and each child is itself multi-threaded → heavy oversubscription; PSB extracts in ~80s standalone but blew past the 150s timeout under contention. Added `--concurrency`/`-j` (default `os.cpus()`, so `build.yml` smoke is unchanged); rc regenerate now runs `--concurrency 2`. Digests are deterministic w.r.t. concurrency, so blessed output is unchanged.

## 4. Batch self-exits + job time cap so a wedge can't hang CI (`ifc_regression_batch_main.ts` + `rc-regression.yml`)
The regenerate step did its work in ~161s but the job sat in that step **1h+** — the batch printed "All tasks completed" and never exited. A timed-out model was SIGTERM'd, reaping the wrapper shell but leaving its wasm grandchild running; the grandchild's open stdout pipe kept node's event loop alive until the job ceiling. Fix: the batch `process.exit(0)`s once all CSVs are written and the diff has run (timeouts now SIGKILL). Verified locally — a forced-timeout run that used to hang now exits in ~5s. The rebless job `timeout-minutes` also caps the job as an outer backstop.

## 5. Steady conway-native perf folded into the rebless job (`ifc_regression_batch_main.ts`, `rc-regression.yml`, `regression/perf_models.txt`)
The parallel regen's timings are noise (oversubscription); the perf-three-* jobs give steady numbers but for the **render** path, not conway's parse+extract. After the regen + gate, the job re-runs **only** the tracked models (`regression/perf_models.txt`) at `--concurrency 1 --perf` — one child at a time, full cores each — emitting steady parse/geometry/total + RSS. This is the conway-native number "PSB → 30s" and the 0.11.800 comparison track. Output goes to a throwaway in-repo folder (never touches the blessed baseline); the CSV is uploaded as an artifact and echoed to the job summary. Rebless `timeout-minutes` 45 → 60 to cover the serial pass.

## Validation
All four failure/hang paths reproduced and fixed locally (Bauprojekt load, PSB timeout signature, forced-timeout no-hang, serial perf run exit 0). Engine guards are inert on well-formed models; concurrency/exit/timeout/perf changes don't affect blessed digests. End-to-end confirmation is the next rc tag / `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz