### PR TITLE
Make a failed wasm heap copy say what went wrong (#485)

### DIFF
--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -57,6 +57,7 @@ import {
 import { MemoizationCapture, RegressionCaptureState } from '../core/regression_capture_state'
 import { ExtractResult } from '../core/shared_constants'
 import Logger from '../logging/logger'
+import { arrayToWasmHeap } from '../core/wasm_heap'
 import {
   advanced_brep_shape_representation,
   advanced_face,
@@ -944,16 +945,7 @@ export class AP214GeometryExtraction {
    * @return {number} Pointer/memory address
    */
   arrayToWasmHeap(array:Float32Array | Uint32Array): any {
-    // Allocate memory for the array within the Wasm module
-    const bytesPerElement = array.BYTES_PER_ELEMENT
-    const numBytes = array.length * bytesPerElement
-    const arrayPtr = this.wasmModule._malloc(numBytes)
-
-    // Create a new Uint8Array view on the Wasm memory buffer, then set the array to it
-    const arrayWasm = new Uint8Array(this.wasmModule.HEAPU8.buffer, arrayPtr, numBytes)
-    arrayWasm.set(new Uint8Array(array.buffer))
-
-    return arrayPtr
+    return arrayToWasmHeap(this.wasmModule, array)
   }
 
   /**

--- a/src/core/wasm_heap.test.ts
+++ b/src/core/wasm_heap.test.ts
@@ -1,0 +1,108 @@
+// Covers the three ways arrayToWasmHeap used to go wrong quietly. All of them
+// are cheap to exercise against a fake module, and none of them needed the
+// geometry wasm - which is the point, since the real one only misbehaves under
+// full-corpus memory pressure (bldrs-ai/conway#485).
+import { describe, expect, test } from '@jest/globals'
+
+import { arrayToWasmHeap, WasmHeapModule } from './wasm_heap'
+
+
+const HEAP_BYTES = 1024
+
+// Named rather than inlined, and non-zero, since what every assertion here
+// actually checks is that the right bytes landed somewhere that starts out
+// zero-filled.
+const PAYLOAD = Float64Array.from( [ 1, 2, 3 ] )
+const TAIL = Float64Array.from( [ 7, 8 ] )
+
+/**
+ * A stand-in for the emscripten module, with a heap we control.
+ *
+ * @param heapBytes Size of the fake heap.
+ * @param malloc What _malloc should hand back.
+ * @return {WasmHeapModule} The fake module.
+ */
+function fakeModule(
+    heapBytes: number, malloc: ( bytes: number ) => number ): WasmHeapModule {
+
+  const heap = new Uint8Array( new ArrayBuffer( heapBytes ) )
+
+  return { _malloc: malloc, HEAPU8: heap }
+}
+
+
+describe( 'arrayToWasmHeap', () => {
+
+  test( 'copies the array and returns the pointer', () => {
+
+    const address = 64
+    const wasmModule = fakeModule( HEAP_BYTES, () => address )
+    const source = PAYLOAD
+
+    expect( arrayToWasmHeap( wasmModule, source ) ).toBe( address )
+
+    const written = new Float64Array(
+      wasmModule.HEAPU8.buffer, address, source.length )
+
+    expect( Array.from( written ) ).toEqual( Array.from( source ) )
+  } )
+
+  // The bug the IFC path had already fixed and the AP214 path had not: a
+  // subarray shares its parent's buffer, so copying `array.buffer` wholesale
+  // silently writes the parent's first bytes instead of the view's.
+  test( 'copies a subarray\'s own window, not its parent buffer', () => {
+
+    const address = 32
+    const wasmModule = fakeModule( HEAP_BYTES, () => address )
+    const parent = Float64Array.from( [ 0, 0, ...TAIL ] )
+    const view = parent.subarray( 2 )
+
+    arrayToWasmHeap( wasmModule, view )
+
+    const written = new Float64Array(
+      wasmModule.HEAPU8.buffer, address, view.length )
+
+    expect( Array.from( written ) ).toEqual( Array.from( TAIL ) )
+  } )
+
+  // 0 is a valid byteOffset, so this used to construct a view happily and
+  // write over whatever lives at address 0 rather than reporting exhaustion.
+  test( 'reports a failed malloc instead of writing to address 0', () => {
+
+    const wasmModule = fakeModule( HEAP_BYTES, () => 0 )
+
+    expect( () => arrayToWasmHeap( wasmModule, PAYLOAD ) )
+      .toThrow( /_malloc failed/ )
+  } )
+
+  test( 'a zero-length copy is not mistaken for a failed malloc', () => {
+
+    const wasmModule = fakeModule( HEAP_BYTES, () => 0 )
+
+    expect( arrayToWasmHeap( wasmModule, new Float64Array( 0 ) ) ).toBe( 0 )
+  } )
+
+  // #485's signature. The bare RangeError says "Invalid typed array length: N"
+  // and nothing else; this asserts the replacement carries the state needed to
+  // tell a stale view from a genuine over-allocation.
+  test( 'a pointer past the end of the heap view reports the heap state', () => {
+
+    const past = HEAP_BYTES - 8
+    const wasmModule = fakeModule( HEAP_BYTES, () => past )
+    const source = PAYLOAD
+
+    expect( () => arrayToWasmHeap( wasmModule, source ) )
+      .toThrow( /outside the heap view/ )
+
+    try {
+      arrayToWasmHeap( wasmModule, source )
+    } catch ( error ) {
+      const message = ( error as Error ).message
+
+      expect( message ).toContain(
+        `ptr ${past} + ${PAYLOAD.byteLength} bytes` )
+      expect( message ).toContain( `byteLength ${HEAP_BYTES}` )
+      expect( message ).toContain( 'ArrayBuffer' )
+    }
+  } )
+} )

--- a/src/core/wasm_heap.test.ts
+++ b/src/core/wasm_heap.test.ts
@@ -102,15 +102,38 @@ describe( 'arrayToWasmHeap', () => {
       expect( message ).toContain(
         `ptr ${past} + ${PAYLOAD.byteLength} bytes` )
       expect( message ).toContain( `byteLength ${HEAP_BYTES}` )
-      // Exact, not toContain: 'ArrayBuffer' is a substring of
-      // 'SharedArrayBuffer', so a containment check could not tell the two
-      // apart - which is the one thing this field exists to do.
+      // 'ArrayBuffer' alone would also match 'SharedArrayBuffer', so this
+      // matches with the surrounding text that pins which field it is, and
+      // asserts the shared spelling is absent - telling the two apart being
+      // the one thing this field exists to do.
       expect( message ).toContain( 'buffer ArrayBuffer byteLength' )
       expect( message ).not.toContain( 'SharedArrayBuffer' )
 
       // Resizable, not growable, is the flag a plain ArrayBuffer carries.
       expect( message ).toContain( 'extensible false' )
     }
+  } )
+
+  // Here the allocation SUCCEEDED and only the view was refused, so this owns
+  // a pointer no caller can reach - and it is #485's own branch, under a
+  // per-record catch, so leaking would mean leaking once per record while
+  // reporting that the heap is in trouble.
+  test( 'frees the allocation it is refusing to view', () => {
+
+    const past = HEAP_BYTES - 8
+    const freed: number[] = []
+
+    const wasmModule: WasmHeapModule = {
+      ...fakeModule( HEAP_BYTES, () => past ),
+      _free: ( pointer: number ) => {
+        freed.push( pointer )
+      },
+    }
+
+    expect( () => arrayToWasmHeap( wasmModule, PAYLOAD ) )
+      .toThrow( /outside the heap view/ )
+
+    expect( freed ).toEqual( [ past ] )
   } )
 } )
 

--- a/src/core/wasm_heap.test.ts
+++ b/src/core/wasm_heap.test.ts
@@ -78,16 +78,29 @@ describe( 'arrayToWasmHeap', () => {
       .toThrow( /_malloc returned an unusable address/ )
   } )
 
-  // The heap's maximum is 4GB and _malloc is a raw i32 export, so any address
-  // at or above 2^31 arrives signed. Unchecked it would pass the upper-bound
-  // test - a negative plus numBytes is not greater than byteLength - and reach
-  // the constructor as a bare "Start offset is outside the bounds".
-  test( 'a negative address is treated as a failed allocation', () => {
+  // A >2GB address is a SUCCESSFUL allocation that arrives signed, because
+  // _malloc is a raw i32 export and every target builds with 4GB max. Treating
+  // it as a failure would hard-fail every copy once the heap passes 2GB, which
+  // is exactly the memory-pressure case #485 is about - so it is normalised,
+  // not rejected. Simulated here by a heap sized past 2GB in address terms
+  // only; nothing that big is allocated.
+  test( 'an address above 2GB is normalised, not read as a failure', () => {
 
-    const wasmModule = fakeModule( HEAP_BYTES, () => -1 )
+    const signedAddress = -2147483648
+    const unsignedAddress = 2147483648
+    const headroom = 4096
 
+    const wasmModule: WasmHeapModule = {
+      _malloc: () => signedAddress,
+      _free: () => { /* unused here */ },
+      HEAPU8: { length: 0, buffer: { byteLength: unsignedAddress + headroom } } as
+        unknown as Uint8Array,
+    }
+
+    // Fails on the copy rather than on the guard, which is the proof it got
+    // past the "unusable address" test with the address intact.
     expect( () => arrayToWasmHeap( wasmModule, PAYLOAD ) )
-      .toThrow( /_malloc returned an unusable address/ )
+      .not.toThrow( /_malloc returned an unusable address/ )
   } )
 
   test( 'a zero-length copy is not mistaken for a failed malloc', () => {

--- a/src/core/wasm_heap.test.ts
+++ b/src/core/wasm_heap.test.ts
@@ -4,7 +4,7 @@
 // full-corpus memory pressure (bldrs-ai/conway#485).
 import { describe, expect, test } from '@jest/globals'
 
-import { arrayToWasmHeap, WasmHeapModule } from './wasm_heap'
+import { arraysToWasmHeap, arrayToWasmHeap, WasmHeapModule } from './wasm_heap'
 
 
 const HEAP_BYTES = 1024
@@ -27,7 +27,7 @@ function fakeModule(
 
   const heap = new Uint8Array( new ArrayBuffer( heapBytes ) )
 
-  return { _malloc: malloc, HEAPU8: heap }
+  return { _malloc: malloc, _free: () => { /* recorded by callers that care */ }, HEAPU8: heap }
 }
 
 
@@ -102,7 +102,58 @@ describe( 'arrayToWasmHeap', () => {
       expect( message ).toContain(
         `ptr ${past} + ${PAYLOAD.byteLength} bytes` )
       expect( message ).toContain( `byteLength ${HEAP_BYTES}` )
-      expect( message ).toContain( 'ArrayBuffer' )
+      // Exact, not toContain: 'ArrayBuffer' is a substring of
+      // 'SharedArrayBuffer', so a containment check could not tell the two
+      // apart - which is the one thing this field exists to do.
+      expect( message ).toContain( 'buffer ArrayBuffer byteLength' )
+      expect( message ).not.toContain( 'SharedArrayBuffer' )
+
+      // Resizable, not growable, is the flag a plain ArrayBuffer carries.
+      expect( message ).toContain( 'extensible false' )
     }
+  } )
+} )
+
+
+describe( 'arraysToWasmHeap', () => {
+
+  test( 'returns pointers in the order the arrays were given', () => {
+
+    const first = 16
+    const stride = 64
+    let next = first
+
+    const wasmModule = fakeModule( HEAP_BYTES, () => {
+      const address = next
+
+      next += stride
+
+      return address
+    } )
+
+    expect( arraysToWasmHeap( wasmModule, [ PAYLOAD, TAIL ] ) )
+      .toEqual( [ first, first + stride ] )
+  } )
+
+  // The point of the batch form: a caller holding several allocations frees
+  // them together at the end, so a throw part-way through would strand the
+  // ones already taken and the retry upstream would do it again.
+  test( 'frees what it already took when a later allocation fails', () => {
+
+    const first = 16
+    const freed: number[] = []
+    let call = 0
+
+    const wasmModule: WasmHeapModule = {
+      ...fakeModule( HEAP_BYTES, () => ( call++ === 0 ? first : 0 ) ),
+      _free: ( pointer: number ) => {
+        freed.push( pointer )
+      },
+    }
+
+    expect( () => arraysToWasmHeap( wasmModule, [ PAYLOAD, TAIL ] ) )
+      .toThrow( /_malloc failed/ )
+
+    expect( freed ).toEqual( [ first ] )
   } )
 } )

--- a/src/core/wasm_heap.test.ts
+++ b/src/core/wasm_heap.test.ts
@@ -4,7 +4,9 @@
 // full-corpus memory pressure (bldrs-ai/conway#485).
 import { describe, expect, test } from '@jest/globals'
 
-import { arraysToWasmHeap, arrayToWasmHeap, WasmHeapModule } from './wasm_heap'
+import {
+  arraysToWasmHeap, arrayToWasmHeap, releaseQuietly, WasmHeapModule,
+} from './wasm_heap'
 
 
 const HEAP_BYTES = 1024
@@ -178,5 +180,40 @@ describe( 'arraysToWasmHeap', () => {
       .toThrow( /_malloc failed/ )
 
     expect( freed ).toEqual( [ first ] )
+  } )
+} )
+
+
+describe( 'releaseQuietly', () => {
+
+  test( 'runs the release', () => {
+
+    let ran = false
+
+    releaseQuietly( () => {
+      ran = true
+    } )
+
+    expect( ran ).toBe( true )
+  } )
+
+  // The point: these run from finally blocks that may be unwinding because the
+  // wasm runtime just failed, and every release re-enters that same runtime.
+  // A throw here would replace the in-flight error, and the per-record catch
+  // upstream would log a generic teardown failure instead of the heap
+  // diagnostic this module exists to produce.
+  test( 'does not let a failed release replace the error being unwound', () => {
+
+    const original = new Error( 'the diagnostic worth keeping' )
+
+    expect( () => {
+      try {
+        throw original
+      } finally {
+        releaseQuietly( () => {
+          throw new Error( 'teardown blew up too' )
+        } )
+      }
+    } ).toThrow( original )
   } )
 } )

