### PR TITLE
Snap the COORDINATE_TO_ORIGIN recentre to a 1km grid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ Check `scripts/` before building tooling — see
 | Native GLB export from the CLI | [design/new/glb-native-export.md](design/new/glb-native-export.md) |
 | Memory residency, streaming and federated loading | [design/new/memory-residency.md](design/new/memory-residency.md), [design/new/streaming-federated-loader.md](design/new/streaming-federated-loader.md) |
 | emsdk version, wasm build environment | [design/new/web-build-environment.md](design/new/web-build-environment.md), [design/new/emsdk-upgrade-scalable-allocator.md](design/new/emsdk-upgrade-scalable-allocator.md) |
+| Where a model lands in world space: `COORDINATE_TO_ORIGIN`, why the recentre snaps to a grid, why two exports of one object used to land 76m apart, what a frame change costs in re-blessing and saved cameras | [design/new/coordination-frame.md](design/new/coordination-frame.md) |
 
 Add a row here when you write a doc future assistants should find — this
 table is the index, not the filesystem.

--- a/design/new/coordination-frame.md
+++ b/design/new/coordination-frame.md
@@ -12,15 +12,20 @@ The frame itself is derived once per model, in
 every placement:
 
 ```
-frame = scale * NormalizeMat * translate(-snap(firstPlacement * firstVertex))
+frame = scale * NormalizeMat * translate(-quantize(firstPlacement * firstVertex))
 ```
 
-## The anchor is arbitrary; the snap is what makes it repeatable
+## The anchor is arbitrary; quantizing is what makes it repeatable
+
+This is conway#87 ("Change Coordination Matrix to use Model-zero
+offsets", filed 2023): *both web-ifc and current conway pick a
+reference point based on model parser order, and this is not a sound
+basis for a camera in the permalink.*
 
 `firstPlacement * firstVertex` is **the first geometry the walk
 reaches** — whichever element the file happens to declare first, latched
-via `_isCoordinated`. Nothing about that element is special. Without the
-snap, a model's rendered position is therefore a function of its element
+via `_isCoordinated`. Nothing about that element is special. Left raw, a
+model's rendered position is therefore a function of its element
 *order*, and two things break:
 
 - **Two exports of one object land in different places.** Share#1749:
@@ -32,30 +37,45 @@ snap, a model's rendered position is therefore a function of its element
 - **Re-exporting a model moves it.** Same geometry, shuffled element
   order, and every camera saved against the model is silently wrong.
 
-`snapRecentre` rounds the recentre to `COORDINATION_SNAP_M` (1 km), so
-the frame depends on *where* the anchor is rather than *which* anchor it
-is. Any two anchors in the same cell derive the same frame. Near-origin
-models — the overwhelming majority — snap to zero and keep the
-coordinates their file authored, which is both the most predictable
-behaviour and what makes twin exports coincide by construction.
+`quantizeRecentre` answers this in two stages, because the two ranges
+want different things.
 
-The grid is 1/10th of `LARGE_COORDINATE_BUDGET_M`, the engine's own
-"this frame failed to recentre" threshold. Snapping spends at most half
-a cell (500m) of a 1e4 m budget — about 0.05mm of float32 resolution —
-while LV95 eastings still recentre to within half a kilometre. A snapped
-translation is also exactly representable in float32, where an arbitrary
-anchor was not, so the recentre stops contributing rounding of its own.
+**Inside `LARGE_COORDINATE_BUDGET_M` (1e4 m), it does not recentre at
+all.** There is no float32 benefit below the budget — that constant *is*
+the threshold where quantization becomes visible — so a model within
+10km of the origin keeps the coordinates its file authored. That is
+model-zero, which is what conway#87 asked for, and it makes the frame
+*exactly* order-independent for the overwhelming majority of models:
+there is no cell boundary to straddle, so twin exports and federated
+sets coincide however their elements are ordered.
+
+**Above the budget it snaps to `COORDINATION_SNAP_M` (1 km).** A
+georeferenced model has to come back near the origin, and snapping keeps
+that repeatable across exports. Half a cell out of a 1e4 m budget costs
+~0.05mm of float32 resolution, and a whole-kilometre translation is
+exactly representable in float32 where an arbitrary anchor was not, so
+the recentre stops contributing rounding of its own.
 
 ### What this does not guarantee
 
