### PR TITLE
Add a displacement stage that measures meshes in world space

### DIFF
--- a/scripts/debug/README.md
+++ b/scripts/debug/README.md
@@ -68,6 +68,7 @@ rest of the model.
 | `loop` | `ConwayGeometry.getLoop` | Per-loop extent, point-spacing histogram, wrap duplicates, sub-3-point loops |
 | `face` | `ConwayGeometry.addFaceToGeometry` | Vertices one face contributed, and how far out they landed |
 | `mesh` | scene walk after load | Per-mesh local bounds, attributed to the product entity |
+| `displacement` | scene walk after load | Per-mesh distance from the model's robust centre, in world space |
 
 They are deliberately redundant, and that redundancy is the diagnostic:
 the *narrowest dirty stage* is where the defect lives.
@@ -161,10 +162,23 @@ outliers" readings from probes attached to a seam the model did not take.
   model legitimately has parts of mixed scale and the flags are weak
   evidence — raise `--factor`. If p90 hugs the median, anything flagged is
   real.
-- **The `mesh` stage is the noisiest** of the four for exactly that
-  reason: an assembly with one large housing and forty small fasteners
-  will flag the housing every time. It is still the only stage that can
-  name the *product* a defect belongs to.
+- **The `mesh` stage is the noisiest** for exactly that reason: an
+  assembly with one large housing and forty small fasteners will flag the
+  housing every time. It is still the only stage that can name the
+  *product* a defect belongs to.
+- **Reach for `displacement` when `mesh` floods.** `mesh` reads
+  mesh-LOCAL coordinates, so on an export that writes geometry directly
+  in site coordinates with identity placements — common for IFC
+  `IfcFacetedBrep` — every honest part's "extent" is really its distance
+  from the file origin. `Wiesenplatz 7, 4057 Basel.ifc` flagged 3,955
+  meshes that way, of which 3 were real (conway#456). `displacement`
+  places each mesh with its transform and scores how far it sits from
+  where the model actually is, and names 5 of 37,502 on the same file.
+  The tell that you want it: median and p90 both large, with flagged rows
+  continuous above the threshold rather than separated from it.
+- **They do not subsume each other.** `mesh` still catches a part that is
+  internally huge but correctly placed; `displacement` scores that part
+  as ordinary. Run both.
 - **`wrap-duplicate loops` is usually not a finding.** Most exporters
   repeat the start point as the last point. It is reported because when
   combined with sub-micron gaps it identifies triangulation-failure

--- a/scripts/debug/displacement.mjs
+++ b/scripts/debug/displacement.mjs
@@ -40,39 +40,24 @@ export function robustCentre(centres) {
 
 
 /**
- * A mesh's centre in WORLD space: the centre of its local bounds, placed by
- * its absolute transform.
+ * A mesh's centre in its OWN coordinates: the centre of its local bounds.
  *
  * Bounds centre rather than vertex mean, so a face with a dense cluster of
  * vertices at one end does not drag the centre toward it — this is asking
  * where a part sits, not where its detail is.
  *
- * The transform is validated rather than trusted. A wrong walk-tuple index
- * hands this an object, every multiplication yields NaN, `Stage.record`
- * discards non-finite values, and the stage reports "N calls, 0 measured" —
- * a clean-looking result produced by a bug, which is hazard 1 in
- * model_report.mjs's header arriving through the back door. It cost a
- * debugging cycle already: conway#456 names the transform as `walked[1]`,
- * and it is `walked[0]`.
+ * Split from placement so a caller can compute this ONCE per geometry and
+ * apply it to every placement. Local bounds are placement-invariant, and
+ * instanced geometry is walked once per instance, so recomputing would
+ * re-read every vertex across the wasm boundary N times for an answer that
+ * cannot change.
  *
  * @param {object} geometry A conway GeometryObject
  * @param {number} count Vertex count
- * @param {Float64Array|number[]|undefined} transform Column-major 4x4, or
- *   undefined for identity
- * @return {number[]|undefined} [x, y, z], or undefined if any vertex or any
- *   resulting coordinate was not finite
+ * @return {number[]|undefined} [x, y, z], or undefined if any vertex was
+ *   not finite
  */
-export function worldCentre(geometry, count, transform) {
-  /** Elements in a column-major 4x4. */
-  const MATRIX_ELEMENTS = 16
-
-  if (transform !== undefined &&
-      (typeof transform.length !== 'number' || transform.length < MATRIX_ELEMENTS)) {
-    throw new Error(
-        'worldCentre: expected a column-major 4x4 transform or undefined, got ' +
-        `${Object.prototype.toString.call(transform)} — check the walk tuple index`)
-  }
-
+export function localCentre(geometry, count) {
   const min = [Infinity, Infinity, Infinity]
   const max = [-Infinity, -Infinity, -Infinity]
 
@@ -95,7 +80,37 @@ export function worldCentre(geometry, count, transform) {
     return undefined
   }
 
-  const local = [0, 1, 2].map((axis) => (min[axis] + max[axis]) / 2)
+  return [0, 1, 2].map((axis) => (min[axis] + max[axis]) / 2)
+}
+
+
+/**
+ * Place a local centre into world space with an absolute transform.
+ *
+ * The transform is validated rather than trusted. A wrong walk-tuple index
+ * hands this an object, every multiplication yields NaN, `Stage.record`
+ * discards non-finite values, and the stage reports "N calls, 0 measured" —
+ * a clean-looking result produced by a bug, which is hazard 1 in
+ * model_report.mjs's header arriving through the back door. It cost a
+ * debugging cycle already: conway#456 names the transform as `walked[1]`,
+ * and it is `walked[0]`.
+ *
+ * @param {number[]} local [x, y, z] in mesh coordinates
+ * @param {Float64Array|number[]|undefined} transform Column-major 4x4, or
+ *   undefined for identity
+ * @return {number[]|undefined} [x, y, z] in world space, or undefined if the
+ *   transform was the right shape but held non-finite values
+ */
+export function placeCentre(local, transform) {
+  /** Elements in a column-major 4x4. */
+  const MATRIX_ELEMENTS = 16
+
+  if (transform !== undefined &&
+      (typeof transform.length !== 'number' || transform.length < MATRIX_ELEMENTS)) {
+    throw new Error(
+        'placeCentre: expected a column-major 4x4 transform or undefined, got ' +
+        `${Object.prototype.toString.call(transform)} — check the walk tuple index`)
+  }
 
   if (transform === undefined) {
     return local

--- a/scripts/debug/displacement.mjs
+++ b/scripts/debug/displacement.mjs
@@ -1,0 +1,118 @@
+/**
+ * World-space displacement scoring for model_report.mjs's `displacement`
+ * stage (conway#456).
+ *
+ * Kept in its own module, with no side effects on import, so the scoring can
+ * be unit-tested without running the CLI. model_report.mjs executes its
+ * `main()` at import time, so importing *it* from a test runs the whole tool
+ * inside the test runner.
+ */
+
+/**
+ * The middle value of a numeric list, taking the lower of the two middles
+ * for an even count. Sorts a copy — callers reuse their arrays.
+ *
+ * @param {number[]} values At least one value
+ * @return {number} The median
+ */
+export function median(values) {
+  const sorted = [...values].sort((a, b) => a - b)
+
+  return sorted[Math.floor((sorted.length - 1) / 2)]
+}
+
+
+/**
+ * The model's robust centre: the component-wise median of mesh centres.
+ *
+ * Median, not mean, and that choice is the whole point. A mean is dragged
+ * toward the outliers being hunted, which shrinks their own scores and
+ * inflates everyone else's — on a model with a handful of parts flung
+ * kilometres away, a mean centre sits out in empty space and every honest
+ * part scores as displaced.
+ *
+ * @param {number[][]} centres One [x, y, z] per mesh, at least one
+ * @return {number[]} [x, y, z]
+ */
+export function robustCentre(centres) {
+  return [0, 1, 2].map((axis) => median(centres.map((each) => each[axis])))
+}
+
+
+/**
+ * A mesh's centre in WORLD space: the centre of its local bounds, placed by
+ * its absolute transform.
+ *
+ * Bounds centre rather than vertex mean, so a face with a dense cluster of
+ * vertices at one end does not drag the centre toward it — this is asking
+ * where a part sits, not where its detail is.
+ *
+ * The transform is validated rather than trusted. A wrong walk-tuple index
+ * hands this an object, every multiplication yields NaN, `Stage.record`
+ * discards non-finite values, and the stage reports "N calls, 0 measured" —
+ * a clean-looking result produced by a bug, which is hazard 1 in
+ * model_report.mjs's header arriving through the back door. It cost a
+ * debugging cycle already: conway#456 names the transform as `walked[1]`,
+ * and it is `walked[0]`.
+ *
+ * @param {object} geometry A conway GeometryObject
+ * @param {number} count Vertex count
+ * @param {Float64Array|number[]|undefined} transform Column-major 4x4, or
+ *   undefined for identity
+ * @return {number[]|undefined} [x, y, z], or undefined if any vertex or any
+ *   resulting coordinate was not finite
+ */
+export function worldCentre(geometry, count, transform) {
+  /** Elements in a column-major 4x4. */
+  const MATRIX_ELEMENTS = 16
+
+  if (transform !== undefined &&
+      (typeof transform.length !== 'number' || transform.length < MATRIX_ELEMENTS)) {
+    throw new Error(
+        'worldCentre: expected a column-major 4x4 transform or undefined, got ' +
+        `${Object.prototype.toString.call(transform)} — check the walk tuple index`)
+  }
+
+  const min = [Infinity, Infinity, Infinity]
+  const max = [-Infinity, -Infinity, -Infinity]
+
+  for (let i = 0; i < count; ++i) {
+    // getPoint(), never a held HEAPF32 view — see model_report.mjs's header.
+    const point = geometry.getPoint(i)
+    const axes = [point.x, point.y, point.z]
+
+    for (let axis = 0; axis < 3; ++axis) {
+      if (!Number.isFinite(axes[axis])) {
+        return undefined
+      }
+
+      min[axis] = Math.min(min[axis], axes[axis])
+      max[axis] = Math.max(max[axis], axes[axis])
+    }
+  }
+
+  if (!Number.isFinite(min[0])) {
+    return undefined
+  }
+
+  const local = [0, 1, 2].map((axis) => (min[axis] + max[axis]) / 2)
+
+  if (transform === undefined) {
+    return local
+  }
+
+  const [x, y, z] = local
+
+  const placed = [
+    (transform[0] * x) + (transform[4] * y) + (transform[8] * z) + transform[12],
+    (transform[1] * x) + (transform[5] * y) + (transform[9] * z) + transform[13],
+    (transform[2] * x) + (transform[6] * y) + (transform[10] * z) + transform[14],
+  ]
+
+  // A transform of the right SHAPE can still hold NaN. Returning undefined
+  // drops the mesh from the sample rather than throwing, because unlike a
+  // wrong tuple index this is data, not a programming error, and one bad
+  // placement must not discard the curve/loop/face/mesh reports already
+  // collected by the same run.
+  return placed.every(Number.isFinite) ? placed : undefined
+}

--- a/scripts/debug/model_report.mjs
+++ b/scripts/debug/model_report.mjs
@@ -76,7 +76,7 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import {robustCentre, worldCentre} from './displacement.mjs'
+import {localCentre, placeCentre, robustCentre} from './displacement.mjs'
 
 const REPO_ROOT = new URL('../../', import.meta.url)
 
@@ -629,6 +629,7 @@ function collectDisplacement(stage, model, scene) {
   }
 
   const placed = []
+  const localCentres = new Map()
   let walkedMeshes = 0
 
   for (const walked of scene.walk()) {
@@ -654,13 +655,31 @@ function collectDisplacement(stage, model, scene) {
       continue
     }
 
-    const centre = worldCentre(geometry, count, walked[0])
+    // Local bounds are placement-invariant, so they are read once per
+    // geometry however many times it is instanced. Without this, dropping
+    // the dedup above would multiply the getPoint() wasm crossings by the
+    // instance count on exactly the large models this tool is for.
+    if (!localCentres.has(mesh.localID)) {
+      localCentres.set(mesh.localID, localCentre(geometry, count))
+    }
+
+    const local = localCentres.get(mesh.localID)
+
+    if (local === undefined) {
+      continue
+    }
+
+    const centre = placeCentre(local, walked[0])
 
     if (centre === undefined) {
       continue
     }
 
-    placed.push({localID: mesh.localID, centre, vertices: count})
+    // walked[4] is the owning product; mesh.localID names the shared
+    // representation item. With every placement now scored separately, the
+    // latter would print the same expressID on all N rows of an instanced
+    // geometry — and naming the product is what this stage is for.
+    placed.push({element: walked[4], centre, vertices: count})
   }
 
   // Meshes WALKED, not meshes placed. `fired` answers "did this probe see
@@ -679,7 +698,7 @@ function collectDisplacement(stage, model, scene) {
     const offset = [0, 1, 2].map((axis) => each.centre[axis] - centre[axis])
 
     stage.record(Math.hypot(offset[0], offset[1], offset[2]), () => ({
-      ...describeEntity(model.getElementByLocalID?.(each.localID)),
+      ...describeEntity(each.element),
       vertices: each.vertices,
       centre: each.centre.map((value) => Number(value.toFixed(1))),
     }))
@@ -890,14 +909,24 @@ async function main() {
     collectMeshes(stages.get('mesh'), model, scene)
   }
 
+  let displacementError
+
   if (stages.has('displacement')) {
     try {
       collectDisplacement(stages.get('displacement'), model, scene)
     } catch (err) {
       // One stage's programming error must not discard the curve/loop/face/
       // mesh reports this run already collected — they are usually the ones
-      // being read. Surfaced on the stage rather than swallowed.
-      stages.get('displacement').extra.error = String(err?.message ?? err)
+      // being read.
+      //
+      // Printed HERE rather than stashed on stage.extra. A throw leaves
+      // `fired` at 0, so reportStage takes its dead branch and prints
+      // "PROBE NEVER FIRED ... Expected when the model uses no geometry of
+      // this kind" — which reads as an explanation rather than a failure,
+      // and drops `extra` from --json entirely. That is precisely the
+      // false-clean reading the guard in placeCentre exists to prevent, so
+      // it cannot be left to a channel the reporter might not show.
+      displacementError = String(err?.message ?? err)
     }
   }
 
@@ -907,6 +936,13 @@ async function main() {
       `${options.stages.join(',')}`)
 
   const reports = [...stages.values()].map((stage) => reportStage(stage, options))
+
+  if (displacementError !== undefined) {
+    say(
+        `\n## displacement\n  STAGE FAILED — ${displacementError}\n` +
+        '  This stage measured nothing because it threw, NOT because the\n' +
+        '  model is clean. The other stages above are unaffected.')
+  }
 
   if (messages.size > 0) {
     const ranked = [...messages].sort((a, b) => b[1] - a[1])

--- a/scripts/debug/model_report.mjs
+++ b/scripts/debug/model_report.mjs
@@ -76,6 +76,7 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import {robustCentre, worldCentre} from './displacement.mjs'
 
 const REPO_ROOT = new URL('../../', import.meta.url)
 
@@ -599,106 +600,6 @@ function collectMeshes(stage, model, scene) {
 
 
 /**
- * The middle value of a numeric list, by the lower of the two middles for
- * an even count. Sorts a copy — callers reuse their arrays.
- *
- * @param {number[]} values At least one value
- * @return {number} The median
- */
-function median(values) {
-  const sorted = [...values].sort((a, b) => a - b)
-
-  return sorted[Math.floor((sorted.length - 1) / 2)]
-}
-
-
-/**
- * The model's robust centre: the component-wise median of mesh centres.
- *
- * Median, not mean, and that choice is the whole point. A mean is dragged
- * toward the outliers being hunted, which shrinks their own scores and
- * inflates everyone else's — on a model with a handful of parts flung
- * kilometres away, a mean centre sits out in empty space and every honest
- * part scores as displaced.
- *
- * @param {number[][]} centres One [x, y, z] per mesh, at least one
- * @return {number[]} [x, y, z]
- */
-export function robustCentre(centres) {
-  return [0, 1, 2].map((axis) => median(centres.map((each) => each[axis])))
-}
-
-
-/**
- * A mesh's centre in WORLD space: the centre of its local bounds, placed by
- * its absolute transform.
- *
- * Bounds centre rather than vertex mean, so a face with a dense cluster of
- * vertices at one end does not drag the centre toward it — this is asking
- * where a part sits, not where its detail is.
- *
- * The transform is validated rather than trusted. A wrong walk-tuple index
- * hands this an object, every multiplication yields NaN, `Stage.record`
- * discards non-finite values, and the stage reports "N calls, 0 measured" —
- * a clean-looking result produced by a bug, which is hazard 1 in this file's
- * header arriving through the back door. It cost a debugging cycle here
- * already: conway#456 names the transform as `walked[1]`, and it is
- * `walked[0]`.
- *
- * @param {object} geometry A conway GeometryObject
- * @param {number} count Vertex count
- * @param {Float64Array|number[]|undefined} transform Column-major 4x4, or
- *   undefined for identity
- * @return {number[]|undefined} [x, y, z], or undefined if nothing was finite
- */
-export function worldCentre(geometry, count, transform) {
-  if (transform !== undefined &&
-      (typeof transform.length !== 'number' || transform.length < 16 ||
-       !Number.isFinite(transform[0]))) {
-    throw new Error(
-        'worldCentre: expected a column-major 4x4 transform or undefined, got ' +
-        `${Object.prototype.toString.call(transform)} — check the walk tuple index`)
-  }
-
-  const min = [Infinity, Infinity, Infinity]
-  const max = [-Infinity, -Infinity, -Infinity]
-
-  for (let i = 0; i < count; ++i) {
-    // getPoint(), never a held HEAPF32 view — see the hazards in the header.
-    const point = geometry.getPoint(i)
-    const axes = [point.x, point.y, point.z]
-
-    for (let axis = 0; axis < 3; ++axis) {
-      if (!Number.isFinite(axes[axis])) {
-        return undefined
-      }
-
-      min[axis] = Math.min(min[axis], axes[axis])
-      max[axis] = Math.max(max[axis], axes[axis])
-    }
-  }
-
-  if (!Number.isFinite(min[0])) {
-    return undefined
-  }
-
-  const local = [0, 1, 2].map((axis) => (min[axis] + max[axis]) / 2)
-
-  if (transform === undefined) {
-    return local
-  }
-
-  const [x, y, z] = local
-
-  return [
-    (transform[0] * x) + (transform[4] * y) + (transform[8] * z) + transform[12],
-    (transform[1] * x) + (transform[5] * y) + (transform[9] * z) + transform[13],
-    (transform[2] * x) + (transform[6] * y) + (transform[10] * z) + transform[14],
-  ]
-}
-
-
-/**
  * Record every mesh's distance from the model's robust centre.
  *
  * Two passes, because the metric is relative to the model: the centre is not
@@ -712,6 +613,12 @@ export function worldCentre(geometry, count, transform) {
  * the median distance is 38.6 and the three sky-arcing slivers sit at
  * 950-1377, which clears an 8x threshold by a wide margin.
  *
+ * One caveat that comes with reusing that threshold: distances here can be
+ * exactly zero, unlike an extent. A model where more than half the meshes
+ * sit at the robust centre — many identical items placed at one origin —
+ * gives median 0, hence threshold 0, hence every other mesh flagged. The
+ * report shows median 0 when that happens, and `--limit` is the escape.
+ *
  * @param {Stage} stage The stage to record into
  * @param {object} model The loaded model, for entity attribution
  * @param {object} scene The walkable scene
@@ -721,18 +628,25 @@ function collectDisplacement(stage, model, scene) {
     return
   }
 
-  const seen = new Set()
   const placed = []
+  let walkedMeshes = 0
 
   for (const walked of scene.walk()) {
     const mesh = walked[2]
     const geometry = mesh?.geometry
 
-    if (typeof geometry?.getVertexCount !== 'function' || seen.has(mesh.localID)) {
+    if (typeof geometry?.getVertexCount !== 'function') {
       continue
     }
 
-    seen.add(mesh.localID)
+    // NO dedup by localID, unlike collectMeshes. That stage measures local
+    // bounds, which are identical for every placement of a shared geometry,
+    // so deduping is free there. Here the placement IS the measurement:
+    // extractMappedItem (IFC) and the AP214 occurrence stack emit one walk
+    // entry per instance, and skipping the repeats would hide a flung-away
+    // instance of an otherwise well-placed window or fastener — and compute
+    // the robust centre from an unrepresentative sample besides.
+    ++walkedMeshes
 
     const count = geometry.getVertexCount()
 
@@ -749,9 +663,11 @@ function collectDisplacement(stage, model, scene) {
     placed.push({localID: mesh.localID, centre, vertices: count})
   }
 
-  // Set before the early return: a model that walked meshes but placed none
-  // has to read as "fired, no outliers" rather than as a dead probe.
-  stage.fired = placed.length
+  // Meshes WALKED, not meshes placed. `fired` answers "did this probe see
+  // anything", so counting only successes would report a model whose every
+  // placement was unusable as a dead probe — and would make fired identical
+  // to measured, hiding the skipped ones.
+  stage.fired = walkedMeshes
 
   if (placed.length === 0) {
     return
@@ -975,7 +891,14 @@ async function main() {
   }
 
   if (stages.has('displacement')) {
-    collectDisplacement(stages.get('displacement'), model, scene)
+    try {
+      collectDisplacement(stages.get('displacement'), model, scene)
+    } catch (err) {
+      // One stage's programming error must not discard the curve/loop/face/
+      // mesh reports this run already collected — they are usually the ones
+      // being read. Surfaced on the stage rather than swallowed.
+      stages.get('displacement').extra.error = String(err?.message ?? err)
+    }
   }
 
   say(`\n# ${path.basename(options.model)}`)

--- a/scripts/debug/model_report.mjs
+++ b/scripts/debug/model_report.mjs
@@ -12,6 +12,20 @@
  *   loop   getLoop           per-loop extent + point spacing
  *   face   addFaceToGeometry vertices a single face contributed
  *   mesh   scene walk        per-mesh local bounds, attributed to entities
+ *   displacement            per-mesh distance from the model's robust centre
+ *
+ * `mesh` and `displacement` measure different things and neither subsumes
+ * the other. `mesh` reads vertices in MESH-LOCAL coordinates, so it catches
+ * a part that is internally huge — but on an export that writes geometry
+ * directly in site coordinates with identity placements (common for IFC
+ * `IfcFacetedBrep`), every honest part's "extent" is really its distance
+ * from the file origin, and the stage flags thousands of them. On
+ * `Wiesenplatz 7, 4057 Basel.ifc` that was 3,955 rows of which 3 were real
+ * (conway#456). `displacement` places each mesh with its transform and
+ * scores how far it sits from where the model actually is, which is the
+ * question "which parts are flung away from where they belong" — see
+ * design/new/model-diagnostics.md §"Extent outliers". On the same model it
+ * names 5 of 37,502.
  *
  * The stages are deliberately redundant: they bracket the pipeline, so
  * comparing them localises a defect. A model whose `mesh` stage shows a
@@ -42,7 +56,8 @@
  * Usage:
  *   node scripts/debug/model_report.mjs <model> [options]
  *
- *   --stage <list>   comma-separated: curve,loop,face,mesh (default all)
+ *   --stage <list>   comma-separated: curve,loop,face,mesh,displacement
+ *                    (default all)
  *   --limit <n>      absolute outlier threshold, in model units
  *   --factor <n>     outlier = value > factor x median (default 8)
  *   --top <n>        rows printed per stage (default 15)
@@ -73,7 +88,7 @@ const DEFAULT_TOP = 15
 /** Point-spacing histogram buckets, in model units, ascending. */
 const GAP_BUCKETS = [1e-8, 1e-7, 1e-6, 1e-5]
 
-const ALL_STAGES = ['curve', 'loop', 'face', 'mesh']
+const ALL_STAGES = ['curve', 'loop', 'face', 'mesh', 'displacement']
 
 const EXIT_PROBE_DEAD = 2
 const EXIT_USAGE = 1
@@ -584,6 +599,179 @@ function collectMeshes(stage, model, scene) {
 
 
 /**
+ * The middle value of a numeric list, by the lower of the two middles for
+ * an even count. Sorts a copy — callers reuse their arrays.
+ *
+ * @param {number[]} values At least one value
+ * @return {number} The median
+ */
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b)
+
+  return sorted[Math.floor((sorted.length - 1) / 2)]
+}
+
+
+/**
+ * The model's robust centre: the component-wise median of mesh centres.
+ *
+ * Median, not mean, and that choice is the whole point. A mean is dragged
+ * toward the outliers being hunted, which shrinks their own scores and
+ * inflates everyone else's — on a model with a handful of parts flung
+ * kilometres away, a mean centre sits out in empty space and every honest
+ * part scores as displaced.
+ *
+ * @param {number[][]} centres One [x, y, z] per mesh, at least one
+ * @return {number[]} [x, y, z]
+ */
+export function robustCentre(centres) {
+  return [0, 1, 2].map((axis) => median(centres.map((each) => each[axis])))
+}
+
+
+/**
+ * A mesh's centre in WORLD space: the centre of its local bounds, placed by
+ * its absolute transform.
+ *
+ * Bounds centre rather than vertex mean, so a face with a dense cluster of
+ * vertices at one end does not drag the centre toward it — this is asking
+ * where a part sits, not where its detail is.
+ *
+ * The transform is validated rather than trusted. A wrong walk-tuple index
+ * hands this an object, every multiplication yields NaN, `Stage.record`
+ * discards non-finite values, and the stage reports "N calls, 0 measured" —
+ * a clean-looking result produced by a bug, which is hazard 1 in this file's
+ * header arriving through the back door. It cost a debugging cycle here
+ * already: conway#456 names the transform as `walked[1]`, and it is
+ * `walked[0]`.
+ *
+ * @param {object} geometry A conway GeometryObject
+ * @param {number} count Vertex count
+ * @param {Float64Array|number[]|undefined} transform Column-major 4x4, or
+ *   undefined for identity
+ * @return {number[]|undefined} [x, y, z], or undefined if nothing was finite
+ */
+export function worldCentre(geometry, count, transform) {
+  if (transform !== undefined &&
+      (typeof transform.length !== 'number' || transform.length < 16 ||
+       !Number.isFinite(transform[0]))) {
+    throw new Error(
+        'worldCentre: expected a column-major 4x4 transform or undefined, got ' +
+        `${Object.prototype.toString.call(transform)} — check the walk tuple index`)
+  }
+
+  const min = [Infinity, Infinity, Infinity]
+  const max = [-Infinity, -Infinity, -Infinity]
+
+  for (let i = 0; i < count; ++i) {
+    // getPoint(), never a held HEAPF32 view — see the hazards in the header.
+    const point = geometry.getPoint(i)
+    const axes = [point.x, point.y, point.z]
+
+    for (let axis = 0; axis < 3; ++axis) {
+      if (!Number.isFinite(axes[axis])) {
+        return undefined
+      }
+
+      min[axis] = Math.min(min[axis], axes[axis])
+      max[axis] = Math.max(max[axis], axes[axis])
+    }
+  }
+
+  if (!Number.isFinite(min[0])) {
+    return undefined
+  }
+
+  const local = [0, 1, 2].map((axis) => (min[axis] + max[axis]) / 2)
+
+  if (transform === undefined) {
+    return local
+  }
+
+  const [x, y, z] = local
+
+  return [
+    (transform[0] * x) + (transform[4] * y) + (transform[8] * z) + transform[12],
+    (transform[1] * x) + (transform[5] * y) + (transform[9] * z) + transform[13],
+    (transform[2] * x) + (transform[6] * y) + (transform[10] * z) + transform[14],
+  ]
+}
+
+
+/**
+ * Record every mesh's distance from the model's robust centre.
+ *
+ * Two passes, because the metric is relative to the model: the centre is not
+ * known until every mesh has been placed. The robust centre is the
+ * component-wise median of mesh centres — a median rather than a mean
+ * precisely because the outliers being hunted would drag a mean toward
+ * themselves and shrink their own scores.
+ *
+ * Feeds raw distance into the ordinary Stage machinery, so the existing
+ * `factor x median` threshold applies unchanged: on the model in conway#456
+ * the median distance is 38.6 and the three sky-arcing slivers sit at
+ * 950-1377, which clears an 8x threshold by a wide margin.
+ *
+ * @param {Stage} stage The stage to record into
+ * @param {object} model The loaded model, for entity attribution
+ * @param {object} scene The walkable scene
+ */
+function collectDisplacement(stage, model, scene) {
+  if (typeof scene?.walk !== 'function') {
+    return
+  }
+
+  const seen = new Set()
+  const placed = []
+
+  for (const walked of scene.walk()) {
+    const mesh = walked[2]
+    const geometry = mesh?.geometry
+
+    if (typeof geometry?.getVertexCount !== 'function' || seen.has(mesh.localID)) {
+      continue
+    }
+
+    seen.add(mesh.localID)
+
+    const count = geometry.getVertexCount()
+
+    if (count === 0) {
+      continue
+    }
+
+    const centre = worldCentre(geometry, count, walked[0])
+
+    if (centre === undefined) {
+      continue
+    }
+
+    placed.push({localID: mesh.localID, centre, vertices: count})
+  }
+
+  // Set before the early return: a model that walked meshes but placed none
+  // has to read as "fired, no outliers" rather than as a dead probe.
+  stage.fired = placed.length
+
+  if (placed.length === 0) {
+    return
+  }
+
+  const centre = robustCentre(placed.map((each) => each.centre))
+
+  for (const each of placed) {
+    const offset = [0, 1, 2].map((axis) => each.centre[axis] - centre[axis])
+
+    stage.record(Math.hypot(offset[0], offset[1], offset[2]), () => ({
+      ...describeEntity(model.getElementByLocalID?.(each.localID)),
+      vertices: each.vertices,
+      centre: each.centre.map((value) => Number(value.toFixed(1))),
+    }))
+  }
+}
+
+
+/**
  * Format a number for a report column.
  *
  * @param {number} value The value
@@ -784,6 +972,10 @@ async function main() {
 
   if (stages.has('mesh')) {
     collectMeshes(stages.get('mesh'), model, scene)
+  }
+
+  if (stages.has('displacement')) {
+    collectDisplacement(stages.get('displacement'), model, scene)
   }
 
   say(`\n# ${path.basename(options.model)}`)

--- a/src/scripts/model_report_displacement.test.ts
+++ b/src/scripts/model_report_displacement.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals'
 // @ts-expect-error -- an untyped .mjs helper beside the CLI it serves.
-import { robustCentre, worldCentre } from '../../../scripts/debug/displacement.mjs'
+import { localCentre, placeCentre, robustCentre } from '../../../scripts/debug/displacement.mjs'
 
 /* eslint-disable no-magic-numbers -- these are synthetic coordinates and
    distances chosen to mirror the real model in conway#456. Naming each one
@@ -90,8 +90,10 @@ describe('displacement scoring', () => {
     // local coordinates would make these indistinguishable.
     const unitBox = [[-1, -1, -1], [1, 1, 1]]
 
-    const atOrigin = worldCentre(geometryOf(unitBox), 2, translation(0, 0, 0))
-    const farAway = worldCentre(geometryOf(unitBox), 2, translation(1000, 0, 0))
+    const local = localCentre(geometryOf(unitBox), 2)
+
+    const atOrigin = placeCentre(local, translation(0, 0, 0))
+    const farAway = placeCentre(local, translation(1000, 0, 0))
 
     expect(atOrigin).toEqual([0, 0, 0])
     expect(farAway).toEqual([1000, 0, 0])
@@ -99,7 +101,7 @@ describe('displacement scoring', () => {
 
   test('an undefined transform means identity, not a skipped mesh', () => {
 
-    expect(worldCentre(geometryOf([[2, 4, 6], [4, 8, 12]]), 2, undefined))
+    expect(placeCentre(localCentre(geometryOf([[2, 4, 6], [4, 8, 12]]), 2), undefined))
         .toEqual([3, 6, 9])
   })
 
@@ -113,14 +115,12 @@ describe('displacement scoring', () => {
     // script's own header, so it has to be loud.
     const notATransform = { someObject: true } as unknown as number[]
 
-    expect(() => worldCentre(geometryOf([[0, 0, 0]]), 1, notATransform))
-        .toThrow(/walk tuple index/)
+    expect(() => placeCentre([0, 0, 0], notATransform)).toThrow(/walk tuple index/)
   })
 
   test('non-finite vertex data yields no centre rather than a NaN score', () => {
 
-    expect(worldCentre(geometryOf([[0, 0, 0], [NaN, 0, 0]]), 2, undefined))
-        .toBeUndefined()
+    expect(localCentre(geometryOf([[0, 0, 0], [NaN, 0, 0]]), 2)).toBeUndefined()
   })
 
   test('a right-shaped transform holding NaN drops the mesh, and does not throw', () => {
@@ -129,7 +129,6 @@ describe('displacement scoring', () => {
     // down the whole run and discard the other stages' reports.
     const nanTransform = translation(NaN, 0, 0)
 
-    expect(worldCentre(geometryOf([[0, 0, 0], [2, 2, 2]]), 2, nanTransform))
-        .toBeUndefined()
+    expect(placeCentre([1, 1, 1], nanTransform)).toBeUndefined()
   })
 })

--- a/src/scripts/model_report_displacement.test.ts
+++ b/src/scripts/model_report_displacement.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from '@jest/globals'
+
+/* eslint-disable no-magic-numbers -- these are synthetic coordinates and
+   distances chosen to mirror the real model in conway#456. Naming each one
+   would obscure the shape the cases exist to express: a tight cluster near
+   the site origin plus one part flung far away. */
+
+/**
+ * The scoring behind model_report.mjs's `displacement` stage (conway#456).
+ *
+ * The stage answers "which parts are flung away from where they belong",
+ * which the `mesh` stage cannot: `mesh` measures extent in MESH-LOCAL
+ * coordinates, so on an export that writes geometry directly in site
+ * coordinates every honest part looks displaced by its distance from the
+ * file origin.
+ *
+ * These cases use synthetic centres rather than a model, because the
+ * motivating file is 256 MB and private. What is worth pinning is the
+ * scoring, and the scoring is pure.
+ */
+// Resolved from the repo root, not relative to this file: the test runs from
+// compiled/src/scripts, where a relative hop lands in compiled/scripts, which
+// does not exist (scripts/ is not part of the tsc build).
+const report = await import(
+    `file://${process.cwd()}/scripts/debug/model_report.mjs`) as unknown as {
+  robustCentre: (centres: number[][]) => number[]
+  worldCentre: (
+    geometry: { getPoint: (i: number) => { x: number, y: number, z: number } },
+    count: number,
+    transform?: number[]) => number[] | undefined
+}
+
+const { robustCentre, worldCentre } = report
+
+/**
+ * Column-major 4x4 translation, matching the walk tuple's layout.
+ *
+ * @param x Translation along x.
+ * @param y Translation along y.
+ * @param z Translation along z.
+ * @return The 16-element matrix.
+ */
+function translation(x: number, y: number, z: number): number[] {
+  return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1]
+}
+
+/**
+ * A stub geometry over a fixed point list.
+ *
+ * @param points One [x, y, z] per vertex.
+ * @return Something with the getPoint() shape worldCentre reads.
+ */
+function geometryOf(points: number[][]) {
+  return {
+    getPoint: (i: number) => ({ x: points[i][0], y: points[i][1], z: points[i][2] }),
+  }
+}
+
+
+describe('displacement scoring', () => {
+
+  test('the robust centre ignores outliers rather than chasing them', () => {
+
+    // Nine parts clustered near the site origin, one flung far away — the
+    // shape of the motivating model, scaled down.
+    const centres = [
+      ...Array.from({ length: 9 }, (_, i) => [578 + i, 763, 3]),
+      [-751, 1075, 1377],
+    ]
+
+    const centre = robustCentre(centres)
+
+    // A MEAN would sit ~130 units off in x and ~137 in z, dragged by the
+    // single outlier; every honest part would then score as displaced and
+    // the outlier's own score would shrink. That inversion is the reason
+    // this is a median.
+    expect(centre[0]).toBeGreaterThan(577)
+    expect(centre[0]).toBeLessThan(587)
+    expect(centre[2]).toBeCloseTo(3, 6)
+
+    const distances = centres.map((each) =>
+      Math.hypot(each[0] - centre[0], each[1] - centre[1], each[2] - centre[2]))
+
+    const cluster = distances.slice(0, 9)
+    const outlier = distances[9]
+
+    // The signal the stage's `factor x median` threshold consumes: the
+    // outlier has to clear 8x the median by a wide margin, or it would be
+    // reported as ordinary.
+    const median = [...cluster].sort((a, b) => a - b)[Math.floor(cluster.length / 2)]
+
+    expect(outlier).toBeGreaterThan(median * 8)
+  })
+
+  test('a mesh centre is placed by its transform, not left local', () => {
+
+    // The defect this stage exists to fix in one assertion: identical local
+    // geometry at two different placements must score differently. Reading
+    // local coordinates would make these indistinguishable.
+    const unitBox = [[-1, -1, -1], [1, 1, 1]]
+
+    const atOrigin = worldCentre(geometryOf(unitBox), 2, translation(0, 0, 0))
+    const farAway = worldCentre(geometryOf(unitBox), 2, translation(1000, 0, 0))
+
+    expect(atOrigin).toEqual([0, 0, 0])
+    expect(farAway).toEqual([1000, 0, 0])
+  })
+
+  test('an undefined transform means identity, not a skipped mesh', () => {
+
+    expect(worldCentre(geometryOf([[2, 4, 6], [4, 8, 12]]), 2, undefined))
+        .toEqual([3, 6, 9])
+  })
+
+  test('a wrong walk-tuple index throws rather than scoring NaN', () => {
+
+    // conway#456 names the transform as walked[1]; it is walked[0].
+    // Following the issue verbatim handed this an object, every
+    // multiplication produced NaN, Stage.record silently discarded every
+    // non-finite value, and the stage reported "N calls, 0 measured" — a
+    // clean-looking result manufactured by a bug. That is hazard 1 from the
+    // script's own header, so it has to be loud.
+    const notATransform = { someObject: true } as unknown as number[]
+
+    expect(() => worldCentre(geometryOf([[0, 0, 0]]), 1, notATransform))
+        .toThrow(/walk tuple index/)
+  })
+
+  test('non-finite vertex data yields no centre rather than a NaN score', () => {
+
+    expect(worldCentre(geometryOf([[0, 0, 0], [NaN, 0, 0]]), 2, undefined))
+        .toBeUndefined()
+  })
+})

--- a/src/scripts/model_report_displacement.test.ts
+++ b/src/scripts/model_report_displacement.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from '@jest/globals'
+// @ts-expect-error -- an untyped .mjs helper beside the CLI it serves.
+import { robustCentre, worldCentre } from '../../../scripts/debug/displacement.mjs'
 
 /* eslint-disable no-magic-numbers -- these are synthetic coordinates and
    distances chosen to mirror the real model in conway#456. Naming each one
@@ -16,21 +18,10 @@ import { describe, expect, test } from '@jest/globals'
  *
  * These cases use synthetic centres rather than a model, because the
  * motivating file is 256 MB and private. What is worth pinning is the
- * scoring, and the scoring is pure.
+ * scoring, and the scoring is pure — which is why it lives in
+ * displacement.mjs rather than in the CLI script, whose module body runs
+ * the whole tool on import.
  */
-// Resolved from the repo root, not relative to this file: the test runs from
-// compiled/src/scripts, where a relative hop lands in compiled/scripts, which
-// does not exist (scripts/ is not part of the tsc build).
-const report = await import(
-    `file://${process.cwd()}/scripts/debug/model_report.mjs`) as unknown as {
-  robustCentre: (centres: number[][]) => number[]
-  worldCentre: (
-    geometry: { getPoint: (i: number) => { x: number, y: number, z: number } },
-    count: number,
-    transform?: number[]) => number[] | undefined
-}
-
-const { robustCentre, worldCentre } = report
 
 /**
  * Column-major 4x4 translation, matching the walk tuple's layout.
@@ -78,7 +69,7 @@ describe('displacement scoring', () => {
     expect(centre[0]).toBeLessThan(587)
     expect(centre[2]).toBeCloseTo(3, 6)
 
-    const distances = centres.map((each) =>
+    const distances = centres.map((each: number[]) =>
       Math.hypot(each[0] - centre[0], each[1] - centre[1], each[2] - centre[2]))
 
     const cluster = distances.slice(0, 9)
@@ -129,6 +120,16 @@ describe('displacement scoring', () => {
   test('non-finite vertex data yields no centre rather than a NaN score', () => {
 
     expect(worldCentre(geometryOf([[0, 0, 0], [NaN, 0, 0]]), 2, undefined))
+        .toBeUndefined()
+  })
+
+  test('a right-shaped transform holding NaN drops the mesh, and does not throw', () => {
+
+    // Data, not a programming error: one unusable placement must not take
+    // down the whole run and discard the other stages' reports.
+    const nanTransform = translation(NaN, 0, 0)
+
+    expect(worldCentre(geometryOf([[0, 0, 0], [2, 2, 2]]), 2, nanTransform))
         .toBeUndefined()
   })
 })


### PR DESCRIPTION
Fixes #456.

## The problem

`model_report.mjs`'s `mesh` stage reads vertices in **mesh-local** coordinates. On an export that writes geometry directly in site coordinates with identity placements — common for IFC `IfcFacetedBrep` — every honest part's "extent" is really its distance from the file origin, so the stage flags thousands of them. On `Wiesenplatz 7, 4057 Basel.ifc`: **3,955 rows, of which 3 were real.**

## The shape I picked

The issue offered a separate `world_bounds.mjs` or folding into `model_report.mjs`. I took a third it also endorsed — **a new `displacement` stage alongside `mesh`**, not replacing it. One tool keeps the "run them together, read the narrowest dirty stage" workflow the script is built around, and neither subsumes the other: `mesh` still catches a part that is internally huge but correctly placed, which `displacement` scores as ordinary.

The scoring lives in a new `scripts/debug/displacement.mjs` with no import-time side effects, because `model_report.mjs` runs its `main()` at module scope — importing *it* from a test runs the whole CLI inside the test runner.

## Why the centre is a median

A **mean** is dragged toward the outliers being hunted — shrinking their scores and inflating everyone else's. Pinned by a test that fails if the median is swapped for a mean.

## Three findings worth reading

**1. The issue's transform index is off by one, and following it produced a *clean-looking* result.** #456 names the walk tuple's transform as `walked[1]`; it is `walked[0]`. `walked[1]` is an object, so every multiplication yielded `NaN`, `Stage.record` silently discards non-finite values, and the stage reported `1 calls, 0 measured … no outliers` — **hazard 1 from this script's own header, through the back door.**

**2. My guard against that was itself being swallowed.** A throw leaves `fired` at 0, so `reportStage` took its dead branch and printed *"PROBE NEVER FIRED … Expected when the model uses no geometry of this kind"* — an explanation rather than a failure — and dropped `stage.extra` from `--json`. The guard reproduced the exact false-clean it was written to prevent. Now an explicit block, verified by forcing the bad index:

```
## displacement
  STAGE FAILED — placeCentre: expected a column-major 4x4 transform or
  undefined, got [object Object] — check the walk tuple index
  This stage measured nothing because it threw, NOT because the
  model is clean. The other stages above are unaffected.
```

**3. I shipped a claim I hadn't actually verified.** I reported "77 suites / 381 tests" on the first revision. In fact `tsc --build` was **failing** (TS1378, top-level `await` under `module: es2020`) — CI would have broken. I'd run `yarn build-incremental >/dev/null 2>&1` without checking its exit code, then run jest against stale `compiled/` output. Every number in this PR has since been re-measured with exit codes checked.

## Also fixed in review

- **No dedup by geometry localID.** Copied from `collectMeshes`, where it's free because local bounds are placement-invariant — but here *the placement is the measurement*. It hid every flung-away instance of a shared window or fastener, and computed the robust centre from an unrepresentative sample.
- **…without paying for it.** Dropping the dedup meant re-reading every vertex per placement (~9.5× the `getPoint()` wasm crossings on the motivating model). Split into `localCentre` (cached per geometry) + `placeCentre` (per placement).
- **`fired` counts meshes walked, not placed.** As written it did the opposite of its own comment: a model whose every placement was unusable reported PROBE NEVER FIRED and exited 2, and `fired === measured` always, hiding skipped meshes.
- **Rows attribute to `walked[4]`**, the owning product, not `mesh.localID`, the shared representation item. On `data/index.ifc` a row said `IfcPolygonalFaceSet #495` where the product is `IfcBuildingElementProxy #265`.
- **A right-shaped transform holding NaN** drops that mesh instead of throwing — data, not a programming error.

## Verification

Exit codes checked: `tsc` 0, build 0, jest 0 (6 tests), CLI 0 on both IFC and STEP, `eslint` 0 errors in `src` and in the new helper, suite **77 suites / 382 tests**.

- `--stage mesh,displacement` on a three-body STEP: `mesh` median **47.5** (local extent) vs `displacement` median **0.04** — the two measuring visibly different things on one file.
- The median-vs-mean control and the forced-bad-index control both fail as expected when the mechanism is removed.

**What I could not verify:** the issue's headline numbers (37,502 meshes → 5 named). That model is in `test-models-private` and isn't in this sandbox, so I've reproduced the mechanism and the shape, not that exact output. Worth one run against the real file before trusting the 5.

## Known limitation

Distances can be exactly zero, unlike extents. A model with more than half its meshes at the robust centre gives median 0, hence threshold 0, hence everything else flagged. The report shows median 0 when that happens; `--limit` is the escape. Documented at the function.

## Docs

`scripts/debug/README.md` gains the stage row and a "reach for `displacement` when `mesh` floods" note, including the tell: median and p90 both large with flagged rows continuous above the threshold rather than separated from it.