### PR TITLE
docs: capture CI regression/cost architecture; freshen stale CI docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Check `scripts/` before building tooling — see
 | What is in `scripts/`, and performance testing | [scripts/README.md](scripts/README.md) |
 | Geometry-quality signals, and which ones Share should surface to users | [design/new/model-diagnostics.md](design/new/model-diagnostics.md) |
 | Regression corpus, digest CSVs, smoke subset vs RC pass | [regression/README.md](regression/README.md), [design/new/step-regression.md](design/new/step-regression.md) |
+| CI tiering, cost rationale, rc/re-bless/LFS runbook | [design/new/ci-regression-cost.md](design/new/ci-regression-cost.md) |
 | STEP support: schemas, coverage, known gaps | [design/new/step-support.md](design/new/step-support.md) |
 | STEP product structure and metadata (the AP242 wrinkle, NIST) | [design/new/step-metadata-nist.md](design/new/step-metadata-nist.md) |
 | Native GLB export from the CLI | [design/new/glb-native-export.md](design/new/glb-native-export.md) |

--- a/README.md
+++ b/README.md
@@ -185,14 +185,25 @@ git merge -X rename-threshold=25 --no-commit
 
 # CI and Testing
 
+CI is **tiered** so full-corpus regression + performance cost is paid once per
+release candidate, not on every push. Full architecture, cost rationale, and
+the rc/re-bless/LFS runbook: [design/new/ci-regression-cost.md](design/new/ci-regression-cost.md).
+
 Every PR is gated on two checks defined in `.github/workflows/build.yml`:
 
 | Job | What it does |
 |---|---|
 | `build` | `yarn install`, WASM + TS compile (WASM cached on the `conway-geom` submodule SHA), `yarn test`, `yarn lint`, and a Tier-A geometry-digest check of the in-repo `data/` models against committed goldens. |
-| `run-ifc-regression` | `needs: build`. Reuses the same WASM cache. Runs the regression batch against the public `test-models` ref (`TEST_MODELS_REF`, default `main`), pinned per-run to the resolved commit SHA; posts a per-PR comment with the resolved SHA + `failed.csv` / `errors.csv` / perf summaries, and uploads the candidate npm tarball + `perf.csv` as workflow artifacts. |
+| `run-ifc-regression` | `needs: build`. Reuses the same WASM cache. Runs the regression batch over the **smoke subset** (`regression/smoke_models.txt`) of the public `test-models` ref (`TEST_MODELS_REF`, default `main`), pinned per-run to the resolved commit SHA. Fails on any `failed.csv` row; digest *changes* are informational (reviewed via the visual-diff comment, blessed at the rc). Posts a per-PR comment with the resolved SHA + smoke-scoped `failed.csv` / `errors.csv` / perf summaries, and uploads the candidate npm tarball + `perf.csv` as workflow artifacts. |
 
