### PR TITLE
Defer products with dangling placements in preview prefix extractions

### DIFF
--- a/src/compat/web-ifc/ifc_api_preview_channel.test.ts
+++ b/src/compat/web-ifc/ifc_api_preview_channel.test.ts
@@ -411,4 +411,152 @@ describe( 'StreamedPreviewChannel', () => {
 
     channel.stop()
   }, 240000 )
+
+  test( 'a product whose placement is beyond the prefix defers instead of extracting unplaced', () => {
+
+    // Revit writes placements near the end of the file, so a mid-parse
+    // prefix can hold a product and its geometry while the product's
+    // IFCLOCALPLACEMENT is still unparsed. Lenient reads null that
+    // dangling reference — indistinguishable from "no placement" — and
+    // the product extracted at the origin: on a georeferenced model the
+    // preview payloads then sat a whole site-offset from the model
+    // (Share#1744, Snowdon door #5014, 88 payloads ~425km out).
+    //
+    // Model the file shape directly: move one product's placement
+    // record to the end of the data section (record order carries no
+    // meaning in STEP) and snapshot the prefix just before it.
+    const DEFERRED_PRODUCT = 396
+    const PLACEMENT_RECORD = '#334='
+
+    const text = new TextDecoder().decode( data )
+    const lines = text.split( '\n' )
+
+    const placementIndex =
+      lines.findIndex( ( line ) => line.startsWith( PLACEMENT_RECORD ) )
+    expect( placementIndex ).toBeGreaterThanOrEqual( 0 )
+
+    const [ placementLine ] = lines.splice( placementIndex, 1 )
+
+    let endsecIndex = -1
+    for ( let where = lines.length - 1; where >= 0; --where ) {
+      if ( lines[ where ].startsWith( 'ENDSEC' ) ) {
+        endsecIndex = where
+        break
+      }
+    }
+    expect( endsecIndex ).toBeGreaterThanOrEqual( 0 )
+
+    lines.splice( endsecIndex, 0, placementLine )
+    const reordered = new TextEncoder().encode( lines.join( '\n' ) )
+
+    const parse = ( wrap?: ( sink: ColumnarIndexSink<EntityTypesIfc> ) =>
+      StepIndexSink<EntityTypesIfc> ): ColumnarIndexSink<EntityTypesIfc> => {
+
+      const sink = new ColumnarIndexSink<EntityTypesIfc>()
+      const { result } = buildIndexStreaming(
+          new BufferByteSource( reordered ),
+          IfcStepParser.Instance,
+          POOL,
+          void 0,
+          wrap !== void 0 ? wrap( sink ) : sink )
+      expect( result ).toBe( ParseResult.COMPLETE )
+      return sink
+    }
+
+    const totalRecords = parse().topLevelCount
+
+    // The moved placement is the final record: a prefix of every record
+    // but the last holds the product + geometry, not the placement.
+    let prefix: StepIndexColumns<EntityTypesIfc> | undefined
+    const fullColumns = parse( ( inner ) => ( {
+      pushTopLevel: ( entry ) => {
+        inner.pushTopLevel( entry )
+        if ( inner.topLevelCount === totalRecords - 1 ) {
+          prefix = inner.snapshot()
+        }
+      },
+      reset: () => inner.reset(),
+    } ) ).finalize()
+
+    expect( prefix ).toBeDefined()
+
+    // Entity expressID -> parent native transforms of its walked
+    // instances, for one generation over the given columns.
+    const placedInstances = (
+        bytes: Uint8Array,
+        columns: StepIndexColumns<EntityTypesIfc> ): Map<number, number[][]> => {
+
+      const generation =
+        ifcPreviewAdapter().buildGeneration( bytes, conwayGeometry, columns )
+      expect( generation ).toBeDefined()
+
+      generation!.runUnits( 0, generation!.unitCount )
+
+      const instances = new Map<number, number[][]>()
+
+      for ( const walked of generation!.scene.walk() ) {
+
+        const [ , nativeTransform, , , entity ] = walked as [
+          unknown,
+          { getValues(): Float64Array | number[] } | undefined,
+          unknown,
+          unknown,
+          { expressID?: number } | undefined,
+        ]
+
+        if ( entity?.expressID === void 0 ) {
+          continue
+        }
+
+        const list = instances.get( entity.expressID ) ?? []
+        list.push( nativeTransform !== void 0 ? [ ...nativeTransform.getValues() ] : [] )
+        instances.set( entity.expressID, list )
+      }
+
+      generation!.dispose()
+      return instances
+    }
+
+    const prefixInstances = placedInstances( reordered, prefix! )
+
+    // Other products still preview from the prefix...
+    expect( prefixInstances.size ).toBeGreaterThan( 0 )
+
+    // ...but the dangling-placement product emitted NOTHING. Before the
+    // fix it extracted with an identity parent — these are exactly the
+    // mis-placed payloads Share#1744 chased.
+    expect( prefixInstances.has( DEFERRED_PRODUCT ) ).toBe( false )
+
+    // A full-file prefix extracts it, placed identically to the
+    // original record order — deferral changes WHEN the product
+    // extracts, never WHERE.
+    const fullInstances = placedInstances( reordered, fullColumns )
+    const reorderedTransforms = fullInstances.get( DEFERRED_PRODUCT )
+
+    expect( reorderedTransforms ).toBeDefined()
+    expect( reorderedTransforms!.length ).toBeGreaterThan( 0 )
+    expect( reorderedTransforms![ 0 ].length ).toBe( 16 )
+
+    const originalSink = new ColumnarIndexSink<EntityTypesIfc>()
+    const { result: originalResult } = buildIndexStreaming(
+        new BufferByteSource( data ),
+        IfcStepParser.Instance,
+        POOL,
+        void 0,
+        originalSink )
+    expect( originalResult ).toBe( ParseResult.COMPLETE )
+
+    const originalInstances = placedInstances( data, originalSink.finalize() )
+    const originalTransforms = originalInstances.get( DEFERRED_PRODUCT )
+
+    expect( originalTransforms ).toBeDefined()
+    expect( reorderedTransforms!.length ).toBe( originalTransforms!.length )
+
+    for ( let where = 0; where < originalTransforms!.length; ++where ) {
+      for ( let component = 0; component < 16; ++component ) {
+        expect( reorderedTransforms![ where ][ component ] )
+            .toBeCloseTo( originalTransforms![ where ][ component ], 10 )
+      }
+    }
+  }, 240000 )
 } )