--- a/src/core/wasm_heap.test.ts
+++ b/src/core/wasm_heap.test.ts
@@ -5,7 +5,8 @@
 import { describe, expect, test } from '@jest/globals'
 
 import {
-  arraysToWasmHeap, arrayToWasmHeap, releaseQuietly, WasmHeapModule,
+  arraysToWasmHeap, arrayToWasmHeap, freeAll, releaseQuietly, WasmHeapModule,
+  withRelease,
 } from './wasm_heap'
 
 
@@ -74,7 +75,19 @@ describe( 'arrayToWasmHeap', () => {
     const wasmModule = fakeModule( HEAP_BYTES, () => 0 )
 
     expect( () => arrayToWasmHeap( wasmModule, PAYLOAD ) )
-      .toThrow( /_malloc failed/ )
+      .toThrow( /_malloc returned an unusable address/ )
+  } )
+
+  // The heap's maximum is 4GB and _malloc is a raw i32 export, so any address
+  // at or above 2^31 arrives signed. Unchecked it would pass the upper-bound
+  // test - a negative plus numBytes is not greater than byteLength - and reach
+  // the constructor as a bare "Start offset is outside the bounds".
+  test( 'a negative address is treated as a failed allocation', () => {
+
+    const wasmModule = fakeModule( HEAP_BYTES, () => -1 )
+
+    expect( () => arrayToWasmHeap( wasmModule, PAYLOAD ) )
+      .toThrow( /_malloc returned an unusable address/ )
   } )
 
   test( 'a zero-length copy is not mistaken for a failed malloc', () => {
@@ -177,7 +190,7 @@ describe( 'arraysToWasmHeap', () => {
     }
 
     expect( () => arraysToWasmHeap( wasmModule, [ PAYLOAD, TAIL ] ) )
-      .toThrow( /_malloc failed/ )
+      .toThrow( /_malloc returned an unusable address/ )
 
     expect( freed ).toEqual( [ first ] )
   } )
@@ -215,5 +228,92 @@ describe( 'releaseQuietly', () => {
         } )
       }
     } ).toThrow( original )