-A merge to `main` re-runs those two jobs and then chains into `auto-publish` (see [Releases](#releases) below).
+A `concurrency` group cancels superseded PR runs (main runs are never
+cancelled, so releases always complete). A merge to `main` re-runs those two
+jobs and then chains into `auto-publish` (see [Releases](#releases) below).
+
+**The full public+private corpus runs once per release candidate** — push an
+`rc-*` tag and `rc-regression.yml` regenerates every baseline (opening a
+reviewable baseline PR per test-models repo) while the `perf-three-*` jobs run
+the full benchmark. See the runbook in the CI-cost doc linked above.
 
 ## Regression batch
 
@@ -209,8 +220,11 @@ The `build` job also runs a fast, hermetic geometry gate over every `data/*.ifc`
 **Tier 1 — Conway-only perf in CI (live).** Every regression run emits a `perf.csv` of `parseTimeMs / geometryTimeMs / totalTimeMs / rssMb / heapUsedMb / heapTotalMb` per model. The top-10 slowest are posted in the PR comment; the full CSV is uploaded as a workflow artifact. This piggybacks on the existing regression batch so cost is ~0 extra runner minutes.
 
 **Tier 2 — full headless-three perf in CI (live).** Two jobs,
-`perf-three-public` and `perf-three-private`, run on `push: main`
-(`needs: run-ifc-regression`). Each downloads the candidate Conway tarball
+`perf-three-public` and `perf-three-private`, run on `rc-*` tags and
+`workflow_dispatch` (`needs: run-ifc-regression`) — once per release
+candidate, not per merge, so per-model timings stay low-variance on the
+isolated runner (see [ci-regression-cost.md](design/new/ci-regression-cost.md)
+for why frequency, not runner size, is the cost lever). Each downloads the candidate Conway tarball
 that the regression job packed, clones [headless-three](https://github.com/bldrs-ai/headless-three)
 at a pinned `H3_SHA`, and forces the whole H3 → adapter → conway chain onto
 the candidate via a yarn `resolutions` override (no `yarn link`), then runs
@@ -305,23 +319,23 @@ npm dist-tag add @bldrs-ai/conway@<VERSION> stable
 
 # Roadmap
 
-The CI / release pipeline is continuous and complete: `build` gates
-`run-ifc-regression`, which gates the headless-three perf jobs, and every
-green merge to `main` auto-publishes (see [Releases](#releases)). The
+The CI / release pipeline is continuous and **tiered**: `build` (fixtures) and
+`run-ifc-regression` (smoke subset) gate every PR; the full public+private
+corpus and the headless-three perf jobs run once per `rc-*` release candidate;
+every green merge to `main` auto-publishes (see [Releases](#releases)). The
+architecture, cost rationale, and rc/re-bless/LFS runbook are in
+[design/new/ci-regression-cost.md](design/new/ci-regression-cost.md). Regression
+renders (the visual-diff comment) and per-model perf-in-CI shipped; the
 umbrella waterfall (#316) and performance-in-CI (#314) issues are closed.
-The optional follow-ups below remain.
 
-### Headless-three perf on PRs
+### Open follow-ups
 
-The `perf-three-public` / `perf-three-private` jobs run on `push: main`
-only — to keep PR wall-time down and to keep the private-models token off
-PR events (forks can't be trusted with it). Running them per-PR, behind a
-gate that withholds the private job from fork PRs, would catch H3
-render-time regressions before merge instead of just after.
-
-### Golden `errors.csv` diffing + regression renders (#288)
-
-Fail a PR when its `errors.csv` diverges from a checked-in golden — "New
-errors detected. Copy errors.csv to golden/errors.csv to accept changes"
-— and attach per-model renders to the regression comment so geometry
-regressions are visible without downloading artifacts.
+- **Errors as a hard gate.** `errors.csv` is regenerated and reviewed (and,
+  at the rc, blessed into the baseline), but a PR is not *failed* on unexpected
+  new errors — only on parse/extract failures (`failed.csv`). A golden-errors
+  gate could fail smoke-scoped error churn that isn't an intended change.
+- **Smoke-list curation.** The smoke subset (`regression/smoke_models.txt`)
+  is a hand-picked spread; as the engine's failure surface shifts, revisit
+  which models best catch regressions cheaply.
+- **Perf-threshold gating.** The `perf-three-*` jobs post deltas but don't
+  fail an rc on a regression; a threshold could turn perf into a release gate.

--- a/design/new/ci-regression-cost.md
+++ b/design/new/ci-regression-cost.md
@@ -1,0 +1,213 @@
+# CI regression & cost architecture
+
+How conway's CI is tiered so full-corpus regression + performance cost is
+paid **once per release candidate** instead of on every push, why it's shaped
+that way, and the operational runbook (cutting an rc, re-blessing baselines,
+the token, the LFS-budget dependency) for keeping it running.
+
+This is the durable home for decisions that otherwise live only in
+`build.yml` / `rc-regression.yml` comments and merged PR descriptions. If you
+change the tiering, the triggers, or the cost trade, update this doc.
+
+Operational quick-reference for *running* the regression batch locally lives
+in [`../../regression/README.md`](../../regression/README.md); this doc is the
+*why* and the CI/release wiring.
+
+
+## The testing pyramid
+
+Three escalating scopes. Cheap and always-on at the bottom; the expensive
+full sweep only at a blessed release point.
+
+| Tier | When | What runs | Gate |
+|---|---|---|---|
+| **A — fixtures** | every PR + merge | unit tests + `data/` geometry goldens (in `build`) | **hard** — a mismatch fails `build` |
+| **B — smoke** | every PR + merge | digest batch over `regression/smoke_models.txt` (~12 models) in `run-ifc-regression` | **hard on failures** — a model that fails to parse/extract blocks; digest *changes* are informational |
+| **C — full corpus + perf** | `rc-*` tag | full public+private digest regression (`rc-regression.yml`) **and** the `perf-three-*` headless-three benchmarks (in `build.yml`) | **hard on failures**; digest churn lands in a reviewable baseline PR |
+
+Tier A is hermetic (no `test-models` clone, no token — protects forks too);
+see the Tier-A section of `../../regression/README.md`. Tiers B and C share
+the same digest batch (`ifc_regression_batch_main.js`), just over different
+model sets.
+
+### Why smoke changes don't gate
+
+A smoke digest *change* is informational, not a failure, on purpose:
+geometry improvements are supposed to change digests. A crash (`failed.csv`
+row) is never intended, so that gates. Intended geometry changes are reviewed
+visually (the visual-diff comment) and **blessed at the rc**, not at PR time.
+
+
+## Why it's tiered this way (the cost rationale)
+
+Every heavy job runs on the `ubuntu-22.04-8vcpu-32gb-300gbssd` runner, billed
+as **Actions Linux 16-core at $0.042/min** — that line item is ~100% of the
+metered spend (the 2-core `Actions Linux` rows bill $0 inside the included
+allotment). So cost ≈ **large-runner minutes**, and the levers are *how often*
+and *how many* jobs hit that runner.
+
+Measured per-job wall time on that runner (representative runs):
+
+| job | wall time |
+|---|---|
+| build (WASM cache hit) | ~2.8 min |
+| run-ifc-regression (full corpus, old) | ~5 min |
+| **perf-three-private** | **~27 min** |
+| **perf-three-public** | **~11 min** |
+| smoke batch step (12 models) | **seconds** |
+
+Findings that drove the design:
+
+1. **Perf was the dominant cost** (~55% of spend) and ran on *every merge*.
+   Per-commit perf attribution is redundant while perf is actively reviewed
+   per-model at PR time, so it moved to `rc-*` tags (#424). Perf **runner size
+   is deliberately not reduced**: for a benchmark, the 8-vcpu headroom buys
+   low-variance timings, not throughput — frequency is the lever, not size.
+2. **The full digest batch ran on every PR** for a whole-corpus signal that a
+   ~12-model smoke subset delivers for correctness at a fraction of the cost
+   (#443). The full corpus still runs — once, at the rc.
+3. **Every PR push spawned a fresh pipeline with no cancellation.** A
+   concurrency group now cancels superseded runs (#399, see below).
+
+Net effect: a PR push dropped from ~13 → ~6 large-runner minutes, a merge from
+~48 → ~8; the full corpus + perf (~40+ min) is paid once per `rc-*` tag.
+
+**Do not "just run everything on PRs again"** to catch breaks earlier — that
+reintroduces the spend this tiering removed. Some delay in finding a break on
+a non-smoke model is the accepted trade; the rc pass is the safety net.
+
+
+## Trigger map
+
+Precise event → jobs (all gates are per-job `if:` in the workflows):
+
+| Event | build | run-ifc-regression (smoke) | visual-diff | perf-three-* | rc-regression (full) | auto-publish |
+|---|---|---|---|---|---|---|
+| pull_request | ✅ | ✅ | if digest changed | — | — | — |
+| push `main` | ✅ | ✅ | — | — | — | ✅ (npm) |
+| push `rc-*` tag | ✅ | ✅ | — | ✅ | ✅ | — |
+| workflow_dispatch | ✅ | ✅ | — | ✅ | ✅ | — |
+
+`auto-publish` is `push:main` only, so an `rc-*` tag never double-publishes.
+The `perf-three-*` jobs live in `build.yml` but gate on
+`startsWith(github.ref, 'refs/tags/rc-')`; the full digest corpus + baseline
+bless is a separate workflow, `rc-regression.yml`, on the same tag.
+
+
+## Concurrency
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+```
+
+- Keyed on `github.ref` (`refs/pull/<n>/merge` is unique per PR), so PRs never
+  cancel each other — only newer pushes to the *same* PR supersede older ones.
+- `cancel-in-progress` is **scoped to `pull_request` only**. Push-to-main runs
+  must run to completion: `auto-publish` tags + publishes each main commit to
+  npm, and each commit ships its own version, so cancelling a main run
+  mid-publish (or skipping a commit's release) is not acceptable. Main runs
+  queue rather than cancel.
+
+
+## Baselines and drift
+
+The digest baselines are committed **in the test-models repos** at
+`regression/test_models/*.csv` (one CSV per model, per-Express-ID geometry
+hashes). `run-ifc-regression` regenerates digests for the smoke subset and
+diffs them against those committed baselines.
+
+**Two-baseline mismatch (the drift you'll see).** The digest gate compares
+the PR engine's output against the *pinned test-models baseline*; the
+per-PR **visual diff** compares the *published npm engine* against the PR
+build. When the baseline hasn't kept pace with released engine changes, a
+model shows as digest-changed but renders pixel-identical (the change already
+shipped). That churn is baseline drift, not a PR regression — which is why:
+
+- the smoke diff is **scoped to the smoke subset** (a batch that only
+  regenerated 12 models would otherwise report every *other* model as
+  "resolved" — the phantom "602 resolved" seen on #443's first run); and
+- the **visual diff is pixel-thresholded** (`--diff-threshold`, default
+  0.05%): identical renders are suppressed to a tally instead of shown as
+  no-op rows (#441). Limitation: the threshold is area-only, so a tiny
+  high-contrast change could fall below it — tune the threshold or the smoke
+  list if that ever bites.
+
+**Re-blessing** regenerates the baselines from the current engine so the
+changed-set again means "this PR moved geometry." That happens as part of the
+rc pass (below) — merging its baseline PRs *is* the bless.
+
+
+## Release-candidate runbook
+
+Continuous release is unchanged: **every green merge to `main` auto-publishes
+to npm** (`auto-publish`, version `<major>.<PR>.<commit>` — see the README).
+The rc flow is the *separate*, deliberate "this is prod-worthy" gate.
+
+To cut one:
+
+```bash
+git tag rc-<name> <sha-on-main>
+git push origin rc-<name>
+```
+
+On that tag push:
+
+1. **`build`** + **`run-ifc-regression`** run as usual (produce the candidate
+   tarball the perf jobs consume).
+2. **`perf-three-public` / `perf-three-private`** run the full H3 benchmark on
+   the isolated runner (low-variance timings) with a delta vs the previous rc.
+3. **`rc-regression.yml`** runs the digest batch over the **entire public and
+   private corpora**, **fails red on any `failed.csv` row** (a bad rc stops
+   here), and opens a **baseline PR in each test-models repo**. That PR's diff
+   *is* the release's regression report.
+4. **Review the two baseline PRs and merge** — that blesses the baselines to
+   this release. From then on, per-PR smoke diffs are drift-free.
+
+Fixing one broken model costs one fix cycle plus one rc re-run (the batch is
+~minutes) — no per-model retest machinery, which isn't worth building at this
+corpus size.
+
+
+## Operational gotchas (learned the hard way)
+
+- **`REBLESS_TOKEN` lives in `conway`'s repo secrets, not the model repos.**
+  `rc-regression.yml` runs *in conway* and uses the token to push branches +
+  open PRs in `test-models` / `test-models-private`. It's a fine-grained PAT
+  with `contents:write` + `pull_requests:write` on **both** model repos
+  (org PAT-approval may be required). The default `GITHUB_TOKEN` is
+  conway-scoped and cannot push cross-repo; the workflow fails fast (on the
+  cheap `setup` job) if the secret is absent.
+
+- **The whole pipeline depends on the test-models Git-LFS budget.** Model
+  files are LFS; a fresh checkout must fetch them. When the org's LFS
+  *bandwidth* budget is exhausted, `git lfs` fetch is refused
+  (`This repository exceeded its LFS budget`) and any fresh pull fails
+  (exit 128). `run-ifc-regression` normally survives on a **warm test-models
+  cache** (keyed on the test-models SHA) — so the failure is *masked* until
+  the cache misses (test-models `main` advances) or a job does a fresh pull
+  (the rc run). Symptom: PRs suddenly red at the test-models checkout with no
+  code change. Fix: add an LFS data pack to the org (Settings → Billing), or
+  as a no-code stopgap set the repo variable `TEST_MODELS_REF` to a SHA whose
+  cache is still warm.
+
+- **`matrix` is not available in a job-level `if:`.** `rc-regression.yml`
+  selects corpora via a dynamic matrix built by a `setup` job, not a
+  job-level `if` on `matrix.*` — the latter is a workflow-validation
+  (startup) failure, not a runtime skip.
+
+- **Blessed digests must be byte-reproducible by a later smoke run.**
+  `rc-regression.yml` builds conway *from source* with the same pinned
+  toolchain + WASM cache key as `run-ifc-regression`. Do **not** switch it to
+  install the published npm package — that can lag main's `conway-geom`
+  submodule SHA and re-introduce drift the moment it's merged.
+
+
+## Cross-refs
+
+- Running the batch / digest modes / fixtures: [`../../regression/README.md`](../../regression/README.md)
+- STEP digest design (post-transform hashing): [`step-regression.md`](step-regression.md)
+- GLB-byte goldens (complementary golden effort): [`glb-snapshot-goldens.md`](glb-snapshot-goldens.md)
+- Release/versioning/npm publish: `README.md` §Releases
+- Source of truth for wiring: `.github/workflows/build.yml`, `.github/workflows/rc-regression.yml`

--- a/design/new/step-regression.md
+++ b/design/new/step-regression.md
@@ -24,7 +24,11 @@ files are most prone to. Read §"The digest" before writing any code.
   `test-models/regression/test_models/`; any drift surfaces as the
   failed.csv / errors.csv the PR comment shows.
 - CI (`.github/workflows/build.yml`, `run-ifc-regression` job) clones
-  `test-models` at a pinned SHA, runs the batch, and posts the diff.
+  `test-models` at a pinned SHA, runs the batch, and posts the diff. Note the
+  batch is **tiered**: per-PR it runs only the smoke subset, and the full
+  corpus runs once per `rc-*` tag — see
+  [`ci-regression-cost.md`](ci-regression-cost.md). The STEP digest below
+  applies at whichever scope the model sits in.
 
 The IFC digest hashes geometry **per entity, before scene assembly**. That
 is correct for IFC, where the bug surface is per-item mesh generation.


### PR DESCRIPTION
## Summary

Makes the tiered-CI overhaul (PRs #399/#424/#441/#442/#443) **durable and discoverable**. That architecture — concurrency cancellation, perf + full-corpus moved to `rc-*` tags, per-PR smoke subset, visual-diff pixel threshold, baseline re-bless — and, more importantly, its *rationale and operational lessons*, lived only in workflow-YAML comments and merged PR descriptions. This writes it down where the next person (or agent) will find it, and corrects the entry-point docs that had gone stale.

Docs only — no behavior change.

## Motivation (the audit)

Grepping every markdown file and workflow for each concept from the overhaul showed the knowledge was scattered and the front door was wrong:
- `concurrency`, `cancel-in-progress`, the LFS-budget dependency, the cost model, `REBLESS_TOKEN` setup: **zero durable markdown** — only workflow comments / PR bodies.
- `README.md` actively misdescribed the pipeline: it said `run-ifc-regression` runs the *full* batch (smoke-only now) and that `perf-three-*` runs on `push: main` (`rc-*` tags now), and its Roadmap declared the pipeline "complete" while listing a follow-up (perf-on-PRs) we deliberately reversed.

`AGENTS.md` (the agent index) and `regression/README.md` (the tiering summary) were already healthy — so this fills the gap rather than duplicating them.

## Changes

- **`design/new/ci-regression-cost.md` (new, 213 lines)** — the durable home:
  - the testing pyramid (fixtures → smoke → full-corpus+perf) and **why** it's tiered: 16-core billing, perf ≈55% of spend, "frequency not runner-size" is the cost lever;
  - a precise event→jobs trigger map;
  - the concurrency decision (and why main is never cancelled);
  - the two-baseline drift model (why smoke diffs are informational, why the visual diff is thresholded, why re-bless);
  - an **rc runbook** — cutting a tag, the baseline PRs, merge-is-bless — plus the two footguns we actually hit: **`REBLESS_TOKEN` must live in conway's secrets, not the model repos**, and **the pipeline depends on the test-models Git-LFS budget** (the warm cache masks exhaustion until a fresh pull or cache miss — the failure that reddened all PRs).
- **`AGENTS.md`** — one index row pointing to the new doc.
- **`README.md`** — corrected the CI/Testing table, Performance Tier 2, and Roadmap; re-pointed to the new doc.
- **`step-regression.md`** — noted the batch is now tiered (smoke per-PR, full per-rc).

## Verification

- All internal doc links checked to resolve (including the `../../` relative links from `design/new/`).
- Architecture details (concurrency block, `rc-*` gating, `REBLESS_TOKEN` requirement, trigger matrix) transcribed from the live merged workflows, not memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyCxwn1wc35pkBiM9VC64V

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyCxwn1wc35pkBiM9VC64V)_