### PR TITLE
Fail a Git LFS pointer stub instead of parsing it as an empty model

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -772,13 +772,14 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           ZERO=test-models/regression/test_models/zero_geometry.csv
+          MAIN=test-models/regression/test_models/main.csv
           ALLOW=regression/zero_geometry_allowlist.txt
           if [ ! -f "$ZERO" ]; then
             echo "No zero_geometry.csv produced."; exit 0
           fi
-          python3 - "$ZERO" "$ALLOW" <<'PY'
-          import csv, sys
-          zero, allow = sys.argv[1], sys.argv[2]
+          python3 - "$ZERO" "$ALLOW" "$MAIN" <<'PY'
+          import csv, os, sys
+          zero, allow, main = sys.argv[1], sys.argv[2], sys.argv[3]
           allowed = set()
           for line in open(allow, encoding='utf-8'):
               line = line.split('#', 1)[0].strip()
@@ -788,12 +789,31 @@ jobs:
           unexpected = [f for f in rows if f not in allowed]
           for f in rows:
               print(f"zero geometry: {f}" + ("" if f in unexpected else "  (allowlisted)"))
+
+          # Stale entries rot silently: an allowlisted model that starts
+          # producing geometry keeps its exemption forever, so a later
+          # regression that empties it again is waved through. main.csv is the
+          # set of models this run actually digested, which is what keeps this
+          # correct on the smoke subset - an entry for a model the run never
+          # touched is neither stale nor confirmed, just absent.
+          ran = set()
+          if os.path.exists(main):
+              ran = {r['file'] for r in csv.DictReader(open(main, newline='', encoding='utf-8'))}
+          stale = sorted((allowed & ran) - set(rows))
+
           if unexpected:
               print("::error::Models loaded but produced NO geometry and are not allowlisted:")
               for f in unexpected:
                   print(f"::error::  {f}")
+          if stale:
+              print("::error::Allowlisted models that now DO produce geometry - "
+                    "delete their lines from regression/zero_geometry_allowlist.txt:")
+              for f in stale:
+                  print(f"::error::  {f}")
+          if unexpected or stale:
               sys.exit(1)
-          print(f"{len(rows)} zero-geometry model(s), all allowlisted.")
+          print(f"{len(rows)} zero-geometry model(s), all allowlisted; "
+                f"{len(allowed & ran)} allowlist entr(ies) exercised and still empty.")
           PY
 
   # ---------------------------------------------------------------------------
@@ -887,11 +907,17 @@ jobs:
 
       # Model files under ifc/ and step/ are git-lfs objects; a manual
       # fetch/checkout (and a cache seeded from one) can leave 132-byte
-      # pointer stubs, which parse as "no geometry" in both engines.
-      # Materialize what we can. A couple of stubs are CHRONIC — their LFS
-      # objects don't restore (same models the regression errors table
-      # flags as unparseable) — so warn and continue: their rows will read
-      # "no geometry" truthfully while every other model still renders.
+      # pointer stubs. Materialize what we can.
+      #
+      # Stubs used to be tolerated here with a warning saying their rows would
+      # read "no geometry" truthfully. That is truthful about the bytes on
+      # disk and false about the model, and it cost real work: two models were
+      # blessed at zero rows and filed as engine bugs (#477) before anyone
+      # noticed the run had never read them. The regression batch now FAILS a
+      # stub instead of parsing it (#486), so a stub can no longer reach a
+      # baseline. This job renders rather than digests, so it still continues
+      # — a stub here costs one blank image, not a committed falsehood — but
+      # the warning now says what it actually means.
       - name: Materialize LFS model files
         run: |
           cd test-models
@@ -903,7 +929,7 @@ jobs:
             LEFT=$(grep -rl "git-lfs.github.com" ifc step 2>/dev/null | wc -l || true)
             echo "stubs after lfs pull: $LEFT"
             if [ "$LEFT" != "0" ]; then
-              echo "::warning::test-models still has $LEFT LFS pointer stub(s); their rows will render as 'no geometry'."
+              echo "::warning::test-models still has $LEFT unsmudged LFS pointer stub(s). These are NOT models: any row below that renders empty for one of them is a missing file, not a geometry regression."
               grep -rl "git-lfs.github.com" ifc step 2>/dev/null || true
             fi
           fi

--- a/.github/workflows/rc-regression.yml
+++ b/.github/workflows/rc-regression.yml
@@ -475,13 +475,14 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           ZERO="${GITHUB_WORKSPACE}/zero_geometry.csv"
+          MAIN=models/regression/test_models/main.csv
           ALLOW=regression/zero_geometry_allowlist.txt
           if [ ! -f "$ZERO" ]; then
             echo "No zero_geometry.csv produced."; exit 0
           fi
