### PR TITLE
Treat an existing comma-containing path as a literal path

### DIFF
--- a/scripts/render_glb.cjs
+++ b/scripts/render_glb.cjs
@@ -16,7 +16,10 @@
  *
  * Each side is a comma-separated list of GLBs merged into one scene —
  * conway's CLI splits large models into multiple chunk files (jet engine),
- * and rendering only one chunk silently drops the rest of the model.
+ * and rendering only one chunk silently drops the rest of the model. A path
+ * that itself contains a comma is handled: an existing file wins over the
+ * comma reading, so `"Wiesenplatz 7, 4057 Basel.glb"` works unquoted-by-luck
+ * or not (conway#457).
  *
  * Pair mode renders both sides with ONE camera framed on the union of
  * the two bounding boxes (writes <outPrefix>-before.png and
@@ -428,9 +431,48 @@ function writePng(path, pixels, size) {
 // CLI
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolve one CLI path argument to the list of GLBs it names.
+ *
+ * A literal path wins over comma-splitting. Several models we ship are named
+ * with commas — `Wiesenplatz 7, 4057 Basel.ifc` and friends — and the CLI's
+ * `-g` output keeps the source basename, so splitting first tore a real path
+ * into pieces that don't exist and reported the first fragment as missing
+ * (conway#457). Splitting is only a fallback, which is enough because a
+ * chunk list's elements are separate files that each have to exist anyway.
+ *
+ * @param {string} spec The path, or a comma-joined list of chunk paths.
+ * @return {string[]} Paths to read, in order.
+ */
+function resolveGlbPaths(spec) {
+  if (fs.existsSync(spec)) {
+    return [spec]
+  }
+
+  const parts = spec.split(',').map((part) => part.trim()).filter(Boolean)
+
+  if (parts.length > 1 && parts.every((part) => fs.existsSync(part))) {
+    return parts
+  }
+
+  // Neither reading holds. Say so naming both, rather than letting the
+  // caller see ENOENT on a fragment they never typed — the failure this
+  // whole function exists to stop being confusing.
+  const missing = parts.filter((part) => !fs.existsSync(part))
+
+  throw new Error(
+      `No such GLB: ${JSON.stringify(spec)}\n` +
+      (parts.length > 1 ?
+        `  Also tried as a ${parts.length}-chunk list; missing: ` +
+          `${missing.map((part) => JSON.stringify(part)).join(', ')}\n` :
+        '') +
+      '  (A path containing a comma is treated as a literal path when it ' +
+      'exists.)')
+}
+
 /** Load one comma-separated GLB list into a single world-space soup. */
 function loadTriangles(glbPathList) {
-  const soups = glbPathList.split(',').map((glbPath) => {
+  const soups = resolveGlbPaths(glbPathList).map((glbPath) => {
     const { json, bin } = parseGlb(fs.readFileSync(glbPath))
     return collectTriangles(json, bin)
   })
@@ -487,4 +529,4 @@ if (require.main === module) {
   main()
 }
 
-module.exports = { diffPixels }
+module.exports = { diffPixels, resolveGlbPaths }

--- a/scripts/render_glb.cjs
+++ b/scripts/render_glb.cjs
@@ -11,15 +11,24 @@
  * accessors.
  *
  * Usage:
- *   render_glb.cjs <in.glb[,in2.glb...]> <out.png> [--size N]
- *   render_glb.cjs --pair <before.glb[,...]> <after.glb[,...]> <outPrefix> [--size N]
+ *   render_glb.cjs <in> <out.png> [--size N]
+ *   render_glb.cjs --pair <before> <after> <outPrefix> [--size N]
  *
- * Each side is a comma-separated list of GLBs merged into one scene —
- * conway's CLI splits large models into multiple chunk files (jet engine),
- * and rendering only one chunk silently drops the rest of the model. A path
- * that itself contains a comma is handled: an existing file wins over the
- * comma reading, so `"Wiesenplatz 7, 4057 Basel.glb"` works unquoted-by-luck
- * or not (conway#457).
+ * where <in> / <before> / <after> is one of:
+ *
+ *   a path                  "model.glb", or "Wiesenplatz 7, 4057 Basel.glb"
+ *   a comma-joined list     "model_test0.glb,model_test1.glb"
+ *   a JSON array           '["a b, c.glb","d.glb"]'
+ *
+ * Chunk lists exist because conway's CLI splits large models across files
+ * (jet engine), and rendering only one chunk silently drops the rest.
+ *
+ * The three forms are tried in the order above, which is what makes a
+ * comma-containing filename work: an existing file wins over the comma
+ * reading (conway#457). Quote it, of course — the shell splits on spaces
+ * before this script sees anything. The JSON form is the only one that can
+ * express a chunk list whose MEMBERS contain commas, since no single file
+ * bears that name; it is what visual_diff_report.cjs passes.
  *
  * Pair mode renders both sides with ONE camera framed on the union of
  * the two bounding boxes (writes <outPrefix>-before.png and
@@ -441,7 +450,9 @@ function writePng(path, pixels, size) {
  * (conway#457). Splitting is only a fallback, which is enough because a
  * chunk list's elements are separate files that each have to exist anyway.
  *
- * @param {string} spec The path, or a comma-joined list of chunk paths.
+ * @param {string} spec A path, a comma-joined list of chunk paths, or a JSON
+ *   array of paths. Tried in that order; see the file header. The JSON form
+ *   is the only one that can express chunk paths containing commas.
  * @return {string[]} Paths to read, in order.
  */
 function resolveGlbPaths(spec) {
@@ -569,11 +580,25 @@ if (require.main === module) {
     // frame's `throw new Error(` rather than anything describing the failure.
     // The PR comment is where these diagnostics are actually read.
     //
-    // The "Error:" prefix is load-bearing for that same regex: a message like
-    // "No such GLB: ..." matches none of its alternatives on its own and
-    // would fall through to lines.pop(), i.e. the last line of a multi-line
-    // message rather than its first.
+    // The "Error:" prefix is what makes the message match that regex at all:
+    // "No such GLB: ..." hits none of its alternatives on its own. In the
+    // common case the stack printed below also opens with "Error: ...", so
+    // the prefix is belt-and-braces there - but a non-Error throw (a bare
+    // string, or anything without .stack) has no such line, and the prefix
+    // is the only thing standing between that and a table cell reading
+    // whatever the last stderr line happened to be.
     process.stderr.write(`Error: ${err && err.message ? err.message : err}\n`)
+
+    // Stack after the message, not instead of it. visual_diff_report.cjs
+    // echoes the whole child stderr into the CI job log, so dropping the
+    // stack would lose the only pointer to a file and line for failures
+    // that are not about paths at all - a truncated GLB throws a RangeError
+    // deep in parseGlb. lines.find() takes the FIRST match, and stack frames
+    // match none of the regex alternatives, so this cannot displace the
+    // message in the PR table.
+    if (err && err.stack) {
+      process.stderr.write(`${err.stack}\n`)
+    }
     process.exit(1)
   }
 }

--- a/scripts/render_glb.cjs
+++ b/scripts/render_glb.cjs
@@ -445,13 +445,46 @@ function writePng(path, pixels, size) {
  * @return {string[]} Paths to read, in order.
  */
 function resolveGlbPaths(spec) {
+  // A JSON array is the unambiguous form, and the only one that works for a
+  // comma-named model big enough to CHUNK: the literal-path rule below cannot
+  // help there, because no single file has that name. Programmatic callers
+  // (visual_diff_report.cjs) pass this; it survives execFileSync with no
+  // shell in the way. A real path never starts with '[' and parses as an
+  // array of strings, so this cannot capture one by accident.
+  if (spec.startsWith('[')) {
+    let parsed = null
+
+    try {
+      parsed = JSON.parse(spec)
+    } catch {
+      parsed = null
+    }
+
+    if (Array.isArray(parsed) && parsed.length > 0 &&
+        parsed.every((part) => typeof part === 'string')) {
+
+      const absent = parsed.filter((part) => !fs.existsSync(part))
+
+      if (absent.length > 0) {
+        throw new Error(
+            `No such GLB in chunk list: ` +
+            `${absent.map((part) => JSON.stringify(part)).join(', ')}`)
+      }
+
+      return parsed
+    }
+  }
+
   if (fs.existsSync(spec)) {
     return [spec]
   }
 
   const parts = spec.split(',').map((part) => part.trim()).filter(Boolean)
 
-  if (parts.length > 1 && parts.every((part) => fs.existsSync(part))) {
+  // `>= 1`, not `> 1`: a trailing comma from a shell-built list ("a.glb,")
+  // should still resolve, and a bare missing path has already failed the
+  // existsSync check above, so there is nothing to lose by trying.
+  if (parts.length >= 1 && parts.every((part) => fs.existsSync(part))) {
     return parts
   }
 
@@ -526,7 +559,23 @@ function main() {
 // Run as a CLI, but stay require()-able so diffPixels can be unit-tested
 // without executing main().
 if (require.main === module) {
-  main()
+  try {
+    main()
+  } catch (err) {
+    // Print the message and exit, rather than letting Node throw. An uncaught
+    // throw leads with a source code frame, and visual_diff_report.cjs's
+    // childFailureDiagnostic takes the FIRST stderr line matching
+    // /error|cannot|not found|bad option|unexpected/i -- which would be the
+    // frame's `throw new Error(` rather than anything describing the failure.
+    // The PR comment is where these diagnostics are actually read.
+    //
+    // The "Error:" prefix is load-bearing for that same regex: a message like
+    // "No such GLB: ..." matches none of its alternatives on its own and
+    // would fall through to lines.pop(), i.e. the last line of a multi-line
+    // message rather than its first.
+    process.stderr.write(`Error: ${err && err.message ? err.message : err}\n`)
+    process.exit(1)
+  }
 }
 
 module.exports = { diffPixels, resolveGlbPaths }

--- a/scripts/visual_diff_report.cjs
+++ b/scripts/visual_diff_report.cjs
@@ -196,7 +196,7 @@ function main() {
       }
       try {
         execFileSync(process.execPath, [
-          renderScript, side.glbs.join(','),
+          renderScript, JSON.stringify(side.glbs),
           path.join(opts.out, `${slug}-${suffix}.png`),
         ], { stdio: 'pipe', timeout: 5 * 60 * 1000 })
         return `![${suffix}](RAW_URL_BASE/${slug}-${suffix}.png)`
@@ -210,7 +210,8 @@ function main() {
     if (base.glbs.length > 0 && cand.glbs.length > 0) {
       try {
         const renderOut = execFileSync(process.execPath, [
-          renderScript, '--pair', base.glbs.join(','), cand.glbs.join(','),
+          renderScript, '--pair',
+          JSON.stringify(base.glbs), JSON.stringify(cand.glbs),
           path.join(opts.out, slug),
         ], { stdio: 'pipe', timeout: 5 * 60 * 1000 })
 

--- a/src/scripts/render_glb_paths.test.ts
+++ b/src/scripts/render_glb_paths.test.ts
@@ -1,0 +1,93 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { describe, expect, test, beforeAll, afterAll } from '@jest/globals'
+import { createRequire } from 'module'
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- render_glb.cjs is an
+   untyped CommonJS CLI script, loaded here through createRequire. */
+
+/**
+ * Path resolution in scripts/render_glb.cjs (conway#457).
+ *
+ * The script accepts a comma-joined chunk list, and used to split on comma
+ * unconditionally — which tore a real path containing a comma into fragments
+ * and reported the first fragment as missing. Several models we ship are
+ * named that way, and `-g` keeps the source basename, so following
+ * scripts/debug/README.md on one of them failed.
+ */
+const require_ = createRequire(import.meta.url)
+
+// Resolved from the repo root rather than relative to this file: the test
+// runs from compiled/src/scripts, where a relative hop would land in
+// compiled/scripts, which does not exist (scripts/ is not part of the tsc
+// build). Jest's rootDir is the repo root.
+const { resolveGlbPaths } =
+  require_(path.resolve(process.cwd(), 'scripts/render_glb.cjs')) as
+    { resolveGlbPaths: (spec: string) => string[] }
+
+let workDir: string
+
+/** A name in the shape that broke: a comma inside a single real filename. */
+const COMMA_NAME = 'Wiesenplatz 7, 4057 Basel_test0.glb'
+
+beforeAll(() => {
+
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'render-glb-paths-'))
+
+  fs.writeFileSync(path.join(workDir, COMMA_NAME), 'not-a-real-glb')
+  fs.writeFileSync(path.join(workDir, 'chunk0.glb'), 'not-a-real-glb')
+  fs.writeFileSync(path.join(workDir, 'chunk1.glb'), 'not-a-real-glb')
+})
+
+afterAll(() => {
+
+  fs.rmSync(workDir, { recursive: true, force: true })
+})
+
+
+describe('render_glb path resolution', () => {
+
+  test('a real path containing a comma resolves to itself (issue #457)', () => {
+
+    const target = path.join(workDir, COMMA_NAME)
+
+    // The regression: this used to come back as ['<dir>/Wiesenplatz 7',
+    // ' 4057 Basel_test0.glb'] and fail on the first, which reads as a
+    // missing file rather than as a parsing decision.
+    expect(resolveGlbPaths(target)).toEqual([target])
+  })
+
+  test('a genuine chunk list still splits', () => {
+
+    const chunks = [
+      path.join(workDir, 'chunk0.glb'),
+      path.join(workDir, 'chunk1.glb'),
+    ]
+
+    expect(resolveGlbPaths(chunks.join(','))).toEqual(chunks)
+  })
+
+  test('a missing path names both readings rather than one fragment', () => {
+
+    const missing = path.join(workDir, 'Nowhere 1, 2345 Somewhere.glb')
+
+    // What the error says is the whole point of the issue: the old failure
+    // surfaced as ENOENT on "Nowhere 1", a string the caller never typed.
+    expect(() => resolveGlbPaths(missing)).toThrow(/No such GLB/)
+    expect(() => resolveGlbPaths(missing)).toThrow(/2-chunk list/)
+  })
+
+  test('a chunk list with one missing member does not silently render the rest', () => {
+
+    const spec = [
+      path.join(workDir, 'chunk0.glb'),
+      path.join(workDir, 'absent.glb'),
+    ].join(',')
+
+    // Rendering the surviving chunk would drop part of the model and look
+    // like a geometry regression in the visual diff, which is worse than
+    // failing.
+    expect(() => resolveGlbPaths(spec)).toThrow(/absent\.glb/)
+  })
+})

--- a/src/scripts/render_glb_paths.test.ts
+++ b/src/scripts/render_glb_paths.test.ts
@@ -68,6 +68,33 @@ describe('render_glb path resolution', () => {
     expect(resolveGlbPaths(chunks.join(','))).toEqual(chunks)
   })
 
+  test('a JSON array resolves chunks whose names contain commas', () => {
+
+    // The case the literal-path rule alone cannot reach: a comma-named model
+    // large enough that the CLI splits it, so no single file bears the name.
+    // visual_diff_report.cjs passes this form.
+    const chunks = [
+      path.join(workDir, COMMA_NAME),
+      path.join(workDir, 'chunk0.glb'),
+    ]
+
+    expect(resolveGlbPaths(JSON.stringify(chunks))).toEqual(chunks)
+  })
+
+  test('a JSON array with a missing member fails rather than rendering part', () => {
+
+    const chunks = [path.join(workDir, 'chunk0.glb'), path.join(workDir, 'gone.glb')]
+
+    expect(() => resolveGlbPaths(JSON.stringify(chunks))).toThrow(/gone\.glb/)
+  })
+
+  test('a trailing comma from a shell-built list still resolves', () => {
+
+    const target = path.join(workDir, 'chunk0.glb')
+
+    expect(resolveGlbPaths(`${target},`)).toEqual([target])
+  })
+
   test('a missing path names both readings rather than one fragment', () => {
 
     const missing = path.join(workDir, 'Nowhere 1, 2345 Somewhere.glb')

--- a/src/scripts/render_glb_paths.test.ts
+++ b/src/scripts/render_glb_paths.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import { execFileSync } from 'child_process'
 import { describe, expect, test, beforeAll, afterAll } from '@jest/globals'
 import { createRequire } from 'module'
 
@@ -103,6 +104,45 @@ describe('render_glb path resolution', () => {
     // surfaced as ENOENT on "Nowhere 1", a string the caller never typed.
     expect(() => resolveGlbPaths(missing)).toThrow(/No such GLB/)
     expect(() => resolveGlbPaths(missing)).toThrow(/2-chunk list/)
+  })
+
+  test('a CLI failure surfaces its own message to visual_diff_report', () => {
+
+    // This contract spans two files and has no other guard. render_glb.cjs
+    // prints "Error: <message>"; visual_diff_report.cjs's
+    // childFailureDiagnostic picks the FIRST stderr line matching its regex
+    // and puts it in the PR comment's table cell. Letting Node throw
+    // uncaught instead degrades every render-failure cell to a source code
+    // frame, with the whole suite otherwise green.
+    //
+    // Scope, honestly: this pins the END-TO-END result, not each mechanism.
+    // Removing the "Error:" prefix alone keeps it passing, because the stack
+    // printed after the message opens with an "Error:" line that matches the
+    // same regex. Both are kept because a non-Error throw has no stack.
+    const script = path.resolve(process.cwd(), 'scripts/render_glb.cjs')
+    const missing = path.join(workDir, 'Nowhere 1, 2345 Somewhere.glb')
+
+    let stderr = ''
+
+    try {
+      execFileSync(
+          process.execPath,
+          [script, missing, path.join(workDir, 'out.png')],
+          { stdio: 'pipe' })
+    } catch (err) {
+      stderr = ((err as { stderr?: Buffer }).stderr ?? '').toString()
+    }
+
+    // The regex is copied from visual_diff_report.cjs:138 deliberately — the
+    // point is to fail here if either side drifts.
+    const picked = stderr.split('\n').filter(Boolean).find(
+        (line) => /error|cannot|not found|bad option|unexpected/i.test(line))
+
+    expect(picked).toMatch(/No such GLB/)
+    expect(picked).toContain('Nowhere 1, 2345 Somewhere.glb')
+
+    // And the stack still reaches the job log, which is a separate consumer.
+    expect(stderr).toMatch(/at resolveGlbPaths/)
   })
 
   test('a chunk list with one missing member does not silently render the rest', () => {


### PR DESCRIPTION
Fixes #457.

## The bug

`scripts/render_glb.cjs` split its path argument on commas unconditionally, to support conway's multi-chunk GLB output. Several models we ship are named with commas — `Wiesenplatz 7, 4057 Basel.ifc`, `Lättichstrasse 4a, 6340 Baar_AECO.ifc` — and the CLI's `-g` output keeps the source basename, so rendering one tore the path into fragments and failed on the first:

```
syscall: 'open', path: 'Wiesenplatz 7'
```

That reads as a missing file rather than as a parsing decision, and rendering one of these models is a documented step in `scripts/debug/README.md`.

## The fix

Three accepted forms, tried in order — a **path**, a **comma-joined list**, a **JSON array**:

- An existing file wins over the comma reading, which fixes the single-GLB case.
- **A JSON array is the only form that can express a chunk list whose *members* contain commas** — no single file bears that name, so the literal-path rule can't help. `visual_diff_report.cjs` now passes this; it survives `execFileSync` with no shell involved, and a real path never starts with `[` and parses as an array of strings.

Review caught that first point: my initial fix only covered comma-named models small enough to export as **one** GLB, and the CI path that actually renders these models joins all chunks with `,`. That case was still broken.

When nothing resolves, the error names both readings rather than reporting ENOENT on a fragment the caller never typed.

## Verification

End-to-end with the rasterizer actually running:

| case | result |
|---|---|
| `"Wiesenplatz 7, 4057 Basel_test0.glb"` (the issue's exact name) | renders, exit 0 |
| JSON array with a comma-named member | renders, exit 0 |
| two-chunk comma list | merges and renders, exit 0 |
| missing comma path | both-readings error |

**Every test was checked against the behaviour it claims to pin**, and one of those checks changed the PR:

- Reverting the literal-path rule → the comma case fails, chunk-list still passes. Discriminates.
- Removing the `catch` in `main()` → the new CLI-contract test fails. Discriminates.
- Removing *only* the `Error:` prefix → **still passes.** The stack printed after the message opens with its own `Error:` line matching the same regex. So the prefix is not load-bearing in that path, and I corrected the comment that claimed it was. Both are kept because a non-`Error` throw has no stack.

Suite: 77 suites / 384 tests.

## Also fixed in review

- **Stack was being dropped from the CI job log.** Printing only `err.message` was a regression against pre-PR behaviour for failures that aren't about paths — a truncated GLB throws a `RangeError` deep in `parseGlb`, and one line with no frame isn't actionable. Stack now prints after the message, where it can't displace it in the PR table.
- **`>= 1` rather than `> 1`** on the split guard, so a trailing comma from a shell-built list (`"a.glb,"`) resolves. A bare missing path has already failed `existsSync` by then.
- **Header claimed** a comma-named path works "unquoted-by-luck or not." It doesn't — the shell splits on spaces first, and the unquoted invocation reproduces this issue's original symptom. Removed.

## Not addressed

The issue's "related gotcha" — `git lfs pull --include` also treating commas as pattern separators, exiting 0 having fetched nothing and leaving a 134-byte pointer stub. That's upstream git-lfs behaviour, not ours. Worth a line in `scripts/debug/README.md` since anyone reproducing a bug on these models hits it first, but that's a docs change with its own reviewer question, so it isn't bundled here.