### PR TITLE
Make two AP214 error messages say what actually happened

### DIFF
--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -157,6 +157,37 @@ import AP214StepModel from './ap214_step_model'
 
 type Mutable<T> = { -readonly [P in keyof T]: T[P] }
 
+/**
+ * Render something thrown that is not an Error, for a log message.
+ *
+ * Interpolating a thrown value straight into a template string is how the
+ * public baseline ended up with 8 rows reading `[object Object]` — a message
+ * that names the face type and then says nothing about the failure. JSON
+ * first so a plain thrown object shows its fields; String() as the fallback
+ * for what JSON cannot take (cycles, BigInt, symbols).
+ *
+ * @param thrown The caught value, known not to be an Error.
+ * @return {string} A description with at least as much information as String().
+ */
+function describeThrown( thrown: unknown ): string {
+
+  try {
+
+    const asJson = JSON.stringify( thrown )
+
+    // undefined for a symbol or a bare undefined; "{}" for an object whose
+    // own properties are all non-enumerable, which is no better than String().
+    if ( asJson !== void 0 && asJson !== '{}' ) {
+      return asJson
+    }
+
+  } catch {
+    // Cyclic, BigInt, or a throwing toJSON - fall through.
+  }
+
+  return String( thrown )
+}
+
 
 /**
  * Extract an AP214 Colour into our RGBA color, using premultiplied alpha.
@@ -2815,9 +2846,14 @@ export class AP214GeometryExtraction {
             `Error extracting face ${EntityTypesAP214[face_.type]} - ${
               error.message}\t\n${error.stack} - expressID: #${face_.expressID}`)
         } else {
+          // A non-Error throw interpolates as "[object Object]" in a template
+          // string, which is what 8 occurrences in the public baseline
+          // actually say - the message names the face type and nothing else.
+          // JSON first so a plain thrown object shows its fields; String() as
+          // the fallback for what JSON cannot take (cycles, BigInt, symbols).
           Logger.error(
             `Error extracting face ${EntityTypesAP214[face_.type]} - ${
-              error} - expressID: #${face_.expressID}`)
+              describeThrown( error )} - expressID: #${face_.expressID}`)
         }
       }
     }
@@ -4492,7 +4528,12 @@ export class AP214GeometryExtraction {
             }
           } catch ( ex ) {
             if (ex instanceof Error) {
-              Logger.error( `Error processing representation item: \n\t${ex.name}\n\t${ex.message}\n\texpressID: #${item.expressID}` )
+              // Stack included for the same reason extractFaces includes it:
+              // this family's message is the same string for every occurrence
+              // ("Value in select must be populated" accounts for all 274 in
+              // the NIST AP242 set), so without a stack there is nothing to
+              // tell one occurrence from another or say WHICH select failed.
+              Logger.error( `Error processing representation item: \n\t${ex.name}\n\t${ex.message}\n\t${ex.stack}\n\texpressID: #${item.expressID}` )
             } else {
               Logger.error(`Unknown exception processing representation item (${ex}) expressID: #${item.expressID}`)
             }


### PR DESCRIPTION
Two small changes, both found while re-measuring #480, both to messages that were hiding the information needed to triage the families they belong to. Between them those families are **282 of the 580 error occurrences** over the NIST corpus.

## `[object Object]`

`extractFaces`' non-Error branch interpolated the thrown value straight into a template string:

```ts
Logger.error(`Error extracting face ${EntityTypesAP214[face_.type]} - ${error} - expressID: #${face_.expressID}`)
```

So 8 rows in the public baseline read, in full:

```
Error extracting face ADVANCED_FACE - [object Object] -
```

The face type, and then nothing — not even the express ID, since the `-` swallows it visually. Routed through a `describeThrown` helper instead: `JSON.stringify` first so a plain thrown object shows its fields, `String()` as the fallback for what JSON cannot take (cycles, BigInt, symbols) or renders uselessly (`{}` from an object with no enumerable own properties).

## A stack on the representation-item catch

It was the one catch in that file without a stack, and its message is byte-identical for every occurrence — all **274** in the public baseline are:

```
Error processing representation item:
	Error
	Value in select must be populated
```

With nothing to tell one occurrence from another, the largest error family in the baseline was untriageable. Adding `ex.stack` pinned it in a single run:

```
    at get styles (AP214E3_2010_gen/presentation_style_assignment.gen.js:35:27)
    at AP214GeometryExtraction.extractStyledItemWithProcessing (ap214_geometry_extraction.js:884:44)
```

— a generated select getter that cannot read `NULL_STYLE(.NULL.)`, the typed form of an enum select member. That is now #489, with the mechanism written down. Not AP242-specific, and latent in every generated select with an enum member.

Worth noting how thin the margin was: I first tallied the error families by their **first line only** and concluded this message was empty and carried no diagnostic, and said so on #480. It was multi-line and the payload was there all along. The stack is what turned "same string 274 times" into a one-line root cause, which is the argument for it staying.

## Expected effect on the baseline

`errors.csv` churn, and that is the point — the messages carry more than they did. No digest changes: nothing here touches extraction, only what gets logged when it fails.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQAv3NMEn9fy1AyGNm3cyN)_