### PR TITLE
Gate the IFC regression on PR draft state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,10 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    # ready_for_review is what makes the draft gate on run-ifc-regression
+    # usable: without it, flipping a draft to ready fires no event and the PR
+    # would sit with no regression result until the next push.
+    types: [opened, synchronize, ready_for_review]
     # Skip the heavy build + IFC regression on doc-only PRs. paths-ignore
     # skips the workflow only when EVERY changed file matches — a PR that
     # also touches code/config still runs the full suite. Push-to-main
@@ -237,6 +240,19 @@ jobs:
   # ---------------------------------------------------------------------------
   run-ifc-regression:
     needs: build
+    # Draft PRs don't run the regression. It is by far the longest job here,
+    # and with several PRs in flight the draft pushes alone can saturate the
+    # 4-job concurrency cap and starve the PRs that are actually ready for
+    # review. `build` is deliberately NOT gated: it is comparatively cheap and
+    # it is the compile + unit-test signal you want while a draft is still
+    # being worked. See AGENTS.md "PR lifecycle".
+    #
+    # A job-level `if` rather than a trigger filter, for the reason spelled
+    # out in the paths-ignore note above: a skipped-by-if job satisfies a
+    # required status check, a workflow that never triggers does not.
+    # The event_name guard keeps push:main and workflow_dispatch running,
+    # where github.event.pull_request is null.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-4vcpu-8gb-150gbssd
     # Expose the packed tarball name so downstream perf jobs can download the
     # artifact by name without re-packing conway.
@@ -696,7 +712,14 @@ jobs:
   # ---------------------------------------------------------------------------
   visual-diff:
     needs: run-ifc-regression
-    if: github.event_name == 'pull_request' && needs.run-ifc-regression.outputs.visual_diff_count != '0'
+    # The draft clause is redundant today — a skipped `needs` job skips this
+    # one regardless — but it is stated so the draft rule is greppable from
+    # every job it governs, and so this stays correct if visual-diff ever
+    # gains an always()/!cancelled() guard.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      needs.run-ifc-regression.outputs.visual_diff_count != '0'
     # Same large runner as every other job that executes the conway CLIs:
     # the MT WASM engine reserves multi-GB (shared) memory at startup, and on
     # the standard 4-vcpu runner every export died with an uncaught allocation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,14 @@ on:
     # emsdk/GENie/emcc step is gated on the wasm cache key, so a hit means only
     # a conway-geom submodule bump pays a real compile. The exception is
     # withdrawing during a cold-cache build — the cancelled run never reaches
-    # the save step, so the replacement pays the full emcc compile. Either way
-    # it buys back the rest of a regression pass, which is the longer half. Not
-    # free the way it is in Share, where every job is gated and the replacement
-    # run skips outright.
+    # the save step, so the replacement pays the full emcc compile.
+    #
+    # Whether that is worth it depends on when you withdraw. During the
+    # regression it clearly is: you stop the longer job and pay at most a
+    # rebuild. During `build` it is pure loss — `run-ifc-regression` needs
+    # `build`, so nothing had started yet and you have bought back nothing.
+    # Not free the way it is in Share, where every job is gated and the
+    # replacement run skips outright.
     #
     # reopened was missing before the draft gate landed. Leaving it out means
     # a reopened PR keeps whatever conclusions sat on its head SHA -- possibly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,20 @@ on:
     # ready_for_review is what makes the draft gate on run-ifc-regression
     # usable: without it, flipping a draft to ready fires no event and the PR
     # would sit with no regression result until the next push.
-    types: [opened, synchronize, ready_for_review]
+    #
+    # converted_to_draft is the other half of that gate, and it works by
+    # cancellation rather than by starting anything: pushing a PR back to
+    # draft fires an event in the same concurrency group below, so
+    # cancel-in-progress kills the regression that is mid-flight and the run
+    # it schedules in its place skips (the PR is a draft again). Without it,
+    # a PR you have explicitly pulled back keeps burning a runner slot to
+    # completion.
+    #
+    # reopened was missing before the draft gate landed. Leaving it out means
+    # a reopened PR keeps whatever conclusions sat on its head SHA -- possibly
+    # a `skipped` regression, which reads as passing -- with nothing to
+    # re-run it.
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     # Skip the heavy build + IFC regression on doc-only PRs. paths-ignore
     # skips the workflow only when EVERY changed file matches — a PR that
     # also touches code/config still runs the full suite. Push-to-main
