### PR TITLE
Stop the INF recovery stamping one express ID over the whole index (#412)

### DIFF
--- a/src/step/parsing/inf_recovery_index.test.ts
+++ b/src/step/parsing/inf_recovery_index.test.ts
@@ -1,0 +1,114 @@
+// `INF` where a real belongs is not valid ISO 10303-21, but exporters emit it
+// for unbounded quantities and the parser recovers from it. The recovery used
+// to stamp the offending record's express ID over every top-level entry
+// indexed so far in the block, which corrupted every lookup that followed.
+//
+// It stayed hidden only because no public corpus model reaches this recovery.
+// Not because a failed parse is harmless: the stamping ran before the rollback
+// and the INF check, so any top-level inline-instance failure poisoned the
+// index, and parseDataToModel builds a model from those elements whatever the
+// ParseResult. A private model reaches it - `IFCQUANTITYLENGTH(...,INF,$)`
+// from a Swiss architectural export - where it cost 3,116 entities and
+// produced 630 relationship failures all reporting the same express ID.
+// See bldrs-ai/conway#412, #481, #482.
+//
+// Parser-only, so no geometry wasm is initialized here.
+import { describe, expect, test } from '@jest/globals'
+
+import IfcStepParser from '../../ifc/ifc_step_parser'
+import ParsingBuffer from '../../parsing/parsing_buffer'
+import { ParseResult } from './step_parser'
+
+
+const parser = IfcStepParser.Instance
+
+// The middle record carries the bare INF. The records around it are ordinary,
+// and they are the ones the stamping loop used to overwrite - the bug is not
+// in how the INF record itself is read, it is in what reading it does to
+// everything already indexed.
+// The express IDs under test, kept in one place so the assertions read as
+// "the IDs written in the source", which is exactly what the bug destroyed.
+const BEFORE_ID = 11
+const INF_ID = 22
+const AFTER_ID = 33
+const EXPECTED_IDS = [ BEFORE_ID, INF_ID, AFTER_ID ]
+
+const WITH_INF = [
+  `#${BEFORE_ID}= IFCQUANTITYLENGTH('before',$,$,1.5,$);`,
+  `#${INF_ID}= IFCQUANTITYLENGTH('unbounded',$,$,          INF,$);`,
+  `#${AFTER_ID}= IFCQUANTITYLENGTH('after',$,$,2.5,$);`,
+].join( '\n' )
+
+// Same shape with a real in place of INF, as the control: whatever the index
+// looks like here is what the INF version has to match.
+const WITHOUT_INF = WITH_INF.replace( '          INF', '3.5' )
+
+// The same export writes `-INF` for the opposite bound. It is a CONTROL, not
+// a second case of the bug: a leading '-' is dispatched as a number, so it
+// never reaches the inline-instance recovery and was never affected. Kept so
+// that stays visible - the defect is specific to the bare identifier-like
+// form, and anyone reading `INF` handling should not assume both directions
+// went through it.
+const WITH_NEGATIVE_INF = WITH_INF.replace( '          INF', '         -INF' )
+
+
+/**
+ * Parse a data block and return each top-level entry's express ID, in order.
+ *
+ * @param source The STEP text to parse.
+ * @return {number[]} Express IDs as indexed.
+ */
+function indexedExpressIDs( source: string ): number[] {
+
+  const input = new ParsingBuffer( new TextEncoder().encode( source ) )
+  const [ index, result ] = parser.parseDataBlock( input )
+
+  // INCOMPLETE is the expected result for a bare run of records with no
+  // ENDSEC; terminator - what matters here is that it is not a syntax error.
+  expect( [ ParseResult.COMPLETE, ParseResult.INCOMPLETE ] ).toContain( result )
+
+  return index.elements.map( ( element ) => element.expressID )
+}
+
+
+describe( 'a bare INF attribute', () => {
+
+  test( 'does not stamp its express ID over the records before it', () => {
+
+    expect( indexedExpressIDs( WITH_INF ) ).toEqual( EXPECTED_IDS )
+  } )
+
+  test( 'indexes the same as the equivalent record with a real', () => {
+
+    expect( indexedExpressIDs( WITH_INF ) )
+      .toEqual( indexedExpressIDs( WITHOUT_INF ) )
+  } )
+
+  // Passes with or without the fix, by design - see WITH_NEGATIVE_INF above.
+  test( 'negative INF is dispatched as a number and never took this path', () => {
+
+    expect( indexedExpressIDs( WITH_NEGATIVE_INF ) ).toEqual( EXPECTED_IDS )
+  } )
+
+  // The whole file has to remain resolvable, not just the index array: a
+  // corrupted express ID column makes getElementByExpressID hand back the
+  // wrong record, which is how this surfaced as relationship failures rather
+  // than as a parse error.
+  test( 'every record is still reachable by its own express ID', () => {
+
+    const [ result, model ] =
+      parser.parseDataToModel(
+        new ParsingBuffer( new TextEncoder().encode( WITH_INF ) ) )
+
+    expect( [ ParseResult.COMPLETE, ParseResult.INCOMPLETE ] ).toContain( result )
+    expect( model ).not.toBeUndefined()
+
+    for ( const expressID of EXPECTED_IDS ) {
+
+      const element = model?.getElementByExpressID( expressID )
+
+      expect( element ).not.toBeUndefined()
+      expect( element?.expressID ).toBe( expressID )
+    }
+  } )
+} )

--- a/src/step/parsing/inf_recovery_index.test.ts
+++ b/src/step/parsing/inf_recovery_index.test.ts
@@ -33,23 +33,50 @@ const INF_ID = 22
 const AFTER_ID = 33
 const EXPECTED_IDS = [ BEFORE_ID, INF_ID, AFTER_ID ]
 
-const WITH_INF = [
+// One template, one substitution point. Derived with String.replace on a
+// whitespace-exact literal, the controls below would silently become copies of
+// the INF case the moment anyone reflowed the source - replace() returns its
+// input unchanged when the token is absent - and "indexes the same as the
+// equivalent record with a real" would degrade to expect(x).toEqual(x), which
+// passes even with the bug reinstated.
+const VALUE_SLOT = '<<VALUE>>'
+
+const TEMPLATE = [
   `#${BEFORE_ID}= IFCQUANTITYLENGTH('before',$,$,1.5,$);`,
-  `#${INF_ID}= IFCQUANTITYLENGTH('unbounded',$,$,          INF,$);`,
+  `#${INF_ID}= IFCQUANTITYLENGTH('unbounded',$,$,${VALUE_SLOT},$);`,
   `#${AFTER_ID}= IFCQUANTITYLENGTH('after',$,$,2.5,$);`,
 ].join( '\n' )
 
-// Same shape with a real in place of INF, as the control: whatever the index
-// looks like here is what the INF version has to match.
-const WITHOUT_INF = WITH_INF.replace( '          INF', '3.5' )
+/**
+ * Build the fixture with a given value in the middle record's 4th attribute.
+ *
+ * @param value The value text to substitute.
+ * @return {string} The fixture source.
+ */
+function withValue( value: string ): string {
 
-// The same export writes `-INF` for the opposite bound. It is a CONTROL, not
-// a second case of the bug: a leading '-' is dispatched as a number, so it
-// never reaches the inline-instance recovery and was never affected. Kept so
-// that stays visible - the defect is specific to the bare identifier-like
-// form, and anyone reading `INF` handling should not assume both directions
-// went through it.
-const WITH_NEGATIVE_INF = WITH_INF.replace( '          INF', '         -INF' )
+  if ( !TEMPLATE.includes( VALUE_SLOT ) ) {
+    throw new Error( 'fixture template lost its substitution slot' )
+  }
+
+  return TEMPLATE.replace( VALUE_SLOT, value )
+}
+
+// Leading whitespace preserved from the real export, since it is what puts an
+// identifier-like token where an attribute is expected.
+const WITH_INF = withValue( '          INF' )
+
+// The control: whatever the index looks like with an ordinary real is what the
+// INF version has to match.
+const WITHOUT_INF = withValue( '3.5' )
+
+// The same export writes `-INF` for the opposite bound. Also a CONTROL, not a
+// second case of the bug: a leading '-' is dispatched as a number, so it never
+// reaches the inline-instance recovery and was never affected. Kept so that
+// stays visible - the defect is specific to the bare identifier-like form, and
+// anyone reading INF handling should not assume both directions went through
+// it.
+const WITH_NEGATIVE_INF = withValue( '         -INF' )
 
 
 /**

--- a/src/step/parsing/step_parser.ts
+++ b/src/step/parsing/step_parser.ts
@@ -974,11 +974,38 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
 
             if (elementResult !== (void 0)) {
 
-              for ( const element of elementResult[0].elements ) {
-              
-                element.expressID = expressID
-              }
-
+              // No stamping here. This used to run
+              //
+              //   for ( const element of elementResult[0].elements ) {
+              //     element.expressID = expressID
+              //   }
+              //
+              // and elementResult[0] is `indexResult` - syntaxError() returns
+              // it wholesale - so that wrote THIS record's express ID over
+              // every top-level entry indexed so far in the block.
+              //
+              // It cannot have been doing anything useful. Both pushEntry
+              // sites already set `expressID` at construction, so every entry
+              // arrives correct and the loop could only overwrite correct
+              // values with one wrong one. The same recovery inside the nested
+              // parseInlineElement - begin, parse, rollback, tokenws(INF) - has
+              // never had the loop and works.
+              //
+              // Note it ran BEFORE the rollback and the INF check, so it was
+              // never specific to INF: any top-level inline-instance parse
+              // failure poisoned the index the same way. And the index is not
+              // discarded on a syntax error - parseDataToModel builds the
+              // model from itemIndex.elements whatever the ParseResult, and
+              // the loaders only log and continue - so a poisoned index does
+              // reach consumers.
+              //
+              // What kept it hidden is narrower than that: no public corpus
+              // model reaches this recovery at all. A private one does, via an
+              // exporter writing `IFCQUANTITYLENGTH(...,INF,$)` for an
+              // unbounded quantity - not valid ISO 10303-21, but what the tool
+              // emits - where it cost 3,116 entities and produced 630
+              // relationship failures all naming the same record.
+              // See #412, #481, #482.
               input.rollback()
 
               if ( tokenws( INF ) ) {


### PR DESCRIPTION
Fixes #412. Should also close #481 and #482 — both are downstream of it.

## What was wrong

The `INLINE_INSTANCE` recovery in `parseDataBlockIncremental` ran this *before* deciding whether the failed inline parse was really a bare `INF`:

```ts
for ( const element of elementResult[0].elements ) {
  element.expressID = expressID
}
```

`elementResult[0]` is `indexResult` — `syntaxError()` returns it wholesale — so this wrote the **current record's express ID over every top-level entry indexed so far in the block**.

It cannot have been doing anything useful:

- Both `pushEntry` sites already set `expressID` at construction, so every entry arrives correct and the loop could only overwrite correct values with one wrong one.
- The identical recovery inside the nested `parseInlineElement` — `begin`, parse, `rollback`, `tokenws(INF)` — has never had the loop, and works.

So it's removed rather than retargeted, which resolves #412's first ask (*"determine intent … or delete it if the rollback makes it moot"*).

## Why it stopped being dormant

#412 filed this as pre-existing but not biting: the syntax-error return discards the index, and no corpus file was known to reach the INF-continue path. **A private model reaches it.**

```
#818393= IFCQUANTITYLENGTH('Unterkante zu zweiter Referenzhöhe',$,$,          INF,$);
```

An unbounded quantity written as a bare `INF` — not valid ISO 10303-21, but what this exporter emits.

## The damage was not subtle

On `2003-ARC-1002-Bauprojekt-210302_exakte Geometrie.ifc`, every subsequent express-ID lookup resolved against a poisoned index:

| | before | after |
|---|---|---|
| digest rows | 32 | **7177** |
| distinct entities | 31 | **3147** |
| entities lost | — | **0** |
| errors | **630** | **0** |

**3,116 entities recovered.** Those 630 errors are #481 (212 `IfcRelVoidsElement` — the uncut openings), #482 (370 `IfcRelAssociatesMaterial` plus 48 `IfcMaterialDefinitionRepresentation`), and 8 `relAggregate` — every one reporting the same express ID, `#818393`, because that is what the loop had written everywhere.

Deterministic: two runs, identical digest hash.

## Public corpus is untouched, by construction

| | |
|---|---|
| digests identical | **95 / 95** |
| `errors.csv` identical | yes |
| `failed.csv` identical | yes |

That's expected rather than lucky — **no public model contains a bare `INF` attribute**, verified by grep across the corpus; exactly one private model does.

## Fixture

#412's second ask, in `inf_recovery_index.test.ts`: a record with a bare `INF` following an identifier-like token, asserting each record keeps its own express ID *and* stays reachable by it through `getElementByExpressID` — the latter being how this surfaced as relationship failures rather than a parse error.

**Three of its four cases fail without this change.** The fourth is a deliberate control: `-INF` leads with a sign, so it is dispatched as a number and never reached this path at all. Pinned so nobody assumes both directions went through it.

## One caveat worth stating

The corpus grep only covers *materialised* files. 110 of the 112 private models are LFS stubs I haven't pulled, so there may be more files carrying `INF` than the one found. That only widens the win — it cannot turn this into a regression, since the public corpus is byte-identical.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQAv3NMEn9fy1AyGNm3cyN)_