+  } )
+} )
+
+
+describe( 'withRelease', () => {
+
+  test( 'releases after the body and returns its value', () => {
+
+    const order: string[] = []
+
+    const result = withRelease(
+      () => {
+        order.push( 'body' )
+
+        return 'value'
+      },
+      () => {
+        order.push( 'release' )
+      } )
+
+    expect( result ).toBe( 'value' )
+    expect( order ).toEqual( [ 'body', 'release' ] )
+  } )
+
+  // The asymmetry this exists for. On the success path a teardown failure is a
+  // real fault with nothing competing to report it, and swallowing it would let
+  // a record be reported COMPLETE with its resources never reclaimed.
+  test( 'propagates a release failure when the body succeeded', () => {
+
+    expect( () => withRelease( () => 'fine', () => {
+      throw new Error( 'release failed' )
+    } ) ).toThrow( /release failed/ )
+  } )
+
+  test( 'keeps the body\'s error when the release fails too', () => {
+
+    const original = new Error( 'the diagnostic worth keeping' )
+
+    expect( () => withRelease(
+      () => {
+        throw original
+      },
+      () => {
+        throw new Error( 'teardown blew up too' )
+      } ) ).toThrow( original )
+  } )
+
+  test( 'still releases when the body throws', () => {
+
+    let released = false
+
+    expect( () => withRelease(
+      () => {
+        throw new Error( 'body failed' )
+      },
+      () => {
+        released = true
+      } ) ).toThrow( /body failed/ )
+
+    expect( released ).toBe( true )
+  } )
+} )
+
+
+describe( 'freeAll', () => {
+
+  // Batched into one statement, the first failure abandons every pointer after
+  // it - which is the whole reason this is not just four _free calls.
+  test( 'frees every pointer even when one throws, and reports the first', () => {
+
+    const freed: number[] = []
+    const bad = 2
+
+    const wasmModule: WasmHeapModule = {
+      ...fakeModule( HEAP_BYTES, () => 0 ),
+      _free: ( pointer: number ) => {
+        if ( pointer === bad ) {
+          throw new Error( 'free failed' )
+        }
+
+        freed.push( pointer )
+      },
+    }
+
+    expect( () => freeAll( wasmModule, [ 1, bad, 3 ] ) ).toThrow( /free failed/ )
+
+    expect( freed ).toEqual( [ 1, 3 ] )
   } )
 } )

--- a/src/core/wasm_heap.ts
+++ b/src/core/wasm_heap.ts
@@ -11,6 +11,9 @@
  * across two models before it could even be located.
  */
 
+import Logger from '../logging/logger'
+
+
 /** What the wasm module exposes that this needs. Deliberately narrow. */
 export interface WasmHeapModule {
   _malloc( bytes: number ): number
@@ -158,4 +161,36 @@ export function arraysToWasmHeap(
   }
 
   return pointers
+}
+
+
+/**
+ * Run a resource release so it cannot replace an exception already in flight.
+ *
+ * Releases here re-enter the wasm runtime - _free, embind delete(), returning
+ * a pooled buffer - and they run from finally blocks that may be unwinding
+ * because that runtime just failed. A throw from one of them would REPLACE the
+ * original error, so the caller upstream would see a generic teardown failure
+ * instead of the diagnostic that says what actually went wrong. Losing the
+ * cause is strictly worse than failing to reclaim memory on a path where the
+ * heap is already lost.
+ *
+ * Reported at debug rather than swallowed outright, so it is still findable
+ * with -vv, and NOT at warning/error: this runs during teardown of an already
+ * failing record, where a second message would be noise on top of the one that
+ * matters.
+ *
+ * @param release The release step to run.
+ */
+export function releaseQuietly( release: () => void ): void {
+
+  try {
+
+    release()
+  } catch ( error ) {
+
+    Logger.debug(
+      `wasm resource release failed during teardown: ${
+        error instanceof Error ? error.message : error}` )
+  }
 }

--- a/src/core/wasm_heap.ts
+++ b/src/core/wasm_heap.ts
@@ -14,6 +14,7 @@
 /** What the wasm module exposes that this needs. Deliberately narrow. */
 export interface WasmHeapModule {
   _malloc( bytes: number ): number
+  _free( pointer: number ): void
   HEAPU8: Uint8Array
 }
 
@@ -24,13 +25,17 @@ export type CopyableArray = Float32Array | Float64Array | Uint32Array
  * Describe the heap and the request, for an error message that is actually
  * actionable.
  *
- * The buffer's kind matters: conway's MT build creates its memory with
- * `shared: true`, so the heap is a growable SharedArrayBuffer and emscripten's
- * updateMemoryViews() early-returns on every growth - the views are
- * length-tracking and auto-extend instead of being rebuilt. If a failure here
- * ever reports a plain ArrayBuffer, or a byteLength behind the pointer, that
- * assumption has broken and the message says so rather than leaving it to be
- * rediscovered.
+ * The buffer's kind matters, and there are two kinds to tell apart, not one.
+ * conway's MT build creates its memory with `shared: true`, so its heap is a
+ * *growable* SharedArrayBuffer; single-threaded builds on emscripten 6 get a
+ * *resizable* ArrayBuffer (see decode_utf8.ts). Both cases have length-tracking
+ * views that extend by themselves, which is why emscripten's
+ * updateMemoryViews() early-returns on growth rather than rebuilding them.
+ *
+ * So both flags are reported. They have different names on the two buffer
+ * types, and printing only one makes every single-threaded failure look like
+ * the assumption has broken when it has not - which would be a false alarm
+ * pointing away from whatever the real cause was.
  *
  * @param wasmModule The module whose heap is being written to.
  * @param arrayPtr The pointer _malloc returned.
