### PR TITLE
EVIDENCE ONLY (do not merge): visual-diff for the revolution CDT fix

### DIFF
--- a/regression/smoke_models.txt
+++ b/regression/smoke_models.txt
@@ -30,3 +30,19 @@ driver board.step
 # baseline yet: first smoke run's digest lands as new and gets blessed
 # with the next baseline PR.
 Right_Hand.step
+
+# EVIDENCE-BRANCH ONLY (bldrs-ai/conway#475) - not for merge.
+#
+# The revolution-CDT fix (conway-geom#165) trades trim fidelity for
+# termination: faces where TryResolve resolved an intersection correctly now
+# take the coarser swept-grid fallback. Locally FM_ARC_DigitalHub is where that
+# shows - same 2236 meshes, 99641 -> 120947 vertices - and it is NOT in the
+# subset above, so the first visual-diff run on this PR rendered six small STEP
+# models and never looked at the one model that actually changes. Adding it
+# here so visual-diff renders it and the tradeoff gets a visual verdict rather
+# than a vertex count.
+#
+# ISSUE_159 is deliberately NOT added: the base side of visual-diff renders the
+# published (unfixed) engine, where that model is the 35-90s runaway this fix
+# exists to remove, and it would likely hang or time out the base render.
+FM_ARC_DigitalHub.ifc


### PR DESCRIPTION
## Do not merge — this exists to produce evidence

Submodule `f01edf3..801c158`, the head of bldrs-ai/conway-geom#165 (an **unmerged** branch).

conway-geom's own CI is build-only. `visual-diff` and `run-ifc-regression` live here, and the fix in that PR has a real fidelity tradeoff that should be seen *before* it merges, not after. Pointing the submodule at an unmerged commit is how to get that evidence without committing to the change.

## What is being evidenced

conway-geom#165 switches the revolution unwrap's CDT from `IntersectingConstraintEdges::TryResolve` to `NotAllowed`, because `insertEdges` never returns on a self-overlapping unwrapped boundary — it allocates until the wasm heap is exhausted and throws. Full root-cause evidence is in https://github.com/bldrs-ai/conway/issues/473#issuecomment-5259746247.

**The win** (ISSUE_159, six consecutive runs): geometry 2.54–2.68 s where it was 2.3 s *or* 35–92 s bimodally; RSS 313–324 MB where it was 322 MB *or* ~3.7 GB; 936 meshes / 67,515 vertices where it was 935 / 64,146. The nondeterminism disappears and geometry goes up.

**The cost**: `TryResolve` and `NotAllowed` differ only when constraint edges intersect — but that is not the same as "only on pathological input". Where `TryResolve` resolved an intersection quickly and correctly, those faces now take the coarser swept-grid fallback, which ignores interior holes and partial trims.

Local measurements:

| model | meshes | vertices (before → after) |
|---|---:|---|
| ISSUE_159 | 935 → **936** | 64,146 → **67,515** |
| FM_ARC_DigitalHub | 2236 → 2236 | 99,641 → **120,947** |
| AC20-FZK-Haus | 151 → 151 | 11,926 → 11,926 (unchanged) |

FM_ARC is the one to look at: same mesh count, ~21 k more vertices. That is the fallback replacing trimmed faces, and whether it is acceptable is a **visual** question, not a numeric one.

## What to read from the run

- `visual-diff` on the STEP/IFC models that change digests — especially anything with revolution faces — is the actual verdict on the tradeoff.
- `run-ifc-regression` should stay clean; a new failure would mean the fallback loses a face outright rather than coarsening it.

If visual-diff shows the fidelity loss is material, the fix needs to become a *bounded* `TryResolve` rather than a swap — CDT exposes no iteration budget today, so that would mean pre-detecting self-intersection (cheap at these sizes: ~94 edges) and only then diverting.

Close this branch once the evidence is recorded on conway-geom#165.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQAv3NMEn9fy1AyGNm3cyN)_