### PR TITLE
A closed edge spans its whole basis curve; bump conway-geom for the sweep (#461)

### DIFF
--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -194,10 +194,26 @@ function isWholeCurveEdge(
     edgeStart: unknown,
     edgeEnd: unknown ): boolean {
 
-  if ( !( basisCurve instanceof b_spline_curve ) ||
-       !( edgeStart instanceof vertex_point ) ||
+  if ( !( edgeStart instanceof vertex_point ) ||
        !( edgeEnd instanceof vertex_point ) ) {
 
+    return false
+  }
+
+  // An edge from a vertex back to ITSELF spans the whole of its basis curve:
+  // that is how STEP writes a closed edge, and trimming a circle by one point
+  // taken twice is how a torus's equator circles were resolving to a single
+  // point - which starved the revolution face of every angular sample it had
+  // and collapsed the swept surface flat (conway#461). The caller's gates make
+  // this safe for an open basis curve too: recovery only replaces the trimmed
+  // result when it was already degenerate AND the untrimmed extraction yields
+  // more points, and an identical-vertex edge over an open curve is degenerate
+  // whichever way it is read.
+  if ( edgeStart.vertex_geometry.localID === edgeEnd.vertex_geometry.localID ) {
+    return true
+  }
+
+  if ( !( basisCurve instanceof b_spline_curve ) ) {
     return false
   }
 


### PR DESCRIPTION
Closes #461. Two halves of one recovery — this TS fix plus bldrs-ai/conway-geom#169 (merged, one full review round, all six findings addressed or documented).

## The failure, end to end

A torus's revolution face passed every check conway makes and still emitted nothing. Two independent bugs stacked:

**conway (this PR):** `isWholeCurveEdge` only recognised `b_spline_curve`, so the #494 whole-curve recovery never fired for the torus's equator circles — **closed edges** (start vertex == end vertex) over `SURFACE_CURVE`-wrapped circles, whose identical trim points resolved the arc to a single point. An edge from a vertex back to itself spans the whole of its basis curve; that is how STEP writes a closed edge. The existing gates keep this safe for open curves: recovery only replaces a trimmed result that was already degenerate, and only when the untrimmed extraction yields more points.

**conway-geom (#169):** the revolution fallback measured its sweep from one centroid per boundary edge — and the centroid of a full circle around the axis sits **on the axis**, carrying no angle. Span 0 → coincident rings → all triangles zero-area → welded away at reification, with `warnFaceAddedNothing` suppressed because triangles *had* been appended.

Both are needed together: with only this one, the bound gains its points and the centroid still lands on the axis.

## Measurement

Create proof fixtures, area vs analytic `4π²Rr`:

| fixture | before | after | bbox |
|---|---|---|---|
| torus-30-8 | 50.0% | **99.77%** | z [−8,0] → **[−8,8]** |
| torus-20-15 | 50.0% | **99.78%** | z [−15,0] → **[−15,15]** |
| torus-50-5 | 50.0% | **100.0%** | z [−5,0] → **[−5,5]** |

Spheres unchanged. Whole public corpus: **87 of 95 digests byte-identical, 8 changed, every change a gain** — 50 entities recovered (`Right_Hand` +11, `nist_stc_10_asme1_ap242-e2` +14, `nist_ftc_10_asme1_rb` +10, `nist_ctc_02_asme1_ap203` +4, `supercap2/3` +4 each, `Assem_gearbox` +2, `Arty_Z7` +1), **zero entities lost anywhere**. Only error movement: supercap's one-point bound reclassifies "too few points" → "collinear" 1:1 as its circle now extracts.

## For the visual diff

The changed smoke models (`Right_Hand.step`, `supercap.step`, `nist_ctc_02`) will show **real pixel differences — recovered faces**. That is the point of the change, not churn to wave through.

## What #461 still carries

Of the issue's three symptoms: **sphere** fixed (#160), **torus** fixed here. The **fillet blends** remain: `box-fillet-r8` measures 79% of OCCT's area, now with *no error reported* (the extraction error it used to throw is gone). That residual is noted on the issue in closing; it is a different surface family (trimmed blends), not the revolution path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQAv3NMEn9fy1AyGNm3cyN)_