@@ -41,15 +46,24 @@ function describeHeap(
     wasmModule: WasmHeapModule, arrayPtr: number, numBytes: number ): string {
 
   const heap = wasmModule.HEAPU8
-  const buffer = heap?.buffer as ( ArrayBuffer | SharedArrayBuffer | undefined )
+  const buffer =
+    heap?.buffer as ( ArrayBuffer | SharedArrayBuffer | undefined ) &
+      { growable?: boolean, resizable?: boolean }
+
+  const shared = typeof SharedArrayBuffer !== 'undefined' &&
+    buffer instanceof SharedArrayBuffer
+
   const kind = buffer === void 0 ? 'none' :
-    ( typeof SharedArrayBuffer !== 'undefined' &&
-      buffer instanceof SharedArrayBuffer ? 'SharedArrayBuffer' : 'ArrayBuffer' )
+    ( shared ? 'SharedArrayBuffer' : 'ArrayBuffer' )
+
+  // Whichever flag this buffer type actually carries. Reported as one field so
+  // a reader does not have to know which name goes with which kind.
+  const extensible = shared ? buffer?.growable : buffer?.resizable
 
   return `ptr ${arrayPtr} + ${numBytes} bytes, ` +
     `heap view length ${heap?.length}, ` +
     `buffer ${kind} byteLength ${buffer?.byteLength}, ` +
-    `growable ${( buffer as { growable?: boolean } )?.growable}`
+    `extensible ${extensible}`
 }
 
 
@@ -98,4 +112,42 @@ export function arrayToWasmHeap(
   destination.set( new Uint8Array( array.buffer, array.byteOffset, numBytes ) )
 
   return arrayPtr
+}
+
+
+/**
+ * Copy several arrays into the wasm heap, all or nothing.
+ *
+ * arrayToWasmHeap throws on a failed allocation, which is the right thing on
+ * its own but turns a caller that allocates N buffers before freeing any into
+ * a leak: the throw on buffer 2 strands buffer 1, the per-record catch
+ * upstream moves to the next record, and the leak repeats - accelerating the
+ * exhaustion being reported. Callers that hold several at once use this
+ * instead, which frees what it took before letting the error out.
+ *
+ * @param wasmModule The module to allocate in.
+ * @param arrays The data to copy, in order.
+ * @return {number[]} Pointers in the same order, owned by the caller.
+ */
+export function arraysToWasmHeap(
+    wasmModule: WasmHeapModule,
+    arrays: readonly CopyableArray[] ): number[] {
+
+  const pointers: number[] = []
+
+  try {
+
+    for ( const array of arrays ) {
+      pointers.push( arrayToWasmHeap( wasmModule, array ) )
+    }
+  } catch ( error ) {
+
+    for ( const pointer of pointers ) {
+      wasmModule._free( pointer )
+    }
+
+    throw error
+  }
+
+  return pointers
 }

--- a/src/core/wasm_heap.ts
+++ b/src/core/wasm_heap.ts
@@ -30,8 +30,8 @@ export type CopyableArray = Float32Array | Float64Array | Uint32Array
  *
  * The buffer's kind matters, and there are two kinds to tell apart, not one.
  * conway's MT build creates its memory with `shared: true`, so its heap is a
- * *growable* SharedArrayBuffer; single-threaded builds on emscripten 6 get a
- * *resizable* ArrayBuffer (see decode_utf8.ts). Both cases have length-tracking
+ * growable SharedArrayBuffer; single-threaded builds on emscripten 6 get a
+ * resizable ArrayBuffer (see decode_utf8.ts). Both cases have length-tracking
  * views that extend by themselves, which is why emscripten's
  * updateMemoryViews() early-returns on growth rather than rebuilding them.
  *
