### PR TITLE
RC regression: retry a timed-out model once before failing the rc

### DIFF
--- a/.github/workflows/rc-regression.yml
+++ b/.github/workflows/rc-regression.yml
@@ -230,6 +230,15 @@ jobs:
       # standalone time (~80s) now that nothing is starved, and catches a
       # genuine hang faster than the old 600s.
       #
+      # Serializing was still not enough on its own: ISSUE_159 timed out AGAIN
+      # running alone at --concurrency 1, reddening the rc with the same bogus
+      # empty-code/signal row. A per-model timeout is a nondeterministic infra
+      # event, not a reproducible parse/geometry failure, so the batch now
+      # retries a timed-out model ONCE before recording it (idempotent digest
+      # regen makes the retry safe). A transient timeout clears on the retry; a
+      # genuine hang times out both times and still lands in failed.csv, so the
+      # gate keeps its teeth against a model that truly never loads.
+      #
       # --perf: with the run already serial, capture every model's steady
       # parse/geometry/total + RSS in one pass. Written to the conway workspace
       # root (NOT the models checkout, so it never touches the diffed baseline)

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -338,6 +338,48 @@ async function runForFile(filePath: string,
   }
 }
 
+
+/**
+ * Run a file's digest, retrying ONCE if the first attempt times out.
+ *
+ * A per-model timeout is not a deterministic parse/geometry failure — it
+ * surfaces as a failed.csv row with an empty code AND empty signal (the
+ * TimeoutError path sets neither) and, historically, has come from transient
+ * core oversubscription on the CI runner rather than the model itself.
+ * ISSUE_159_kleine_Wohnung_R22.ifc (a geometry-dense ~18.5k-item model) has
+ * reddened the rc-regression gate this way twice: first co-scheduled at
+ * --concurrency 2, then again running ALONE at --concurrency 1, so serializing
+ * the batch was not enough to make it reliable.
+ *
+ * Digest regeneration is idempotent, so a second attempt is safe: a transient
+ * timeout clears on the retry, while a genuine hang times out both times and
+ * still lands in failed.csv — the gate keeps its protective value against a
+ * model that truly never loads. Only timeouts are retried; a real non-zero
+ * exit or signal is returned immediately (those ARE deterministic).
+ *
+ * @param filePath   Model file to digest.
+ * @param outputPath Digest output path (without extension).
+ * @param maxTimeout Per-attempt timeout in ms.
+ * @param perfPath   Optional path the child writes its one-row perf CSV to.
+ * @return The first attempt's result, or the retry's result on a timeout.
+ */
+async function runForFileWithTimeoutRetry(filePath: string,
+    outputPath: string, maxTimeout: number, perfPath?: string): Promise<RunResults> {
+  const timedOut = (r: RunResults): boolean =>
+    r.type === 'Failed' && r.message === 'Execution timed out'
+
+  const first = await runForFile(filePath, outputPath, maxTimeout, perfPath)
+  if (!timedOut(first)) {
+    return first
+  }
+
+  console.log(
+      `"${path.basename(filePath)}" timed out; retrying once ` +
+      `(a transient timeout clears, a true hang times out again).`,
+  )
+  return runForFile(filePath, outputPath, maxTimeout, perfPath)
+}
+
 // Model files the regression harness understands: IFC plus STEP AP214.
 const SUPPORTED_MODEL_EXTENSIONS = ['.ifc', '.stp', '.step']
 
@@ -472,7 +514,7 @@ async function processIFCFilesInParallel(
       const perfChildPath = perfDir ?
         path.join(perfDir, `${path.parse(ifcPath).name}.perf.csv`) :
         undefined
-      const fileResults = await runForFile(
+      const fileResults = await runForFileWithTimeoutRetry(
           ifcPath,
           path.join(outputPath, path.parse(ifcPath).name),
           maxTimeout,
@@ -552,7 +594,7 @@ async function recursiveWalk(
       const perfChildPath = perfDir ?
         path.join(perfDir, `${path.parse(resolved).name}.perf.csv`) :
         undefined
-      const fileResults = await runForFile(
+      const fileResults = await runForFileWithTimeoutRetry(
           resolved,
           path.join(outputPath, path.parse(resolved).name),
           maxTimeout,


### PR DESCRIPTION
## Why

The [rc-1.450.1353 regression run](https://github.com/bldrs-ai/conway/actions/runs/31047961006) went **red on a single model**, `ISSUE_159_kleine_Wohnung_R22.ifc`, reported as a NEW failure with the signature `,,` — **empty `code` AND empty `signal`**.

That signature is produced by exactly one code path: the batch's `TimeoutError` handler (it sets neither `code` nor `signal`; an OOM `SIGKILL` would populate `signal`). So the model hit the 300 s per-model timeout — and it did so **running alone**: the run log shows `Active tasks: 1 → 0` throughout, confirming `--concurrency 1` was in effect.

This is the *second* time ISSUE_159 (a geometry-dense ~18.5k-item model) has reddened this gate this way — first co-scheduled at `--concurrency 2`, then again alone at `--concurrency 1`. Serializing the batch (the fix in #450) was not enough to make it reliable.

Meanwhile the rc itself was healthy: it **resolved two real baseline failures** (`nist_ftc_08`, `nist_ftc_11`) with **zero new deterministic regressions**, and the private corpus passed fully. The red was pure CI flakiness, not an engine regression.

## What

A per-model timeout is a **nondeterministic infra event** (transient core oversubscription on the runner), not a reproducible parse/geometry failure. So the batch now **retries a timed-out model once** before recording it in `failed.csv`:

- Digest regeneration is idempotent → the retry is safe.
- A transient timeout **clears** on the retry (rc stays green).
- A genuine hang **times out both times** and still lands in `failed.csv` → the gate keeps its teeth against a model that truly never loads.
- Non-timeout failures (a real non-zero exit or signal) are returned immediately — only timeouts are retried.

Applied at both `runForFile` call sites (parallel + recursive) via a new `runForFileWithTimeoutRetry` wrapper; the `rc-regression.yml` comment is updated to document the behavior.

## Testing

- `yarn eslint src/ifc/ifc_regression_batch_main.ts` — 0 errors.
- Standalone `tsc --noEmit` on the changed file — clean. (The full `tsc --build` / `yarn test` can't run in this session because the `conway-geom` submodule isn't provisioned here; conway CI runs the full gate on this PR.)

To validate the fix end-to-end, re-tag an `rc-*` on a commit that includes this change (or `workflow_dispatch` the RC regression against `public`) — ISSUE_159 should clear on retry and the run go green.

## Related

Unblocks bumping Share to `@bldrs-ai/conway@1.450.1353` — see the companion Share PR (bldrs-ai/Share `claude/rc-1450-1353-diagnosis-4mvs82`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJ3nekfLtsEvV2cGScbHzN)_