@@ -250,8 +263,14 @@ jobs:
     # A job-level `if` rather than a trigger filter, for the reason spelled
     # out in the paths-ignore note above: a skipped-by-if job satisfies a
     # required status check, a workflow that never triggers does not.
-    # The event_name guard keeps push:main and workflow_dispatch running,
-    # where github.event.pull_request is null.
+    #
+    # The event_name clause is defensive, not load-bearing. On push and
+    # workflow_dispatch `github.event.pull_request` is null, and Actions
+    # coerces both sides of `==` to a number when the types differ, so a bare
+    # `draft == false` would evaluate `0 == 0` and run anyway. Relying on that
+    # coercion would make merges -- and with them auto-publish, which needs
+    # this job -- hinge on a documented-but-obscure corner of the expression
+    # language. The clause states the intent instead.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-4vcpu-8gb-150gbssd
     # Expose the packed tarball name so downstream perf jobs can download the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,12 @@ on:
     # burning a runner slot to completion.
     #
     # Note what the replacement run does, since `build` here is ungated: it
-    # re-runs the full emscripten build, then stops before the regression.
-    # So withdrawing a PR trades a partial build plus a rebuild for the rest
-    # of a regression pass — worth it, because the regression is by far the
-    # longer of the two, but it is not free the way it is in Share (where
-    # every job is gated and the replacement run skips outright).
+    # re-runs `build`, then stops before the regression. That is usually
+    # cheap — every emsdk/GENie/emcc step is gated on the wasm cache key, and
+    # the run just cancelled will have populated it, so only a conway-geom
+    # submodule bump pays a real compile. Either way it buys back the rest of
+    # a regression pass. Not quite free the way it is in Share, where every
+    # job is gated and the replacement run skips outright.
     #
     # reopened was missing before the draft gate landed. Leaving it out means
     # a reopened PR keeps whatever conclusions sat on its head SHA -- possibly
@@ -63,17 +64,22 @@ on:
 # main commit ships its own version, so cancelling a main run mid-publish (or
 # skipping a commit's release) is not acceptable.
 #
-# The key for non-PR events is the COMMIT, not the ref, and that is what
-# actually delivers the guarantee the paragraph above claims. Every push to
-# main shares one ref, so a ref-keyed group put them all in a single queue —
-# and `cancel-in-progress: false` does not mean "never cancel": GitHub cancels
-# any run still PENDING in a group when a newer one joins it. Merge three
-# commits inside one pipeline window and the middle one's run was cancelled
-# before it started, silently skipping that commit's release. Keying on
-# github.sha gives each main commit its own group, so they run in parallel and
-# none can evict another.
+# Keep this keyed on the REF for push:main, not on github.sha, even though the
+# ref key has a known cost. Because every main push shares one ref they all
+# land in one group and run one at a time — and `cancel-in-progress: false`
+# does not mean "never cancel": GitHub cancels a run still PENDING in a group
+# when a newer one joins, so merging three commits inside one pipeline window
+# drops the middle one's run and skips that commit's release.
+#
+# That is the lesser problem. The serialization is what keeps auto-publish's
+# versions monotonic: two main runs publishing concurrently can land out of
+# order, and the out-of-order path below (`npm publish --tag latest`, ~line
+# 1696) then deliberately drags npm's `latest` BACK onto the older commit. A
+# skipped release is recoverable by re-running the job; a `latest` pointing
+# backwards is shipped to every consumer. Making these parallel needs the
+# publish step to be ordering-safe first — see conway#468.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,14 @@ on:
     # burning a runner slot to completion.
     #
     # Note what the replacement run does, since `build` here is ungated: it
-    # re-runs `build`, then stops before the regression. That is usually
-    # cheap — every emsdk/GENie/emcc step is gated on the wasm cache key, and
-    # the run just cancelled will have populated it, so only a conway-geom
-    # submodule bump pays a real compile. Either way it buys back the rest of
-    # a regression pass. Not quite free the way it is in Share, where every
-    # job is gated and the replacement run skips outright.
+    # re-runs `build`, then stops before the regression. Usually cheap: every
+    # emsdk/GENie/emcc step is gated on the wasm cache key, so a hit means only
+    # a conway-geom submodule bump pays a real compile. The exception is
+    # withdrawing during a cold-cache build — the cancelled run never reaches
+    # the save step, so the replacement pays the full emcc compile. Either way
+    # it buys back the rest of a regression pass, which is the longer half. Not
+    # free the way it is in Share, where every job is gated and the replacement
+    # run skips outright.
     #
     # reopened was missing before the draft gate landed. Leaving it out means
     # a reopened PR keeps whatever conclusions sat on its head SHA -- possibly