@@ -81,20 +81,23 @@ export function arrayToWasmHeap(
     wasmModule: WasmHeapModule, array: CopyableArray ): number {
 
   const numBytes = array.length * array.BYTES_PER_ELEMENT
-  const arrayPtr = wasmModule._malloc( numBytes )
 
-  // _malloc returns 0 on failure, which is a valid byteOffset, so the view
+  // Normalised, not rejected. _malloc is bound raw from wasmExports and
+  // returns i32, and every target builds with MAXIMUM_MEMORY=4GB, so a
+  // perfectly good address at or above 2^31 arrives here NEGATIVE. Treating
+  // that as a failure would hard-fail every copy once the heap passes 2GB -
+  // which is the memory-pressure scenario #485 is about - so it is converted
+  // the way emscripten's own glue does (`HEAPU32[ptr >>> 2 >>> 0]`) and used
+  // in that form for the bounds test, the view, the free and the message.
+  // Left signed it would also pass the bounds test below, since a negative
+  // plus numBytes is not greater than byteLength.
+  const arrayPtr = wasmModule._malloc( numBytes ) >>> 0
+
+  // 0 is _malloc's failure return and also a valid byteOffset, so the view
   // below would be constructed happily and this would go on to write over
   // whatever lives at address 0 - corrupting the heap instead of reporting
   // that it is exhausted.
-  //
-  // Negative is the same failure wearing a different hat. The heap's maximum
-  // is 4GB (maximum: 65536 pages), _malloc is a raw i32 export, and any
-  // address at or above 2^31 arrives here signed - which then passes the upper
-  // bound check below, because a negative plus numBytes is not greater than
-  // byteLength. Left unchecked it reaches the constructor as a bare
-  // "Start offset is outside the bounds", skipping the cleanup underneath.
-  if ( ( arrayPtr === 0 && numBytes > 0 ) || arrayPtr < 0 ) {
+  if ( arrayPtr === 0 && numBytes > 0 ) {
 
     throw new Error(
       `wasm _malloc returned an unusable address for ${numBytes} bytes - ` +

--- a/src/core/wasm_heap.ts
+++ b/src/core/wasm_heap.ts
@@ -98,10 +98,18 @@ export function arrayToWasmHeap(
   // indistinguishable from a dozen other causes.
   if ( arrayPtr + numBytes > heapBuffer.byteLength ) {
 
+    const description = describeHeap( wasmModule, arrayPtr, numBytes )
+
+    // The allocation SUCCEEDED and only the view is refused, so this owns a
+    // pointer nobody else can reach - arraysToWasmHeap's cleanup cannot see it
+    // because it was never returned. Leaking here would mean leaking once per
+    // record, under a per-record catch, while reporting that the heap is in
+    // trouble.
+    wasmModule._free( arrayPtr )
+
     throw new Error(
       'wasm heap allocation lies outside the heap view - ' +
-      `the view is stale or the heap grew without it. ` +
-      describeHeap( wasmModule, arrayPtr, numBytes ) )
+      `the view is stale or the heap grew without it. ${description}` )
   }
 
   const destination = new Uint8Array( heapBuffer, arrayPtr, numBytes )

--- a/src/core/wasm_heap.ts
+++ b/src/core/wasm_heap.ts
@@ -87,10 +87,17 @@ export function arrayToWasmHeap(
   // below would be constructed happily and this would go on to write over
   // whatever lives at address 0 - corrupting the heap instead of reporting
   // that it is exhausted.
-  if ( arrayPtr === 0 && numBytes > 0 ) {
+  //
+  // Negative is the same failure wearing a different hat. The heap's maximum
+  // is 4GB (maximum: 65536 pages), _malloc is a raw i32 export, and any
+  // address at or above 2^31 arrives here signed - which then passes the upper
+  // bound check below, because a negative plus numBytes is not greater than
+  // byteLength. Left unchecked it reaches the constructor as a bare
+  // "Start offset is outside the bounds", skipping the cleanup underneath.
+  if ( ( arrayPtr === 0 && numBytes > 0 ) || arrayPtr < 0 ) {
 
     throw new Error(
-      `wasm _malloc failed for ${numBytes} bytes - ` +
+      `wasm _malloc returned an unusable address for ${numBytes} bytes - ` +
       describeHeap( wasmModule, arrayPtr, numBytes ) )
   }
 
@@ -108,7 +115,7 @@ export function arrayToWasmHeap(
     // because it was never returned. Leaking here would mean leaking once per
     // record, under a per-record catch, while reporting that the heap is in
     // trouble.
-    wasmModule._free( arrayPtr )
+    releaseQuietly( () => wasmModule._free( arrayPtr ) )
 
     throw new Error(
       'wasm heap allocation lies outside the heap view - ' +
@@ -153,8 +160,10 @@ export function arraysToWasmHeap(
     }
   } catch ( error ) {
 
+    // Individually, and quietly. One free throwing must not strand the rest,
+    // and must not replace the allocation error being propagated.
     for ( const pointer of pointers ) {
-      wasmModule._free( pointer )
+      releaseQuietly( () => wasmModule._free( pointer ) )
     }
 
     throw error
@@ -192,5 +201,74 @@ export function releaseQuietly( release: () => void ): void {
     Logger.debug(
       `wasm resource release failed during teardown: ${
         error instanceof Error ? error.message : error}` )
+  }
+}
+
+
+/**
+ * Run `body`, then release - propagating a release failure on success, and
+ * suppressing it only when something is already being unwound.
+ *
+ * That asymmetry is the point. releaseQuietly on its own is right during
+ * unwinding and wrong otherwise: on the success path a teardown failure is a
+ * real fault with nothing competing to report it, and swallowing it would let
+ * a record be reported COMPLETE while its resources were never reclaimed. So
+ * the quiet treatment applies to exactly the case it was argued for.
+ *
+ * @param body The work that needs the resource.
+ * @param release How to give the resource back.
+ * @return {T} Whatever body returned.
+ */
+export function withRelease<T>( body: () => T, release: () => void ): T {
+
+  let result: T
+
+  try {
+
+    result = body()
+  } catch ( error ) {
+
+    releaseQuietly( release )
+
+    throw error
+  }
+
+  release()
+
+  return result
+}
+
+
+/**
+ * Free several pointers, independently.
+ *
+ * One failing free must not abandon the rest - batching them into a single
+ * statement means the first failure strands every pointer after it - and it
+ * must not be lost either, so the first error is re-thrown once they have all
+ * been attempted. Combined with withRelease that gives the wanted behaviour on
+ * both paths: everything is freed either way, and the failure surfaces on the
+ * success path while staying quiet during unwinding.
+ *
+ * @param wasmModule The module the pointers belong to.
+ * @param pointers The allocations to release.
+ */
+export function freeAll(
+    wasmModule: WasmHeapModule, pointers: readonly number[] ): void {
+
+  let firstFailure: unknown
+
+  for ( const pointer of pointers ) {
+
+    try {
+
+      wasmModule._free( pointer )
+    } catch ( error ) {
+
+      firstFailure ??= error
+    }
+  }
+
+  if ( firstFailure !== void 0 ) {
+    throw firstFailure
   }
 }

--- a/src/core/wasm_heap.ts
+++ b/src/core/wasm_heap.ts
@@ -1,0 +1,101 @@
+/**
+ * Copying JS-side arrays into the wasm heap.
+ *
+ * This lives in one place because the two geometry extractors had a copy each,
+ * and the copies had drifted: one honoured the source view's window and the
+ * other did not, and neither checked what _malloc returned. The failure modes
+ * are quiet enough to be worth naming here.
+ *
+ * See bldrs-ai/conway#485 for what an uninstrumented failure on this path
+ * costs: `Invalid typed array length: 80`, no context, and two sightings
+ * across two models before it could even be located.
+ */
+
+/** What the wasm module exposes that this needs. Deliberately narrow. */
+export interface WasmHeapModule {
+  _malloc( bytes: number ): number
+  HEAPU8: Uint8Array
+}
+
+export type CopyableArray = Float32Array | Float64Array | Uint32Array
+
+
+/**
+ * Describe the heap and the request, for an error message that is actually
+ * actionable.
+ *
+ * The buffer's kind matters: conway's MT build creates its memory with
+ * `shared: true`, so the heap is a growable SharedArrayBuffer and emscripten's
+ * updateMemoryViews() early-returns on every growth - the views are
+ * length-tracking and auto-extend instead of being rebuilt. If a failure here
+ * ever reports a plain ArrayBuffer, or a byteLength behind the pointer, that
+ * assumption has broken and the message says so rather than leaving it to be
+ * rediscovered.
+ *
+ * @param wasmModule The module whose heap is being written to.
+ * @param arrayPtr The pointer _malloc returned.
+ * @param numBytes The size of the intended copy.
+ * @return {string} A description of the heap state.
+ */
+function describeHeap(
+    wasmModule: WasmHeapModule, arrayPtr: number, numBytes: number ): string {
+
+  const heap = wasmModule.HEAPU8
+  const buffer = heap?.buffer as ( ArrayBuffer | SharedArrayBuffer | undefined )
+  const kind = buffer === void 0 ? 'none' :
+    ( typeof SharedArrayBuffer !== 'undefined' &&
+      buffer instanceof SharedArrayBuffer ? 'SharedArrayBuffer' : 'ArrayBuffer' )
+
+  return `ptr ${arrayPtr} + ${numBytes} bytes, ` +
+    `heap view length ${heap?.length}, ` +
+    `buffer ${kind} byteLength ${buffer?.byteLength}, ` +
+    `growable ${( buffer as { growable?: boolean } )?.growable}`
+}
+
+
+/**
+ * Copy an array into a fresh wasm heap allocation.
+ *
+ * @param wasmModule The module to allocate in.
+ * @param array The data to copy. May be a view into a larger buffer.
+ * @return {number} Pointer to the copy, owned by the caller.
+ */
+export function arrayToWasmHeap(
+    wasmModule: WasmHeapModule, array: CopyableArray ): number {
+
+  const numBytes = array.length * array.BYTES_PER_ELEMENT
+  const arrayPtr = wasmModule._malloc( numBytes )
+
+  // _malloc returns 0 on failure, which is a valid byteOffset, so the view
+  // below would be constructed happily and this would go on to write over
+  // whatever lives at address 0 - corrupting the heap instead of reporting
+  // that it is exhausted.
+  if ( arrayPtr === 0 && numBytes > 0 ) {
+
+    throw new Error(
+      `wasm _malloc failed for ${numBytes} bytes - ` +
+      describeHeap( wasmModule, arrayPtr, numBytes ) )
+  }
+
+  const heapBuffer = wasmModule.HEAPU8.buffer
+
+  // Checked rather than left to the TypedArray constructor, whose RangeError
+  // is just "Invalid typed array length: N" - true, unactionable, and
+  // indistinguishable from a dozen other causes.
+  if ( arrayPtr + numBytes > heapBuffer.byteLength ) {
+
+    throw new Error(
+      'wasm heap allocation lies outside the heap view - ' +
+      `the view is stale or the heap grew without it. ` +
+      describeHeap( wasmModule, arrayPtr, numBytes ) )
+  }
+
+  const destination = new Uint8Array( heapBuffer, arrayPtr, numBytes )
+
+  // Honour the source view's own window: subarray() results share their
+  // parent's backing buffer, so copying `array.buffer` wholesale reads the
+  // wrong bytes, and the wrong number of them, for anything that is a view.
+  destination.set( new Uint8Array( array.buffer, array.byteOffset, numBytes ) )
+
+  return arrayPtr
+}

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -198,7 +198,9 @@ import { IfcMaterialCache } from './ifc_material_cache'
 import { IfcSceneBuilder, IfcSceneTransform } from './ifc_scene_builder'
 import IfcStepModel from './ifc_step_model'
 import Logger from '../logging/logger'
-import { arrayToWasmHeap, arraysToWasmHeap, releaseQuietly } from '../core/wasm_heap'
+import {
+  arraysToWasmHeap, arrayToWasmHeap, freeAll, withRelease,
+} from '../core/wasm_heap'
 // import fs from 'fs'
 import Environment, { EnvironmentType } from '../utilities/environment'
 import { REFLECTANCE_METHOD_PERMISSIVE,
@@ -1014,83 +1016,76 @@ export class IfcGeometryExtraction {
       startIndicesBufferOffsetsArray,
     ] )
 
-    // finally, not a straight-line free at the end. Per-record extraction
-    // errors are caught upstream and are expected on malformed models, so
-    // anything in here throwing - buildIndexedPolygonalFaceVector,
-    // extractParseBuffer, parseVertexVector, or the embind call - used to
-    // strand all four pointers plus the pooled parse buffer and the two native
-    // objects, once per faceset. On a model with 15,777 facesets that is a leak
-    // large enough to cause the exhaustion it would then be blamed on.
+    // Each acquisition is paired with its release through withRelease, which
+    // propagates a release failure on the success path and suppresses it only
+    // while something is already being unwound. Per-record extraction errors
+    // are caught upstream and expected on malformed models, so anything in
+    // here throwing used to strand all four pointers plus the pooled parse
+    // buffer and the two native objects, once per faceset - on a model with
+    // 15,777 facesets, a leak large enough to cause the exhaustion it would
+    // then be blamed on.
     //
-    // Every release goes through releaseQuietly, because these run while an
-    // exception may already be in flight and all of them re-enter the wasm
-    // runtime. If that runtime is the thing that failed, a release throwing
-    // would REPLACE the original error, and the per-record catch upstream would
-    // log a generic embind failure in place of the heap diagnostic this whole
-    // change exists to produce.
-    let geometry: GeometryObject
+    // Suppressing during unwinding matters as much as the release itself:
+    // every one of these re-enters the wasm runtime, and if that runtime is
+    // what failed, a throw here would REPLACE the in-flight error and the
+    // catch upstream would log a generic teardown failure instead of the heap
+    // diagnostic this change exists to produce.
+    const geometry = withRelease(
+      () => {
 
-    try {
+          const polygonalFaceVector =
+            this.wasmModule.buildIndexedPolygonalFaceVector(
+                indicesArrayPtr,
+                indicesArray.length,
+                startIndicesArrayPtr,
+                polygonalFaceBufferOffsetsArrayPtr,
+                polygonalFaceBufferOffsetsArray.length,
+                startIndicesBufferOffsetsArrayPtr,
+                startIndicesBufferOffsetsArray.length)
 
-      const polygonalFaceVector = this.wasmModule.buildIndexedPolygonalFaceVector(
-          indicesArrayPtr,
-          indicesArray.length,
-          startIndicesArrayPtr,
-          polygonalFaceBufferOffsetsArrayPtr,
-          polygonalFaceBufferOffsetsArray.length,
-          startIndicesBufferOffsetsArrayPtr,
-          startIndicesBufferOffsetsArray.length)
+          return withRelease(
+            () => {
 
-      try {
+              const pointsParseBuffer = this.conwayModel.nativeParseBuffer()
 
-        const pointsParseBuffer = this.conwayModel.nativeParseBuffer()
-        let pointsArrayNative
+              // Released around parseVertexVector too, not just the extract:
+              // it is pooled, so leaking it also loses whatever resize() grew.
+              const pointsArrayNative = withRelease(
+                () => {
 
-        // Released here rather than after parseVertexVector, so a throw inside
-        // extractParseBuffer or parseVertexVector still returns it to the pool.
-        // It is pooled, so leaking it also loses whatever resize() grew for it.
-        try {
+                  if ( !entity.Coordinates.extractParseBuffer(
+                      0,
+                      0,
+                      0,
+                      pointsParseBuffer,
+                      this.wasmModule,
+                      true ) ) {
 
-          if ( !entity.Coordinates.extractParseBuffer(
-              0,
-              0,
-              0,
-              pointsParseBuffer,
-              this.wasmModule,
-              true ) ) {
+                    pointsParseBuffer.resize( 0 )
+                  }
 
-            pointsParseBuffer.resize( 0 )
-          }
+                  return this.wasmModule.parseVertexVector( pointsParseBuffer )
+                },
+                () => this.conwayModel.freeParseBuffer( pointsParseBuffer ) )
 
-          pointsArrayNative = this.wasmModule.parseVertexVector( pointsParseBuffer )
-        } finally {
-          releaseQuietly( () => this.conwayModel.freeParseBuffer( pointsParseBuffer ) )
-        }
-
-        try {
-
-          const parameters: ParamsPolygonalFaceSet = {
-            indicesPerFace: indicesPerFace,
-            points: pointsArrayNative,
-            faces: polygonalFaceVector,
-          }
-
-          geometry = this.conwayModel.getPolygonalFaceSetGeometry(parameters)
-        } finally {
-          releaseQuietly( () => pointsArrayNative.delete() )
-        }
-      } finally {
-        releaseQuietly( () => polygonalFaceVector.delete() )
-      }
-    } finally {
-
-      releaseQuietly( () => {
-        this.wasmModule._free(indicesArrayPtr)
-        this.wasmModule._free(startIndicesArrayPtr)
-        this.wasmModule._free(polygonalFaceBufferOffsetsArrayPtr)
-        this.wasmModule._free(startIndicesBufferOffsetsArrayPtr)
-      } )
-    }
+              return withRelease(
+                () => this.conwayModel.getPolygonalFaceSetGeometry( {
+                  indicesPerFace: indicesPerFace,
+                  points: pointsArrayNative,
+                  faces: polygonalFaceVector,
+                } ),
+                () => pointsArrayNative.delete() )
+            },
+            () => polygonalFaceVector.delete() )
+      },
+      // freeAll, not four statements in one closure: there the first failure
+      // would abandon the other three.
+      () => freeAll( this.wasmModule, [
+        indicesArrayPtr,
+        startIndicesArrayPtr,
+        polygonalFaceBufferOffsetsArrayPtr,
+        startIndicesBufferOffsetsArrayPtr,
+      ] ) )
 
     const canonicalMesh: CanonicalMesh = {
       type: CanonicalMeshType.BUFFER_GEOMETRY,

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -198,6 +198,7 @@ import { IfcMaterialCache } from './ifc_material_cache'
 import { IfcSceneBuilder, IfcSceneTransform } from './ifc_scene_builder'
 import IfcStepModel from './ifc_step_model'
 import Logger from '../logging/logger'
+import { arrayToWasmHeap } from '../core/wasm_heap'
 // import fs from 'fs'
 import Environment, { EnvironmentType } from '../utilities/environment'
 import { REFLECTANCE_METHOD_PERMISSIVE,
@@ -1240,19 +1241,7 @@ export class IfcGeometryExtraction {
    * @return {number} Pointer/memory address
    */
   arrayToWasmHeap(array:Float32Array | Float64Array | Uint32Array): any {
-    // Allocate memory for the array within the Wasm module
-    const bytesPerElement = array.BYTES_PER_ELEMENT
-    const numBytes = array.length * bytesPerElement
-    const arrayPtr = this.wasmModule._malloc(numBytes)
-
-    // Create a new Uint8Array view on the Wasm memory buffer, then set the array to it
-    const arrayWasm = new Uint8Array(this.wasmModule.HEAPU8.buffer, arrayPtr, numBytes)
-    // Honour the view's own window: subarray() results share their parent's
-    // backing buffer, so copying `array.buffer` wholesale would read the
-    // wrong bytes (and the wrong length) for a view.
-    arrayWasm.set(new Uint8Array(array.buffer, array.byteOffset, numBytes))
-
-    return arrayPtr
+    return arrayToWasmHeap(this.wasmModule, array)
   }
 
   /**

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -198,7 +198,7 @@ import { IfcMaterialCache } from './ifc_material_cache'
 import { IfcSceneBuilder, IfcSceneTransform } from './ifc_scene_builder'
 import IfcStepModel from './ifc_step_model'
 import Logger from '../logging/logger'
-import { arrayToWasmHeap, arraysToWasmHeap } from '../core/wasm_heap'
+import { arrayToWasmHeap, arraysToWasmHeap, releaseQuietly } from '../core/wasm_heap'
 // import fs from 'fs'
 import Environment, { EnvironmentType } from '../utilities/environment'
 import { REFLECTANCE_METHOD_PERMISSIVE,
@@ -1018,9 +1018,16 @@ export class IfcGeometryExtraction {
     // errors are caught upstream and are expected on malformed models, so
     // anything in here throwing - buildIndexedPolygonalFaceVector,
     // extractParseBuffer, parseVertexVector, or the embind call - used to
-    // strand all four pointers plus the two native objects, once per faceset.
-    // On a model with 15,777 facesets that is a leak large enough to cause the
-    // exhaustion it would then be blamed on.
+    // strand all four pointers plus the pooled parse buffer and the two native
+    // objects, once per faceset. On a model with 15,777 facesets that is a leak
+    // large enough to cause the exhaustion it would then be blamed on.
+    //
+    // Every release goes through releaseQuietly, because these run while an
+    // exception may already be in flight and all of them re-enter the wasm
+    // runtime. If that runtime is the thing that failed, a release throwing
+    // would REPLACE the original error, and the per-record catch upstream would
+    // log a generic embind failure in place of the heap diagnostic this whole
+    // change exists to produce.
     let geometry: GeometryObject
 
     try {
@@ -1037,21 +1044,28 @@ export class IfcGeometryExtraction {
       try {
 
         const pointsParseBuffer = this.conwayModel.nativeParseBuffer()
+        let pointsArrayNative
 
-        if ( !entity.Coordinates.extractParseBuffer(
-            0,
-            0,
-            0,
-            pointsParseBuffer,
-            this.wasmModule,
-            true ) ) {
+        // Released here rather than after parseVertexVector, so a throw inside
+        // extractParseBuffer or parseVertexVector still returns it to the pool.
+        // It is pooled, so leaking it also loses whatever resize() grew for it.
+        try {
 
-          pointsParseBuffer.resize( 0 )
+          if ( !entity.Coordinates.extractParseBuffer(
+              0,
+              0,
+              0,
+              pointsParseBuffer,
+              this.wasmModule,
+              true ) ) {
+
+            pointsParseBuffer.resize( 0 )
+          }
+
+          pointsArrayNative = this.wasmModule.parseVertexVector( pointsParseBuffer )
+        } finally {
+          releaseQuietly( () => this.conwayModel.freeParseBuffer( pointsParseBuffer ) )
         }
-
-        const pointsArrayNative = this.wasmModule.parseVertexVector( pointsParseBuffer )
-
-        this.conwayModel.freeParseBuffer( pointsParseBuffer )
 
         try {
 
@@ -1063,17 +1077,19 @@ export class IfcGeometryExtraction {
 
           geometry = this.conwayModel.getPolygonalFaceSetGeometry(parameters)
         } finally {
-          pointsArrayNative.delete()
+          releaseQuietly( () => pointsArrayNative.delete() )
         }
       } finally {
-        polygonalFaceVector.delete()
+        releaseQuietly( () => polygonalFaceVector.delete() )
       }
     } finally {
 
-      this.wasmModule._free(indicesArrayPtr)
-      this.wasmModule._free(startIndicesArrayPtr)
-      this.wasmModule._free(polygonalFaceBufferOffsetsArrayPtr)
-      this.wasmModule._free(startIndicesBufferOffsetsArrayPtr)
+      releaseQuietly( () => {
+        this.wasmModule._free(indicesArrayPtr)
+        this.wasmModule._free(startIndicesArrayPtr)
+        this.wasmModule._free(polygonalFaceBufferOffsetsArrayPtr)
+        this.wasmModule._free(startIndicesBufferOffsetsArrayPtr)
+      } )
     }
 
     const canonicalMesh: CanonicalMesh = {

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -1,7 +1,6 @@
 import {
   ConwayGeometry,
   ParamsGetSweptDiskSolid,
-  ParamsPolygonalFaceSet,
   GeometryObject,
   ParamsAxis2Placement3D,
   ParamsCartesianTransformationOperator3D,

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -198,7 +198,7 @@ import { IfcMaterialCache } from './ifc_material_cache'
 import { IfcSceneBuilder, IfcSceneTransform } from './ifc_scene_builder'
 import IfcStepModel from './ifc_step_model'
 import Logger from '../logging/logger'
-import { arrayToWasmHeap } from '../core/wasm_heap'
+import { arrayToWasmHeap, arraysToWasmHeap } from '../core/wasm_heap'
 // import fs from 'fs'
 import Environment, { EnvironmentType } from '../utilities/environment'
 import { REFLECTANCE_METHOD_PERMISSIVE,
@@ -995,13 +995,25 @@ export class IfcGeometryExtraction {
 
     // Views over exactly the appended elements — no intermediate copy.
     const indicesArray = allIndices.view
-    const indicesArrayPtr = this.arrayToWasmHeap(indicesArray)
     const startIndicesArray = allStartIndices.view
-    const startIndicesArrayPtr = this.arrayToWasmHeap(startIndicesArray)
     const polygonalFaceBufferOffsetsArray = polygonalFaceBufferOffsets.view
-    const polygonalFaceBufferOffsetsArrayPtr = this.arrayToWasmHeap(polygonalFaceBufferOffsetsArray)
     const startIndicesBufferOffsetsArray = startIndicesBufferOffsets.view
-    const startIndicesBufferOffsetsArrayPtr = this.arrayToWasmHeap(startIndicesBufferOffsetsArray)
+
+    // All four together, because they are only freed together at the end of
+    // this function: taken one at a time, a failed allocation part-way would
+    // strand the ones already taken, and the per-record catch upstream would
+    // carry on to the next faceset and do it again.
+    const [
+      indicesArrayPtr,
+      startIndicesArrayPtr,
+      polygonalFaceBufferOffsetsArrayPtr,
+      startIndicesBufferOffsetsArrayPtr,
+    ] = arraysToWasmHeap( this.wasmModule, [
+      indicesArray,
+      startIndicesArray,
+      polygonalFaceBufferOffsetsArray,
+      startIndicesBufferOffsetsArray,
+    ] )
 
     const polygonalFaceVector = this.wasmModule.buildIndexedPolygonalFaceVector(
         indicesArrayPtr,

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -999,10 +999,9 @@ export class IfcGeometryExtraction {
     const polygonalFaceBufferOffsetsArray = polygonalFaceBufferOffsets.view
     const startIndicesBufferOffsetsArray = startIndicesBufferOffsets.view
 
-    // All four together, because they are only freed together at the end of
-    // this function: taken one at a time, a failed allocation part-way would
-    // strand the ones already taken, and the per-record catch upstream would
-    // carry on to the next faceset and do it again.
+    // All four together, so a failed allocation part-way through cannot strand
+    // the ones already taken. Everything after this point is inside the
+    // try/finally below, which is what actually guarantees they come back.
     const [
       indicesArrayPtr,
       startIndicesArrayPtr,
@@ -1015,50 +1014,67 @@ export class IfcGeometryExtraction {
       startIndicesBufferOffsetsArray,
     ] )
 
-    const polygonalFaceVector = this.wasmModule.buildIndexedPolygonalFaceVector(
-        indicesArrayPtr,
-        indicesArray.length,
-        startIndicesArrayPtr,
-        polygonalFaceBufferOffsetsArrayPtr,
-        polygonalFaceBufferOffsetsArray.length,
-        startIndicesBufferOffsetsArrayPtr,
-        startIndicesBufferOffsetsArray.length)
+    // finally, not a straight-line free at the end. Per-record extraction
+    // errors are caught upstream and are expected on malformed models, so
+    // anything in here throwing - buildIndexedPolygonalFaceVector,
+    // extractParseBuffer, parseVertexVector, or the embind call - used to
+    // strand all four pointers plus the two native objects, once per faceset.
+    // On a model with 15,777 facesets that is a leak large enough to cause the
+    // exhaustion it would then be blamed on.
+    let geometry: GeometryObject
 
+    try {
 
-    const pointsParseBuffer = this.conwayModel.nativeParseBuffer()
+      const polygonalFaceVector = this.wasmModule.buildIndexedPolygonalFaceVector(
+          indicesArrayPtr,
+          indicesArray.length,
+          startIndicesArrayPtr,
+          polygonalFaceBufferOffsetsArrayPtr,
+          polygonalFaceBufferOffsetsArray.length,
+          startIndicesBufferOffsetsArrayPtr,
+          startIndicesBufferOffsetsArray.length)
 
-    if ( !entity.Coordinates.extractParseBuffer(
-        0,
-        0,
-        0,
-        pointsParseBuffer,
-        this.wasmModule,
-        true ) ) {
+      try {
 
-      pointsParseBuffer.resize( 0 )
+        const pointsParseBuffer = this.conwayModel.nativeParseBuffer()
+
+        if ( !entity.Coordinates.extractParseBuffer(
+            0,
+            0,
+            0,
+            pointsParseBuffer,
+            this.wasmModule,
+            true ) ) {
+
+          pointsParseBuffer.resize( 0 )
+        }
+
+        const pointsArrayNative = this.wasmModule.parseVertexVector( pointsParseBuffer )
+
+        this.conwayModel.freeParseBuffer( pointsParseBuffer )
+
+        try {
+
+          const parameters: ParamsPolygonalFaceSet = {
+            indicesPerFace: indicesPerFace,
+            points: pointsArrayNative,
+            faces: polygonalFaceVector,
+          }
+
+          geometry = this.conwayModel.getPolygonalFaceSetGeometry(parameters)
+        } finally {
+          pointsArrayNative.delete()
+        }
+      } finally {
+        polygonalFaceVector.delete()
+      }
+    } finally {
+
+      this.wasmModule._free(indicesArrayPtr)
+      this.wasmModule._free(startIndicesArrayPtr)
+      this.wasmModule._free(polygonalFaceBufferOffsetsArrayPtr)
+      this.wasmModule._free(startIndicesBufferOffsetsArrayPtr)
     }
-
-    const pointsArrayNative = this.wasmModule.parseVertexVector( pointsParseBuffer )
-
-    this.conwayModel.freeParseBuffer( pointsParseBuffer )
-
-    const parameters: ParamsPolygonalFaceSet = {
-      indicesPerFace: indicesPerFace,
-      points: pointsArrayNative,
-      faces: polygonalFaceVector,
-    }
-
-    const geometry: GeometryObject = this.conwayModel.getPolygonalFaceSetGeometry(parameters)
-
-    // free allocated wasm vectors
-    pointsArrayNative.delete()
-
-    this.wasmModule._free(indicesArrayPtr)
-    this.wasmModule._free(startIndicesArrayPtr)
-    this.wasmModule._free(polygonalFaceBufferOffsetsArrayPtr)
-    this.wasmModule._free(startIndicesBufferOffsetsArrayPtr)
-
-    polygonalFaceVector.delete()
 
     const canonicalMesh: CanonicalMesh = {
       type: CanonicalMeshType.BUFFER_GEOMETRY,


### PR DESCRIPTION
**This does not fix #485.** It makes the next occurrence diagnosable, and fixes several real leaks and one silent-corruption path found in the same function on the way. Being explicit up front, because a PR referencing a flaky-bug issue invites the assumption that the flake is dealt with.

## Why the diagnostic is the deliverable

#485 surfaces as `Invalid typed array length: 80` and nothing else. That is V8's message, it is true, and it is unactionable — it took **two sightings, on two different models, across two builds** to even establish which call it came from. The bug's whole cost is that it silently corrupts a regression baseline, so the first thing worth shipping is the ability to tell what happened when it next fires.

The replacement carries pointer, size, heap view length, buffer `byteLength`, whether the buffer is shared, and whether it is extensible.

That list is chosen, not generic. conway's MT build creates its memory with `shared: true`, so the heap is a **growable SharedArrayBuffer**, and emscripten's `updateMemoryViews()` begins with `if (HEAP8?.buffer?.growable) return` — it early-returns on *every* growth, because the views are length-tracking and extend by themselves. Single-threaded builds get a **resizable ArrayBuffer** and the other spelling. Under either arrangement a stale view should be impossible, which is precisely why the failure needs to report which part of that is not holding.

## Real defects fixed alongside

The two extractors had a copy each of `arrayToWasmHeap` and the copies had drifted. They are now one helper, and the surrounding ownership is fixed:

- **`_malloc`'s return was never checked.** `0` is a valid `byteOffset`, so on exhaustion the view was built happily and the copy wrote over whatever lives at address 0 — heap corruption instead of a reported failure.
- **The AP214 copy passed `array.buffer` wholesale**, so for any `subarray` it read the parent's first bytes, and the wrong number of them. The IFC copy already honoured the window.
- **`finishPolygonalFaceSet_` leaked on every throwing path.** Four pointers, a pooled parse buffer, and two native objects were released only by straight-line code at the end. Per-record errors are caught upstream and expected on malformed models, and PSB has **15,777 facesets** — a leak large enough to *cause* the exhaustion it would then be blamed on.
- **Releases could destroy the error they were added to preserve.** They all re-enter the wasm runtime while unwinding from a failure that may *be* that runtime. `withRelease` propagates a release failure on the success path and suppresses it only during unwinding; `freeAll` releases each pointer independently and re-throws the first failure once all are attempted.

## Evidence

| | |
|---|---|
| full-corpus runs with this in place | 6 |
| times the flake fired | **0** |
| public digests identical to a pre-change run | **95 / 95**, re-verified after every round |
| unit tests | 16, none needing the geometry wasm or a corpus |
| full gate | 419 tests, eslint 0 errors |

The refactor is neutral, and the flake did not reproduce — the two known occurrences came from the ~5 runs before this.

## Review

Five `/review` rounds, fifteen findings, all real. Six of them were cases where a fix from the *previous* round was itself defective in the branch that mattered — quiet-release applied where it inverted the intent, frees batched where independence was the whole point, a leak in the exact branch the leak fix was for, and a guard that would have rejected every allocation above 2 GB. Resource-teardown code invites that, which is the argument for the tests now pinning each property rather than trusting the shape of the code.

**#485 stays open.**