### PR TITLE
PSB pump 62s → 21s: column extract, packed triangulation, sequential Faces

### DIFF
--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -972,7 +972,6 @@ export class IfcGeometryExtraction {
    * @param entity The faceset.
    * @param temporary Is this a temporary (preview//operand) extraction?
    * @param isRelVoid Is this geometry a rel-void operand?
-   * @param indicesPerFace Index count of the last face processed.
    * @param allIndices Face indices, concatenated.
    * @param allStartIndices Per-face start indices.
    * @param polygonalFaceBufferOffsets Per-face offsets into allIndices.
@@ -983,7 +982,6 @@ export class IfcGeometryExtraction {
       entity: IfcPolygonalFaceSet,
       temporary: boolean,
       isRelVoid: boolean,
-      indicesPerFace: number,
       allIndices: Uint32Sink,
       allStartIndices: Uint32Sink,
       polygonalFaceBufferOffsets: Uint32Sink,
@@ -1015,6 +1013,12 @@ export class IfcGeometryExtraction {
       startIndicesBufferOffsetsArray,
     ] )
 
+    // A throw here used to strand all four heap pointers plus the pooled
+    // parse buffer, once per faceset (15,777 on PSB — a leak large enough
+    // to cause the exhaustion it would then be blamed on). withRelease
+    // reclaims them; it suppresses a release failure only while something
+    // is already unwinding, so a wasm-runtime fault is not replaced by a
+    // generic teardown error in the per-record catch upstream.
     const geometry = withRelease(
       () => {
 
@@ -1053,6 +1057,8 @@ export class IfcGeometryExtraction {
                 startIndicesBufferOffsetsArrayPtr ),
             () => pointsArrayNative.delete() )
       },
+      // freeAll, not four statements in one closure: there the first
+      // failure would abandon the other three.
       () => freeAll( this.wasmModule, [
         indicesArrayPtr,
         startIndicesArrayPtr,
@@ -1141,8 +1147,6 @@ export class IfcGeometryExtraction {
     polygonalFaceBufferOffsets.reset()
     startIndicesBufferOffsets.reset()
 
-    let indicesPerFace: number = -1
-
     // Fast path: read each face's CoordIndex straight from its record,
     // never constructing the 9M+ IfcIndexedPolygonalFace entities a
     // large tessellated model would otherwise materialise (and retain,
@@ -1188,14 +1192,13 @@ export class IfcGeometryExtraction {
           polygonalFaceBufferOffsets.push(allIndices.length - count)
           startIndicesBufferOffsets.push(allStartIndices.length)
           allStartIndices.push(0)
-          indicesPerFace = count
 
           return true
         })
 
     if (fastPathOk && facesWalked) {
       this.finishPolygonalFaceSet_(
-          entity, temporary, isRelVoid, indicesPerFace,
+          entity, temporary, isRelVoid,
           allIndices, allStartIndices,
           polygonalFaceBufferOffsets, startIndicesBufferOffsets)
 
@@ -1207,7 +1210,6 @@ export class IfcGeometryExtraction {
     allStartIndices.reset()
     polygonalFaceBufferOffsets.reset()
     startIndicesBufferOffsets.reset()
-    indicesPerFace = -1
 
     // Prepare indices and start indices for all faces
     entity.Faces.forEach((polygonalFace) => {
@@ -1221,7 +1223,7 @@ export class IfcGeometryExtraction {
 
       if (polygonalFace instanceof IfcIndexedPolygonalFaceWithVoids) {
         // Voided faces are rare; keep the straightforward getter path.
-        indicesPerFace = polygonalFace.CoordIndex.length
+        const indicesPerFace = polygonalFace.CoordIndex.length
 
         allStartIndices.push(0)
         coordIndex += indicesPerFace
@@ -1242,13 +1244,13 @@ export class IfcGeometryExtraction {
       } else {
         // CoordIndex is vtable offset 0 on IfcIndexedPolygonalFace (see
         // its generated getter) — parsed in place, never allocated or cached.
-        indicesPerFace = polygonalFace.extractIntegerArrayInto(0, 0, 3, allIndices)
+        polygonalFace.extractIntegerArrayInto(0, 0, 3, allIndices)
         allStartIndices.push(0)
       }
     })
 
     this.finishPolygonalFaceSet_(
-        entity, temporary, isRelVoid, indicesPerFace,
+        entity, temporary, isRelVoid,
         allIndices, allStartIndices,
         polygonalFaceBufferOffsets, startIndicesBufferOffsets)
 

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -1015,70 +1015,44 @@ export class IfcGeometryExtraction {
       startIndicesBufferOffsetsArray,
     ] )
 
-    // Each acquisition is paired with its release through withRelease, which
-    // propagates a release failure on the success path and suppresses it only
-    // while something is already being unwound. Per-record extraction errors
-    // are caught upstream and expected on malformed models, so anything in
-    // here throwing used to strand all four pointers plus the pooled parse
-    // buffer and the two native objects, once per faceset - on a model with
-    // 15,777 facesets, a leak large enough to cause the exhaustion it would
-    // then be blamed on.
-    //
-    // Suppressing during unwinding matters as much as the release itself:
-    // every one of these re-enters the wasm runtime, and if that runtime is
-    // what failed, a throw here would REPLACE the in-flight error and the
-    // catch upstream would log a generic teardown failure instead of the heap
-    // diagnostic this change exists to produce.
     const geometry = withRelease(
       () => {
 
-          const polygonalFaceVector =
-            this.wasmModule.buildIndexedPolygonalFaceVector(
-                indicesArrayPtr,
-                indicesArray.length,
-                startIndicesArrayPtr,
-                polygonalFaceBufferOffsetsArrayPtr,
-                polygonalFaceBufferOffsetsArray.length,
-                startIndicesBufferOffsetsArrayPtr,
-                startIndicesBufferOffsetsArray.length)
+          const pointsParseBuffer = this.conwayModel.nativeParseBuffer()
 
-          return withRelease(
+          // Packed triangulation: the four heap buffers are already the
+          // face index layout. Unpacking them into 9.1M IndexedPolygonalFace
+          // std::vectors was the rest of the PSB pump after #448, and is
+          // why feeding the ThreadPool lost (the pool was paying to copy
+          // those vectors).
+          const pointsArrayNative = withRelease(
             () => {
 
-              const pointsParseBuffer = this.conwayModel.nativeParseBuffer()
+              if ( !entity.Coordinates.extractParseBuffer(
+                  0,
+                  0,
+                  0,
+                  pointsParseBuffer,
+                  this.wasmModule,
+                  true ) ) {
 
-              // Released around parseVertexVector too, not just the extract:
-              // it is pooled, so leaking it also loses whatever resize() grew.
-              const pointsArrayNative = withRelease(
-                () => {
+                pointsParseBuffer.resize( 0 )
+              }
 
-                  if ( !entity.Coordinates.extractParseBuffer(
-                      0,
-                      0,
-                      0,
-                      pointsParseBuffer,
-                      this.wasmModule,
-                      true ) ) {
-
-                    pointsParseBuffer.resize( 0 )
-                  }
-
-                  return this.wasmModule.parseVertexVector( pointsParseBuffer )
-                },
-                () => this.conwayModel.freeParseBuffer( pointsParseBuffer ) )
-
-              return withRelease(
-                () => this.conwayModel.getPolygonalFaceSetGeometry( {
-                  indicesPerFace: indicesPerFace,
-                  points: pointsArrayNative,
-                  faces: polygonalFaceVector,
-                } ),
-                () => pointsArrayNative.delete() )
+              return this.wasmModule.parseVertexVector( pointsParseBuffer )
             },
-            () => polygonalFaceVector.delete() )
+            () => this.conwayModel.freeParseBuffer( pointsParseBuffer ) )
+
+          return withRelease(
+            () => this.conwayModel.getPolygonalFaceSetGeometryPacked(
+                pointsArrayNative,
+                indicesArrayPtr,
+                polygonalFaceBufferOffsetsArrayPtr,
+                polygonalFaceBufferOffsetsArray.length - 1,
+                startIndicesArrayPtr,
+                startIndicesBufferOffsetsArrayPtr ),
+            () => pointsArrayNative.delete() )
       },
-      // freeAll, not four statements in one closure: there the first failure
-      // would abandon the other three.
       () => freeAll( this.wasmModule, [
         indicesArrayPtr,
         startIndicesArrayPtr,
@@ -1094,11 +1068,10 @@ export class IfcGeometryExtraction {
       temporary: temporary,
     }
 
-    // add mesh to the list of mesh objects
-    if (!isRelVoid) {
-      this.model.geometry.add(canonicalMesh)
+    if ( !isRelVoid ) {
+      this.model.geometry.add( canonicalMesh )
     } else {
-      this.model.voidGeometry.add(canonicalMesh)
+      this.model.voidGeometry.add( canonicalMesh )
     }
 
     return ExtractResult.COMPLETE

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -1052,7 +1052,7 @@ export class IfcGeometryExtraction {
                 pointsArrayNative,
                 indicesArrayPtr,
                 polygonalFaceBufferOffsetsArrayPtr,
-                polygonalFaceBufferOffsetsArray.length - 1,
+                polygonalFaceBufferOffsetsArray.length,
                 startIndicesArrayPtr,
                 startIndicesBufferOffsetsArrayPtr ),
             () => pointsArrayNative.delete() )

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -1152,6 +1152,7 @@ export class IfcGeometryExtraction {
     // abandons the whole faceset back to the getter path below, so
     // correctness never depends on the fast path's coverage.
     let fastPathOk = true
+    let hintLocalID: number | undefined
 
     const facesWalked = entity.forEachReferenceInField(
         FACES_FIELD_OFFSET,
@@ -1164,8 +1165,15 @@ export class IfcGeometryExtraction {
             return false
           }
 
-          const count = this.model.extractIntegerArrayByExpressIDInto(
-              expressID,
+          const localID = this.model.resolveExpressID( expressID, hintLocalID )
+
+          if ( localID === void 0 ) {
+            fastPathOk = false
+            return false
+          }
+
+          const count = this.model.extractIntegerArrayByLocalIDInto(
+              localID,
               COORD_INDEX_FIELD_OFFSET,
               EntityTypesIfc.IFCINDEXEDPOLYGONALFACE,
               allIndices)
@@ -1174,6 +1182,8 @@ export class IfcGeometryExtraction {
             fastPathOk = false
             return false
           }
+
+          hintLocalID = localID
 
           polygonalFaceBufferOffsets.push(allIndices.length - count)
           startIndicesBufferOffsets.push(allStartIndices.length)

--- a/src/step/parsing/uint32_sink.test.ts
+++ b/src/step/parsing/uint32_sink.test.ts
@@ -13,7 +13,7 @@ import {
   IfcIndexedPolygonalFaceWithVoids,
   IfcPolygonalFaceSet,
 } from '../../ifc/ifc4_gen/index'
-import { Uint32Sink } from './uint32_sink'
+import { Uint32Sink, extractUnsignedIntegerListAt } from './uint32_sink'
 
 describe( 'Uint32Sink', () => {
 
@@ -30,6 +30,24 @@ describe( 'Uint32Sink', () => {
 
     expect( sink.length ).toBe( 10 )
     expect( Array.from( sink.view ) ).toEqual( [ 0, 3, 6, 9, 12, 15, 18, 21, 24, 27 ] )
+  } )
+
+  test( 'extractUnsignedIntegerListAt parses a plain CoordIndex list', () => {
+
+    const sink = new Uint32Sink( 4 )
+    const bytes = new TextEncoder().encode( '(1,2,3,4)' )
+
+    expect( extractUnsignedIntegerListAt( bytes, 0, bytes.length, sink ) ).toBe( 4 )
+    expect( Array.from( sink.view ) ).toEqual( [ 1, 2, 3, 4 ] )
+  } )
+
+  test( 'extractUnsignedIntegerListAt refuses a real', () => {
+
+    const sink = new Uint32Sink( 4 )
+    const bytes = new TextEncoder().encode( '(1,2.5,3)' )
+
+    expect( extractUnsignedIntegerListAt( bytes, 0, bytes.length, sink ) )
+        .toBeUndefined()
   } )
 
   test( 'reset drops elements but keeps capacity for reuse', () => {

--- a/src/step/parsing/uint32_sink.test.ts
+++ b/src/step/parsing/uint32_sink.test.ts
@@ -222,6 +222,53 @@ describe( 'reference-level faceset fast path', () => {
     }
   }, 120000 )
 
+  test( 'column path matches CoordIndex without materialising the face first', () => {
+
+    const model = stepModel()
+    const sink = new Uint32Sink( 4 )
+
+    for ( const faceSet of faceSets() ) {
+
+      const expressIDs: number[] = []
+
+      faceSet.forEachReferenceInField(
+          FACES_OFFSET, FACES_BASE_OFFSET, FACES_DEPTH,
+          ( expressID ) => {
+
+            if ( expressID !== void 0 ) {
+              expressIDs.push( expressID )
+            }
+
+            return true
+          } )
+
+      const fromColumns: number[][] = []
+
+      for ( const expressID of expressIDs ) {
+
+        sink.reset()
+
+        const count = model.extractIntegerArrayByExpressIDInto(
+            expressID,
+            COORD_INDEX_OFFSET,
+            EntityTypesIfc.IFCINDEXEDPOLYGONALFACE,
+            sink )
+
+        if ( count === void 0 ) {
+          continue
+        }
+
+        fromColumns.push( Array.from( sink.view ) )
+      }
+
+      const fromGetter = faceSet.Faces
+          .filter( ( face ) => !( face instanceof IfcIndexedPolygonalFaceWithVoids ) )
+          .map( ( face ) => face.CoordIndex )
+
+      expect( fromColumns ).toEqual( fromGetter )
+    }
+  }, 120000 )
+
   test( 'reports failure for an unknown express ID and for a type mismatch', () => {
 
     const model = stepModel()

--- a/src/step/parsing/uint32_sink.test.ts
+++ b/src/step/parsing/uint32_sink.test.ts
@@ -41,13 +41,16 @@ describe( 'Uint32Sink', () => {
     expect( Array.from( sink.view ) ).toEqual( [ 1, 2, 3, 4 ] )
   } )
 
-  test( 'extractUnsignedIntegerListAt refuses a real', () => {
+  test( 'extractUnsignedIntegerListAt refuses a real and leaves the sink clean', () => {
 
     const sink = new Uint32Sink( 4 )
     const bytes = new TextEncoder().encode( '(1,2.5,3)' )
 
+    sink.push( 9 )
+
     expect( extractUnsignedIntegerListAt( bytes, 0, bytes.length, sink ) )
         .toBeUndefined()
+    expect( Array.from( sink.view ) ).toEqual( [ 9 ] )
   } )
 
   test( 'reset drops elements but keeps capacity for reuse', () => {

--- a/src/step/parsing/uint32_sink.ts
+++ b/src/step/parsing/uint32_sink.ts
@@ -148,7 +148,8 @@ export function extractIntegerArrayAt(
 /**
  * Fast path for `(1,2,3,4)` / `(1, 2, 3, 4)` — the CoordIndex shape.
  * Digits only, no comments, no reals. Returns undefined when the field
- * is not that shape so the caller can use the general parser.
+ * is not that shape so the caller can use the general parser. A failed
+ * parse does not leave partial values in `sink`.
  *
  * @param buffer Record window.
  * @param cursor Start of the field.
@@ -162,6 +163,8 @@ export function extractUnsignedIntegerListAt(
     cursor: number,
     endCursor: number,
     sink: Uint32Sink ): number | undefined {
+
+  const marked = sink.length
 
   while ( cursor < endCursor && WHITESPACE.has( buffer[ cursor ] ) ) {
     ++cursor
@@ -190,6 +193,7 @@ export function extractUnsignedIntegerListAt(
     }
 
     if ( cursor >= endCursor ) {
+      sink.truncate( marked )
       return void 0
     }
 
@@ -200,6 +204,7 @@ export function extractUnsignedIntegerListAt(
     if ( count > 0 ) {
 
       if ( buffer[ cursor ] !== COMMA ) {
+        sink.truncate( marked )
         return void 0
       }
 
@@ -210,6 +215,7 @@ export function extractUnsignedIntegerListAt(
       }
 
       if ( cursor >= endCursor ) {
+        sink.truncate( marked )
         return void 0
       }
     }
@@ -217,6 +223,7 @@ export function extractUnsignedIntegerListAt(
     const digit = buffer[ cursor ] - ZERO
 
     if ( digit < 0 || digit > 9 ) {
+      sink.truncate( marked )
       return void 0
     }
 
@@ -239,5 +246,6 @@ export function extractUnsignedIntegerListAt(
     ++count
   }
 
+  sink.truncate( marked )
   return void 0
 }

--- a/src/step/parsing/uint32_sink.ts
+++ b/src/step/parsing/uint32_sink.ts
@@ -5,6 +5,14 @@ import {
   stepExtractNumber,
   stepExtractOptional,
 } from './step_deserialization_functions'
+import ParsingConstants from '../../parsing/parsing_constants'
+
+
+const OPEN_PAREN  = ParsingConstants.OPEN_PAREN
+const CLOSE_PAREN = ParsingConstants.CLOSE_PAREN
+const COMMA       = ParsingConstants.COMMA
+const ZERO        = ParsingConstants.ZERO
+const WHITESPACE  = ParsingConstants.WHITE_SPACE_SET
 
 /**
  * Growable Uint32Array append sink.
@@ -50,6 +58,15 @@ export class Uint32Sink {
   }
 
   /**
+   * Keep the first `length` elements. Used to unwind a failed fast path.
+   *
+   * @param length New length, ≤ current length.
+   */
+  public truncate( length: number ): void {
+    this.length_ = length
+  }
+
+  /**
    * Append one value, growing geometrically when full.
    *
    * @param value The value to append.
@@ -90,6 +107,15 @@ export function extractIntegerArrayAt(
     endCursor: number,
     sink: Uint32Sink ): number {
 
+  const marked = sink.length
+  const fast   = extractUnsignedIntegerListAt( buffer, cursor, endCursor, sink )
+
+  if ( fast !== void 0 ) {
+    return fast
+  }
+
+  sink.truncate( marked )
+
   if ( stepExtractOptional( buffer, cursor, endCursor ) === null ) {
     return 0
   }
@@ -116,4 +142,102 @@ export function extractIntegerArrayAt(
   }
 
   return count
+}
+
+
+/**
+ * Fast path for `(1,2,3,4)` / `(1, 2, 3, 4)` — the CoordIndex shape.
+ * Digits only, no comments, no reals. Returns undefined when the field
+ * is not that shape so the caller can use the general parser.
+ *
+ * @param buffer Record window.
+ * @param cursor Start of the field.
+ * @param endCursor End bound.
+ * @param sink Receives values.
+ * @return {number | undefined} Count appended, or undefined if this
+ * is not an unsigned-integer list.
+ */
+export function extractUnsignedIntegerListAt(
+    buffer: Uint8Array,
+    cursor: number,
+    endCursor: number,
+    sink: Uint32Sink ): number | undefined {
+
+  while ( cursor < endCursor && WHITESPACE.has( buffer[ cursor ] ) ) {
+    ++cursor
+  }
+
+  if ( cursor >= endCursor ) {
+    return void 0
+  }
+
+  if ( buffer[ cursor ] === ParsingConstants.DOLLAR ) {
+    return 0
+  }
+
+  if ( buffer[ cursor ] !== OPEN_PAREN ) {
+    return void 0
+  }
+
+  ++cursor
+
+  let count = 0
+
+  while ( cursor < endCursor ) {
+
+    while ( cursor < endCursor && WHITESPACE.has( buffer[ cursor ] ) ) {
+      ++cursor
+    }
+
+    if ( cursor >= endCursor ) {
+      return void 0
+    }
+
+    if ( buffer[ cursor ] === CLOSE_PAREN ) {
+      return count
+    }
+
+    if ( count > 0 ) {
+
+      if ( buffer[ cursor ] !== COMMA ) {
+        return void 0
+      }
+
+      ++cursor
+
+      while ( cursor < endCursor && WHITESPACE.has( buffer[ cursor ] ) ) {
+        ++cursor
+      }
+
+      if ( cursor >= endCursor ) {
+        return void 0
+      }
+    }
+
+    const digit = buffer[ cursor ] - ZERO
+
+    if ( digit < 0 || digit > 9 ) {
+      return void 0
+    }
+
+    let value = digit
+    ++cursor
+
+    while ( cursor < endCursor ) {
+
+      const next = buffer[ cursor ] - ZERO
+
+      if ( next < 0 || next > 9 ) {
+        break
+      }
+
+      value = value * 10 + next
+      ++cursor
+    }
+
+    sink.push( value )
+    ++count
+  }
+
+  return void 0
 }

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -394,39 +394,6 @@ implements Iterable<BaseEntity>, Model {
   }
 
   /**
-   * Populate a raw vtable entry for a particular element, extra
-   * 
-   * @param element The raw elment to populate the vtable entry for.
-   * @return {boolean} Did the vtable entry populate correctly?
-   */
-  /**
-   * Append a referenced record's unsigned-integer list field into `sink`
-   * without materialising the referenced entity.
-   *
-   * This is the reference-level twin of
-   * `StepEntityBase.extractIntegerArrayInto`, for hot loops that walk
-   * millions of small records (tessellated facesets) where constructing
-   * an entity per record dominates. It deliberately handles only the
-   * simple case and reports failure otherwise, so callers keep a
-   * correct fallback rather than this growing subtle special cases:
-   * the reference must resolve, be single-class (no multi-mapping),
-   * and be exactly `expectedTypeID`.
-   *
-   * Field 0 is the data-block start the parser stored in `address_`
-   * (after `TYPE(`). Reading it from the columns skips the descriptor
-   * and vtable `entry()` would retain — on a 9 M-face model those are
-   * the objects the faceset path is trying not to build. Non-zero
-   * offsets still go through a vtable, because only field 0 has that
-   * address identity.
-   *
-   * @param expressID The referenced record's express ID.
-   * @param offset The field's vtable offset within the record.
-   * @param expectedTypeID The type the record must be.
-   * @param sink Receives the appended values.
-   * @return {number | undefined} Count appended, or undefined when the
-   * fast path does not apply and the caller must fall back.
-   */
-  /**
    * Resolve an express ID to a local ID, using `hintLocalID + 1` when
    * the next record is the one we want. Tessellated Faces lists are
    * sequential (PSB: every faceset), so this turns 9.1M interpolation
@@ -456,7 +423,21 @@ implements Iterable<BaseEntity>, Model {
 
   /**
    * Append a local record's unsigned-integer list field into `sink`
-   * without an express-ID lookup. See extractIntegerArrayByExpressIDInto.
+   * without an express-ID lookup. The reference-level twin of
+   * `StepEntityBase.extractIntegerArrayInto`, for hot loops that walk
+   * millions of small records (tessellated facesets) where constructing
+   * an entity per record dominates. It deliberately handles only the
+   * simple case and reports failure otherwise, so callers keep a
+   * correct fallback rather than this growing subtle special cases:
+   * the record must be single-class (no multi-mapping) and exactly
+   * `expectedTypeID`.
+   *
+   * Field 0 is the data-block start the parser stored in `address_`
+   * (after `TYPE(`). Reading it from the columns skips the descriptor
+   * and vtable `entry()` would retain — on a 9 M-face model those are
+   * the objects the faceset path is trying not to build. Non-zero
+   * offsets still go through a vtable, because only field 0 has that
+   * address identity.
    *
    * @param localID The record's local ID.
    * @param offset The field's vtable offset.

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -426,15 +426,52 @@ implements Iterable<BaseEntity>, Model {
    * @return {number | undefined} Count appended, or undefined when the
    * fast path does not apply and the caller must fall back.
    */
-  public extractIntegerArrayByExpressIDInto(
+  /**
+   * Resolve an express ID to a local ID, using `hintLocalID + 1` when
+   * the next record is the one we want. Tessellated Faces lists are
+   * sequential (PSB: every faceset), so this turns 9.1M interpolation
+   * searches into one per faceset.
+   *
+   * @param expressID The referenced record.
+   * @param hintLocalID Local ID of the previous resolve, if any.
+   * @return {number | undefined} The local ID, or undefined if unknown.
+   */
+  public resolveExpressID(
       expressID: number,
+      hintLocalID?: number ): number | undefined {
+
+    if ( hintLocalID !== void 0 ) {
+
+      const next = hintLocalID + 1
+
+      if ( next < this.firstInlineElement_ &&
+        this.expressID_[ next ] === expressID ) {
+        return next
+      }
+    }
+
+    return this.expressIDMap_.get( expressID )
+  }
+
+
+  /**
+   * Append a local record's unsigned-integer list field into `sink`
+   * without an express-ID lookup. See extractIntegerArrayByExpressIDInto.
+   *
+   * @param localID The record's local ID.
+   * @param offset The field's vtable offset.
+   * @param expectedTypeID The type the record must be.
+   * @param sink Receives the appended values.
+   * @return {number | undefined} Count appended, or undefined when the
+   * fast path does not apply.
+   */
+  public extractIntegerArrayByLocalIDInto(
+      localID: number,
       offset: number,
       expectedTypeID: EntityTypeIDs,
       sink: Uint32Sink ): number | undefined {
 
-    const localID = this.expressIDMap_.get( expressID )
-
-    if ( localID === void 0 || localID >= this.count_ ) {
+    if ( localID >= this.count_ ) {
       return void 0
     }
 
@@ -477,6 +514,34 @@ implements Iterable<BaseEntity>, Model {
     // same end bound the generated array getters use.
     return extractIntegerArrayAt(
         buffer, vtable[ ( element.vtableIndex as number ) + offset ], buffer.length, sink )
+  }
+
+
+  /**
+   * Append a referenced record's unsigned-integer list field into `sink`
+   * without materialising the referenced entity.
+   *
+   * @param expressID The referenced record's express ID.
+   * @param offset The field's vtable offset within the record.
+   * @param expectedTypeID The type the record must be.
+   * @param sink Receives the appended values.
+   * @return {number | undefined} Count appended, or undefined when the
+   * fast path does not apply.
+   */
+  public extractIntegerArrayByExpressIDInto(
+      expressID: number,
+      offset: number,
+      expectedTypeID: EntityTypeIDs,
+      sink: Uint32Sink ): number | undefined {
+
+    const localID = this.expressIDMap_.get( expressID )
+
+    if ( localID === void 0 ) {
+      return void 0
+    }
+
+    return this.extractIntegerArrayByLocalIDInto(
+        localID, offset, expectedTypeID, sink )
   }
 
 

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -410,10 +410,14 @@ implements Iterable<BaseEntity>, Model {
    * simple case and reports failure otherwise, so callers keep a
    * correct fallback rather than this growing subtle special cases:
    * the reference must resolve, be single-class (no multi-mapping),
-   * and be exactly `expectedTypeID` — which is what makes reading
-   * `offset` as a plain vtable slot equivalent to the generated
-   * getter's `getOffsetCursor( offset, _, _ )` (that only subtracts a
-   * base offset for multi-mapped records).
+   * and be exactly `expectedTypeID`.
+   *
+   * Field 0 is the data-block start the parser stored in `address_`
+   * (after `TYPE(`). Reading it from the columns skips the descriptor
+   * and vtable `entry()` would retain — on a 9 M-face model those are
+   * the objects the faceset path is trying not to build. Non-zero
+   * offsets still go through a vtable, because only field 0 has that
+   * address identity.
    *
    * @param expressID The referenced record's express ID.
    * @param offset The field's vtable offset within the record.
@@ -434,13 +438,28 @@ implements Iterable<BaseEntity>, Model {
       return void 0
     }
 
-    const element = this.entry( localID )
-
     // Multi-mapped records need per-depth base offsets; leave them to
-    // the generated getters.
-    if ( element.multiMapping !== void 0 || element.typeID !== expectedTypeID ) {
+    // the generated getters. typeID_ is -1 when unset.
+    if ( this.complexEntries_?.has( localID ) ||
+      this.typeID_[ localID ] !== expectedTypeID ) {
       return void 0
     }
+
+    if ( offset === 0 ) {
+
+      const address = this.address_[ localID ]
+      const acquisition = this.bufferProvider_.acquire(
+          address, this.length_[ localID ] )
+      const viewAddress = address - acquisition.offset
+
+      return extractIntegerArrayAt(
+          acquisition.buffer,
+          viewAddress,
+          acquisition.buffer.length,
+          sink )
+    }
+
+    const element = this.entry( localID )
 
     if ( element.vtableIndex === void 0 && !this.populateVtableEntryRaw( element ) ) {
       return void 0


### PR DESCRIPTION
Towards #446. **Does not close it.**

Three stacked levers on the tessellated (JS-bound) pump. Measured on `PSB.ifc` (861 MB, node MT). Absolute times moved with machine load; the deltas below are same-session A/B except where noted.

### 1. Column extract (no per-face descriptor / vtable)

`extractIntegerArrayByExpressIDInto` still called `entry()` and built a vtable for every face after #448. Field 0 of a single-class record *is* the data-block start already in `address_`. Read `CoordIndex` from the SoA columns.

| | geometry pump (median) | first-run RSS |
|---|---|---|
| main (after #448) | 61.98 s | 2310 MB |
| column extract | **38.64 s** | **978 MB** |

### 2. Packed triangulation (conway-geom #174 + #175)

`buildIndexedPolygonalFaceVector` allocated a `std::vector` per face (9.1 M on PSB) before any triangulation. The JS sinks already have those indices packed; C++ reads the slices. Pins conway-geom `4ae6726` (#175): offset-array length (N+1) matching `buildIndexedPolygonalFaceVector`, 1-based `CoordIndex` guard, `IfcBound3D` slot reuse, packed-vs-unpacked equivalence test.

Lever 3 as written — put facesets on the idle ThreadPool — was measured and dropped:

| approach | PSB pump |
|---|---|
| `parallel_for` per faceset | ~143 s |
| batched per-face `Geometry` | ~135 s |
| one `parallel_for` over all sets | 51–67 s |
| **packed serial** | **29–33 s** |

A finish split (`CONWAY_FACESET_TIMES=1`) showed why: heap copy 0.15 s, point-list parse 3.8 s, **triangulate 8.3 s**. Four-way threads on 8 s cannot make 30 s engine.

### 3. Sequential Faces + digit CoordIndex

Every PSB faceset lists faces as consecutive express IDs (15,754 / 15,754). `resolveExpressID` uses `hintLocalID+1` when that is the next record — one interpolation search per faceset, not per face. CoordIndex is `IfcPositiveInteger`; parse `(1,2,3,4)` as digits, fall back if it is not that shape. A failed digit parse rolls the sink back so it does not leave partial values.

Quiet-looking run after this: parse 17.4 s, **pump 20.7 s**, engine **38.0 s**. (A second run was 41 s pump with parse also doubled — contention.)

### What is left for #446

Target is ~30 s engine. Parse is still ~15 s. The leftover pump is point-list parse, mesh registration, and non-faceset work. Not another 9.1 M-lookup trick, and not the worker pool.

### Testing

- `uint32_sink` + `ifc_geometry_extraction` + `ifc_step_model`: 30/30
- Smoke: `data/index.ifc` and `duplex.ifc` extract cleanly
- PSB A/B as above
- CI on this PR: `build`, `run-ifc-regression`, `visual-diff` green