@@ -74,10 +76,15 @@ on:
 # That is the lesser problem. The serialization is what keeps auto-publish's
 # versions monotonic: two main runs publishing concurrently can land out of
 # order, and the out-of-order path below (`npm publish --tag latest`, ~line
-# 1696) then deliberately drags npm's `latest` BACK onto the older commit. A
-# skipped release is recoverable by re-running the job; a `latest` pointing
-# backwards is shipped to every consumer. Making these parallel needs the
-# publish step to be ordering-safe first — see conway#468.
+# 1696) then deliberately drags npm's `latest` BACK onto the older commit,
+# shipping it to every consumer.
+#
+# Note the dropped commit's release is NOT simply re-runnable — re-running it
+# later computes a version below the one already published, which lands on
+# that same `--tag latest` branch and causes the exact regression the
+# serialization is here to prevent. Skip the release, or fix the publish step
+# to be ordering-safe (which is what making these parallel needs anyway).
+# Both tracked in conway#468.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,17 @@ on:
     # would sit with no regression result until the next push.
     #
     # converted_to_draft is the other half of that gate, and it works by
-    # cancellation rather than by starting anything: pushing a PR back to
-    # draft fires an event in the same concurrency group below, so
-    # cancel-in-progress kills the regression that is mid-flight and the run
-    # it schedules in its place skips (the PR is a draft again). Without it,
-    # a PR you have explicitly pulled back keeps burning a runner slot to
-    # completion.
+    # cancellation: pushing a PR back to draft fires an event in the same
+    # concurrency group below, so cancel-in-progress kills the run that is
+    # mid-flight. Without it, a PR you have explicitly pulled back keeps
+    # burning a runner slot to completion.
+    #
+    # Note what the replacement run does, since `build` here is ungated: it
+    # re-runs the full emscripten build, then stops before the regression.
+    # So withdrawing a PR trades a partial build plus a rebuild for the rest
+    # of a regression pass — worth it, because the regression is by far the
+    # longer of the two, but it is not free the way it is in Share (where
+    # every job is gated and the replacement run skips outright).
     #
     # reopened was missing before the draft gate landed. Leaving it out means
     # a reopened PR keeps whatever conclusions sat on its head SHA -- possibly
@@ -57,8 +62,18 @@ on:
 # runs must run to completion — auto-publish tags + publishes to npm, and each
 # main commit ships its own version, so cancelling a main run mid-publish (or
 # skipping a commit's release) is not acceptable.
+#
+# The key for non-PR events is the COMMIT, not the ref, and that is what
+# actually delivers the guarantee the paragraph above claims. Every push to
+# main shares one ref, so a ref-keyed group put them all in a single queue —
+# and `cancel-in-progress: false` does not mean "never cancel": GitHub cancels
+# any run still PENDING in a group when a newer one joins it. Merge three
+# commits inside one pipeline window and the middle one's run was cancelled
+# before it started, silently skipping that commit's release. Keying on
+# github.sha gives each main commit its own group, so they run in parallel and
+# none can evict another.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,58 @@ than rebuilding per edit.
 
 This repo uses yarn 1.22.22.
 