-          python3 - "$ZERO" "$ALLOW" <<'PYEOF'
-          import csv, sys
-          zero, allow = sys.argv[1], sys.argv[2]
+          python3 - "$ZERO" "$ALLOW" "$MAIN" <<'PYEOF'
+          import csv, os, sys
+          zero, allow, main = sys.argv[1], sys.argv[2], sys.argv[3]
           allowed = set()
           for line in open(allow, encoding='utf-8'):
               line = line.split('#', 1)[0].strip()
@@ -491,10 +492,25 @@ jobs:
           unexpected = [f for f in rows if f not in allowed]
           for f in rows:
               print(f"zero geometry: {f}" + ("" if f in unexpected else "  (allowlisted)"))
+
+          # Same anti-rot check as the smoke job; see build.yml for the
+          # reasoning. It matters more here: this is the run that blesses.
+          ran = set()
+          if os.path.exists(main):
+              ran = {r['file'] for r in csv.DictReader(open(main, newline='', encoding='utf-8'))}
+          stale = sorted((allowed & ran) - set(rows))
+
           if unexpected:
               print("::error::Models loaded but produced NO geometry and are not allowlisted:")
               for f in unexpected:
                   print(f"::error::  {f}")
+          if stale:
+              print("::error::Allowlisted models that now DO produce geometry - "
+                    "delete their lines from regression/zero_geometry_allowlist.txt:")
+              for f in stale:
+                  print(f"::error::  {f}")
+          if unexpected or stale:
               sys.exit(1)
-          print(f"{len(rows)} zero-geometry model(s), all allowlisted.")
+          print(f"{len(rows)} zero-geometry model(s), all allowlisted; "
+                f"{len(allowed & ran)} allowlist entr(ies) exercised and still empty.")
           PYEOF

--- a/regression/zero_geometry_allowlist.txt
+++ b/regression/zero_geometry_allowlist.txt
@@ -3,8 +3,17 @@
 # A model that loads and emits nothing is a total failure from a user's point
 # of view — an empty viewer with no diagnostic — but it exits 0, writes no
 # failed.csv row, and may emit no errors, so nothing else in the harness sees
-# it. The regression batch now writes zero_geometry.csv, and CI fails on any
+# it. The regression batch writes zero_geometry.csv, and CI fails on any
 # model in it that is NOT listed here.
+#
+# CI also fails the other way: a model listed here that DOES produce geometry
+# fails too, and its line must be deleted. Without that, a stale line silently
+# gives up coverage for its model forever. That is not hypothetical — this
+# file shipped with two such lines. `NEMA 23 - 76mm.STEP` and
+# `ISSUE_098_...IFC` were listed as real zero-geometry bugs (#477) when in
+# fact the blessing run had read 132-byte Git LFS pointer stubs instead of the
+# models; materialized, they produce 266 and 45,558 digest rows. The batch now
+# fails a stub outright rather than parsing it as an empty model (#486).
 #
 # This is deliberately a short, hand-maintained, issue-annotated file rather
 # than a generated blessed CSV. errors.csv shows what the generated kind turns
@@ -12,17 +21,7 @@
 # genuine 30s/3.4GB runaway sitting among them unnoticed (#473). Adding a line
 # here should require writing down why, and every line should have an issue.
 #