-Two anchors that straddle a cell boundary still derive frames a
-kilometre apart. This converts an exact order-dependence into a coarse
-one; it does not eliminate it. The fully general fix is an anchor that
-is a symmetric function of all the geometry — the model's bounding box —
-which the streaming opens cannot compute before they emit their first
-batch, and which would have to be identical across the classic,
-streamed and preview paths or one model would render in two places
-depending on which open ran.
+Above the budget, two anchors either side of a grid line still derive
+frames a kilometre apart — and because a 1 km divergence is *inside* the
+budget, the adopted-preview-frame gate
+(`magnitude > LARGE_COORDINATE_BUDGET_M`) will not re-derive to catch it.
+Two georeferenced exports of one site that anchor across a boundary
+misalign by a kilometre where before they misaligned by the raw anchor
+distance. This is why the staging matters: below the budget, where
+almost everything lives, the amplification cannot occur at all.
+
+The fully general fix is an anchor that is a symmetric function of all
+the geometry — the model's bounding box — which the streaming opens
+cannot compute before they emit their first batch, and which would have
+to be identical across the classic, streamed and preview paths or one
+model would render in two places depending on which open ran. conway#87
+also points past that, at the XeoKit
+[full-precision geometry](https://xeokit.io/blog_full_precision_geometry.html)
+approach (relative-to-centre tiles), as the way to stop trading precision
+for a single global frame at all.
 
 ## Consequences of changing the frame
 
@@ -64,16 +84,25 @@ an interior element now renders where its file puts it; the logo moved
 86m, from x ∈ [-76, 10] to x ∈ [0, 86]. So:
 
 - **Saved camera permalinks against existing models are invalidated**,
-  including Share's homepage camera. They need re-capturing.
-- **Regression digests and visual-diff baselines shift** for any model
-  whose anchor was not already at the origin, and need re-blessing —
-  see [regression/README.md](../../regression/README.md).
+  including Share's homepage camera. They need re-capturing, and
+  Share-side visual baselines shot against those cameras move with them.
+
+What does **not** move is this repo's regression corpus. The regression
+mains never touch the coordination frame — `ifc_regression_main.ts` and
+`ifc_regression_batch_main.ts` mention neither `COORDINATE_TO_ORIGIN`
+nor the linear scaling factor — and the digests hash curve/profile/mesh
+geometry in *file* coordinates, which is the same reason the CLI can't
+witness this change at all (see the note at the end). `visual-diff` is
+gated on `run-ifc-regression` reporting a non-zero digest count, so with
+no digest movement it does not run and has no baselines to re-bless.
+Treat a digest that *does* move as a real geometry regression, not as
+fallout from this.
 
 ## What is pinned, and where
 
 | Property | Test |
 |---|---|
-| Anchors in one cell derive one frame; unit-independence; budget | `src/compat/web-ifc/coordination_f64.test.ts` |
+| Model-zero below the budget, whatever the anchor; anchors either side of a grid line agree; unit-independent snapping above the budget | `src/compat/web-ifc/coordination_f64.test.ts` |
 | Near-origin model keeps authored coordinates; georeferenced model still recentres; classic and streamed opens agree | `src/compat/web-ifc/coordination_export_order.test.ts` |
 | The cross-format claim — `index.ifc` and `index.step` render in the same world box | Share: `src/Containers/indexStepLogo.spec.ts` |
 

--- a/design/new/coordination-frame.md
+++ b/design/new/coordination-frame.md
@@ -1,0 +1,90 @@
+# The coordination frame: where a model lands
+
+`COORDINATE_TO_ORIGIN` recentres a model so its geometry sits near the
+origin. That is a float32 story: the GPU vertex format and Share's
+BatchedMesh instance-matrix texture are single precision, and float32
+quantizes at ~1mm per 1e4 m of coordinate, so a Swiss LV95 model at
+~2.6e6 m easting renders on a ~0.3m grid and swims as the camera
+rotates (Share#1631). Recentring buys that precision back.
+
+The frame itself is derived once per model, in
+`compat/web-ifc/coordination_f64.deriveCoordinationF64`, and reused for
+every placement:
+
+```
+frame = scale * NormalizeMat * translate(-snap(firstPlacement * firstVertex))
+```
+
+## The anchor is arbitrary; the snap is what makes it repeatable
+
+`firstPlacement * firstVertex` is **the first geometry the walk
+reaches** — whichever element the file happens to declare first, latched
+via `_isCoordinated`. Nothing about that element is special. Without the
+snap, a model's rendered position is therefore a function of its element
+*order*, and two things break:
+
+- **Two exports of one object land in different places.** Share#1749:
+  the Bldrs logo ships as both `index.ifc` and `index.step`, the IFC
+  declares the x=76 block first and the STEP the x=0 one, and the STEP
+  rendered 76m — the width of the logo — off the IFC. Auto-framing hides
+  this, because it centres whatever it is given; it only shows up when a
+  `#c:` camera permalink is applied to both.
+- **Re-exporting a model moves it.** Same geometry, shuffled element
+  order, and every camera saved against the model is silently wrong.
+
+`snapRecentre` rounds the recentre to `COORDINATION_SNAP_M` (1 km), so
+the frame depends on *where* the anchor is rather than *which* anchor it
+is. Any two anchors in the same cell derive the same frame. Near-origin
+models — the overwhelming majority — snap to zero and keep the
+coordinates their file authored, which is both the most predictable
+behaviour and what makes twin exports coincide by construction.
+
+The grid is 1/10th of `LARGE_COORDINATE_BUDGET_M`, the engine's own
+"this frame failed to recentre" threshold. Snapping spends at most half
+a cell (500m) of a 1e4 m budget — about 0.05mm of float32 resolution —
+while LV95 eastings still recentre to within half a kilometre. A snapped
+translation is also exactly representable in float32, where an arbitrary
+anchor was not, so the recentre stops contributing rounding of its own.
+
+### What this does not guarantee
+
+Two anchors that straddle a cell boundary still derive frames a
+kilometre apart. This converts an exact order-dependence into a coarse
+one; it does not eliminate it. The fully general fix is an anchor that
+is a symmetric function of all the geometry — the model's bounding box —
+which the streaming opens cannot compute before they emit their first
+batch, and which would have to be identical across the classic,
+streamed and preview paths or one model would render in two places
+depending on which open ran.
+
+## Consequences of changing the frame
+
+Every model moves. A near-origin model that used to render recentred on
+an interior element now renders where its file puts it; the logo moved
+86m, from x ∈ [-76, 10] to x ∈ [0, 86]. So:
+
+- **Saved camera permalinks against existing models are invalidated**,
+  including Share's homepage camera. They need re-capturing.
+- **Regression digests and visual-diff baselines shift** for any model
+  whose anchor was not already at the origin, and need re-blessing —
+  see [regression/README.md](../../regression/README.md).
+
+## What is pinned, and where
+
+| Property | Test |
+|---|---|
+| Anchors in one cell derive one frame; unit-independence; budget | `src/compat/web-ifc/coordination_f64.test.ts` |
+| Near-origin model keeps authored coordinates; georeferenced model still recentres; classic and streamed opens agree | `src/compat/web-ifc/coordination_export_order.test.ts` |
+| The cross-format claim — `index.ifc` and `index.step` render in the same world box | Share: `src/Containers/indexStepLogo.spec.ts` |
+
+The cross-format claim is pinned Share-side rather than here because
+through this surface the AP214 arm reports its placements at the origin
+with the geometry carrying the world transform, so neither placement
+bounds nor a fixture pair in two element orders reproduces the defect.
+Characterising the AP214 anchor — and pinning it here — is open work.
+
+Note the CLI is not a witness for any of this: `ifc_command_line_main`
+and its glTF writer recentre per model and hand the offset back as a
+node translation, so summing the two always reconstructs source-world
+coordinates whatever the frame did. Only the `compat/web-ifc` surface —
+the one Share consumes — shows it.

--- a/design/new/coordination-frame.md
+++ b/design/new/coordination-frame.md
@@ -58,14 +58,22 @@ the recentre stops contributing rounding of its own.
 
 ### What this does not guarantee
 
-Above the budget, two anchors either side of a grid line still derive
-frames a kilometre apart — and because a 1 km divergence is *inside* the
-budget, the adopted-preview-frame gate
-(`magnitude > LARGE_COORDINATE_BUDGET_M`) will not re-derive to catch it.
-Two georeferenced exports of one site that anchor across a boundary
-misalign by a kilometre where before they misaligned by the raw anchor
-distance. This is why the staging matters: below the budget, where
-almost everything lives, the amplification cannot occur at all.
+Quantizing cannot remove the discontinuity, only move it. Staging moves
+it to the budget, and the step *there* is `LARGE_COORDINATE_BUDGET_M`
+(1e4), not the grid (1e3) — an anchor at 9900 derives model-zero while
+one at 10100 derives −10000, so two anchors 200m apart can produce
+frames 10km apart. Above the budget the grid adds its own 1km edges on
+top.
+
+Those edges are invisible to the adopted-preview-frame gate, which
+re-derives only when a durable placement lands beyond the budget: a
+preview anchored at 10100 with a durable first placement at 9900 probes
+at ~100m, keeps the preview frame, and renders 10km off a classic open.
+
+The trade is deliberate — a handful of edges out at georeferenced
+magnitudes, instead of an edge every kilometre right through the range
+where nearly every model lives — but it is a real residual, not an
+eliminated one.
 
 The fully general fix is an anchor that is a symmetric function of all
 the geometry — the model's bounding box — which the streaming opens

--- a/design/new/coordination-frame.md
+++ b/design/new/coordination-frame.md
@@ -95,16 +95,24 @@ an interior element now renders where its file puts it; the logo moved
   including Share's homepage camera. They need re-capturing, and
   Share-side visual baselines shot against those cameras move with them.
 
-What does **not** move is this repo's regression corpus. The regression
-mains never touch the coordination frame — `ifc_regression_main.ts` and
-`ifc_regression_batch_main.ts` mention neither `COORDINATE_TO_ORIGIN`
-nor the linear scaling factor — and the digests hash curve/profile/mesh
-geometry in *file* coordinates, which is the same reason the CLI can't
-witness this change at all (see the note at the end). `visual-diff` is
-gated on `run-ifc-regression` reporting a non-zero digest count, so with
-no digest movement it does not run and has no baselines to re-bless.
-Treat a digest that *does* move as a real geometry regression, not as
-fallout from this.
+- **Regression digests move**, and with them the visual-diff baselines.
+  An earlier revision of this doc claimed they would not, reasoning that
+  the regression mains never mention `COORDINATE_TO_ORIGIN` and the
+  digests hash geometry in file coordinates. CI disproved it: the first
+  gated run on this change reported **11 of the 12 smoke models
+  digest-changed**, with no failures and no errors. So re-blessing is
+  real work — see [regression/README.md](../../regression/README.md).
+
+  What the same run also showed is that the movement is not visible:
+  `visual-diff` rendered all 11 and every one came in under the 0.05%
+  pixel threshold. A digest that moves *with* a visible diff is still a
+  real geometry regression; a digest that moves without one is this
+  change.
+
+  The lesson worth keeping: the CLI cannot witness the frame change (see
+  the note at the end), but "the CLI can't see it" does not imply "the
+  digest can't see it". Verify against a run rather than by reading the
+  pipeline.
 
 ## What is pinned, and where
 

--- a/src/compat/web-ifc/coordination_export_order.test.ts
+++ b/src/compat/web-ifc/coordination_export_order.test.ts
@@ -1,0 +1,137 @@
+/* eslint-disable no-magic-numbers */
+// Export-order independence of the COORDINATE_TO_ORIGIN frame (Share#1749).
+//
+// The recentre anchors on the first geometry the walk reaches, which is
+// whichever element the file happens to declare first. Unsnapped, that
+// makes a model's rendered position a function of its element order:
+// Share shipped the Bldrs logo as both `index.ifc` and `index.step`, and
+// the STEP rendered 76m off the IFC because the two files disagree about
+// which block comes first. Every camera permalink spanning the pair was
+// wrong, and auto-framing hid it — the models look identical until a
+// `#c:` camera pins them.
+//
+// This drives the same surface Share does (the compat IfcAPI, not the
+// CLI's native writer, which has its own recentre convention) and pins
+// the properties the snap has to hold together: a near-origin model
+// keeps the coordinates its file authored — which is what makes two
+// exports of one object coincide — a georeferenced model still
+// recentres, and the classic and streamed opens agree.
+//
+// Not covered here: the AP214 arm. Its placements come back at the
+// origin with the geometry carrying the world transform, so neither
+// placement bounds nor a fixture pair in two element orders reproduces
+// the defect through this surface; the cross-format claim is pinned
+// Share-side instead (`src/Containers/indexStepLogo.spec.ts`, which
+// compares the rendered bounds of `index.ifc` and `index.step`).
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { LARGE_COORDINATE_BUDGET_M, COORDINATION_SNAP_M } from './coordination_f64'
+import { FlatMesh, IfcAPI } from './ifc_api'
+
+const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
+
+let api: IfcAPI
+let local: Uint8Array
+let georeferenced: Uint8Array
+
+/**
+ * World-space bounds of every placed geometry in a model, as the
+ * consumer sees them: the placement translation is what Share stamps
+ * onto its instances.
+ *
+ * @param modelID An open model.
+ * @return {{min: number[], max: number[]}} Translation bounds.
+ */
+function placementBounds( modelID: number ): { min: number[], max: number[] } {
+
+  const min = [Infinity, Infinity, Infinity]
+  const max = [-Infinity, -Infinity, -Infinity]
+
+  api.StreamAllMeshes( modelID, ( mesh: FlatMesh ) => {
+    for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+
+      const t = mesh.geometries.get( where ).flatTransformation
+
+      for ( let axis = 0; axis < 3; ++axis ) {
+        min[ axis ] = Math.min( min[ axis ], t[ 12 + axis ] )
+        max[ axis ] = Math.max( max[ axis ], t[ 12 + axis ] )
+      }
+    }
+  } )
+
+  return { min, max }
+}
+
+beforeAll( async () => {
+  api = new IfcAPI()
+  await api.Init()
+
+  local = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+  georeferenced = new Uint8Array( fs.readFileSync( 'data/index_georeferenced.ifc' ) )
+}, 120000 )
+
+describe( 'COORDINATE_TO_ORIGIN export-order independence (Share#1749)', () => {
+
+  test( 'a near-origin model keeps its authored coordinates', async () => {
+
+    const modelID = await api.OpenModel( local, { ...SETTINGS } )
+    const { min, max } = placementBounds( modelID )
+
+    expect( Number.isFinite( min[ 0 ] ) ).toBe( true )
+
+    // The logo's first-declared block sits at x=76, so the unsnapped
+    // frame used to drag the whole model 76m negative. Snapped, the
+    // anchor lands in the origin cell and the model stays where the file
+    // put it — which is what makes a second export of the same object
+    // coincide with it regardless of element order.
+    expect( Math.max( ...min.map( Math.abs ), ...max.map( Math.abs ) ) )
+        .toBeLessThan( COORDINATION_SNAP_M )
+    expect( min[ 0 ] ).toBeGreaterThanOrEqual( 0 )
+
+    api.CloseModel( modelID )
+  }, 120000 )
+
+  test( 'a georeferenced model still recentres, inside the budget', async () => {
+
+    const modelID = await api.OpenModel( georeferenced, { ...SETTINGS } )
+    const { min, max } = placementBounds( modelID )
+
+    // Snapping costs at most half a cell on top of the model's own
+    // extent; the budget is the threshold above which float32 jitter
+    // becomes visible (Share#1631).
+    expect( Math.max( ...min.map( Math.abs ), ...max.map( Math.abs ) ) )
+        .toBeLessThan( LARGE_COORDINATE_BUDGET_M )
+
+    // The applied-frame report (Share#1634) is not asserted here: only
+    // the deferred pump records it, and
+    // `ifc_api_preview_coordination.test.ts` already covers that path.
+    api.CloseModel( modelID )
+  }, 120000 )
+
+  test( 'the classic and streamed opens agree on the frame', async () => {
+
+    // Both paths derive through deriveCoordinationF64, so the snap has
+    // to leave them identical — otherwise one model renders in two
+    // places depending on which open Share happened to take. Compared
+    // through the emitted placements rather than
+    // GetAppliedCoordinationMatrix, which only the deferred pump fills
+    // in: on these two opens it reports the identity contract for both,
+    // so comparing it would pass no matter what the frames did.
+    const classicID = await api.OpenModel( georeferenced, { ...SETTINGS } )
+    const classic = placementBounds( classicID )
+    api.CloseModel( classicID )
+
+    const streamedID = await api.OpenModelStreamed( georeferenced, { ...SETTINGS } )
+    const streamed = placementBounds( streamedID )
+    api.CloseModel( streamedID )
+
+    expect( Number.isFinite( classic.min[ 0 ] ) ).toBe( true )
+
+    for ( let axis = 0; axis < 3; ++axis ) {
+      expect( streamed.min[ axis ] ).toBeCloseTo( classic.min[ axis ], 6 )
+      expect( streamed.max[ axis ] ).toBeCloseTo( classic.max[ axis ], 6 )
+    }
+  }, 120000 )
+} )

--- a/src/compat/web-ifc/coordination_f64.test.ts
+++ b/src/compat/web-ifc/coordination_f64.test.ts
@@ -107,23 +107,46 @@ describe( 'coordination_f64', () => {
     expect( metres[ TRANSLATION_X ] ).toBe( -2_600_000 )
   } )
 
-  test( 'keeps a georeferenced model well inside the recentre budget', () => {
+  test( 'keeps a georeferenced model inside the recentre budget', () => {
     // Above the budget the recentre engages and snapping trades
-    // exactness for order-independence; the trade has to stay well
-    // inside LARGE_COORDINATE_BUDGET_M, the threshold above which a
-    // frame counts as having failed to recentre at all.
+    // exactness for order-independence. Once engaged every component is
+    // snapped, so each keeps at most half a cell and the anchor lands
+    // within half a cell in each axis — measured as a distance so the
+    // bound is a property of the anchor, like the stage decision itself.
+    // The outer bound that matters is LARGE_COORDINATE_BUDGET_M, the
+    // threshold above which a frame counts as not having recentred.
     const identity = glmatrix.mat4.create()
     const ref = { x: 2_600_000.31, y: 1_200_000.17, z: 412.5 }
     const coord = deriveCoordinationF64( identity, ref, NORMALIZE_MAT, 1 )
     // NORMALIZE_MAT is Z-up -> Y-up, so the source y/z components land in
     // the frame's z/y translation slots.
-    const residual = Math.max(
-        Math.abs( ref.x + coord[ TRANSLATION_X ] ),
-        Math.abs( ref.z + coord[ TRANSLATION_Y ] ),
-        Math.abs( ref.y - coord[ TRANSLATION_Z ] ) )
+    const residual = Math.hypot(
+        ref.x + coord[ TRANSLATION_X ],
+        ref.z + coord[ TRANSLATION_Y ],
+        ref.y - coord[ TRANSLATION_Z ] )
 
-    expect( residual ).toBeLessThanOrEqual( COORDINATION_SNAP_M / 2 )
-    expect( residual ).toBeLessThan( LARGE_COORDINATE_BUDGET_M / 10 )
+    // sqrt(3) half-cells is the true worst case; assert both it and the
+    // budget so a future edit that widens either is caught.
+    expect( residual ).toBeLessThanOrEqual( COORDINATION_SNAP_M )
+    expect( residual ).toBeLessThan( LARGE_COORDINATE_BUDGET_M )
+  } )
+
+  test( 'recentres a model whose offset is spread across axes', () => {
+    // The stage decision is the anchor's distance from the origin, not
+    // any one component: (9km, 9km, 9km) is 15.6km out — past the budget
+    // — while no single component crosses it. Deciding per component
+    // would leave this model in file coordinates and quietly undo the
+    // float32 jitter fix the budget exists to enforce.
+    const identity = glmatrix.mat4.create()
+    const coord = deriveCoordinationF64(
+        identity, { x: 9000, y: 9000, z: 9000 }, NORMALIZE_MAT, 1 )
+    const residual = Math.hypot(
+        9000 + coord[ TRANSLATION_X ],
+        9000 + coord[ TRANSLATION_Y ],
+        9000 - coord[ TRANSLATION_Z ] )
+
+    expect( coord[ TRANSLATION_X ] ).not.toBe( 0 )
+    expect( residual ).toBeLessThan( LARGE_COORDINATE_BUDGET_M )
   } )
 
   test( 'places a LV95-magnitude element exactly where float32 mis-lands it', () => {
@@ -152,7 +175,13 @@ describe( 'coordination_f64', () => {
     placementF64[ TRANSLATION_Y ] = ref.y
     placementF64[ TRANSLATION_Z ] = ref.z
 
-    // Where it must land: the within-cell remainder, in Y-up axes.
+    // Where it must land: the within-cell remainder of every component.
+    // The stage decision is made once on the whole anchor, and this one
+    // is far past the budget, so all three components snap — including
+    // z=412.5, whose nearest grid multiple is 0 and which therefore
+    // keeps its full value. (A per-component budget test would leave z
+    // untouched for a different reason and agree here by coincidence;
+    // this mirrors what quantizeRecentre actually does.)
     const rem = ( v: number ) =>
       v - Math.round( v / COORDINATION_SNAP_M ) * COORDINATION_SNAP_M
     const expected = [ rem( ref.x ), rem( ref.z ), -rem( ref.y ) ]

--- a/src/compat/web-ifc/coordination_f64.test.ts
+++ b/src/compat/web-ifc/coordination_f64.test.ts
@@ -2,6 +2,11 @@
 import { describe, expect, test } from '@jest/globals'
 import * as glmatrix from 'gl-matrix'
 import {
+  COORDINATION_SNAP_M,
+  LARGE_COORDINATE_BUDGET_M,
+  TRANSLATION_X,
+  TRANSLATION_Y,
+  TRANSLATION_Z,
   composeTransformF64,
   deriveCoordinationF64,
   mat4MultiplyF64,
@@ -51,43 +56,110 @@ describe( 'coordination_f64', () => {
     }
   } )
 
-  test( 'recentres a LV95-magnitude reference exactly where float32 mis-lands it', () => {
-    // The georeferencing jitter mechanism: the recentre translation
-    // negates a reference point at Swiss LV95 magnitude (~2.6M easting).
-    // Stored in a Float32Array it quantizes to the ~0.31 m grid (float32
-    // ULP at 2.6M), so the reference lands cm-to-dm off the origin — a
-    // per-model positional error baked into every emitted transform. The
-    // float64 recentre lands it exactly.
-    const identity = glmatrix.mat4.create() // placement; world via the point
+  test( 'derives one frame for anchors sharing a snap cell (export-order independence)', () => {
+    // The Share#1749 shape: two exports of one object disagree about
+    // which element comes first, so the walk anchors on points 76m
+    // apart. Both must still derive the same frame, or the two files
+    // render 76m apart and no camera permalink spans them.
+    const identity = glmatrix.mat4.create()
+    const first = deriveCoordinationF64(
+        identity, { x: 76, y: -11.4504049888, z: 0 }, NORMALIZE_MAT, 1 )
+    const second = deriveCoordinationF64(
+        identity, { x: 0, y: -11.4504049888, z: 0 }, NORMALIZE_MAT, 1 )
+
+    expect( second ).toEqual( first )
+    // Near-origin models snap to zero, i.e. they keep their authored
+    // coordinates: the frame is the bare Y-up normalize.
+    expect( first[ TRANSLATION_X ] ).toBe( 0 )
+    expect( first[ TRANSLATION_Y ] ).toBe( 0 )
+    expect( first[ TRANSLATION_Z ] ).toBe( 0 )
+  } )
+
+  test( 'snaps on the same metre grid whatever the source unit', () => {
+    // Same object, one file in metres and one in millimetres: the
+    // millimetre file's anchor is 1000x larger and its scaleFactor
+    // 1000x smaller, so both must land on the same metre frame.
+    const identity = glmatrix.mat4.create()
+    const metres = deriveCoordinationF64(
+        identity, { x: 2_600_076, y: 412, z: 0 }, NORMALIZE_MAT, 1 )
+    const millimetres = deriveCoordinationF64(
+        identity, { x: 2_600_076_000, y: 412_000, z: 0 }, NORMALIZE_MAT, 0.001 )
+
+    for ( const i of [ TRANSLATION_X, TRANSLATION_Y, TRANSLATION_Z ] ) {
+      expect( millimetres[ i ] ).toBeCloseTo( metres[ i ], 6 )
+    }
+    expect( metres[ TRANSLATION_X ] ).toBe( -2_600_000 )
+  } )
+
+  test( 'keeps a georeferenced model well inside the recentre budget', () => {
+    // Snapping trades exactness for order-independence; the trade has to
+    // stay well inside LARGE_COORDINATE_BUDGET_M, the threshold above
+    // which a frame counts as having failed to recentre at all.
+    const identity = glmatrix.mat4.create()
     const ref = { x: 2_600_000.31, y: 1_200_000.17, z: 412.5 }
+    const coord = deriveCoordinationF64( identity, ref, NORMALIZE_MAT, 1 )
+    // NORMALIZE_MAT is Z-up -> Y-up, so the source y/z components land in
+    // the frame's z/y translation slots.
+    const residual = Math.max(
+        Math.abs( ref.x + coord[ TRANSLATION_X ] ),
+        Math.abs( ref.z + coord[ TRANSLATION_Y ] ),
+        Math.abs( ref.y - coord[ TRANSLATION_Z ] ) )
 
-    /**
-     * Apply a column-major 4x4 to a point.
-     *
-     * @param m 16-element matrix.
-     * @param p The point.
-     * @return {number} The transformed point's distance from origin.
-     */
-    const originDist = ( m: ArrayLike<number> ) => Math.hypot(
-        m[ 0 ] * ref.x + m[ 4 ] * ref.y + m[ 8 ] * ref.z + m[ 12 ],
-        m[ 1 ] * ref.x + m[ 5 ] * ref.y + m[ 9 ] * ref.z + m[ 13 ],
-        m[ 2 ] * ref.x + m[ 6 ] * ref.y + m[ 10 ] * ref.z + m[ 14 ] )
+    expect( residual ).toBeLessThanOrEqual( COORDINATION_SNAP_M / 2 )
+    expect( residual ).toBeLessThan( LARGE_COORDINATE_BUDGET_M / 10 )
+  } )
 
-    // float64 recentre (the fix).
-    const distF64 = originDist( deriveCoordinationF64( identity, ref, NORMALIZE_MAT, 1 ) )
+  test( 'places a LV95-magnitude element exactly where float32 mis-lands it', () => {
+    // The georeferencing jitter mechanism (Share#1631): an element placed
+    // at Swiss LV95 magnitude (~2.6M easting) is composed against the
+    // recentre frame, and float32 ULP at 2.6M is ~0.31m. Run through
+    // gl-matrix's Float32Array that composition quantizes, and the
+    // element lands cm-to-dm from where the frame says — a positional
+    // error baked into every emitted transform. The float64 path lands it
+    // exactly.
+    //
+    // Note the frame's own translation is now snapped to whole kilometres
+    // (COORDINATION_SNAP_M), which happens to be exactly representable in
+    // float32 — so the loss this pins is in the composition against the
+    // element's full-precision placement, which is where it always
+    // mattered: that product is what becomes the FlatMesh transform.
+    const ref = { x: 2_600_000.31, y: 1_200_000.17, z: 412.5 }
+    const frame = deriveCoordinationF64(
+        glmatrix.mat4.create(), ref, NORMALIZE_MAT, 1 )
 
-    // Old float32 gl-matrix recentre: the translation is stored in a
-    // Float32Array, quantizing the -2.6M component.
-    const tp = glmatrix.vec4.create()
-    glmatrix.vec4.transformMat4( tp, [ ref.x, ref.y, ref.z, 1 ], identity )
-    const coordF32 = glmatrix.mat4.create()
-    glmatrix.mat4.fromTranslation( coordF32, [ -tp[ 0 ], -tp[ 1 ], -tp[ 2 ] ] )
-    glmatrix.mat4.multiply( coordF32, NORMALIZE_MAT as unknown as glmatrix.mat4, coordF32 )
-    const distF32 = originDist( coordF32 )
+    // An element sitting on that reference point.
+    const placement = glmatrix.mat4.create()
+    glmatrix.mat4.identity( placement )
+    const placementF64 = Array.from( placement )
+    placementF64[ TRANSLATION_X ] = ref.x
+    placementF64[ TRANSLATION_Y ] = ref.y
+    placementF64[ TRANSLATION_Z ] = ref.z
 
-    // float64 lands sub-micron; float32 is off by cm+.
-    expect( distF64 ).toBeLessThan( 1e-6 )
-    expect( distF32 ).toBeGreaterThan( 1e-2 )
+    // Where it must land: the within-cell remainder, in Y-up axes.
+    const rem = ( v: number ) =>
+      v - Math.round( v / COORDINATION_SNAP_M ) * COORDINATION_SNAP_M
+    const expected = [ rem( ref.x ), rem( ref.z ), -rem( ref.y ) ]
+
+    const f64 = composeTransformF64( frame, placementF64 )
+
+    // The old path's loss: the placement crosses the wasm boundary as a
+    // glm::dmat4 but was rebuilt with gl-matrix `mat4.fromValues`, i.e.
+    // stored in a Float32Array — quantizing its 2.6M component to the
+    // ~0.31m float32 grid before anything is composed. Snapping the frame
+    // does not rescue that; only keeping the placement in float64 does.
+    const f32 = composeTransformF64( frame, new Float32Array( placementF64 ) )
+
+    const errF64 = Math.max(
+        Math.abs( f64[ TRANSLATION_X ] - expected[ 0 ] ),
+        Math.abs( f64[ TRANSLATION_Y ] - expected[ 1 ] ),
+        Math.abs( f64[ TRANSLATION_Z ] - expected[ 2 ] ) )
+    const errF32 = Math.max(
+        Math.abs( f32[ TRANSLATION_X ] - expected[ 0 ] ),
+        Math.abs( f32[ TRANSLATION_Y ] - expected[ 1 ] ),
+        Math.abs( f32[ TRANSLATION_Z ] - expected[ 2 ] ) )
+
+    expect( errF64 ).toBeLessThan( 1e-6 )
+    expect( errF32 ).toBeGreaterThan( 1e-2 )
   } )
 
   test( 'near origin float64 and float32 agree (fixtures unaffected)', () => {

--- a/src/compat/web-ifc/coordination_f64.test.ts
+++ b/src/compat/web-ifc/coordination_f64.test.ts
@@ -56,11 +56,11 @@ describe( 'coordination_f64', () => {
     }
   } )
 
-  test( 'derives one frame for anchors sharing a snap cell (export-order independence)', () => {
+  test( 'below the budget every anchor derives model-zero (export-order independence)', () => {
     // The Share#1749 shape: two exports of one object disagree about
     // which element comes first, so the walk anchors on points 76m
-    // apart. Both must still derive the same frame, or the two files
-    // render 76m apart and no camera permalink spans them.
+    // apart. Both must derive the same frame, or the two files render
+    // 76m apart and no camera permalink spans them.
     const identity = glmatrix.mat4.create()
     const first = deriveCoordinationF64(
         identity, { x: 76, y: -11.4504049888, z: 0 }, NORMALIZE_MAT, 1 )
@@ -68,14 +68,30 @@ describe( 'coordination_f64', () => {
         identity, { x: 0, y: -11.4504049888, z: 0 }, NORMALIZE_MAT, 1 )
 
     expect( second ).toEqual( first )
-    // Near-origin models snap to zero, i.e. they keep their authored
-    // coordinates: the frame is the bare Y-up normalize.
+    // Model-zero (conway#87): the frame is the bare Y-up normalize and
+    // the model keeps the coordinates its file authored.
     expect( first[ TRANSLATION_X ] ).toBe( 0 )
     expect( first[ TRANSLATION_Y ] ).toBe( 0 )
     expect( first[ TRANSLATION_Z ] ).toBe( 0 )
   } )
 
-  test( 'snaps on the same metre grid whatever the source unit', () => {
+  test( 'anchors either side of a grid line below the budget still agree', () => {
+    // Why the recentre is staged rather than snapped everywhere: a
+    // straight snap turns a small anchor disagreement into a full-cell
+    // one. A site-grid model at x ~ 500m whose preview channel anchors
+    // at 480 and whose durable walk anchors at 520 would derive frames
+    // 1km apart — and the adopted-frame gate only re-derives past
+    // LARGE_COORDINATE_BUDGET_M, so it would keep the wrong one and
+    // render 1km off a classic open. Below the budget both are zero.
+    const identity = glmatrix.mat4.create()
+    const below = deriveCoordinationF64( identity, { x: 480, y: 0, z: 0 }, NORMALIZE_MAT, 1 )
+    const above = deriveCoordinationF64( identity, { x: 520, y: 0, z: 0 }, NORMALIZE_MAT, 1 )
+
+    expect( above ).toEqual( below )
+    expect( below[ TRANSLATION_X ] ).toBe( 0 )
+  } )
+
+  test( 'recentres only once past the budget, on the same metre grid whatever the source unit', () => {
     // Same object, one file in metres and one in millimetres: the
     // millimetre file's anchor is 1000x larger and its scaleFactor
     // 1000x smaller, so both must land on the same metre frame.
@@ -92,9 +108,10 @@ describe( 'coordination_f64', () => {
   } )
 
   test( 'keeps a georeferenced model well inside the recentre budget', () => {
-    // Snapping trades exactness for order-independence; the trade has to
-    // stay well inside LARGE_COORDINATE_BUDGET_M, the threshold above
-    // which a frame counts as having failed to recentre at all.
+    // Above the budget the recentre engages and snapping trades
+    // exactness for order-independence; the trade has to stay well
+    // inside LARGE_COORDINATE_BUDGET_M, the threshold above which a
+    // frame counts as having failed to recentre at all.
     const identity = glmatrix.mat4.create()
     const ref = { x: 2_600_000.31, y: 1_200_000.17, z: 412.5 }
     const coord = deriveCoordinationF64( identity, ref, NORMALIZE_MAT, 1 )

--- a/src/compat/web-ifc/coordination_f64.ts
+++ b/src/compat/web-ifc/coordination_f64.ts
@@ -148,43 +148,60 @@ export function mat4MultiplyF64(
  *    representable where the raw anchor was not, so the recentre itself
  *    stops contributing rounding.
  *
- * The staging also matters for the adopted-preview-frame gate: snapping
- * *everything* would let a local model whose preview and durable anchors
- * straddle a cell boundary (say x=480 and x=520) derive frames a full
- * kilometre apart, which the gate's `magnitude > LARGE_COORDINATE_BUDGET_M`
- * check cannot see. Below the budget both now derive zero, so they agree
- * exactly. Above the budget the amplification survives in principle —
- * two anchors either side of a boundary on a georeferenced model — which
- * is the residual noted in design/new/coordination-frame.md.
+ * **Quantizing cannot remove the discontinuity, only move it**, and it
+ * is worth being precise about where this one sits, because it is not
+ * where you would guess. Snapping *everything* to the grid would put a
+ * 1km step at every cell edge, including around the near-origin models
+ * that make up almost the whole corpus. Staging moves it to the budget:
+ * inside, every anchor derives model-zero and there is no edge at all;
+ * the single remaining edge is the budget itself, where the step is
+ * `LARGE_COORDINATE_BUDGET_M` (1e4), not the grid (1e3) — an anchor at
+ * 9900 derives zero and one at 10100 derives -10000.
+ *
+ * That edge is also invisible to the adopted-preview-frame gate, which
+ * re-derives only when a durable placement lands beyond the budget: a
+ * preview anchored at 10100 and a durable first placement at 9900 probe
+ * at ~100m, so the preview frame is kept and the model renders 10km off
+ * a classic open. The trade is deliberate — one edge that a georeferenced
+ * model may sit near, rather than an edge every kilometre through the
+ * range where nearly every model lives — but it is a real residual, not
+ * an eliminated one. design/new/coordination-frame.md tracks it, and
+ * conway#87's relative-to-centre direction is what removes it properly.
  */
 export const COORDINATION_SNAP_M = 1e3
 
 /**
- * The recentre for one translation component: zero while the coordinate
- * is small enough not to need one, else snapped to COORDINATION_SNAP_M.
+ * The recentre for an anchor: all zeros while the anchor is close enough
+ * to the origin not to need one, else each component snapped to
+ * COORDINATION_SNAP_M.
  *
- * Works in source units — the value is pre-scale, so both the budget and
- * the grid convert by the same `scaleFactor` the caller is about to
+ * The stage decision is made **once, on the anchor's distance from the
+ * origin**, and applied to all three components together. Deciding per
+ * component would leave a model offset diagonally — say (9km, 9km, 9km),
+ * 15.6km out and well past the budget — with no recentre at all, since
+ * no single component crosses the threshold. That silently regresses the
+ * float32 jitter fix (Share#1631) the budget exists to enforce.
+ *
+ * Works in source units: the values are pre-scale, so both the budget
+ * and the grid convert by the same `scaleFactor` the caller is about to
  * apply (a millimetre model snaps every 1e6 source units, a metre model
- * every 1e3). A degenerate scale factor leaves the value untouched
- * rather than producing a non-finite frame.
+ * every 1e3).
  *
- * @param value One translation component, in source units.
- * @param scaleFactor The linear scaling factor to metres.
- * @return {number} The recentre for that component, in source units.
+ * @param values The three translation components, in source units.
+ * @param scaleFactor The linear scaling factor to metres; already
+ * sanitized by the caller.
+ * @return {number[]} The recentre per component, in source units.
  */
-function quantizeRecentre(value: number, scaleFactor: number): number {
-  if (!Number.isFinite(value) || !Number.isFinite(scaleFactor) || scaleFactor <= 0) {
-    return Number.isFinite(value) ? value : 0
-  }
+function quantizeRecentre(values: number[], scaleFactor: number): number[] {
+  const finite = values.map((v) => (Number.isFinite(v) ? v : 0))
 
-  if (Math.abs(value) * scaleFactor <= LARGE_COORDINATE_BUDGET_M) {
-    return 0
+  if (Math.hypot(...finite) * scaleFactor <= LARGE_COORDINATE_BUDGET_M) {
+    return [0, 0, 0]
   }
 
   const gridSourceUnits = COORDINATION_SNAP_M / scaleFactor
 
-  return Math.round(value / gridSourceUnits) * gridSourceUnits
+  return finite.map((v) => Math.round(v / gridSourceUnits) * gridSourceUnits)
 }
 
 /**
@@ -211,23 +228,29 @@ export function deriveCoordinationF64(
 
   const p = placement !== undefined ? sanitize16(placement) : IDENTITY
   const { x, y, z } = point
+  // Sanitized once, here, so the promise the rest of this function makes
+  // about degenerate input actually holds: a NaN/Infinite factor from a
+  // malformed unit-assignment chain would otherwise pass the recentre
+  // guard and then poison every component through the scale matrix below.
+  const scale1 = Number.isFinite(scaleFactor) && scaleFactor > 0 ? scaleFactor : 1
 
   // transformedPt = placement * (x, y, z, 1)
   const tx = p[0] * x + p[4] * y + p[8] * z + p[12]
   const ty = p[1] * x + p[5] * y + p[9] * z + p[13]
   const tz = p[2] * x + p[6] * y + p[10] * z + p[14]
 
-  // translate(-snap(transformedPt))
+  // translate(-quantize(transformedPt))
+  const recentre = quantizeRecentre([-tx, -ty, -tz], scale1)
   const translate = IDENTITY.slice()
-  translate[12] = quantizeRecentre(-tx, scaleFactor)
-  translate[13] = quantizeRecentre(-ty, scaleFactor)
-  translate[14] = quantizeRecentre(-tz, scaleFactor)
+  translate[12] = recentre[0]
+  translate[13] = recentre[1]
+  translate[14] = recentre[2]
 
   // scale(scaleFactor)
   const scale = [
-    scaleFactor, 0, 0, 0,
-    0, scaleFactor, 0, 0,
-    0, 0, scaleFactor, 0,
+    scale1, 0, 0, 0,
+    0, scale1, 0, 0,
+    0, 0, scale1, 0,
     0, 0, 0, 1,
   ]
 

--- a/src/compat/web-ifc/coordination_f64.ts
+++ b/src/compat/web-ifc/coordination_f64.ts
@@ -115,13 +115,13 @@ export function mat4MultiplyF64(
 }
 
 /**
- * Grid (metres) the recentre translation snaps to.
+ * Grid (metres) a recentre snaps to once it is needed at all.
  *
  * The anchor a recentre is derived from is the *first geometry* the walk
  * reaches, which is an arbitrary interior element: whichever one the file
- * happens to declare first. Left unsnapped, that makes a model's world
+ * happens to declare first. Left as-is, that makes a model's world
  * position a function of its element order, with two consequences users
- * see:
+ * see (conway#87, "not a sound basis for a camera in the permalink"):
  *
  *  - Two exports of one object — the same logo as IFC and as STEP, a part
  *    re-exported by a different CAD kernel — land in different places,
@@ -131,43 +131,55 @@ export function mat4MultiplyF64(
  *  - Re-exporting a model with the element order shuffled moves it, so
  *    every camera permalink saved against it is silently wrong.
  *
- * Snapping the recentre to a coarse grid makes the frame depend on
- * *where* the anchor is rather than *which* anchor it is: any two anchors
- * in the same cell derive the same frame, so exports of one object agree
- * whenever they anchor within a cell of each other. Models near the
- * origin — the overwhelming majority — snap to zero and simply keep their
- * authored coordinates, which is both the most predictable behaviour and
- * what makes twin exports coincide by construction.
+ * `quantizeRecentre` answers that in two stages, because the two ranges
+ * want different things:
  *
- * The grid is 1/10th of LARGE_COORDINATE_BUDGET_M, the engine's own
- * "this frame failed to recentre" threshold: snapping spends at most
- * 500m (half a cell) of a 1e4 m budget, ~0.05mm of float32 resolution at
- * the GPU, while the georeferenced case it exists for — LV95 eastings at
- * ~2.6e6 m — still recentres to within half a kilometre of the origin.
+ *  - **Inside LARGE_COORDINATE_BUDGET_M, do not recentre at all.** There
+ *    is no float32 benefit below the budget — that constant *is* the
+ *    threshold where quantization becomes visible — so a model within
+ *    10km of the origin simply keeps the coordinates its file authored.
+ *    That is model-zero, conway#87's proposal, and it makes the frame
+ *    exactly order-independent for the overwhelming majority of models
+ *    rather than order-independent-per-cell.
+ *  - **Above it, snap to this grid.** A georeferenced model has to come
+ *    back near the origin, and snapping keeps that repeatable across
+ *    exports. Half a cell (500m) out of a 1e4 m budget costs ~0.05mm of
+ *    float32 resolution, and a whole-kilometre translation is exactly
+ *    representable where the raw anchor was not, so the recentre itself
+ *    stops contributing rounding.
  *
- * A snapped translation is also exactly representable where the raw
- * anchor was not: whole kilometres (and their whole-unit equivalents in
- * millimetre files) survive the float32 vertex/matrix path without
- * rounding, so the recentre itself stops contributing error.
+ * The staging also matters for the adopted-preview-frame gate: snapping
+ * *everything* would let a local model whose preview and durable anchors
+ * straddle a cell boundary (say x=480 and x=520) derive frames a full
+ * kilometre apart, which the gate's `magnitude > LARGE_COORDINATE_BUDGET_M`
+ * check cannot see. Below the budget both now derive zero, so they agree
+ * exactly. Above the budget the amplification survives in principle —
+ * two anchors either side of a boundary on a georeferenced model — which
+ * is the residual noted in design/new/coordination-frame.md.
  */
 export const COORDINATION_SNAP_M = 1e3
 
 /**
- * Snap one recentre component to COORDINATION_SNAP_M.
+ * The recentre for one translation component: zero while the coordinate
+ * is small enough not to need one, else snapped to COORDINATION_SNAP_M.
  *
- * Works in source units — the value is pre-scale, so the grid converts
- * by the same `scaleFactor` the caller is about to apply (a millimetre
- * model snaps every 1e6 source units, a metre model every 1e3). A
- * degenerate scale factor leaves the value untouched rather than
- * producing a non-finite frame.
+ * Works in source units — the value is pre-scale, so both the budget and
+ * the grid convert by the same `scaleFactor` the caller is about to
+ * apply (a millimetre model snaps every 1e6 source units, a metre model
+ * every 1e3). A degenerate scale factor leaves the value untouched
+ * rather than producing a non-finite frame.
  *
  * @param value One translation component, in source units.
  * @param scaleFactor The linear scaling factor to metres.
- * @return {number} The snapped component, in source units.
+ * @return {number} The recentre for that component, in source units.
  */
-function snapRecentre(value: number, scaleFactor: number): number {
+function quantizeRecentre(value: number, scaleFactor: number): number {
   if (!Number.isFinite(value) || !Number.isFinite(scaleFactor) || scaleFactor <= 0) {
     return Number.isFinite(value) ? value : 0
+  }
+
+  if (Math.abs(value) * scaleFactor <= LARGE_COORDINATE_BUDGET_M) {
+    return 0
   }
 
   const gridSourceUnits = COORDINATION_SNAP_M / scaleFactor
@@ -178,10 +190,11 @@ function snapRecentre(value: number, scaleFactor: number): number {
 /**
  * Derive the coordination (recentre) matrix in float64, matching the
  * gl-matrix op sequence exactly:
- * `scale * NormalizeMat * translate(-snap(placement * point))`.
+ * `scale * NormalizeMat * translate(-quantize(placement * point))`.
  *
- * The snap is what keeps the derived frame independent of which element
- * a file declares first — see COORDINATION_SNAP_M for why that matters.
+ * The quantization is what keeps the derived frame independent of which
+ * element a file declares first — see COORDINATION_SNAP_M for why that
+ * matters, and why it is staged around LARGE_COORDINATE_BUDGET_M.
  *
  * @param placement The native placement (16 elements, column-major
  * float64 from `getValues()`); `undefined` is treated as identity.
@@ -206,9 +219,9 @@ export function deriveCoordinationF64(
 
   // translate(-snap(transformedPt))
   const translate = IDENTITY.slice()
-  translate[12] = snapRecentre(-tx, scaleFactor)
-  translate[13] = snapRecentre(-ty, scaleFactor)
-  translate[14] = snapRecentre(-tz, scaleFactor)
+  translate[12] = quantizeRecentre(-tx, scaleFactor)
+  translate[13] = quantizeRecentre(-ty, scaleFactor)
+  translate[14] = quantizeRecentre(-tz, scaleFactor)
 
   // scale(scaleFactor)
   const scale = [

--- a/src/compat/web-ifc/coordination_f64.ts
+++ b/src/compat/web-ifc/coordination_f64.ts
@@ -115,9 +115,73 @@ export function mat4MultiplyF64(
 }
 
 /**
+ * Grid (metres) the recentre translation snaps to.
+ *
+ * The anchor a recentre is derived from is the *first geometry* the walk
+ * reaches, which is an arbitrary interior element: whichever one the file
+ * happens to declare first. Left unsnapped, that makes a model's world
+ * position a function of its element order, with two consequences users
+ * see:
+ *
+ *  - Two exports of one object — the same logo as IFC and as STEP, a part
+ *    re-exported by a different CAD kernel — land in different places,
+ *    because they disagree about which element comes first. Share#1749
+ *    hit exactly this: `index.step` sat 76m off `index.ifc` because the
+ *    IFC declares the x=76 block first and the STEP the x=0 one.
+ *  - Re-exporting a model with the element order shuffled moves it, so
+ *    every camera permalink saved against it is silently wrong.
+ *
+ * Snapping the recentre to a coarse grid makes the frame depend on
+ * *where* the anchor is rather than *which* anchor it is: any two anchors
+ * in the same cell derive the same frame, so exports of one object agree
+ * whenever they anchor within a cell of each other. Models near the
+ * origin — the overwhelming majority — snap to zero and simply keep their
+ * authored coordinates, which is both the most predictable behaviour and
+ * what makes twin exports coincide by construction.
+ *
+ * The grid is 1/10th of LARGE_COORDINATE_BUDGET_M, the engine's own
+ * "this frame failed to recentre" threshold: snapping spends at most
+ * 500m (half a cell) of a 1e4 m budget, ~0.05mm of float32 resolution at
+ * the GPU, while the georeferenced case it exists for — LV95 eastings at
+ * ~2.6e6 m — still recentres to within half a kilometre of the origin.
+ *
+ * A snapped translation is also exactly representable where the raw
+ * anchor was not: whole kilometres (and their whole-unit equivalents in
+ * millimetre files) survive the float32 vertex/matrix path without
+ * rounding, so the recentre itself stops contributing error.
+ */
+export const COORDINATION_SNAP_M = 1e3
+
+/**
+ * Snap one recentre component to COORDINATION_SNAP_M.
+ *
+ * Works in source units — the value is pre-scale, so the grid converts
+ * by the same `scaleFactor` the caller is about to apply (a millimetre
+ * model snaps every 1e6 source units, a metre model every 1e3). A
+ * degenerate scale factor leaves the value untouched rather than
+ * producing a non-finite frame.
+ *
+ * @param value One translation component, in source units.
+ * @param scaleFactor The linear scaling factor to metres.
+ * @return {number} The snapped component, in source units.
+ */
+function snapRecentre(value: number, scaleFactor: number): number {
+  if (!Number.isFinite(value) || !Number.isFinite(scaleFactor) || scaleFactor <= 0) {
+    return Number.isFinite(value) ? value : 0
+  }
+
+  const gridSourceUnits = COORDINATION_SNAP_M / scaleFactor
+
+  return Math.round(value / gridSourceUnits) * gridSourceUnits
+}
+
+/**
  * Derive the coordination (recentre) matrix in float64, matching the
  * gl-matrix op sequence exactly:
- * `scale * NormalizeMat * translate(-(placement * point))`.
+ * `scale * NormalizeMat * translate(-snap(placement * point))`.
+ *
+ * The snap is what keeps the derived frame independent of which element
+ * a file declares first — see COORDINATION_SNAP_M for why that matters.
  *
  * @param placement The native placement (16 elements, column-major
  * float64 from `getValues()`); `undefined` is treated as identity.
@@ -140,11 +204,11 @@ export function deriveCoordinationF64(
   const ty = p[1] * x + p[5] * y + p[9] * z + p[13]
   const tz = p[2] * x + p[6] * y + p[10] * z + p[14]
 
-  // translate(-transformedPt)
+  // translate(-snap(transformedPt))
   const translate = IDENTITY.slice()
-  translate[12] = -tx
-  translate[13] = -ty
-  translate[14] = -tz
+  translate[12] = snapRecentre(-tx, scaleFactor)
+  translate[13] = snapRecentre(-ty, scaleFactor)
+  translate[14] = snapRecentre(-tz, scaleFactor)
 
   // scale(scaleFactor)
   const scale = [


### PR DESCRIPTION
Addresses **#87** (filed 2023, `severe`) — *"both web-ifc and current conway pick a reference point based on model parser order, and this is not a sound basis for a camera in the permalink"*, with model-zero proposed as the answer. Deliberately **not** "Fixes": see [What #87 still wants](#what-87-still-wants) below. Surfaced again by [Share#1749](https://github.com/bldrs-ai/Share/pull/1749), where the Bldrs logo shipped as both `index.ifc` and `index.step` rendered 76m apart.

## What the recentre anchors on

`deriveCoordinationF64` derives one frame per model from **the first geometry the walk reaches** — whichever element the file happens to declare first, latched via `_isCoordinated`. Nothing about that element is special, so a model's rendered position is a function of its element order:

- **Two exports of one object land in different places.** The IFC declares the x=76 block first, the STEP the x=0 one, so the two files rendered 76m — the width of the logo — apart. Auto-framing hides it; only a `#c:` camera applied to both reveals it.
- **Re-exporting a model with its elements shuffled moves it**, silently invalidating every camera permalink saved against it.

## The change

`quantizeRecentre` stages the recentre around `LARGE_COORDINATE_BUDGET_M`:

- **Inside the budget (1e4 m): no recentre at all.** There is no float32 benefit below the budget — that constant *is* the threshold where quantization becomes visible — so the model keeps the coordinates its file authored. That's model-zero, #87's proposal, and it makes the frame *exactly* order-independent for the overwhelming majority of models: no cell boundary to straddle, so twin exports and federated sets coincide however their elements are ordered.
- **Above it: snap to 1 km.** A georeferenced model has to come back near the origin, and snapping keeps that repeatable across exports.

The stage decision is made once, on the anchor's **distance** from the origin, and applied to all three components — a per-component test left a diagonally-offset model (9km, 9km, 9km — 15.6km out) with no recentre at all, quietly undoing the Share#1631 jitter fix.

One choke point: all ~10 derive sites across the IFC proxy, the AP214 proxy and the preview channel inherit it, so the classic, streamed and preview paths cannot drift apart.

### What it does not fix

Quantizing cannot remove the discontinuity, only move it. The step at the budget boundary is 1e4, not the 1km grid — an anchor at 9900 derives model-zero, one at 10100 derives −10000 — and the adopted-preview-frame gate cannot see a divergence that size (a durable placement 100m from the adopted frame probes well under the budget). The trade is deliberate: a handful of edges out at georeferenced magnitudes, instead of an edge every kilometre through the range where nearly every model lives. It is documented, not eliminated.

### What #87 still wants

- ✅ Parser-order dependence, for anything inside the budget.
- ❌ *"We should have a design that future proofs against this"* — the [XeoKit full-precision](https://xeokit.io/blog_full_precision_geometry.html) direction (relative-to-centre tiles). Not attempted; this still trades precision for one global frame.
- ❌ The budget-boundary residual above.

So #87 stays open with a comment on what's left, per the repo's lifecycle.

## Scope — what is and is not pinned

**The IFC arm is pinned end-to-end.** `coordination_export_order.test.ts` fails without the change with `Expected >= 0, Received -76` — the exact defect, through the same compat `IfcAPI` surface Share consumes.

**The AP214 arm is not.** Through this surface its placements come back at the origin with the geometry carrying the world transform, so neither placement bounds nor a fixture pair in two element orders reproduces the defect. I removed a test that appeared to cover it after finding it passed with the change disabled. The cross-format claim is pinned Share-side instead (`src/Containers/indexStepLogo.spec.ts`). Characterising the AP214 anchor is open work, flagged in the design doc.

**The CLI is not a witness for any of this.** `ifc_command_line_main` and its glTF writer recentre per model and hand the offset back as a node translation, so summing the two always reconstructs source-world coordinates whatever the frame did. I initially "confirmed" the fix that way and the check was vacuous.

## What it costs to land

Every model whose anchor was not already at the origin moves — the logo shifts 86m, from x ∈ [-76, 10] to x ∈ [0, 86]. **Saved camera permalinks are invalidated**, Share's homepage camera included, along with any Share-side visual baseline shot against them.

**Regression digests and visual-diff baselines also move and need re-blessing.** An earlier revision of this description claimed they would not — reasoning that the regression mains never mention `COORDINATE_TO_ORIGIN` and the digests hash file coordinates. The first gated run disproved it: **11 of 12 smoke models digest-changed**, no failures, no errors, one pre-existing `No basis found for brep!` resolved on `nist_ctc_02_asme1_rc.stp`. Mitigating fact from the same run: `visual-diff` rendered all 11 and every one came in **under the 0.05% pixel threshold** — the movement is real but not visible.

## Testing

- 431 unit tests pass (`yarn test`), 4 new; each verified non-vacuous by removing the code it guards.
- Gated CI on this branch: regression clean, visual-diff below threshold on every changed digest.
- New coverage: model-zero below the budget whatever the anchor; anchors either side of a grid line agree; a diagonally-offset model still recentres; unit-independent snapping above the budget; near-origin model keeps authored coordinates; classic and streamed opens agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Vh2vC2y6Q5jgzfTzyRvmA