--- a/src/compat/web-ifc/ifc_api_preview_channel.test.ts
+++ b/src/compat/web-ifc/ifc_api_preview_channel.test.ts
@@ -34,19 +34,21 @@ let conwayGeometry: ConwayGeometry
 let data: Uint8Array
 
 /**
- * Parse index.ifc's data block into a fresh columnar sink.
+ * Parse an IFC data block into a fresh columnar sink.
  *
  * @param wrap Optional sink wrapper (snapshot triggers).
+ * @param bytes The source bytes (defaults to index.ifc).
  * @return {ColumnarIndexSink} The filled sink.
  */
 function buildSink(
     wrap?: ( sink: ColumnarIndexSink<EntityTypesIfc> ) =>
-      StepIndexSink<EntityTypesIfc> ): ColumnarIndexSink<EntityTypesIfc> {
+      StepIndexSink<EntityTypesIfc>,
+    bytes?: Uint8Array ): ColumnarIndexSink<EntityTypesIfc> {
 
   const sink = new ColumnarIndexSink<EntityTypesIfc>()
 
   const { result } = buildIndexStreaming(
-      new BufferByteSource( data ),
+      new BufferByteSource( bytes ?? data ),
       IfcStepParser.Instance,
       POOL,
       void 0,
@@ -449,26 +451,12 @@ describe( 'StreamedPreviewChannel', () => {
     lines.splice( endsecIndex, 0, placementLine )
     const reordered = new TextEncoder().encode( lines.join( '\n' ) )
 
-    const parse = ( wrap?: ( sink: ColumnarIndexSink<EntityTypesIfc> ) =>
-      StepIndexSink<EntityTypesIfc> ): ColumnarIndexSink<EntityTypesIfc> => {
-
-      const sink = new ColumnarIndexSink<EntityTypesIfc>()
-      const { result } = buildIndexStreaming(
-          new BufferByteSource( reordered ),
-          IfcStepParser.Instance,
-          POOL,
-          void 0,
-          wrap !== void 0 ? wrap( sink ) : sink )
-      expect( result ).toBe( ParseResult.COMPLETE )
-      return sink
-    }
-
-    const totalRecords = parse().topLevelCount
+    const totalRecords = buildSink( void 0, reordered ).topLevelCount
 
     // The moved placement is the final record: a prefix of every record
     // but the last holds the product + geometry, not the placement.
     let prefix: StepIndexColumns<EntityTypesIfc> | undefined
-    const fullColumns = parse( ( inner ) => ( {
+    const fullColumns = buildSink( ( inner ) => ( {
       pushTopLevel: ( entry ) => {
         inner.pushTopLevel( entry )
         if ( inner.topLevelCount === totalRecords - 1 ) {
@@ -476,7 +464,7 @@ describe( 'StreamedPreviewChannel', () => {
         }
       },
       reset: () => inner.reset(),
-    } ) ).finalize()
+    } ), reordered ).finalize()
 
     expect( prefix ).toBeDefined()
 
@@ -537,16 +525,7 @@ describe( 'StreamedPreviewChannel', () => {
     expect( reorderedTransforms!.length ).toBeGreaterThan( 0 )
     expect( reorderedTransforms![ 0 ].length ).toBe( 16 )
 
-    const originalSink = new ColumnarIndexSink<EntityTypesIfc>()
-    const { result: originalResult } = buildIndexStreaming(
-        new BufferByteSource( data ),
-        IfcStepParser.Instance,
-        POOL,
-        void 0,
-        originalSink )
-    expect( originalResult ).toBe( ParseResult.COMPLETE )
-
-    const originalInstances = placedInstances( data, originalSink.finalize() )
+    const originalInstances = placedInstances( data, buildSink().finalize() )
     const originalTransforms = originalInstances.get( DEFERRED_PRODUCT )
 
     expect( originalTransforms ).toBeDefined()

--- a/src/compat/web-ifc/streamed_preview_channel.ts
+++ b/src/compat/web-ifc/streamed_preview_channel.ts
@@ -197,6 +197,19 @@ export function ifcPreviewAdapter(): PreviewSchemaAdapter {
       // don't flood the report (DOWA: 1164 styled-item errors).
       extraction.quietRecoverableLogging = true
 
+      // A product whose placement records sit beyond this prefix must
+      // defer, not extract unplaced: Revit writes placements near the
+      // end of the file, so an early product can reference a placement
+      // the index does not hold yet. Lenient reads null the dangling
+      // reference and the product extracts at the origin — on a
+      // georeferenced model the emitted payloads then sit a site-offset
+      // away from the model (Share#1744: Snowdon's door #5014 put 88
+      // payloads ~425km out, and the camera follow framed them). The
+      // per-unit catch below already treats a throwing product as
+      // not-yet-extractable; this makes a dangling placement throw like
+      // any other unparsed forward reference.
+      extraction.deferDanglingPlacements = true
+
       // Preview-only preparation: skip the relationship sweeps whose
       // entity materialization dominates per-generation cost.
       extraction.prepareDemandExtraction( true )

--- a/src/compat/web-ifc/streamed_preview_channel.ts
+++ b/src/compat/web-ifc/streamed_preview_channel.ts
@@ -207,7 +207,10 @@ export function ifcPreviewAdapter(): PreviewSchemaAdapter {
       // payloads ~425km out, and the camera follow framed them). The
       // per-unit catch below already treats a throwing product as
       // not-yet-extractable; this makes a dangling placement throw like
-      // any other unparsed forward reference.
+      // any other unparsed forward reference. The classic-mode cursor
+      // does not re-run passed units, so a deferred product sits out
+      // the preview and the durable pump renders it — an empty slot,
+      // never geometry at the wrong placement.
       extraction.deferDanglingPlacements = true
 
       // Preview-only preparation: skip the relationship sweeps whose

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -5570,11 +5570,6 @@ export class IfcGeometryExtraction {
   }
 
   /**
-   *
-   * @param from
-   * @param isRelVoid
-   */
-  /**
    * Resolve and extract a product's placement with dangling references
    * treated as errors (deferDanglingPlacements mode).
    *
@@ -5592,10 +5587,12 @@ export class IfcGeometryExtraction {
    * The throw intentionally propagates: the demand seam
    * (`extractProductGeometryByLocalID` callers, the preview adapter's
    * per-unit catch) already treats a throwing product as
-   * not-yet-extractable and leaves it to a later prefix or the durable
-   * pump. Nothing is memoized on the throwing path — the generated
-   * getters only cache on successful extraction — so a later, longer
-   * prefix re-reads cleanly.
+   * not-yet-extractable and leaves it to the durable pump — the IFC
+   * channel's forward-only unit cursor does not re-run passed
+   * ordinals. Nothing is memoized on the throwing path — the generated
+   * getters only cache on successful extraction — so an adapter mode
+   * that does retry (AP214's retryEmptyUnits, or a future IFC
+   * equivalent) re-reads cleanly against its longer prefix.
    *
    * @param product The product whose placement to resolve.
    */
@@ -5620,6 +5617,11 @@ export class IfcGeometryExtraction {
     }
   }
 
+  /**
+   *
+   * @param from
+   * @param isRelVoid
+   */
   extractPlacement(from: IfcObjectPlacement, isRelVoid: boolean = false) {
 
     let result: IfcSceneTransform | undefined
@@ -6485,11 +6487,16 @@ export class IfcGeometryExtraction {
 
       // Strict placement resolution for prefix extractions: dangling
       // references throw here (see extractPlacementStrict_) and the
-      // demand seam reports the product as not-yet-extractable, so a
-      // later, longer prefix retries it — instead of extracting the
-      // product unplaced. This read must be the entity's FIRST
-      // ObjectPlacement access: the generated getters memoize, and a
-      // lenient read would cache null for a dangling reference.
+      // demand seam reports the product as not-yet-extractable —
+      // instead of extracting the product unplaced. The IFC preview
+      // channel's forward-only cursor does not re-run a passed unit, so
+      // a deferred product simply never previews and the durable pump
+      // renders it; that is the existing contract for every product
+      // whose extraction throws on an unparsed forward reference, and
+      // an empty slot beats geometry at the wrong placement. This read
+      // must be the entity's FIRST ObjectPlacement access: the
+      // generated getters memoize, and a lenient read would cache null
+      // for a dangling reference.
       this.extractPlacementStrict_(product)
     } else {
 

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -429,6 +429,23 @@ export class IfcGeometryExtraction {
    * durable extraction keeps full logging. Mirrors AP214's flag. */
   public quietRecoverableLogging!: boolean
 
+  /** When true, a product whose ObjectPlacement — or any record in its
+   * placement chain — is a dangling forward reference is treated as not
+   * yet extractable (the extraction throws, and the caller skips the
+   * product) instead of being silently extracted UNPLACED.
+   *
+   * Set by the parse-time preview channel's PREFIX extractions. A
+   * mid-parse prefix nulls dangling optional references
+   * (`nullOnErrors`), so a product whose placement record sits beyond
+   * the prefix — Revit writes placements near the end of the file, e.g.
+   * Snowdon's first door is record #5014 with its IFCLOCALPLACEMENT at
+   * #789283 — read as "no placement" and extracted at the origin. On a
+   * georeferenced model the preview then composed
+   * coordination x identity, emitting geometry ~425km from the model
+   * (Share#1744). The durable extraction runs on the full model, where
+   * nothing dangles, and keeps the classic lenient read. */
+  public deferDanglingPlacements: boolean = false
+
   constructor(
     private readonly conwayModel: ConwayGeometry,
     public readonly model: IfcStepModel,
@@ -5557,6 +5574,52 @@ export class IfcGeometryExtraction {
    * @param from
    * @param isRelVoid
    */
+  /**
+   * Resolve and extract a product's placement with dangling references
+   * treated as errors (deferDanglingPlacements mode).
+   *
+   * The model's `nullOnErrors` (default true) turns a reference to an
+   * unindexed record into a silent null, which is indistinguishable from
+   * a genuinely absent (`$`) optional attribute. On a mid-parse prefix
+   * that conflation is exactly wrong: "placement record not indexed
+   * yet" must defer the product, while "product has no placement" may
+   * extract unplaced, matching the classic path. Flipping
+   * `nullOnErrors` off for the duration makes the step layer throw on
+   * the dangling read (`extractElement`), anywhere in the chain —
+   * IFCLOCALPLACEMENT ancestors and their axis/point records included,
+   * since `extractPlacement` resolves them through the same layer.
+   *
+   * The throw intentionally propagates: the demand seam
+   * (`extractProductGeometryByLocalID` callers, the preview adapter's
+   * per-unit catch) already treats a throwing product as
+   * not-yet-extractable and leaves it to a later prefix or the durable
+   * pump. Nothing is memoized on the throwing path — the generated
+   * getters only cache on successful extraction — so a later, longer
+   * prefix re-reads cleanly.
+   *
+   * @param product The product whose placement to resolve.
+   */
+  private extractPlacementStrict_(product: IfcProduct): void {
+
+    const model = this.model
+    const priorNullOnErrors = model.nullOnErrors
+
+    model.nullOnErrors = false
+
+    try {
+
+      const objectPlacement = product.ObjectPlacement
+
+      if (objectPlacement !== null) {
+
+        this.extractPlacement(objectPlacement)
+      }
+    } finally {
+
+      model.nullOnErrors = priorNullOnErrors
+    }
+  }
+
   extractPlacement(from: IfcObjectPlacement, isRelVoid: boolean = false) {
 
     let result: IfcSceneTransform | undefined
@@ -6418,11 +6481,24 @@ export class IfcGeometryExtraction {
           product instanceof IfcSpace ||
           product instanceof IfcOpeningStandardCase
 
-    const objectPlacement = product.ObjectPlacement
+    if (this.deferDanglingPlacements) {
 
-    if (objectPlacement !== null) {
+      // Strict placement resolution for prefix extractions: dangling
+      // references throw here (see extractPlacementStrict_) and the
+      // demand seam reports the product as not-yet-extractable, so a
+      // later, longer prefix retries it — instead of extracting the
+      // product unplaced. This read must be the entity's FIRST
+      // ObjectPlacement access: the generated getters memoize, and a
+      // lenient read would cache null for a dangling reference.
+      this.extractPlacementStrict_(product)
+    } else {
 
-      this.extractPlacement(objectPlacement)
+      const objectPlacement = product.ObjectPlacement
+
+      if (objectPlacement !== null) {
+
+        this.extractPlacement(objectPlacement)
+      }
     }
 
     const representations = product.Representation


### PR DESCRIPTION
Fixes the mis-placed parse-time preview geometry behind bldrs-ai/Share#1744 (Snowdon invisible during streaming load).

## The bug

The preview channel extracts products against a **prefix** of the columnar index. A product whose `IFCLOCALPLACEMENT` sits beyond the prefix — Revit writes placements near the end of the file, so an early product routinely references one — reads its `ObjectPlacement` through the lenient step layer (`nullOnErrors`), which turns the dangling reference into a silent null. That is indistinguishable from "product has no placement", so the product extracts **unplaced**: its mapped-item operator becomes the scene root and every leaf composes against identity.

On a georeferenced model the payloads then land a full site-offset from the model. Snowdon: door `#5014` (record 5014, placement at record `#789283`) emitted 88 payloads at `coordination × identity` — exactly the coordination translation, ~425 km from the building — and Share's camera follow framed the union, shrinking the model to a sub-pixel speck for the whole load. Probe data from an instrumented package:

```
preview walk, all 88 leaves:  raw = IDENTITY  → out = (-417589.48, -243.48, 78704.27)
durable walk, same leaves:    raw = site-composed placement → out = (2.81, -10.74, -1.94)
```

The durable pump extracts from the full model and was always correct; the capture watermark made the wrong preview payloads permanent for the load. The coordination frame itself was valid — the durable walk adopted and validated it, which is why `[deferred] preview coordination frame rejected` never fired.

## The fix

New `IfcGeometryExtraction.deferDanglingPlacements` mode, set by the IFC preview adapter. It resolves the placement chain with `nullOnErrors` off, so a dangling reference anywhere in the chain throws — and the adapter's per-unit catch already treats a throwing product as not-yet-extractable, exactly how unparsed forward references in representation items are handled today. A later, longer prefix (or the durable pump) extracts the product with its real placement.

- Genuine `$` placements still extract unplaced, matching the classic path (`stepExtractOptional` distinguishes `$` from a dangling reference under strict mode).
- Durable/classic extractions keep the lenient read — behavior is unchanged outside preview prefix extractions.
- The strict read must be the entity's *first* `ObjectPlacement` access (generated getters memoize); `extractProductGeometry`'s placement block is that first access, and nothing is cached on the throwing path.

## Test

Reorders `index.ifc` so product `#396`'s placement record is the final data record (record order carries no meaning in STEP), snapshots the prefix just before it, and drives the adapter directly:

- prefix generation: other products extract, `#396` emits **nothing** (before this fix it extracted with an identity parent — the exact Share#1744 payloads; verified the test fails against the pre-fix behavior)
- full-file generation: `#396` extracts placed identically to the original record order — deferral changes *when* a product extracts, never *where*

`compiled/src/compat/web-ifc` + `ifc_scene_builder` suites: 14 suites / 66 tests green.

## Share-side

Share `8d9692c` (in bldrs-ai/Share#1744) independently rejects preview payloads >100× the accumulated preview radius, so even an engine regression here can no longer steer the camera. Once this ships in a release, Share's conway pin can pick it up and the preview will simply place the affected products correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCRAAy2HyxhUbx1PjprjA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJCRAAy2HyxhUbx1PjprjA)_