### PR TITLE
AP214: declare the face sense as known for the tessellator (#459)

### DIFF
--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -3377,6 +3377,13 @@ export class AP214GeometryExtraction {
 
     nativeSurface.sameSense = from.same_sense
 
+    // Declares the flag above as real, so the tessellator may orient the
+    // face against the surface normal. Extractors that leave this false
+    // (the IFC path today) keep the older projection-based orientation
+    // rather than having a default-constructed sense read as an answer.
+    // See https://github.com/bldrs-ai/conway/issues/459.
+    nativeSurface.sameSenseKnown = true
+
     const parameters: ParamsAddFaceToGeometry = {
       boundsArray: bound3DVector,
       advancedBrep: true,


### PR DESCRIPTION
The conway side of #459. Pairs with **bldrs-ai/conway-geom#157**, which has now **merged**; this bumps the submodule to its merge commit on `main` (`69a17a2`).

## Why

conway-geom's CDT unwrap paths for cylinders and cones decided triangle winding with `orient2D`, which projects each triangle onto **its own** best axis pair and forces a positive sign there. Consistent on a plane, where one projection serves every triangle; meaningless on a surface that turns. Roughly half of every cylinder came back wound inward while planar faces were always correct.

conway-geom#157 orients those faces against the surface's own analytic normal instead, together with the STEP `same_sense` flag — which is what distinguishes a boss from the bore it sits in.

## What this changes

Two lines plus the submodule pointer. The extractor already copies `advanced_face.same_sense` onto the native surface; it now also sets `sameSenseKnown`, telling the tessellator that value is real.

That flag is opt-in for a reason. `IfcSurface::sameSense` defaults to `false` and is only ever populated from JS — the AP214 path sets it, **the IFC path never has**. Without the flag, conway-geom#157 would have read that default as an answer and inverted every IFC advanced-face cylinder and cone: the same defect, in reverse, on the larger workload. Gating on an explicit "this was populated" flag means IFC keeps exactly the behaviour it has today until its extractor is fixed separately.

## Verification

STEP, on a bracket with a cylindrical boss, four bores and four corner rounds:

| | before | after |
|---|---|---|
| faces fully outward | 6 of 16 (all planar) | **16 of 16** |
| boss lateral | 45 out / 47 in | 92 / 0 |
| each bore | 47 out / 45 in | 92 / 0 |
| divergence volume | 21852.56 | **27123.49** |
| Z-projection volume | 27101.73 | **27123.49** |
| X-projection volume | 18143.77 | **27123.49** |

Those three estimators agree only on a closed, consistently oriented mesh; analytic is 27144.67 mm³, so the remaining 0.08% is ordinary chord error.

Across a STEP corpus spanning the surface types (`bldrs-ai/Create`, `yarn proof`), orientation goes from **24/65 to 55/65** parts clean, re-measured against the merged submodule.

IFC, confirming the gate: digests for `data/index.ifc` and `data/block.ifc` are **byte-identical** across the change. `yarn test` is 75 suites / 372 tests green.

## Expected CI signal

Winding is part of the regression digests (`dumpToOBJ` emits triangle vertex order), so **STEP models with cylindrical or conical faces will show digest changes** — that is this change working, not drift. IFC digests should not move. The visual diff should be unchanged either way, since Share renders `DoubleSide`.

## Known remaining paths

Correcting an omission from the first draft of this description: the **legacy non-unwrap fallbacks are reachable and still inconsistent.** When `triangulateUnwrappedLoops` fails, or a cone boundary samples its apex (`sawAxisPoint`), the cylinder and cone fall through to a path that still consumes a `sameSense` negated on `glm::dot( vecZ, vecX ) > 0` — a test on two orthonormal columns of the placement whose sign is rounding noise. Such a face can end up wound opposite to its unwrapped siblings inside one solid.

That is not a regression — both arms were wrong before, and one is now right — but it is not "dead code" either, as I originally described it. Split out as **#463** with the suggested handedness fix, because changing it alters legacy-path output for models this STEP corpus never reaches.

Also out of scope: the parts still failing orientation are sphere, torus, revolution and linear-extrusion paths, which have their own `appendMeshToGeometry` calls. The spherical and toroidal ones are blocked behind #461 regardless — those faces currently produce no geometry to orient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQAv3NMEn9fy1AyGNm3cyN