+## PR lifecycle
+
+Several PRs are usually in flight at once, and the CI runners are a
+shared, capped resource (4 concurrent jobs). A PR that runs the full
+suite on every push while it is still being reworked starves the PRs
+that are actually ready. So work moves through these five steps, in
+order:
+
+1. **Open the PR as a draft.** Not "open it and mark it draft" —
+   `create_pull_request` takes `draft: true`. Heavy CI is gated on
+   draft state (see below), so a draft costs a build, not a full
+   regression pass.
+2. **Leave it in draft until `/review` has run and every finding is
+   handled.** Handled means fixed, or answered in the PR thread with
+   why it is not a defect. Do not flip to ready with open findings.
+3. **Flip it out of draft** (`update_pull_request` with
+   `draft: false`). That fires `ready_for_review`, which is what
+   triggers the gated jobs — this is the point where CI actually runs.
+4. **Drive CI to green.** If fixing CI changed the diff in any way
+   beyond a trivial revert, `/review` again — the reviewed diff is not
+   the merged diff otherwise.
+5. **Then land it:** bring the PR description up to date with what the
+   change actually became, merge, and close or narrow the issues it
+   resolves. An issue that is only partly addressed gets a comment
+   saying what is left, not a close.
+
+### What the draft gate covers
+
+| Job | Draft PR | Ready PR |
+|---|---|---|
+| `build` (compile + unit tests) | runs | runs |
+| `run-ifc-regression` | **skipped** | runs |
+| `visual-diff` | **skipped** | runs (when digests changed) |
+
+`build` is deliberately left ungated: it is the cheap compile and
+unit-test signal you want while a draft is still moving.
+
+Two mechanics worth knowing before you edit `.github/workflows/build.yml`:
+
+- The gate is a **job-level `if:`**, not a trigger filter. A
+  skipped-by-if job reports a conclusion and satisfies a required
+  status check; a workflow that never triggers reports nothing and
+  leaves the PR waiting forever. This is the same trap the
+  `paths-ignore` note in that file warns about.
+- `ready_for_review` must stay in the `pull_request` `types:` list.
+  Without it, flipping a draft to ready fires no event at all and step
+  3 above silently does nothing.
+
+The same lifecycle and the same gate shape apply in
+[Share](https://github.com/bldrs-ai/Share) — see its `AGENTS.md` for
+which jobs are gated there.
+
 ## Debugging a bad model
 
 When a model renders wrong — spikes, missing parts, exploded assemblies —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,18 @@ Two mechanics worth knowing before you edit `.github/workflows/build.yml`:
   status check; a workflow that never triggers reports nothing and
   leaves the PR waiting forever. This is the same trap the
   `paths-ignore` note in that file warns about.
-- `ready_for_review` must stay in the `pull_request` `types:` list.
-  Without it, flipping a draft to ready fires no event at all and step
-  3 above silently does nothing.
+- `ready_for_review` and `converted_to_draft` must stay in the
+  `pull_request` `types:` list. Without the first, flipping a draft to
+  ready fires no event at all and step 3 above silently does nothing.
+  The second is what lets pulling a PR *back* to draft cancel a
+  regression that is already mid-flight, via the workflow's
+  `cancel-in-progress` group — otherwise it runs to completion for a PR
+  you have explicitly withdrawn.
+- The `github.event_name != 'pull_request' ||` clause in each gate is
+  defensive, not load-bearing: Actions coerces mismatched `==` operands
+  to numbers, so `null == false` is already true on push and
+  `workflow_dispatch`. Keep it anyway — merges (and `auto-publish`,
+  which needs the regression) should not hinge on that coercion.
 
 The same lifecycle and the same gate shape apply in
 [Share](https://github.com/bldrs-ai/Share) — see its `AGENTS.md` for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,10 @@ tidier:
   regression that is already mid-flight, via the workflow's
   `cancel-in-progress` group — otherwise it runs to completion for a PR
   you have explicitly withdrawn. Note the replacement run re-runs
-  `build` (which is ungated) before stopping — usually cheap, since the
-  wasm cache key the cancelled run populated still hits. Free in Share,
-  where every job is gated.
+  `build` (which is ungated) before stopping — cheap on a wasm cache
+  hit, but a full emcc compile if you withdraw *during* a cold-cache
+  build, since `actions/cache` saves in a post-job step the cancelled
+  job never reaches. Free in Share, where every job is gated.
 - The `github.event_name != 'pull_request' ||` clause in each gate is
   defensive, not load-bearing: Actions coerces mismatched `==` operands
   to numbers, so `null == false` is already true on push and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,9 @@ tidier:
   regression that is already mid-flight, via the workflow's
   `cancel-in-progress` group — otherwise it runs to completion for a PR
   you have explicitly withdrawn. Note the replacement run re-runs
-  `build` (which is ungated) before stopping, so withdrawing trades a
-  rebuild for the rest of a regression pass. Worth it here; free in
-  Share, where every job is gated.
+  `build` (which is ungated) before stopping — usually cheap, since the
+  wasm cache key the cancelled run populated still hits. Free in Share,
+  where every job is gated.
 - The `github.event_name != 'pull_request' ||` clause in each gate is
   defensive, not load-bearing: Actions coerces mismatched `==` operands
   to numbers, so `null == false` is already true on push and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,9 @@ order:
 `build` is deliberately left ungated: it is the cheap compile and
 unit-test signal you want while a draft is still moving.
 
-Two mechanics worth knowing before you edit `.github/workflows/build.yml`:
+Mechanics worth knowing before you edit `.github/workflows/build.yml`
+— each of these is load-bearing, so don't prune the list to make it
+tidier:
 
 - The gate is a **job-level `if:`**, not a trigger filter. A
   skipped-by-if job reports a conclusion and satisfies a required
@@ -73,7 +75,10 @@ Two mechanics worth knowing before you edit `.github/workflows/build.yml`:
   The second is what lets pulling a PR *back* to draft cancel a
   regression that is already mid-flight, via the workflow's
   `cancel-in-progress` group — otherwise it runs to completion for a PR
-  you have explicitly withdrawn.
+  you have explicitly withdrawn. Note the replacement run re-runs
+  `build` (which is ungated) before stopping, so withdrawing trades a
+  rebuild for the rest of a regression pass. Worth it here; free in
+  Share, where every job is gated.
 - The `github.event_name != 'pull_request' ||` clause in each gate is
   defensive, not load-bearing: Actions coerces mismatched `==` operands
   to numbers, so `null == false` is already true on push and


### PR DESCRIPTION
Implements the conway half of the multi-PR CI policy, and documents the surrounding lifecycle in `AGENTS.md`.

## Why

Several PRs are usually in flight at once against a runner pool capped at 4 concurrent jobs. `run-ifc-regression` is by far the longest job here, so draft pushes on a PR that is still being reworked can saturate the cap and starve the PRs that are actually ready for review.

## What changes

| Job | Draft PR | Ready PR |
|---|---|---|
| `build` (compile + unit tests) | runs | runs |
| `run-ifc-regression` | **skipped** | runs |
| `visual-diff` | **skipped** | runs (when digests changed) |

`build` is deliberately left ungated — it's comparatively cheap and it's the compile + unit-test signal worth having while a draft is still moving.

Trigger `types:` gains `ready_for_review` (what starts the gated jobs at step 3), `converted_to_draft` (what lets pulling a PR *back* to draft cancel a run mid-flight, via the concurrency group), and `reopened` (missing before, and more costly now that a stale `skipped` regression reads as passing).

## Mechanics, for reviewers

- **Job-level `if:`, not a trigger filter.** The trap the existing `paths-ignore` note already warns about: a skipped-by-if job reports a conclusion and satisfies a required status check; a workflow that never triggers reports nothing and leaves the PR waiting forever.
- **The `github.event_name != 'pull_request' ||` clause is defensive, not load-bearing.** Actions coerces mismatched `==` operands to numbers, so `null == false` is already `0 == 0` on push and `workflow_dispatch`. Kept anyway — no merge, and no `auto-publish`, should hinge on that coercion.

## What review changed, and one thing it reverted

Six review rounds. The substantive outcome:

- **A concurrency change was made and then reverted.** An intermediate commit keyed non-PR runs on `github.sha` to stop main's runs queueing (a pending run *is* cancelled when a third joins the group, so a middle commit's release gets silently skipped). Review caught that the serialization this removes is load-bearing: two main runs publishing concurrently can land out of order, and the out-of-order path runs `npm publish --tag latest`, dragging npm's `latest` **backwards** onto the older commit. A skipped release is a gap; a backwards `latest` ships to every consumer. Reverted, with the reasoning recorded in the comment so the next person doesn't retry it. **The underlying defect is pre-existing and now filed as #468** — including that a dropped release is *not* safely re-runnable, since a re-run computes a lower version and lands on that same branch.
- Several comment claims were wrong and are corrected: the cache does **not** always survive a cancelled build (`actions/cache` saves in a post-job step the cancelled job never reaches), and withdrawing a PR only pays off if you do it *during* the regression — during `build` it's pure loss, since `run-ifc-regression` needs `build` and nothing had started.

## The lifecycle it documents

`AGENTS.md` gains a **PR lifecycle** section: open as draft → keep it there until `/review` findings are all handled → flip to ready (which triggers the gated jobs) → drive CI green, re-reviewing if the fixes changed the diff → update the description, merge, and close or narrow the issues.

## Verification

Workflow YAML parses; the gate resolves per job as intended; `auto-publish` and `perf-three-*` are push/dispatch-only and unaffected.

**Verified live on this PR.** As a draft it showed `build` only — no regression, no visual-diff. Flipping it to ready fired `ready_for_review` and started the gated jobs, which is the step-3 mechanic working end to end.

Companion PR in Share: bldrs-ai/Share#1746.