-# One basename per line; '#' starts a comment. Remove a line the moment its
-# model starts producing geometry — the gate does not check that a listed
-# model is STILL empty, so a stale entry silently gives up coverage.
-
-# --- Real bugs: supported schema, zero geometry (#477) ---
-
-# AP214 (AUTOMOTIVE_DESIGN), 1.1 MB. Supported schema, emits nothing.
-NEMA 23 - 76mm.STEP
-
-# IFC2X3, 72.9 MB. Supported schema, emits nothing. Largest impact of the set.
-ISSUE_098_R8_F1_MAB_AR_M3_XX_XXX_MO_7000.IFC
+# One basename per line; '#' starts a comment.
 
 # --- Unsupported schema: expected until the schema lands ---
 

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -115,6 +115,17 @@ interface RunSuccessResults {
 interface RunErrorResults extends ExecException {
 
   type: 'Failed'
+
+  /**
+   * Human-readable cause, for failures the harness diagnoses itself rather
+   * than reading off a child's exit.
+   *
+   * ExecException's own fields cannot carry one: `code` is a number and
+   * `signal` is a NodeJS.Signals. Written into failed.csv's signal column,
+   * which is free text, so the row says what happened instead of leaving the
+   * reader to infer it from two empty fields the way a timeout does.
+   */
+  failureReason?: string
 }
 
 type RunResults = RunSuccessResults | RunErrorResults
@@ -349,6 +360,30 @@ async function runForFile(filePath: string,
 
   console.log(`Current File: ${filePath}`)
 
+  // A model file that is still an unsmudged Git LFS pointer is NOT a model,
+  // and must not reach a child. Both engines parse the 132-byte placeholder
+  // as an empty document and exit 0, so without this it reads as a
+  // successful load of a model with no geometry - and a blessing run commits
+  // that to the baseline, where it stays. It already happened: NEMA 23 and
+  // ISSUE_098 were blessed at zero rows and filed as engine bugs (#477)
+  // before anyone noticed the run had never read them. See #486.
+  //
+  // Checked before the stale-digest removal below, deliberately: a local
+  // checkout that failed to smudge should not also destroy the good
+  // committed digest for that model.
+  if (await isGitLfsPointer(filePath)) {
+    console.error(
+        `::error::"${path.basename(filePath)}" is an unsmudged Git LFS pointer, not a model. ` +
+        `Run \`git lfs pull\` in the models checkout.`)
+
+    return {
+      type: 'Failed',
+      message: 'Git LFS pointer stub, not a model file',
+      failureReason: 'lfs-pointer-stub',
+      name: 'Error',
+    }
+  }
+
   // Remove any stale digest before the child runs. Without this, a child that
   // dies without writing one leaves the committed baseline CSV in place, the
   // batch hashes THAT, and the model reports an unchanged hash with no failure
@@ -429,6 +464,50 @@ async function runForFile(filePath: string,
 
 // Model files the regression harness understands: IFC plus STEP AP214.
 const SUPPORTED_MODEL_EXTENSIONS = ['.ifc', '.stp', '.step']
+
+/**
+ * First bytes of a Git LFS pointer file, per the v1 pointer spec. The spec
+ * fixes this as the first line of every pointer, so a prefix match is exact
+ * rather than a heuristic - and no STEP or IFC file can begin this way, both
+ * being required to start with `ISO-10303-21;`.
+ */
+const GIT_LFS_POINTER_PREFIX = 'version https://git-lfs.github.com/spec/v1'
+
+/**
+ * Whether this file is an unsmudged Git LFS pointer rather than the model it
+ * stands for.
+ *
+ * Reads only the prefix: pointers are ~132 bytes, and a real model may be
+ * hundreds of megabytes.
+ *
+ * @param filePath Model file to inspect.
+ * @return {Promise<boolean>} True if the file is an LFS pointer stub.
+ */
+async function isGitLfsPointer( filePath: string ): Promise<boolean> {
+
+  let handle: fsPromises.FileHandle | undefined
+
+  try {
+
+    handle = await fsPromises.open( filePath, 'r' )
+
+    const buffer = Buffer.alloc( GIT_LFS_POINTER_PREFIX.length )
+    const { bytesRead } = await handle.read( buffer, 0, buffer.length, 0 )
+
+    return bytesRead === buffer.length &&
+      buffer.toString( 'utf8' ) === GIT_LFS_POINTER_PREFIX
+
+  } catch {
+
+    // Unreadable is not this function's business to report - let the child
+    // run and fail with whatever the real problem is.
+    return false
+
+  } finally {
+
+    await handle?.close()
+  }
+}
 
 /**
  * Whether this is a STEP (AP214) model file by extension.
@@ -598,10 +677,13 @@ async function processIFCFilesInParallel(
       }
     } else {
       // it's 'Failed'
+      // failureReason takes the signal column when the harness diagnosed the
+      // failure itself, so the row says what happened instead of leaving a
+      // reader to infer it from two empty fields. See RunErrorResults.
       failedLines.push(
           `${csvSafeString(path.basename(ifcPath))},` +
           `${csvSafeString(fileResults.code?.toString() ?? '')},` +
-          `${csvSafeString(fileResults.signal ?? '')}\n`,
+          `${csvSafeString(fileResults.failureReason ?? fileResults.signal ?? '')}\n`,
       )
     }
   }
@@ -671,10 +753,11 @@ async function recursiveWalk(
           zeroGeometryLines.push(`${csvSafeString(path.basename(resolved))}\n`)
         }
       } else {
+        // See the parallel path's copy for why failureReason wins here.
         failedLines.push(
             `${csvSafeString(path.basename(resolved))},${csvSafeString(
                 fileResults.code?.toString() ?? '',
-            )},${csvSafeString(fileResults.signal ?? '')}\n`,
+            )},${csvSafeString(fileResults.failureReason ?? fileResults.signal ?? '')}\n`,
         )
       }
     }


### PR DESCRIPTION
Closes #486. Follows #484, which built the zero-geometry gate this exposes a hole in.

## The bug

An unsmudged Git LFS pointer is 132 bytes of text. Both engines parse it as an empty document and exit 0, so the harness recorded it as a **successful load of a model with no geometry**. A blessing run then committed that to the baseline, where it stayed.

```
$ printf 'version https://git-lfs.github.com/spec/v1\noid sha256:...\nsize 2380763\n' > fake.ifc
$ node ./compiled/src/ifc/ifc_regression_main.js -d fake.ifc out
Invalid STEP detected in parse, but no syntax error detected
Parse incomplete but no errors
No IfcProjects found?
$ wc -l out.csv ; echo $?
1                       # header only
0
```

It already cost real work. `NEMA 23 - 76mm.STEP` and `ISSUE_098_...IFC` are blessed with header-only digests carrying exactly those parse errors, and I filed them as engine bugs in #477 on that evidence. Materialized and re-run against `main` they produce **266** and **45,558** digest rows. Those two are the only models in the 580-row public baseline carrying the signature, which matches the "a couple of stubs are CHRONIC" comment that has been sitting in `build.yml` all along.

It is not confined to CI either: my first local smoke run while validating #484 reported **10 of 12** models as zero-geometry, because the checkout had never been smudged, with nothing on screen saying so.

## The fix

**Detect the pointer prefix and fail, without running a child.** The v1 spec fixes `version https://git-lfs.github.com/spec/v1` as the first line of every pointer, and no STEP or IFC file can begin that way — both must start `ISO-10303-21;` — so this is exact, not a heuristic. Only the prefix is read; a real model may be hundreds of megabytes.

The row lands in `failed.csv`, behind the hard gate both workflows already have. No new gate to maintain, and a local run now says what is wrong instead of quietly reporting an empty corpus.

Two details worth calling out:

- The check runs **before** #484's stale-digest removal, deliberately. A checkout that failed to smudge should not also destroy the good committed digest for that model.
- `failed.csv`'s signal column now carries a reason for failures the harness diagnoses itself. `ExecException`'s own fields cannot hold one — `code` is a number, `signal` is a `NodeJS.Signals` — so this adds a `failureReason` on the result type that takes that column. It keeps the three-column format, and means the row reads `lfs-pointer-stub` instead of leaving you to infer the cause from two empty fields the way a timeout does.

## Allowlist rot, now gated

The two stale entries are gone, and the gate gains the check that would have caught them: **an allowlisted model that DOES produce geometry now fails**, with the fix being "delete this line".

Without it a stale line gives up coverage for its model forever, so a later regression that empties it again is waved through. #484's allowlist header warned about exactly this; it should not have been a warning in a comment, and it was already true of two of the four lines on day one.

Keyed on `main.csv` — the set of models the run actually digested — so it stays correct on the smoke subset: an entry for a model this run never touched is neither stale nor confirmed, just absent.

## visual-diff's warning, corrected

That job said stub rows would read "no geometry" *truthfully*. It is truthful about the bytes on disk and false about the model. It renders rather than digests, so a stub there costs one blank image rather than a committed falsehood and it still continues — but the warning now says what it means, so nobody reads a blank render as a geometry regression.

## Verification

End to end, both modes. A folder with two stubs (`.ifc` and `.step`) and one real model:

```
::error::"stub.ifc" is an unsmudged Git LFS pointer, not a model. Run `git lfs pull` in the models checkout.
::error::"stub2.step" is an unsmudged Git LFS pointer, not a model. Run `git lfs pull` in the models checkout.

=== failed.csv:                     === zero_geometry.csv:    === main.csv:
file,code,signal                    file                      file,hash,errors
stub.ifc,,lfs-pointer-stub                                    create-a-tube.step,6282159...,0
stub2.step,,lfs-pointer-stub
```

Identical in `--parallel` and serial. The stubs no longer reach `zero_geometry.csv` at all — they are failures now, not empty models — and the real model digests normally.

The anti-rot check was exercised against a synthetic `main.csv` where an allowlisted model produced geometry: it exits 1 naming that model, while an allowlisted model still empty passes silently and a non-allowlisted model with geometry is ignored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQAv3NMEn9fy1AyGNm3cyN)_