### PR TITLE
Read a typed enum in a select, not just the bare form

### DIFF
--- a/scripts/code-gen.cjs
+++ b/scripts/code-gen.cjs
@@ -6,6 +6,19 @@ const path = require('path');
 
 const ifcGenPath = path.resolve(__dirname, '../external/IFC-gen-internal');
 
+// The generator revision this repo's checked-in *.gen.ts were produced by.
+// Step it forward deliberately, in a PR that also carries the regenerated
+// output, so the two never disagree.
+//
+// This used to follow whatever the default branch happened to be, and that
+// silently rotted: main sat 14 months behind the branch that actually
+// generated our code (no multiReference support), so running `yarn code-gen`
+// would have rewritten ~966 files and DELETED that support, with nothing to
+// warn you. Verified at this SHA: regenerating both schemas reproduces the
+// checked-in output byte for byte, 1111 AP214 files and 1180 IFC4 files, zero
+// differences.
+const IFC_GEN_REVISION = '94ff4cc19399fa1baad9bb687cd1e2cde778b18c';
+
 function runCommand(command, options = {}) {
   try {
     execSync(command, { stdio: 'inherit', ...options });
@@ -32,6 +45,19 @@ function main() {
       console.log('Could not clone IFC-gen-internal. Please ensure you have access rights.');
       process.exit(0); // Exit gracefully
     }
+  }
+
+  // Pin every run, not just a fresh clone: an existing checkout is whatever
+  // the last person left it at, and generating from that is how the output
+  // drifts from what the pin claims produced it.
+  console.log(`Checking out IFC-gen-internal at ${IFC_GEN_REVISION}...`);
+
+  if (!runCommand(`git fetch --depth 1 origin ${IFC_GEN_REVISION}`, { cwd: ifcGenPath }) ||
+      !runCommand(`git checkout --detach ${IFC_GEN_REVISION}`, { cwd: ifcGenPath })) {
+    console.error(
+      `Could not check out IFC-gen-internal at ${IFC_GEN_REVISION}. ` +
+      'Refusing to generate from an unknown revision.');
+    process.exit(1);
   }
 
   // Run the code generation

--- a/src/AP214E3_2010/AP214E3_2010_gen/presentation_style_assignment.gen.ts
+++ b/src/AP214E3_2010/AP214E3_2010_gen/presentation_style_assignment.gen.ts
@@ -12,6 +12,7 @@ import { externally_defined_style } from "./index"
 import { null_style, null_styleDeserializeStep } from "./index"
 import {
   stepExtractOptional,
+  stepEnterTypedValue,
   stepExtractArrayToken,
   stepExtractArrayBegin,
   skipValue,
@@ -49,7 +50,7 @@ export  class presentation_style_assignment extends founded_item {
 
       while ( signedCursor0 >= 0 ) {
         const value1Untyped : StepEntityBase< EntityTypesAP214 > | null_style | undefined = 
-          this.extractBufferReference( buffer, cursor, endCursor ) ?? null_styleDeserializeStep( buffer, cursor, endCursor )
+          this.extractBufferReference( buffer, cursor, endCursor ) ?? null_styleDeserializeStep( buffer, stepEnterTypedValue( buffer, cursor, endCursor, 'NULL_STYLE' ), endCursor )
 
         if ( !( value1Untyped instanceof pre_defined_presentation_style ) && !( value1Untyped instanceof point_style ) && !( value1Untyped instanceof curve_style ) && !( value1Untyped instanceof surface_style_usage ) && !( value1Untyped instanceof symbol_style ) && !( value1Untyped instanceof fill_area_style ) && !( value1Untyped instanceof text_style ) && !( value1Untyped instanceof approximation_tolerance ) && !( value1Untyped instanceof externally_defined_style ) && value1Untyped !== null_style.NULL ) {
           throw new Error( 'Value in select must be populated' )

--- a/src/AP214E3_2010/ap214_typed_select_enum.test.ts
+++ b/src/AP214E3_2010/ap214_typed_select_enum.test.ts
@@ -1,0 +1,88 @@
+// A select member whose type is an enum may be written bare or in its typed
+// form - `.NULL.` or `NULL_STYLE(.NULL.)`. Inside a SELECT the typed form is
+// how a reader tells which member the value is, so exporters use it, and the
+// NIST AP242 set uses it throughout.
+//
+// Reading the typed form used to throw 'Value in select must be populated',
+// because the generated getter's enum fallback is a bare parse starting at
+// the cursor and the wrapper made it fail. Entity-valued members were never
+// affected - the parser indexes an inline TYPENAME(...) entity and
+// extractBufferReference resolves it by address - so this was specific to
+// enum members, and `null_style` is the only enum inside a select in either
+// schema. It accounted for 274 of the public regression baseline's error
+// rows, every one of them a lost styled item. See bldrs-ai/conway#489.
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import AP214StepParser from './ap214_step_parser'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ParseResult } from '../step/parsing/step_parser'
+import { null_style, presentation_style_assignment } from './AP214E3_2010_gen'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+
+
+const conwayGeom = new ConwayGeometry()
+
+/**
+ * Initialize the wasm.
+ */
+async function initializeWasm() {
+
+  await conwayGeom.initialize()
+}
+
+const parser = AP214StepParser.Instance
+
+// Lifted from nist_stc_06_asme1_ap242-e3.stp, which produces 82 of these.
+// The surrounding ANNOTATION_PLANE is what actually got dropped in the
+// corpus: the throw escaped the styled-item extraction and was caught per
+// representation item.
+const TYPED_STYLE = `#10028 = PRESENTATION_STYLE_ASSIGNMENT((NULL_STYLE(.NULL.)));`
+
+// The same value written bare, which always worked. Kept alongside so a
+// change that fixes one by breaking the other cannot pass.
+const BARE_STYLE = `#10028 = PRESENTATION_STYLE_ASSIGNMENT((.NULL.));`
+
+const STYLE_EXPRESS_ID = 10028
+
+/**
+ * Parse one PRESENTATION_STYLE_ASSIGNMENT and read back its styles.
+ *
+ * @param source The STEP text to parse.
+ * @return {Array<unknown>} The resolved styles array.
+ */
+function stylesOf( source: string ): Array<unknown> {
+
+  const [ result, model ] =
+    parser.parseDataToModel( new ParsingBuffer( new TextEncoder().encode( source ) ) )
+
+  if ( model === void 0 ||
+    ( result !== ParseResult.COMPLETE && result !== ParseResult.INCOMPLETE ) ) {
+    throw new Error( `parse failed with result ${result}` )
+  }
+
+  const assignment = model.getElementByExpressID( STYLE_EXPRESS_ID )
+
+  if ( !( assignment instanceof presentation_style_assignment ) ) {
+    throw new Error( 'expected a presentation_style_assignment' )
+  }
+
+  return assignment.styles
+}
+
+
+beforeAll( async () => {
+  await initializeWasm()
+})
+
+describe( 'a typed enum in a select', () => {
+
+  test( 'NULL_STYLE(.NULL.) resolves instead of throwing', () => {
+
+    expect( stylesOf( TYPED_STYLE ) ).toEqual( [ null_style.NULL ] )
+  })
+
+  test( 'the bare form still resolves', () => {
+
+    expect( stylesOf( BARE_STYLE ) ).toEqual( [ null_style.NULL ] )
+  })
+})

--- a/src/ifc/ifc4_gen/IfcPresentationStyleAssignment.gen.ts
+++ b/src/ifc/ifc4_gen/IfcPresentationStyleAssignment.gen.ts
@@ -6,6 +6,7 @@ import { IfcSurfaceStyle } from "./index"
 import { IfcTextStyle } from "./index"
 import {
   stepExtractOptional,
+  stepEnterTypedValue,
   stepExtractArrayToken,
   stepExtractArrayBegin,
   skipValue,
@@ -43,7 +44,7 @@ export  class IfcPresentationStyleAssignment extends StepEntityBase< EntityTypes
 
       while ( signedCursor0 >= 0 ) {
         const value1Untyped : StepEntityBase< EntityTypesIfc > | IfcNullStyle | undefined = 
-          this.extractBufferReference( buffer, cursor, endCursor ) ?? IfcNullStyleDeserializeStep( buffer, cursor, endCursor )
+          this.extractBufferReference( buffer, cursor, endCursor ) ?? IfcNullStyleDeserializeStep( buffer, stepEnterTypedValue( buffer, cursor, endCursor, 'IFCNULLSTYLE' ), endCursor )
 
         if ( !( value1Untyped instanceof IfcCurveStyle ) && !( value1Untyped instanceof IfcFillAreaStyle ) && !( value1Untyped instanceof IfcSurfaceStyle ) && !( value1Untyped instanceof IfcTextStyle ) && value1Untyped !== IfcNullStyle.NULL ) {
           throw new Error( 'Value in select must be populated' )

--- a/src/ifc/ifc_typed_select_enum.test.ts
+++ b/src/ifc/ifc_typed_select_enum.test.ts
@@ -1,0 +1,80 @@
+// A select member whose type is an enum may be written bare or in its typed
+// form - `.NULL.` or `NULL_STYLE(.NULL.)`. Inside a SELECT the typed form is
+// how a reader tells which member the value is, so exporters use it, and the
+// NIST AP242 set uses it throughout.
+//
+// Reading the typed form used to throw 'Value in select must be populated',
+// because the generated getter's enum fallback is a bare parse starting at
+// the cursor and the wrapper made it fail. Entity-valued members were never
+// affected - the parser indexes an inline TYPENAME(...) entity and
+// extractBufferReference resolves it by address - so this was specific to
+// enum members, and `null_style` / `IfcNullStyle` is the only enum inside a
+// select in either schema. It accounted for 274 of the public regression
+// baseline's error rows, every one of them a lost styled item. See
+// bldrs-ai/conway#489.
+//
+// Both schemas are covered: the fix is emitted by the generator at two sites,
+// one per schema, and a regeneration that reverted either would otherwise
+// ship green. scripts/code-gen.cjs clones the generator unpinned, so that is
+// not a hypothetical.
+//
+// Parser-only, so no geometry wasm is initialized here - importing it would
+// make this fail at import in a checkout without the Dist built, for a
+// dependency it never uses.
+import { describe, expect, test } from '@jest/globals'
+
+import IfcStepParser from './ifc_step_parser'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ParseResult } from '../step/parsing/step_parser'
+import { IfcNullStyle, IfcPresentationStyleAssignment } from './ifc4_gen'
+
+
+const parser = IfcStepParser.Instance
+
+const TYPED_STYLE =
+  `#10028 = IFCPRESENTATIONSTYLEASSIGNMENT((IFCNULLSTYLE(.NULL.)));`
+
+// The same value written bare, which always worked. Kept alongside so a
+// change that fixes one by breaking the other cannot pass.
+const BARE_STYLE = `#10028 = IFCPRESENTATIONSTYLEASSIGNMENT((.NULL.));`
+
+const STYLE_EXPRESS_ID = 10028
+
+/**
+ * Parse one IFCPRESENTATIONSTYLEASSIGNMENT and read back its styles.
+ *
+ * @param source The STEP text to parse.
+ * @return {Array<unknown>} The resolved styles array.
+ */
+function stylesOf( source: string ): Array<unknown> {
+
+  const [ result, model ] =
+    parser.parseDataToModel( new ParsingBuffer( new TextEncoder().encode( source ) ) )
+
+  if ( model === void 0 ||
+    ( result !== ParseResult.COMPLETE && result !== ParseResult.INCOMPLETE ) ) {
+    throw new Error( `parse failed with result ${result}` )
+  }
+
+  const assignment = model.getElementByExpressID( STYLE_EXPRESS_ID )
+
+  if ( !( assignment instanceof IfcPresentationStyleAssignment ) ) {
+    throw new Error( 'expected an IfcPresentationStyleAssignment' )
+  }
+
+  return assignment.Styles
+}
+
+
+describe( 'a typed enum in an IFC select', () => {
+
+  test( 'IFCNULLSTYLE(.NULL.) resolves instead of throwing', () => {
+
+    expect( stylesOf( TYPED_STYLE ) ).toEqual( [ IfcNullStyle.NULL ] )
+  })
+
+  test( 'the bare form still resolves', () => {
+
+    expect( stylesOf( BARE_STYLE ) ).toEqual( [ IfcNullStyle.NULL ] )
+  })
+})

--- a/src/step/parsing/step_deserialization_functions.test.ts
+++ b/src/step/parsing/step_deserialization_functions.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, test } from '@jest/globals'
 
 import {
   releaseScratchParsingBuffer,
+  stepEnterTypedValue,
   stepExtractNumber,
 } from './step_deserialization_functions'
 
@@ -39,5 +40,84 @@ describe( 'releaseScratchParsingBuffer', () => {
     releaseScratchParsingBuffer()
 
     expect( stepExtractNumber( bytes, 0, bytes.length ) ).toBe( REAL_VALUE )
+  })
+})
+
+
+describe( 'stepEnterTypedValue', () => {
+
+  /**
+   * Encode and enter, returning both the cursor and what it points at, so a
+   * failed expectation says which byte the function landed on.
+   *
+   * @param text The STEP text to read from position 0.
+   * @param typeName The expected wrapper type name.
+   * @return {[number, string]} The returned cursor and the character there.
+   */
+  const enter = ( text: string, typeName: string ): [ number, string ] => {
+
+    const bytes = new TextEncoder().encode( text )
+    const cursor = stepEnterTypedValue( bytes, 0, bytes.length, typeName )
+
+    return [ cursor, text[ cursor ] ?? '' ]
+  }
+
+  test( 'enters a matching wrapper, landing on the value', () => {
+
+    // The case from bldrs-ai/conway#489: 274 occurrences in the public
+    // regression baseline, every one of them throwing and losing its
+    // styled item because the enum parse started on the 'N'.
+    // Positions derived rather than written out, so the expectation says
+    // "just past the wrapper" rather than asserting an opaque index.
+    expect( enter( 'NULL_STYLE(.NULL.)', 'NULL_STYLE' ) )
+        .toEqual( [ 'NULL_STYLE('.length, '.' ] )
+    expect( enter( 'IFCNULLSTYLE(.NULL.)', 'IFCNULLSTYLE' ) )
+        .toEqual( [ 'IFCNULLSTYLE('.length, '.' ] )
+  })
+
+  test( 'leaves a bare value alone', () => {
+
+    // Both forms are legal for a select member, so entering must be a no-op
+    // on the bare one rather than a precondition.
+    expect( enter( '.NULL.', 'NULL_STYLE' ) ).toEqual( [ 0, '.' ] )
+  })
+
+  test( 'does not treat a lower-case spelling as the type name', () => {
+
+    // Not a policy choice here: StepEntityIdentifierParser matches
+    // `[A-Z][A-Z0-9_]*`, so a lower-case wrapper is not an identifier at all
+    // and the value is left to be read bare (where it then fails as the
+    // malformed input it is).
+    expect( enter( 'null_style(.NULL.)', 'NULL_STYLE' ) ).toEqual( [ 0, 'n' ] )
+  })
+
+  test( 'skips whitespace and comments before and after the paren', () => {
+
+    const spaced = 'NULL_STYLE /* c */ ( /* d */ .NULL.)'
+
+    expect( enter( spaced, 'NULL_STYLE' ) ).toEqual( [ spaced.indexOf( '.NULL.' ), '.' ] )
+  })
+
+  test( 'refuses a wrapper that is not this type', () => {
+
+    // The point of verifying the name rather than skipping any identifier:
+    // a mismatched wrapper stays a type error instead of being silently
+    // read as the member it is not.
+    expect( enter( 'SOME_OTHER_TYPE(.NULL.)', 'NULL_STYLE' ) ).toEqual( [ 0, 'S' ] )
+
+    // A prefix must not match either - length is checked before the bytes.
+    expect( enter( 'NULL_STYLE_EXTRA(.NULL.)', 'NULL_STYLE' ) ).toEqual( [ 0, 'N' ] )
+  })
+
+  test( 'refuses an identifier with no parenthesis', () => {
+
+    expect( enter( 'NULL_STYLE', 'NULL_STYLE' ) ).toEqual( [ 0, 'N' ] )
+    expect( enter( 'NULL_STYLE.NULL.', 'NULL_STYLE' ) ).toEqual( [ 0, 'N' ] )
+  })
+
+  test( 'refuses a reference or a bare number', () => {
+
+    expect( enter( '#4085', 'NULL_STYLE' ) ).toEqual( [ 0, '#' ] )
+    expect( enter( '0.7', 'NULL_STYLE' ) ).toEqual( [ 0, '0' ] )
   })
 })

--- a/src/step/parsing/step_deserialization_functions.ts
+++ b/src/step/parsing/step_deserialization_functions.ts
@@ -500,6 +500,88 @@ export function* stepExtractArray(
 
 
 /**
+ * Step past a `TYPENAME(` wrapper to the value inside it, when the value at
+ * the cursor is written in its typed form and the type name matches.
+ *
+ * A select member may be written either bare or typed — `.NULL.` or
+ * `NULL_STYLE(.NULL.)` — and inside a SELECT the typed form is how a reader
+ * tells which member it is, so exporters legitimately use it. Entity-valued
+ * members already handle both, because the parser indexes an inline
+ * `TYPENAME(...)` entity and `extractBufferReference` resolves it by address.
+ * A member whose type is an enum has no entity to index, so its deserializer
+ * is a bare parse starting at the cursor, and the wrapper makes it fail.
+ * That cost 274 of the public regression baseline's error rows — every
+ * `PRESENTATION_STYLE_ASSIGNMENT((NULL_STYLE(.NULL.)))` in the corpus threw
+ * and lost its styled item. See bldrs-ai/conway#489.
+ *
+ * The type name is verified rather than skipped past, so this accepts only
+ * the value's own typed form: a mismatched wrapper stays a type error
+ * instead of being silently read as the member it isn't.
+ *
+ * @param buffer The buffer to read from.
+ * @param cursor The position the value starts at.
+ * @param endCursor The last position accessible for this read in the buffer.
+ * @param typeName The expected STEP type name of the wrapper, upper case —
+ * StepEntityIdentifierParser matches `[A-Z][A-Z0-9_]*`, so a lower-case
+ * spelling is not an identifier here and never reaches the comparison.
+ * @return {number} The position just inside the wrapper's parenthesis, or
+ * `cursor` unchanged when the value is not this type's typed form.
+ */
+export function stepEnterTypedValue(
+    buffer: Uint8Array,
+    cursor: number,
+    endCursor: number,
+    typeName: string ): number {
+
+  const identifierEnd = identifierParser.match( buffer, cursor, endCursor )
+
+  if ( identifierEnd === void 0 || ( identifierEnd - cursor ) !== typeName.length ) {
+    return cursor
+  }
+
+  for ( let where = 0; where < typeName.length; ++where ) {
+
+    if ( buffer[ cursor + where ] !== typeName.charCodeAt( where ) ) {
+      return cursor
+    }
+  }
+
+  let inner = identifierEnd
+  let previousCursor: number
+
+  do {
+    previousCursor = inner
+
+    while ( inner < endCursor && WHITESPACE.has( buffer[ inner ] ) ) {
+      ++inner
+    }
+
+    inner = commentParser( buffer, inner, endCursor ) ?? inner
+  }
+  while ( previousCursor !== inner )
+
+  if ( inner >= endCursor || buffer[ inner ] !== OPEN_PAREN ) {
+    return cursor
+  }
+
+  ++inner
+
+  do {
+    previousCursor = inner
+
+    while ( inner < endCursor && WHITESPACE.has( buffer[ inner ] ) ) {
+      ++inner
+    }
+
+    inner = commentParser( buffer, inner, endCursor ) ?? inner
+  }
+  while ( previousCursor !== inner )
+
+  return inner
+}
+
+
+/**
  * Extracts an inline element and returns its cursor, or none if it can't be found.
  *
  * @param buffer The buffer to extract it from.

--- a/src/step/parsing/step_deserialization_functions.ts
+++ b/src/step/parsing/step_deserialization_functions.ts
@@ -546,38 +546,12 @@ export function stepEnterTypedValue(
     }
   }
 
-  let inner = identifierEnd
-  let previousCursor: number
-
-  do {
-    previousCursor = inner
-
-    while ( inner < endCursor && WHITESPACE.has( buffer[ inner ] ) ) {
-      ++inner
-    }
-
-    inner = commentParser( buffer, inner, endCursor ) ?? inner
-  }
-  while ( previousCursor !== inner )
-
-  if ( inner >= endCursor || buffer[ inner ] !== OPEN_PAREN ) {
-    return cursor
-  }
-
-  ++inner
-
-  do {
-    previousCursor = inner
-
-    while ( inner < endCursor && WHITESPACE.has( buffer[ inner ] ) ) {
-      ++inner
-    }
-
-    inner = commentParser( buffer, inner, endCursor ) ?? inner
-  }
-  while ( previousCursor !== inner )
-
-  return inner
+  // Delegate the rest to the inline-element reader rather than repeating its
+  // identifier/whitespace/comment/paren walk. Sharing it is not just less
+  // code: entity-valued select members reach their value through that exact
+  // function, so a divergence here would mean the two kinds of member in the
+  // SAME select disagreed about where a typed value begins.
+  return stepExtractInlineElemement( buffer, cursor, endCursor ) ?? cursor
 }
 
 


### PR DESCRIPTION
Closes #489. Companion to bldrs-ai/IFC-gen-internal#1 (merged, `94ff4cc`), which carries the generator change these two `.gen.ts` files come from.

## The bug

A select member may be written bare or typed — `.NULL.` or `NULL_STYLE(.NULL.)`. Inside a `SELECT` the typed form is how a reader tells *which member* the value is, so exporters use it; the NIST AP242 set uses it throughout.

Entity-valued members already handled both — the parser indexes an inline `TYPENAME(...)` entity and `extractBufferReference` resolves it by address, which is why `CURVE_STYLE`'s `POSITIVE_LENGTH_MEASURE(0.7)` reads fine.

A member whose type is an **enum** has no entity to index, so the generated fallback is a bare parse from the cursor:

```ts
this.extractBufferReference( buffer, cursor, endCursor )
  ?? null_styleDeserializeStep( buffer, cursor, endCursor )
```

`StepEnumParser` requires a `.` at the cursor, sees the `N` of `NULL_STYLE`, and returns `undefined`. `undefined` then satisfies every negated `instanceof` in the guard, so the getter threw `Value in select must be populated` and the whole styled item was lost.

**274 of the public regression baseline's error rows** — every `PRESENTATION_STYLE_ASSIGNMENT((NULL_STYLE(.NULL.)))` in the corpus, and 47% of its entire error surface.

## The change

`stepEnterTypedValue` returns the cursor to parse at: inside the wrapper when the value is written typed, unchanged when it is not. The generated getter now calls it around the cursor:

```ts
?? null_styleDeserializeStep( buffer, stepEnterTypedValue( buffer, cursor, endCursor, 'NULL_STYLE' ), endCursor )
```

The type name is **verified** rather than skipped past, so a mismatched wrapper stays a type error instead of being silently read as the member it isn't. That's the reason this belongs in the generator rather than in `StepEnumParser` — the generator knows the expected name, the parser only holds the value map. Fixing it in the parser would have made *all* enum parsing lax, including bare attribute slots.

Only two generated files change. `null_style` / `IfcNullStyle` is the only enum inside a select in either schema, so that is the whole blast radius:

```
AP214: 1111 files → 1 differs   (presentation_style_assignment.gen.ts)
IFC4:  1180 files → 1 differs   (IfcPresentationStyleAssignment.gen.ts)
```

I established that baseline before changing anything, by regenerating **unchanged** and confirming both schemas reproduce the checked-in output byte-for-byte — so the diff here is attributable entirely to this fix rather than to generator drift.

## Also here: the generator is now pinned

`scripts/code-gen.cjs` cloned the generator with no ref, so `yarn code-gen` generated from whatever `main` happened to be. That rotted silently — `main` sat **14 months** behind the branch that actually produced our checked-in `.gen.ts` and had no `multiReference` support, so running codegen would have rewritten ~966 files and *deleted* that support with no warning. It is what let the drift go unnoticed.

Now pinned to `94ff4cc`, checked out on **every** run rather than only on a fresh clone, since an existing checkout is whatever the last person left it at. A revision that can't be fetched fails the run instead of generating from an unknown one.

Exercised both ways: a fresh clone lands on the pin, and a checkout forced back to the old `main` (`d2a48ef`) gets corrected to it.

Left as a clone rather than a submodule deliberately — the repo is private, so a submodule would make every CI checkout need credentials for it, where codegen is an occasional developer task that currently fails soft.

## Tests

Unit coverage of `stepEnterTypedValue`: matching wrapper, bare value, mismatched wrapper, prefix that must not match, missing parenthesis, references and bare numbers, and interleaved whitespace/comments.

Plus a fixture per schema — `ap214_typed_select_enum.test.ts` and `ifc_typed_select_enum.test.ts` — carrying the real entity:

```
#10028 = PRESENTATION_STYLE_ASSIGNMENT((NULL_STYLE(.NULL.)));
#10028 = IFCPRESENTATIONSTYLEASSIGNMENT((IFCNULLSTYLE(.NULL.)));
```

Both confirmed to reproduce the bug rather than merely pass — restoring the pre-fix getter fails the typed case with the original error while the bare-form case still passes. Both schemas are covered because the fix is emitted at two sites and a regeneration reverting either would otherwise ship green.

Suite: 401 tests across 80 files.

## Expected effect on the baseline

`errors.csv` loses 274 rows once the corpus runs. Whether **digests** move depends on whether AP214 hashes style entities into the digest — the `supercap.step` baseline has only `BREP_WITH_VOIDS` / `ADVANCED_FACE` / `MANIFOLD_SOLID_BREP` rows, which suggests not, but the smoke subset can't answer it (no smoke model carries this entity). The rc pass will.

No geometry change either way: the throw happened after `extractRepresentationItem` had already succeeded, so what was being lost was styling, not shape.