### PR TITLE
Fix perf baseline artifact selection to exclude debug artifacts

### DIFF
--- a/.github/actions/perf-delta/action.yml
+++ b/.github/actions/perf-delta/action.yml
@@ -49,8 +49,17 @@ runs:
             repo: context.repo.repo,
             per_page: 100,
           });
+          // Snapshot artifacts are named <prefix><run_id>, so require exactly
+          // digits after the prefix. A bare startsWith(prefix) also matches the
+          // sibling `perf-three-public-benchdir-<run_id>` debug artifact, which
+          // is uploaded `if: always()` — i.e. even from a FAILED benchmark run,
+          // whose partial performance-detail.csv would then silently become the
+          // next delta's baseline. The plain snapshot only uploads on success,
+          // so anchoring to it keeps the baseline a completed run's data.
+          const snapshotName = new RegExp(
+            '^' + prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\d+$');
           const prior = arts
-            .filter(a => a.name.startsWith(prefix) && !a.expired && a.workflow_run.id !== context.runId)
+            .filter(a => snapshotName.test(a.name) && !a.expired && a.workflow_run.id !== context.runId)
             .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
           if (prior) {
             core.setOutput('found', 'true');

--- a/design/new/ci-regression-cost.md
+++ b/design/new/ci-regression-cost.md
@@ -138,6 +138,19 @@ shipped). That churn is baseline drift, not a PR regression — which is why:
 changed-set again means "this PR moved geometry." That happens as part of the
 rc pass (below) — merging its baseline PRs *is* the bless.
 
+**Perf baselines are artifact-anchored, not committed.** The `perf-three-*`
+jobs diff against the most recent prior `perf-three-{public,private}-<run_id>`
+snapshot artifact (see `.github/actions/perf-delta`) — after a blessed rc,
+that is the blessed run's numbers until the next rc/dispatch run replaces
+them. Only the exact `<prefix><run_id>` snapshot counts (the `-benchdir-`
+debug artifact is excluded: it uploads even from failed runs). Two
+consequences: artifacts expire after ~90 days, so an rc gap longer than that
+degrades the next run to a snapshot-only comment (no delta, by design,
+non-fatal); and the baseline is "last successful run", not "last *blessed*
+run" — a workflow_dispatch perf run between rcs becomes the new comparison
+point. The serial conway-native load timings from `rc-regression.yml`
+(`perf-serial-*` artifacts) are informational only; nothing diffs them yet.
+
 
 ## Release-candidate runbook
 


### PR DESCRIPTION
## Summary
This change fixes the perf-delta action to correctly identify performance baseline artifacts by using exact name matching instead of prefix matching. This prevents debug artifacts (which are uploaded even from failed runs) from being incorrectly used as baselines for performance comparisons.

## Key Changes
- Updated `.github/actions/perf-delta/action.yml` to use a regex pattern that matches snapshot artifacts exactly (`<prefix><run_id>` with digits only) instead of a simple `startsWith()` check
- The regex explicitly excludes the `perf-three-*-benchdir-*` debug artifacts, which are uploaded unconditionally (`if: always()`) and may contain incomplete data from failed runs
- Added detailed comments explaining why exact matching is necessary to maintain baseline integrity

## Implementation Details
- The snapshot artifact name pattern requires the prefix followed by one or more digits (`^\d+$`), ensuring only completed snapshot artifacts are selected
- Debug artifacts (`-benchdir-`) are excluded because they upload even when benchmark runs fail, which would cause partial/invalid performance data to become the next run's baseline
- The regex properly escapes the prefix to handle any special characters
- Updated the design documentation to clarify that perf baselines are artifact-anchored (not committed) and explain the implications of artifact expiration and baseline selection behavior

https://claude.ai/code/session_017aFwv5guzfLksdT1QhEZaS