### PR TITLE
M1b: store-backed open + Geometry progress

### DIFF
--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -383,6 +383,44 @@ export class IfcAPI {
   }
 
   /**
+   * M1b store-backed open (conway extension; feature-detect with
+   * `typeof api.OpenModelStream === 'function'`). Parses through a
+   * moving window over `store` and keeps the model windowed from
+   * birth — the source is never one JS `ArrayBuffer`. Geometry
+   * extract on the deferred path must use
+   * {@link ExtractGeometryBatchAsync} so product closures can be
+   * paged in.
+   *
+   * IFC only; other formats return -1 (caller should fall back to
+   * buffering + OpenModelStreamed).
+   *
+   * @param store External store holding the source bytes (OPFS File).
+   * @param settings settings for loading the model
+   * @return {Promise<number>} model ID, or -1 on failure
+   */
+  async OpenModelStream(
+      store: StepExternalByteStore,
+      settings?: Loadersettings ): Promise<number> {
+
+    const modelIdResult = this.globalModelIDCounter++
+
+    const result =
+      await IfcApiModelPassthroughFactory.fromStore(
+          modelIdResult,
+          store,
+          this.wasmModule,
+          settings)
+
+    if ( result === void 0 ) {
+      return -1
+    }
+
+    this.models.set( modelIdResult, result )
+
+    return modelIdResult
+  }
+
+  /**
    * Set conway's console-echo log threshold, web-ifc compatible surface
    * (numeric LogLevel enum). Embedders (e.g. Share) use this to quiet a
    * clean load's console down to warnings/errors — conway issue #301.
@@ -851,6 +889,37 @@ export class IfcAPI {
       meshCallback?: (mesh: FlatMesh) => void ): {extracted: number, remaining: number} {
 
     const result = this.models.get(modelID)
+
+    if (result?.extractGeometryBatch === void 0) {
+      return {extracted: 0, remaining: 0}
+    }
+
+    return result.extractGeometryBatch(batchSize, meshCallback)
+  }
+
+  /**
+   * Async twin of {@link ExtractGeometryBatch}: pages each product's
+   * source-byte closure before extracting it. Required for models
+   * opened with {@link OpenModelStream}; a no-op-prefetch on a
+   * resident-source deferred open. Feature-detect with
+   * `typeof api.ExtractGeometryBatchAsync === 'function'`.
+   *
+   * @param modelID handle retrieved by OpenModelStream / OpenModelStreamed
+   * @param batchSize max products to extract this call
+   * @param meshCallback receives each newly-extracted product's mesh
+   * @return {Promise<object>} `{extracted, remaining}`
+   */
+  async ExtractGeometryBatchAsync(
+      modelID: number,
+      batchSize: number,
+      meshCallback?: (mesh: FlatMesh) => void ):
+      Promise<{extracted: number, remaining: number}> {
+
+    const result = this.models.get(modelID)
+
+    if (result?.extractGeometryBatchAsync !== void 0) {
+      return result.extractGeometryBatchAsync(batchSize, meshCallback)
+    }
 
     if (result?.extractGeometryBatch === void 0) {
       return {extracted: 0, remaining: 0}

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -107,6 +107,42 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     api.CloseModel( deferredID )
   }, 240000 )
 
+  test( 'deferred pump emits a Geometry progress phase', async () => {
+
+    const events: { phase: string, completed: number, total?: number }[] = []
+    const deferredID = await api.OpenModelStreamed( buffer, {
+      ...SETTINGS,
+      DEFER_GEOMETRY: true,
+      ON_PROGRESS: ( event ) => {
+        events.push( {
+          phase: event.phase,
+          completed: event.completed,
+          total: event.total,
+        } )
+      },
+    } )
+
+    expect( deferredID ).toBeGreaterThanOrEqual( 0 )
+
+    for ( ; ; ) {
+      const { extracted, remaining } = api.ExtractGeometryBatch( deferredID, 7 )
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+
+    const parseEvents = events.filter( ( event ) => event.phase === 'dataParse' )
+    const geometryEvents = events.filter( ( event ) => event.phase === 'geometry' )
+
+    expect( parseEvents.length ).toBeGreaterThan( 0 )
+    expect( geometryEvents.length ).toBeGreaterThan( 0 )
+    expect( geometryEvents[ 0 ].completed ).toBe( 0 )
+    expect( geometryEvents[ geometryEvents.length - 1 ].completed ).
+        toBe( geometryEvents[ geometryEvents.length - 1 ].total )
+
+    api.CloseModel( deferredID )
+  }, 240000 )
+
   test( 'StreamAllMeshes on a deferred model drains the pump and matches classic', async () => {
 
     const classicID = api.OpenModel( buffer, SETTINGS )

--- a/src/compat/web-ifc/ifc_api_model_passthrough.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough.ts
@@ -25,6 +25,15 @@ export interface IfcApiModelPassthrough {
   extractGeometryBatch?(
     batchSize: number,
     meshCallback?: (mesh: FlatMesh) => void): {extracted: number, remaining: number}
+
+  /**
+   * Async twin of extractGeometryBatch — pages windowed source ranges
+   * before each product extract (M1b). Feature-detect with typeof.
+   */
+  extractGeometryBatchAsync?(
+    batchSize: number,
+    meshCallback?: (mesh: FlatMesh) => void):
+    Promise<{extracted: number, remaining: number}>
   getCoordinationMatrix(): number[]
 
   /**

--- a/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough_factory.ts
@@ -5,6 +5,11 @@ import { IfcApiModelPassthrough } from './ifc_api_model_passthrough'
 import { IfcApiProxyAP214 } from './ifc_api_proxy_ap214'
 import { IfcApiProxyIfc } from './ifc_api_proxy_ifc'
 import Logger from '../../logging/logger'
+import { StepExternalByteStore } from '../../step/step_buffer_provider'
+
+/** Prefix used to sniff FILE_SCHEMA without paging the whole file. */
+// eslint-disable-next-line no-magic-numbers
+const STORE_DETECT_PREFIX_BYTES = 64 * 1024
 
 /**
  * The factory to construct models.
@@ -165,6 +170,49 @@ export class IfcApiModelPassthroughFactory {
     }
 
     return IfcApiModelPassthroughFactory.fromAsync(modelID, data, wasmModule, settings)
+  }
+
+  /**
+   * Store-backed open (M1b): IFC models parse through a moving window
+   * over `store` and stay windowed from birth. Non-IFC formats are not
+   * implemented on this path — the caller should fall back to buffering
+   * and fromStreamed.
+   *
+   * @param modelID
+   * @param store External store holding the source bytes.
+   * @param wasmModule
+   * @param settings
+   * @return {Promise<IfcApiModelPassthrough | undefined>}
+   */
+  public static async fromStore(
+      modelID: number,
+      store: StepExternalByteStore,
+      wasmModule: any,
+      settings?: Loadersettings ): Promise<IfcApiModelPassthrough | undefined> {
+
+    const prefixLen = Math.min( store.byteLength, STORE_DETECT_PREFIX_BYTES )
+    const prefix = await store.read( 0, prefixLen )
+    const modelFormat = ModelFormatDetector.detect( new ParsingBuffer( prefix ) )
+
+    if ( modelFormat === ModelFormatType.IFC ) {
+
+      try {
+
+        return await IfcApiProxyIfc.createFromStore(
+            modelID, store, wasmModule, settings )
+      } catch ( e ) {
+
+        const message = e instanceof Error ? e.message : String( e )
+
+        Logger.warning(
+            `Store-backed open failed for model ${modelID}: ${message}` )
+      }
+    } else {
+
+      Logger.warning(
+          'Store-backed open is IFC-only; use OpenModelStreamed with a buffer ' +
+          `for format ${modelFormat}` )
+    }
   }
 
   /**

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -79,6 +79,8 @@ interface Ap214ProxyLoadState {
   scene: AP214SceneBuilder
   conwayGeometry: AP214GeometryExtraction
   geometryTimeInMs: number
+  /** Parse tracker, kept so the deferred batch pump can emit Geometry. */
+  tracker?: ProgressTracker
 }
 
 /**
@@ -100,6 +102,12 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
 
   /** Was this model opened without extraction (DEFER_GEOMETRY)? */
   private deferredMode_: boolean = false
+
+  /** Parse/load tracker — deferred opens resume it for the Geometry phase. */
+  private progressTracker_?: ProgressTracker
+
+  /** True once beginPhase('geometry') has fired for this deferred pump. */
+  private geometryPhaseStarted_: boolean = false
 
   /** Has finishDemandExtraction run (deferred models, once)? */
   private demandFinished_: boolean = false
@@ -222,6 +230,7 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
     this.conwaywasm = loadState.conwaywasm
     this.conwayGeometry_ = loadState.conwayGeometry
     this.deferredMode_ = loadState.deferred === true
+    this.progressTracker_ = loadState.tracker
 
     const statistics = Logger.getStatistics(modelID)
 
@@ -576,6 +585,7 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
         scene: conwayGeometry.scene,
         conwayGeometry,
         geometryTimeInMs: 0,
+        tracker,
       }
     }
 
@@ -1308,8 +1318,22 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
     // any consumer knowing the schema.
     const units = Math.max(1, Math.floor(batchSize / AP214_UNITS_PER_PRODUCT_BATCH))
 
+    if (this.progressTracker_ !== void 0 && !this.geometryPhaseStarted_) {
+      this.progressTracker_.beginPhase(
+          'geometry', 'products', extraction.demandUnitCount)
+      this.geometryPhaseStarted_ = true
+    }
+
     const extracted = extraction.extractDemandUnitBatch(units)
     const remaining = extraction.demandUnitCount - extraction.demandUnitCursor
+
+    if (this.progressTracker_ !== void 0) {
+      if (remaining === 0) {
+        this.progressTracker_.endPhase(extraction.demandUnitCount)
+      } else {
+        this.progressTracker_.update(extraction.demandUnitCursor)
+      }
+    }
 
     if (remaining === 0 && !this.demandFinished_) {
       this.demandFinished_ = true

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -78,6 +78,8 @@ interface IfcProxyLoadState {
   scene: IfcSceneBuilder
   conwayGeometry: IfcGeometryExtraction
   geometryTimeInMs: number
+  /** Parse tracker, kept so the deferred batch pump can emit Geometry. */
+  tracker?: ProgressTracker
 }
 
 /**
@@ -101,6 +103,12 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
   /** Was this model opened without extraction (DEFER_GEOMETRY)? */
   private deferredMode_: boolean = false
+
+  /** Parse/load tracker — deferred opens resume it for the Geometry phase. */
+  private progressTracker_?: ProgressTracker
+
+  /** True once beginPhase('geometry') has fired for this deferred pump. */
+  private geometryPhaseStarted_: boolean = false
 
   /** Deferred-mode product worklist (file order), lazily enumerated. */
   private demandProducts_?: number[]
@@ -199,6 +207,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     this.conwaywasm = loadState.conwaywasm
     this.conwayGeometry_ = loadState.conwayGeometry
     this.deferredMode_ = loadState.deferred === true
+    this.progressTracker_ = loadState.tracker
 
     const statistics = Logger.getStatistics(modelID)
 
@@ -823,6 +832,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         scene: conwayGeometry.scene,
         conwayGeometry,
         geometryTimeInMs: 0,
+        tracker,
       }
     }
 
@@ -1535,16 +1545,25 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       this.demandAggregatesCursor_ = 0
     }
 
+    const products = this.demandProducts_ ?? []
+    const aggregates = this.demandAggregates_ ?? []
+    const totalWork = products.length + aggregates.length
+
+    if (this.progressTracker_ !== void 0 && !this.geometryPhaseStarted_) {
+      this.progressTracker_.beginPhase('geometry', 'products', totalWork)
+      this.geometryPhaseStarted_ = true
+    }
+
     const budget = Math.max(batchSize, 1)
     const end = Math.min(
         this.demandCursor_ + budget,
-        this.demandProducts_.length)
+        products.length)
 
     let extracted = 0
 
     for (; this.demandCursor_ < end; ++this.demandCursor_) {
 
-      const localID = this.demandProducts_[this.demandCursor_]
+      const localID = products[this.demandCursor_]
 
       if (this.conwayGeometry_.extractProductGeometryByLocalID(localID)) {
         ++extracted
@@ -1556,9 +1575,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // the same per-call budget — batch-by-batch, not as one end-of-load
     // stall — so aggregate parts stream in cut, exactly once, with
     // final content (see demandAggregates_).
-    const aggregates = this.demandAggregates_ ?? []
-
-    if (this.demandCursor_ >= this.demandProducts_.length &&
+    if (this.demandCursor_ >= products.length &&
         this.demandAggregatesCursor_ < aggregates.length) {
 
       const aggregatesEnd = Math.min(
@@ -1578,10 +1595,21 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       this.streamNewMeshes_(meshCallback)
     }
 
+    const remaining = (products.length - this.demandCursor_) +
+        (aggregates.length - this.demandAggregatesCursor_)
+
+    if (this.progressTracker_ !== void 0) {
+      const completed = totalWork - remaining
+      if (remaining === 0) {
+        this.progressTracker_.endPhase(totalWork)
+      } else {
+        this.progressTracker_.update(completed)
+      }
+    }
+
     return {
       extracted,
-      remaining: (this.demandProducts_.length - this.demandCursor_) +
-        (aggregates.length - this.demandAggregatesCursor_),
+      remaining,
     }
   }
 

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -15,7 +15,7 @@ import {
   RawLineData,
   Vector,
 } from './ifc_api'
-import { StepExternalByteStore } from '../../step/step_buffer_provider'
+import { StepExternalByteStore, WindowedStepBufferProvider } from '../../step/step_buffer_provider'
 import { IfcApiModelPassthrough } from './ifc_api_model_passthrough'
 import { NodeValueHandle } from './properties_passthrough'
 import * as glmatrix from 'gl-matrix'
@@ -28,9 +28,10 @@ import { formatModelLine } from '../../core/progress_log'
 import { extractModelInfo } from '../../loaders/loading_utilities'
 import IfcStepParser from '../../ifc/ifc_step_parser'
 import ParsingBuffer from '../../parsing/parsing_buffer'
-import { BufferByteSource } from '../../step/parsing/byte_source'
+import { BufferByteSource, StoreByteSource } from '../../step/parsing/byte_source'
 import {
   buildIndexStreamingAsync,
+  buildColumnarIndexStreamingAsync,
 } from '../../step/parsing/streaming_index_builder'
 import { ColumnarIndexSink } from '../../step/parsing/columnar_index'
 import {
@@ -440,6 +441,31 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         modelID, data, new ConwayGeometry(wasmModule), settings, true)
 
     return new IfcApiProxyIfc(modelID, data, wasmModule, settings, loadState)
+  }
+
+  /**
+   * M1b store-backed open: parse through a moving window over `store`
+   * and keep the model windowed from birth — the source is never held
+   * as one `ArrayBuffer`. Geometry extract pages product closures
+   * through {@link extractGeometryBatchAsync}.
+   *
+   * @param modelID The model ID being opened.
+   * @param store External store holding the source bytes.
+   * @param wasmModule The wasm module.
+   * @param settings Loader settings (ON_PROGRESS is honored).
+   * @return {Promise<IfcApiProxyIfc>} The constructed proxy.
+   */
+  public static async createFromStore(
+      modelID: number,
+      store: StepExternalByteStore,
+      wasmModule: any,
+      settings?: Loadersettings ): Promise<IfcApiProxyIfc> {
+
+    const loadState = await IfcApiProxyIfc.parseColumnarFromStore(
+        modelID, store, new ConwayGeometry(wasmModule), settings,
+        settings?.DEFER_GEOMETRY === true )
+
+    return new IfcApiProxyIfc(modelID, new Uint8Array( 0 ), wasmModule, settings, loadState)
   }
 
   /**
@@ -867,6 +893,149 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       stepHeader,
       model,
       scene,
+      conwayGeometry,
+      geometryTimeInMs: endTime - startTime,
+    }
+  }
+
+
+  /**
+   * Windowed-from-birth twin of parseColumnarAndExtractAsync: the
+   * source stays in `store`, parse windows are filled through it, and
+   * the model never holds a resident copy. Preview-during-parse is
+   * skipped (that channel needs a resident prefix). Deferred opens
+   * page prep closures before prepareDemandExtraction; non-deferred
+   * opens drain the demand pump with per-product residency.
+   *
+   * @param modelID The model ID being opened.
+   * @param store External store holding the source bytes.
+   * @param conwaywasm The conway geometry wasm wrapper.
+   * @param settings Loader settings (ON_PROGRESS is honored).
+   * @param deferGeometry Skip extraction (Share demand pump).
+   * @return {Promise<IfcProxyLoadState>} Everything the constructor tail needs.
+   */
+  private static async parseColumnarFromStore(
+      modelID: number,
+      store: StepExternalByteStore,
+      conwaywasm: ConwayGeometry,
+      settings?: Loadersettings,
+      deferGeometry: boolean = false ): Promise<IfcProxyLoadState> {
+
+    const tracker = IfcApiProxyIfc.makeTracker(settings)
+    const allTimeStart = Date.now()
+    const parser = IfcStepParser.Instance
+    const fileSize = store.byteLength
+
+    tracker?.beginPhase('headerParse', 'bytes', fileSize)
+
+    const headerLen = Math.min( fileSize, STREAMED_PARSE_POOL_BYTES )
+    const headerBytes = await store.read( 0, headerLen )
+    const [stepHeader, result0] = parser.parseHeader( new ParsingBuffer( headerBytes ) )
+
+    Logger.createStatistics(modelID)
+
+    const statistics = Logger.getStatistics(modelID)
+
+    IfcApiProxyIfc.reportHeaderParseResult(result0, new ParsingBuffer( headerBytes ), modelID)
+
+    const modelInfo = extractModelInfo(stepHeader, fileSize)
+
+    Logger.info(formatModelLine(modelInfo))
+    settings?.ON_MODEL_INFO?.(modelInfo)
+
+    tracker?.beginPhase('dataParse', 'bytes', fileSize)
+
+    const parseTick = tracker !== void 0 ?
+      (cursorBytes: number) => tracker.update(cursorBytes) : void 0
+
+    const parseStartTime = Date.now()
+
+    const { result, columns } = await buildColumnarIndexStreamingAsync(
+        new StoreByteSource( store ),
+        parser,
+        STREAMED_PARSE_POOL_BYTES,
+        void 0,
+        parseTick )
+
+    const parseEndTime = Date.now()
+
+    tracker?.endPhase(fileSize)
+
+    if (result !== ParseResult.COMPLETE) {
+      Logger.warning(`[OpenModelStream]: streamed parse result ${result}`)
+      statistics?.setLoadStatus('PARSE_FAIL')
+      throw new Error( 'Streamed parse did not complete' )
+    }
+
+    const provider = new WindowedStepBufferProvider( store )
+    const model = new IfcStepModel( void 0, columns, provider )
+
+    statistics?.setParseTime(parseEndTime - parseStartTime)
+
+    const conwayGeometry = new IfcGeometryExtraction(conwaywasm, model)
+
+    await conwayGeometry.ensureResidentForDemandPrep()
+    conwayGeometry.prepareDemandExtraction()
+
+    if (deferGeometry) {
+
+      statistics?.setProductCount(model.typeCount(IfcProduct))
+
+      return {
+        conwaywasm,
+        deferred: true,
+        allTimeStart,
+        stepHeader,
+        model,
+        scene: conwayGeometry.scene,
+        conwayGeometry,
+        geometryTimeInMs: 0,
+        tracker,
+      }
+    }
+
+    tracker?.beginPhase('geometry', 'products')
+
+    const startTime = Date.now()
+
+    const aggregateTargets = conwayGeometry.aggregateTargetLocalIDs()
+    let completed = 0
+
+    tracker?.setPhaseTotal( model.typeCount( IfcProduct ) )
+
+    for ( const product of model.types( IfcProduct ) ) {
+
+      if ( aggregateTargets.has( product.localID ) ) {
+        continue
+      }
+
+      await conwayGeometry.ensureResidentForProductExtract( product.localID )
+      conwayGeometry.extractProductGeometryByLocalID( product.localID )
+      ++completed
+      tracker?.update( completed )
+    }
+
+    for ( const relAggregate of model.types( IfcRelAggregates ) ) {
+
+      await conwayGeometry.ensureResidentForAggregateExtract( relAggregate )
+      conwayGeometry.extractRelAggregateGeometry( relAggregate )
+      ++completed
+      tracker?.update( completed )
+    }
+
+    const endTime = Date.now()
+
+    tracker?.endPhase()
+
+    statistics?.setProductCount(model.typeCount(IfcProduct))
+    statistics?.setGeometryTypeCounts(conwayGeometry.geometryTypeCounts)
+
+    return {
+      conwaywasm,
+      allTimeStart,
+      stepHeader,
+      model,
+      scene: conwayGeometry.scene,
       conwayGeometry,
       geometryTimeInMs: endTime - startTime,
     }
@@ -1511,7 +1680,74 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       return {extracted: 0, remaining: 0}
     }
 
-    if (this.demandProducts_ === void 0) {
+    if (this.model[0].isSourceExternal) {
+      throw new Error(
+          'ExtractGeometryBatch is synchronous and cannot page a windowed ' +
+          'source — use ExtractGeometryBatchAsync' )
+    }
+
+    this.ensureDemandWorklists_()
+
+    return this.pumpGeometryBatch_(batchSize, meshCallback)
+  }
+
+  /**
+   * Async twin of {@link extractGeometryBatch}: pages each product's
+   * `#ref` closure before extracting it, so a model opened through
+   * {@link IfcApiProxyIfc.createFromStore} (windowed from birth) can
+   * be pumped. Safe on a resident source (prefetch is a no-op).
+   *
+   * @param batchSize Max products to extract this call (min 1).
+   * @param meshCallback Receives each newly-extracted product's mesh.
+   * @return {Promise<object>} `{extracted, remaining}`.
+   */
+  async extractGeometryBatchAsync(
+      batchSize: number,
+      meshCallback?: (mesh: FlatMesh) => void ):
+      Promise<{extracted: number, remaining: number}> {
+
+    if (!this.deferredMode_) {
+      return {extracted: 0, remaining: 0}
+    }
+
+    this.ensureDemandWorklists_()
+
+    if (!this.model[0].isSourceExternal) {
+      return this.pumpGeometryBatch_(batchSize, meshCallback)
+    }
+
+    const products = this.demandProducts_ ?? []
+    const aggregates = this.demandAggregates_ ?? []
+    const budget = Math.max(batchSize, 1)
+    const productEnd = Math.min(this.demandCursor_ + budget, products.length)
+
+    for (let where = this.demandCursor_; where < productEnd; ++where) {
+      await this.conwayGeometry_.ensureResidentForProductExtract(products[where])
+    }
+
+    if (this.demandCursor_ >= products.length) {
+
+      const remainingBudget = budget
+      const aggregatesEnd = Math.min(
+          this.demandAggregatesCursor_ + remainingBudget, aggregates.length)
+
+      for (let where = this.demandAggregatesCursor_; where < aggregatesEnd; ++where) {
+        await this.conwayGeometry_.ensureResidentForAggregateExtract(aggregates[where])
+      }
+    }
+
+    return this.pumpGeometryBatch_(batchSize, meshCallback)
+  }
+
+  /**
+   * Enumerate the deferred worklists once (file-order products, then
+   * rel-aggregates). Shared by the sync and async pumps.
+   */
+  private ensureDemandWorklists_(): void {
+
+    if (this.demandProducts_ !== void 0) {
+      return
+    }
 
       // Aggregate-target products are extracted ONLY by the
       // rel-aggregates pass below (with the relating object's master
@@ -1543,7 +1779,19 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       this.demandAggregates_ = aggregates
       this.demandCursor_ = 0
       this.demandAggregatesCursor_ = 0
-    }
+  }
+
+  /**
+   * Synchronous extract of the next batch. Caller must have paged
+   * ranges if the source is windowed.
+   *
+   * @param batchSize Max products this call.
+   * @param meshCallback Optional mesh consumer.
+   * @return {object} `{extracted, remaining}`.
+   */
+  private pumpGeometryBatch_(
+      batchSize: number,
+      meshCallback?: (mesh: FlatMesh) => void ): {extracted: number, remaining: number} {
 
     const products = this.demandProducts_ ?? []
     const aggregates = this.demandAggregates_ ?? []

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -974,8 +974,13 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     const conwayGeometry = new IfcGeometryExtraction(conwaywasm, model)
 
-    await conwayGeometry.ensureResidentForDemandPrep()
-    conwayGeometry.prepareDemandExtraction()
+    const prepPins = await conwayGeometry.ensureResidentForDemandPrep()
+
+    try {
+      conwayGeometry.prepareDemandExtraction()
+    } finally {
+      model.unpinLocalIDs( prepPins )
+    }
 
     if (deferGeometry) {
 
@@ -1009,16 +1014,38 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         continue
       }
 
-      await conwayGeometry.ensureResidentForProductExtract( product.localID )
-      conwayGeometry.extractProductGeometryByLocalID( product.localID )
+      const pins =
+        await conwayGeometry.ensureResidentForProductExtract( product.localID )
+
+      try {
+        conwayGeometry.extractProductGeometryByLocalID( product.localID )
+      } catch ( error ) {
+        Logger.error(
+            `Error extracting product ${product.expressID}: ` +
+            `${error instanceof Error ? error.message : String( error )}` )
+      } finally {
+        model.unpinLocalIDs( pins )
+      }
+
       ++completed
       tracker?.update( completed )
     }
 
     for ( const relAggregate of model.types( IfcRelAggregates ) ) {
 
-      await conwayGeometry.ensureResidentForAggregateExtract( relAggregate )
-      conwayGeometry.extractRelAggregateGeometry( relAggregate )
+      const pins =
+        await conwayGeometry.ensureResidentForAggregateExtract( relAggregate )
+
+      try {
+        conwayGeometry.extractRelAggregateGeometry( relAggregate )
+      } catch ( error ) {
+        Logger.error(
+            `Error extracting aggregate ${relAggregate.expressID}: ` +
+            `${error instanceof Error ? error.message : String( error )}` )
+      } finally {
+        model.unpinLocalIDs( pins )
+      }
+
       ++completed
       tracker?.update( completed )
     }
@@ -1718,25 +1745,81 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     const products = this.demandProducts_ ?? []
     const aggregates = this.demandAggregates_ ?? []
+    const totalWork = products.length + aggregates.length
     const budget = Math.max(batchSize, 1)
-    const productEnd = Math.min(this.demandCursor_ + budget, products.length)
+    let extracted = 0
 
-    for (let where = this.demandCursor_; where < productEnd; ++where) {
-      await this.conwayGeometry_.ensureResidentForProductExtract(products[where])
+    if (this.progressTracker_ !== void 0 && !this.geometryPhaseStarted_) {
+      this.progressTracker_.beginPhase('geometry', 'products', totalWork)
+      this.geometryPhaseStarted_ = true
     }
 
-    if (this.demandCursor_ >= products.length) {
+    const productEnd = Math.min(this.demandCursor_ + budget, products.length)
 
-      const remainingBudget = budget
-      const aggregatesEnd = Math.min(
-          this.demandAggregatesCursor_ + remainingBudget, aggregates.length)
+    for (; this.demandCursor_ < productEnd; ++this.demandCursor_) {
 
-      for (let where = this.demandAggregatesCursor_; where < aggregatesEnd; ++where) {
-        await this.conwayGeometry_.ensureResidentForAggregateExtract(aggregates[where])
+      const localID = products[this.demandCursor_]
+      const pins =
+        await this.conwayGeometry_.ensureResidentForProductExtract(localID)
+
+      try {
+        if (this.conwayGeometry_.extractProductGeometryByLocalID(localID)) {
+          ++extracted
+        }
+      } catch (error) {
+        Logger.error(
+            `Error extracting product localID ${localID}: ` +
+            `${error instanceof Error ? error.message : String(error)}`)
+      } finally {
+        this.model[0].unpinLocalIDs(pins)
       }
     }
 
-    return this.pumpGeometryBatch_(batchSize, meshCallback)
+    if (this.demandCursor_ >= products.length &&
+        this.demandAggregatesCursor_ < aggregates.length) {
+
+      const aggregatesEnd = Math.min(
+          this.demandAggregatesCursor_ + (budget - extracted),
+          aggregates.length)
+
+      for (; this.demandAggregatesCursor_ < aggregatesEnd;
+        ++this.demandAggregatesCursor_) {
+
+        const relAggregate = aggregates[this.demandAggregatesCursor_]
+        const pins =
+          await this.conwayGeometry_.ensureResidentForAggregateExtract(
+              relAggregate)
+
+        try {
+          this.conwayGeometry_.extractRelAggregateGeometry(relAggregate)
+          ++extracted
+        } catch (error) {
+          Logger.error(
+              `Error extracting aggregate ${relAggregate.expressID}: ` +
+              `${error instanceof Error ? error.message : String(error)}`)
+        } finally {
+          this.model[0].unpinLocalIDs(pins)
+        }
+      }
+    }
+
+    if (meshCallback !== void 0) {
+      this.streamNewMeshes_(meshCallback)
+    }
+
+    const remaining = (products.length - this.demandCursor_) +
+        (aggregates.length - this.demandAggregatesCursor_)
+
+    if (this.progressTracker_ !== void 0) {
+      const completed = totalWork - remaining
+      if (remaining === 0) {
+        this.progressTracker_.endPhase(totalWork)
+      } else {
+        this.progressTracker_.update(completed)
+      }
+    }
+
+    return {extracted, remaining}
   }
 
   /**

--- a/src/compat/web-ifc/ifc_api_streamed_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_streamed_open.test.ts
@@ -142,4 +142,53 @@ describe( 'OpenModelStreamed', () => {
 
     expect( await api.OpenModelStreamed( garbage, SETTINGS ) ).toBe( -1 )
   }, 120000 )
+
+  test( 'OpenModelStream parses from a store without a resident buffer', async () => {
+
+    const store = new InMemoryStepByteStore( buffer )
+    const modelID = await api.OpenModelStream( store, SETTINGS )
+
+    expect( modelID ).toBeGreaterThanOrEqual( 0 )
+
+    const passthrough = api.getPassthrough( modelID )!
+
+    expect( passthrough.sourceIsExternal ).toBe( true )
+
+    const streamedID = await api.OpenModelStreamed( buffer, SETTINGS )
+
+    expect( captureMeshes( modelID ) ).toEqual( captureMeshes( streamedID ) )
+
+    api.CloseModel( modelID )
+    api.CloseModel( streamedID )
+  }, 240000 )
+
+  test( 'OpenModelStream + DEFER_GEOMETRY pumps via ExtractGeometryBatchAsync', async () => {
+
+    const store = new InMemoryStepByteStore( buffer )
+    const deferredID = await api.OpenModelStream(
+        store, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    expect( deferredID ).toBeGreaterThanOrEqual( 0 )
+
+    const captured: object[] = []
+
+    for ( ; ; ) {
+
+      const { extracted, remaining } = await api.ExtractGeometryBatchAsync(
+          deferredID, 8, ( mesh ) => {
+            captured.push( { expressID: mesh.expressID } )
+          } )
+
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+
+    expect( captured.length ).toBeGreaterThan( 0 )
+
+    expect( () => api.ExtractGeometryBatch( deferredID, 8 ) )
+        .toThrow( /ExtractGeometryBatchAsync/ )
+
+    api.CloseModel( deferredID )
+  }, 240000 )
 } )

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -6402,12 +6402,15 @@ export class IfcGeometryExtraction {
    * the relationship sweeps succeed on a windowed source. Call before
    * the first prepare on a model whose source is external.
    *
-   * @return {Promise<void>} Resolves when the prep set is resident.
+   * @return {Promise<Set<number>>} Pinned local IDs — caller must
+   * {@link StepModelBase.unpinLocalIDs} after prepare/extract.
    */
-  public async ensureResidentForDemandPrep(): Promise< void > {
+  public async ensureResidentForDemandPrep(): Promise< Set< number > > {
+
+    const pinned = new Set< number >()
 
     if ( !this.model.isSourceExternal ) {
-      return
+      return pinned
     }
 
     const prepTypes = [
@@ -6422,9 +6425,11 @@ export class IfcGeometryExtraction {
     for ( const type of prepTypes ) {
 
       for ( const expressID of this.model.expressIDsOfTypes( type ) ) {
-        await this.model.ensureResidentClosureByExpressID( expressID )
+        await this.model.ensureResidentClosureByExpressID( expressID, void 0, pinned )
       }
     }
+
+    return pinned
   }
 
   /**
@@ -6433,12 +6438,16 @@ export class IfcGeometryExtraction {
    * (those are inverse — not written in the product record).
    *
    * @param localID The product's local ID.
-   * @return {Promise<void>} Resolves when the extract set is resident.
+   * @return {Promise<Set<number>>} Pinned local IDs — caller must unpin
+   * after extract.
    */
-  public async ensureResidentForProductExtract( localID: number ): Promise< void > {
+  public async ensureResidentForProductExtract(
+      localID: number,
+      seen?: Set< number > ):
+      Promise< Set< number > > {
 
     if ( !this.model.isSourceExternal ) {
-      return
+      return seen ?? new Set< number >()
     }
 
     const extra: number[] = []
@@ -6454,7 +6463,8 @@ export class IfcGeometryExtraction {
       extra.push( material )
     }
 
-    const visited = await this.model.ensureResidentClosureByLocalID( localID, extra )
+    const visited =
+      await this.model.ensureResidentClosureByLocalID( localID, extra, seen )
     const styleExtra: number[] = []
 
     for ( const visitedID of visited ) {
@@ -6473,8 +6483,10 @@ export class IfcGeometryExtraction {
     }
 
     if ( styleExtra.length > 0 ) {
-      await this.model.ensureResidentClosureByLocalID( localID, styleExtra )
+      await this.model.ensureResidentClosureByLocalID( localID, styleExtra, visited )
     }
+
+    return visited
   }
 
   /**
@@ -6483,32 +6495,36 @@ export class IfcGeometryExtraction {
    * and every related product.
    *
    * @param relAggregate The relationship to prefetch.
-   * @return {Promise<void>} Resolves when the extract set is resident.
+   * @return {Promise<Set<number>>} Pinned local IDs — caller must unpin
+   * after extract.
    */
   public async ensureResidentForAggregateExtract(
-      relAggregate: IfcRelAggregates ): Promise< void > {
+      relAggregate: IfcRelAggregates ): Promise< Set< number > > {
 
     if ( !this.model.isSourceExternal ) {
-      return
+      return new Set< number >()
     }
 
-    await this.model.ensureResidentClosureByLocalID( relAggregate.localID )
+    const pinned =
+      await this.model.ensureResidentClosureByLocalID( relAggregate.localID )
 
     const relating = relAggregate.RelatingObject
 
     if ( relating !== null && relating !== void 0 ) {
-      await this.ensureResidentForProductExtract( relating.localID )
+      await this.ensureResidentForProductExtract( relating.localID, pinned )
     }
 
     const related = relAggregate.RelatedObjects
 
     if ( related === null || related === void 0 ) {
-      return
+      return pinned
     }
 
     for ( const product of related ) {
-      await this.ensureResidentForProductExtract( product.localID )
+      await this.ensureResidentForProductExtract( product.localID, pinned )
     }
+
+    return pinned
   }
 
   /**

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -6398,6 +6398,120 @@ export class IfcGeometryExtraction {
   }
 
   /**
+   * Page in every record {@link prepareDemandExtraction} will read, so
+   * the relationship sweeps succeed on a windowed source. Call before
+   * the first prepare on a model whose source is external.
+   *
+   * @return {Promise<void>} Resolves when the prep set is resident.
+   */
+  public async ensureResidentForDemandPrep(): Promise< void > {
+
+    if ( !this.model.isSourceExternal ) {
+      return
+    }
+
+    const prepTypes = [
+      IfcProject,
+      IfcRelAssociatesMaterial,
+      IfcMaterialDefinitionRepresentation,
+      IfcRelVoidsElement,
+      IfcStyledItem,
+      IfcRelAggregates,
+    ]
+
+    for ( const type of prepTypes ) {
+
+      for ( const expressID of this.model.expressIDsOfTypes( type ) ) {
+        await this.model.ensureResidentClosureByExpressID( expressID )
+      }
+    }
+  }
+
+  /**
+   * Page in the `#ref` closure a per-product extract will acquire,
+   * including this product's voids, bound materials and styled items
+   * (those are inverse — not written in the product record).
+   *
+   * @param localID The product's local ID.
+   * @return {Promise<void>} Resolves when the extract set is resident.
+   */
+  public async ensureResidentForProductExtract( localID: number ): Promise< void > {
+
+    if ( !this.model.isSourceExternal ) {
+      return
+    }
+
+    const extra: number[] = []
+    const voids = this.productToVoidGeometryMap.get( localID )
+
+    if ( voids !== void 0 ) {
+      extra.push( ...voids )
+    }
+
+    const material = this.materials.relMaterialsMap.get( localID )
+
+    if ( material !== void 0 ) {
+      extra.push( material )
+    }
+
+    const visited = await this.model.ensureResidentClosureByLocalID( localID, extra )
+    const styleExtra: number[] = []
+
+    for ( const visitedID of visited ) {
+
+      const styled = this.materials.styledItemMap.get( visitedID )
+
+      if ( styled !== void 0 ) {
+        styleExtra.push( styled )
+      }
+
+      const definition = this.materials.materialDefinitionsMap.get( visitedID )
+
+      if ( definition !== void 0 ) {
+        styleExtra.push( definition )
+      }
+    }
+
+    if ( styleExtra.length > 0 ) {
+      await this.model.ensureResidentClosureByLocalID( localID, styleExtra )
+    }
+  }
+
+  /**
+   * Page in the records {@link extractRelAggregateGeometry} will
+   * acquire: the relationship, the relating product (and its voids)
+   * and every related product.
+   *
+   * @param relAggregate The relationship to prefetch.
+   * @return {Promise<void>} Resolves when the extract set is resident.
+   */
+  public async ensureResidentForAggregateExtract(
+      relAggregate: IfcRelAggregates ): Promise< void > {
+
+    if ( !this.model.isSourceExternal ) {
+      return
+    }
+
+    await this.model.ensureResidentClosureByLocalID( relAggregate.localID )
+
+    const relating = relAggregate.RelatingObject
+
+    if ( relating !== null && relating !== void 0 ) {
+      await this.ensureResidentForProductExtract( relating.localID )
+    }
+
+    const related = relAggregate.RelatedObjects
+
+    if ( related === null || related === void 0 ) {
+      return
+    }
+
+    for ( const product of related ) {
+      await this.ensureResidentForProductExtract( product.localID )
+    }
+  }
+
+  /**
    * The whole-model walk's SECOND product pass, shared with the demand
    * pump: for every IfcRelAggregates, re-extract the related products
    * with the relating object's rel-voids as a master override. This

--- a/src/ifc/ifc_step_parser.ts
+++ b/src/ifc/ifc_step_parser.ts
@@ -3,8 +3,11 @@ import StepParser, {ParseProgressCallback, ParseResult} from '../step/parsing/st
 import EntityTypesIfc from './ifc4_gen/entity_types_ifc.gen'
 import EntitTypesIfcSearch from './ifc4_gen/entity_types_search.gen'
 import IfcStepModel from './ifc_step_model'
-import { ByteSource } from '../step/parsing/byte_source'
-import { buildColumnarIndexStreaming } from '../step/parsing/streaming_index_builder'
+import { ByteSource, ReadableByteSource } from '../step/parsing/byte_source'
+import {
+  buildColumnarIndexStreaming,
+  buildColumnarIndexStreamingAsync,
+} from '../step/parsing/streaming_index_builder'
 import {
   StepExternalByteStore,
   WindowedStepBufferProvider,
@@ -110,6 +113,47 @@ export default class IfcStepParser extends StepParser< EntityTypesIfc > {
     // per-record object phase never exists, so peak heap is window + columns.
     const { columns, result } =
       buildColumnarIndexStreaming( source, this, opts?.pool ?? DEFAULT_STREAM_POOL_BYTES )
+
+    const provider =
+      new WindowedStepBufferProvider( store, opts?.chunkBytes, opts?.maxResidentChunks )
+
+    return [result, new IfcStepModel( void 0, columns, provider )]
+  }
+
+  /**
+   * Cooperative twin of {@link parseStreamToModel}: the index build
+   * yields to the event loop and can fill windows from an async
+   * {@link ReadableByteSource} (an OPFS `File.slice()` store). The
+   * model is still windowed — geometry extract must
+   * `ensureResident` first.
+   *
+   * @param source Sync or async byte source feeding the parse.
+   * @param store Async external store backing the windowed model.
+   * @param opts Optional window sizing plus parse progress.
+   * @return {Promise<[ParseResult, IfcStepModel | undefined]>} The
+   * parse result and the windowed model.
+   */
+  public async parseStreamToModelAsync(
+      source: ReadableByteSource,
+      store: StepExternalByteStore,
+      opts?: {
+        pool?: number
+        chunkBytes?: number
+        maxResidentChunks?: number
+        onProgress?: ( absoluteByteCursor: number ) => void
+      } ):
+      Promise<[ParseResult, IfcStepModel | undefined]> {
+
+    if ( store.byteLength !== source.byteLength ) {
+      throw new Error(
+          `Streaming store byteLength ${store.byteLength} does not match ` +
+          `source byteLength ${source.byteLength}` )
+    }
+
+    const { columns, result } =
+      await buildColumnarIndexStreamingAsync(
+          source, this, opts?.pool ?? DEFAULT_STREAM_POOL_BYTES,
+          void 0, opts?.onProgress )
 
     const provider =
       new WindowedStepBufferProvider( store, opts?.chunkBytes, opts?.maxResidentChunks )

--- a/src/ifc/ifc_stream_open.test.ts
+++ b/src/ifc/ifc_stream_open.test.ts
@@ -9,7 +9,7 @@ import { beforeAll, describe, expect, test } from '@jest/globals'
 
 import ParsingBuffer from '../parsing/parsing_buffer'
 import IfcStepParser from './ifc_step_parser'
-import { openStreamedIfcModel } from './ifc_stream_open'
+import { openStreamedIfcModel, openStreamedIfcModelFromStore } from './ifc_stream_open'
 import { BufferByteSource } from '../step/parsing/byte_source'
 import { InMemoryStepByteStore } from '../step/step_buffer_provider'
 import { ParseResult } from '../step/parsing/step_parser'
@@ -100,5 +100,17 @@ describe( 'openStreamedIfcModel (Phase B3)', () => {
         new BufferByteSource( bytes ),
         new InMemoryStepByteStore( bytes.subarray( 0, 100 ) ) ) )
         .toThrow( /does not match/ )
+  } )
+
+  test( 'openStreamedIfcModelFromStore matches the sync open', async () => {
+    const store = new InMemoryStepByteStore( bytes )
+    const fromStore = await openStreamedIfcModelFromStore( store, { pool: 4 * 1024 } )
+    const streamed = openStreamedIfcModel(
+        new BufferByteSource( bytes ), store, { pool: 4 * 1024 } )
+
+    expect( fromStore.result ).toBe( ParseResult.COMPLETE )
+    expect( fromStore.model!.isSourceExternal ).toBe( true )
+    expect( [ ...fromStore.model!.expressIDsOfTypes( IfcRoot ) ] )
+        .toEqual( [ ...streamed.model!.expressIDsOfTypes( IfcRoot ) ] )
   } )
 } )

--- a/src/ifc/ifc_stream_open.ts
+++ b/src/ifc/ifc_stream_open.ts
@@ -1,7 +1,8 @@
-import { ByteSource } from '../step/parsing/byte_source'
+import { ByteSource, ReadableByteSource, StoreByteSource } from '../step/parsing/byte_source'
 import { StepIndexColumns } from '../step/parsing/columnar_index'
 import {
   buildColumnarIndexStreaming,
+  buildColumnarIndexStreamingAsync,
   StreamingIndexStats,
 } from '../step/parsing/streaming_index_builder'
 import { ParseResult, StepHeader } from '../step/parsing/step_parser'
@@ -122,4 +123,72 @@ export function openStreamedIfcModel(
     columns,
     stats,
   }
+}
+
+
+/**
+ * Cooperative twin of {@link openStreamedIfcModel}: the index build
+ * yields to the event loop and can fill windows from an async
+ * {@link ReadableByteSource}. Pass a {@link StoreByteSource} wrapping
+ * `store` to parse a file that is already in OPFS without ever
+ * holding it as one `ArrayBuffer`.
+ *
+ * @param source Sync or async parse source.
+ * @param store The random-access store the model reads from afterwards.
+ * @param options See {@link StreamedIfcOpenOptions} plus `onProgress`.
+ * @return {Promise<StreamedIfcOpen>} The model + header, columns, diagnostics.
+ */
+export async function openStreamedIfcModelAsync(
+    source: ReadableByteSource,
+    store: StepExternalByteStore,
+    options?: StreamedIfcOpenOptions & {
+      onProgress?: ( absoluteByteCursor: number ) => void
+    } ): Promise<StreamedIfcOpen> {
+
+  if ( store.byteLength !== source.byteLength ) {
+    throw new Error(
+        `Streaming store byteLength ${store.byteLength} does not match ` +
+        `source byteLength ${source.byteLength}` )
+  }
+
+  const { header, columns, result, stats } = await buildColumnarIndexStreamingAsync(
+      source,
+      IfcStepParser.Instance,
+      options?.pool ?? DEFAULT_STREAM_POOL_BYTES,
+      options?.onRecordIndexed,
+      options?.onProgress )
+
+  if ( result !== ParseResult.COMPLETE ) {
+    return { model: void 0, result, header, columns, stats }
+  }
+
+  const provider = new WindowedStepBufferProvider(
+      store, options?.chunkBytes, options?.maxResidentChunks )
+
+  return {
+    model: new IfcStepModel( void 0, columns, provider ),
+    result,
+    header,
+    columns,
+    stats,
+  }
+}
+
+
+/**
+ * Open a windowed IFC model from a store alone — parse windows and
+ * post-parse reads share `store`. This is the M1b embedder entry for
+ * a file already sitting in OPFS.
+ *
+ * @param store The source of truth for the file bytes.
+ * @param options See {@link openStreamedIfcModelAsync}.
+ * @return {Promise<StreamedIfcOpen>} The model + header, columns, diagnostics.
+ */
+export function openStreamedIfcModelFromStore(
+    store: StepExternalByteStore,
+    options?: StreamedIfcOpenOptions & {
+      onProgress?: ( absoluteByteCursor: number ) => void
+    } ): Promise<StreamedIfcOpen> {
+
+  return openStreamedIfcModelAsync( new StoreByteSource( store ), store, options )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,12 +44,27 @@ export {
 // `/demand`, and `/mem` — which is where new conway-native APIs land (the
 // web-ifc compat shim stays an adapter and is headed for retirement). The
 // flat re-exports below are kept for root-import compatibility.
-export { openStreamedIfcModel, StreamedIfcOpen, StreamedIfcOpenOptions } from './ifc/ifc_stream_open'
+export {
+  openStreamedIfcModel,
+  openStreamedIfcModelAsync,
+  openStreamedIfcModelFromStore,
+  StreamedIfcOpen,
+  StreamedIfcOpenOptions,
+} from './ifc/ifc_stream_open'
 export {
   buildColumnarIndexStreaming,
   buildColumnarIndexStreamingAsync,
 } from './step/parsing/streaming_index_builder'
-export { ByteSource, BufferByteSource } from './step/parsing/byte_source'
+export {
+  ByteSource,
+  BufferByteSource,
+  AsyncByteSource,
+  ReadableByteSource,
+  StoreByteSource,
+  SyncAccessHandleByteSource,
+  SyncAccessHandleLike,
+} from './step/parsing/byte_source'
+export { scanExpressRefs } from './step/parsing/express_ref_scan'
 export {
   StepExternalByteStore,
   InMemoryStepByteStore,

--- a/src/namespace_surface.test.ts
+++ b/src/namespace_surface.test.ts
@@ -12,7 +12,10 @@ describe( 'plane namespace surface', () => {
 
   test( 'stream exposes the fixed-memory open plane', () => {
     expect( typeof stream.openStreamedIfcModel ).toBe( 'function' )
+    expect( typeof stream.openStreamedIfcModelFromStore ).toBe( 'function' )
     expect( typeof stream.BufferByteSource ).toBe( 'function' )
+    expect( typeof stream.StoreByteSource ).toBe( 'function' )
+    expect( typeof stream.SyncAccessHandleByteSource ).toBe( 'function' )
     expect( typeof stream.InMemoryStepByteStore ).toBe( 'function' )
     expect( typeof stream.WindowedStepBufferProvider ).toBe( 'function' )
     expect( typeof stream.serializeIndexSidecarFromColumns ).toBe( 'function' )

--- a/src/step/parsing/byte_source.test.ts
+++ b/src/step/parsing/byte_source.test.ts
@@ -1,0 +1,64 @@
+/* eslint-disable no-magic-numbers */
+import { describe, expect, test } from '@jest/globals'
+
+import {
+  BufferByteSource,
+  StoreByteSource,
+  SyncAccessHandleByteSource,
+} from './byte_source'
+import { InMemoryStepByteStore } from '../step_buffer_provider'
+import { FileDescriptorByteSource } from './byte_source_node'
+
+
+describe( 'ByteSource implementations', () => {
+
+  const bytes = new Uint8Array( [10, 20, 30, 40, 50] )
+
+  test( 'BufferByteSource copies a range', () => {
+    const source = new BufferByteSource( bytes )
+    const into = new Uint8Array( 4 )
+
+    expect( source.read( 1, 3, into, 1 ) ).toBe( 3 )
+    expect( [ ...into ] ).toEqual( [0, 20, 30, 40] )
+  } )
+
+  test( 'StoreByteSource matches BufferByteSource over the same bytes', async () => {
+    const source = new StoreByteSource( new InMemoryStepByteStore( bytes ) )
+    const into = new Uint8Array( 3 )
+
+    expect( await source.read( 2, 10, into, 0 ) ).toBe( 3 )
+    expect( [ ...into ] ).toEqual( [30, 40, 50] )
+  } )
+
+  test( 'SyncAccessHandleByteSource reads through the handle contract', () => {
+    const handle = {
+      getSize: () => bytes.length,
+      read( buffer: Uint8Array, options?: { at?: number } ): number {
+        const at = options?.at ?? 0
+        const want = Math.min( buffer.length, bytes.length - at )
+
+        buffer.set( bytes.subarray( at, at + want ) )
+        return want
+      },
+    }
+    const source = new SyncAccessHandleByteSource( handle )
+    const into = new Uint8Array( 2 )
+
+    expect( source.read( 3, 2, into, 0 ) ).toBe( 2 )
+    expect( [ ...into ] ).toEqual( [40, 50] )
+  } )
+
+  test( 'FileDescriptorByteSource reads index.ifc without holding it', () => {
+    const source = FileDescriptorByteSource.open( 'data/index.ifc' )
+
+    try {
+      const head = new Uint8Array( 15 )
+      const got = source.read( 0, 15, head, 0 )
+
+      expect( got ).toBe( 15 )
+      expect( new TextDecoder().decode( head ).startsWith( 'ISO-10303-21;' ) ).toBe( true )
+    } finally {
+      source.close()
+    }
+  } )
+} )

--- a/src/step/parsing/byte_source.ts
+++ b/src/step/parsing/byte_source.ts
@@ -71,3 +71,149 @@ export class BufferByteSource implements ByteSource {
     return end - offset
   }
 }
+
+
+/**
+ * A `ByteSource` whose `read` is asynchronous — a `StepExternalByteStore`
+ * (OPFS `File.slice()`), or any other store that cannot serve bytes
+ * synchronously on this thread. `buildIndexStreamingAsync` accepts either
+ * this or a sync {@link ByteSource}; the sync builder does not.
+ */
+export interface AsyncByteSource {
+
+  /** Total length of the source in bytes. */
+  readonly byteLength: number
+
+  /**
+   * Read up to `length` bytes starting at `offset` into `into` at
+   * `intoOffset`. Same contract as {@link ByteSource.read}, but async.
+   *
+   * @param offset Absolute source offset to read from.
+   * @param length Maximum number of bytes to read.
+   * @param into Destination buffer.
+   * @param intoOffset Offset within `into` to write at.
+   * @return {Promise<number>} The number of bytes copied.
+   */
+  read(
+      offset: number, length: number, into: Uint8Array, intoOffset: number ): Promise<number>
+}
+
+
+/**
+ * Either a sync or async positioned byte source. The cooperative index
+ * builder awaits each fill; a sync source just resolves immediately.
+ */
+export type ReadableByteSource = ByteSource | AsyncByteSource
+
+
+/**
+ * Minimal sync-access handle (OPFS `FileSystemSyncAccessHandle` in a
+ * worker). Defined here so the source has no DOM lib dependency.
+ */
+export interface SyncAccessHandleLike {
+
+  /**
+   * Read into `buffer` starting at file offset `options.at`.
+   *
+   * @param buffer Destination view.
+   * @param options `{ at }` file offset (default 0).
+   * @return {number} Bytes copied.
+   */
+  read( buffer: Uint8Array, options?: { at?: number } ): number
+
+  /**
+   * @return {number} File size in bytes.
+   */
+  getSize(): number
+}
+
+
+/**
+ * A `ByteSource` over an OPFS (or similar) synchronous access handle —
+ * the worker-side parse feed for M1b write-through. Reads never
+ * materialise the file as one `ArrayBuffer`.
+ */
+export class SyncAccessHandleByteSource implements ByteSource {
+
+  /**
+   * @param handle_ A sync-access handle already opened on the file.
+   */
+  constructor( private readonly handle_: SyncAccessHandleLike ) {}
+
+  /**
+   * @return {number} The file length.
+   */
+  public get byteLength(): number {
+    return this.handle_.getSize()
+  }
+
+  /**
+   * @param offset Absolute source offset to read from.
+   * @param length Maximum number of bytes to read.
+   * @param into Destination buffer.
+   * @param intoOffset Offset within `into` to write at.
+   * @return {number} The number of bytes copied.
+   */
+  public read(
+      offset: number, length: number, into: Uint8Array, intoOffset: number ): number {
+
+    const end = Math.min( offset + length, this.byteLength )
+
+    if ( end <= offset ) {
+      return 0
+    }
+
+    const want = end - offset
+
+    return this.handle_.read( into.subarray( intoOffset, intoOffset + want ), { at: offset } )
+  }
+}
+
+
+/**
+ * An {@link AsyncByteSource} over a {@link StepExternalByteStore} — the
+ * main-thread parse feed for a file that is already in OPFS (or any
+ * store whose `read` is async). Peak parse scratch is one window, not
+ * the whole file.
+ */
+export class StoreByteSource implements AsyncByteSource {
+
+  /**
+   * @param store_ The external store (same bytes the model will page).
+   */
+  constructor( private readonly store_: {
+    readonly byteLength: number
+    read( offset: number, length: number ): Promise<Uint8Array>
+  } ) {}
+
+  /**
+   * @return {number} The store length.
+   */
+  public get byteLength(): number {
+    return this.store_.byteLength
+  }
+
+  /**
+   * @param offset Absolute source offset to read from.
+   * @param length Maximum number of bytes to read.
+   * @param into Destination buffer.
+   * @param intoOffset Offset within `into` to write at.
+   * @return {Promise<number>} The number of bytes copied.
+   */
+  public async read(
+      offset: number, length: number, into: Uint8Array, intoOffset: number ): Promise<number> {
+
+    const end = Math.min( offset + length, this.store_.byteLength )
+
+    if ( end <= offset ) {
+      return 0
+    }
+
+    const want = end - offset
+    const bytes = await this.store_.read( offset, want )
+
+    into.set( bytes.subarray( 0, want ), intoOffset )
+
+    return Math.min( bytes.byteLength, want )
+  }
+}

--- a/src/step/parsing/byte_source_node.ts
+++ b/src/step/parsing/byte_source_node.ts
@@ -1,0 +1,68 @@
+import fs from 'fs'
+
+import { ByteSource } from './byte_source'
+
+
+/**
+ * A `ByteSource` over a Node file descriptor — the node/test twin of
+ * `SyncAccessHandleByteSource`. The file is never held as one JS
+ * buffer; each `read` is `fs.readSync` into the caller's window.
+ *
+ * The caller owns the fd (open + close). This class does not close it.
+ */
+export class FileDescriptorByteSource implements ByteSource {
+
+  /**
+   * @param fd_ An fd open for reading.
+   * @param byteLength_ File size in bytes (`fstat.size`).
+   */
+  constructor(
+      private readonly fd_: number,
+      private readonly byteLength_: number ) {}
+
+  /**
+   * Open `path` read-only and wrap it. Caller must {@link close}.
+   *
+   * @param path Filesystem path.
+   * @return {FileDescriptorByteSource} The source.
+   */
+  public static open( path: string ): FileDescriptorByteSource {
+
+    const fd = fs.openSync( path, 'r' )
+
+    return new FileDescriptorByteSource( fd, fs.fstatSync( fd ).size )
+  }
+
+  /**
+   * @return {number} The file length.
+   */
+  public get byteLength(): number {
+    return this.byteLength_
+  }
+
+  /**
+   * Close the underlying fd. Further reads throw.
+   */
+  public close(): void {
+    fs.closeSync( this.fd_ )
+  }
+
+  /**
+   * @param offset Absolute source offset to read from.
+   * @param length Maximum number of bytes to read.
+   * @param into Destination buffer.
+   * @param intoOffset Offset within `into` to write at.
+   * @return {number} The number of bytes copied.
+   */
+  public read(
+      offset: number, length: number, into: Uint8Array, intoOffset: number ): number {
+
+    const end = Math.min( offset + length, this.byteLength_ )
+
+    if ( end <= offset ) {
+      return 0
+    }
+
+    return fs.readSync( this.fd_, into, intoOffset, end - offset, offset )
+  }
+}

--- a/src/step/parsing/express_ref_scan.test.ts
+++ b/src/step/parsing/express_ref_scan.test.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-magic-numbers */
+import { describe, expect, test } from '@jest/globals'
+
+import { scanExpressRefs } from './express_ref_scan'
+
+
+/**
+ * @param text STEP text to scan.
+ * @return {number[]} Referenced express IDs.
+ */
+function scan( text: string ): number[] {
+  return scanExpressRefs( new TextEncoder().encode( text ) )
+}
+
+
+describe( 'scanExpressRefs', () => {
+
+  test( 'collects distinct #ids in first-seen order', () => {
+    expect( scan( '#10=IFCWALL(#20,#20,#30);' ) ).toEqual( [10, 20, 30] )
+  } )
+
+  test( 'ignores hashes inside STEP strings and doubled quotes', () => {
+    expect( scan( "#1=IFCLABEL('door #99 is fine');#2=IFCNAME('it''s #8');" ) )
+        .toEqual( [1, 2] )
+  } )
+
+  test( 'ignores hashes inside binary blobs', () => {
+    expect( scan( '#1=IFCBLOB("#99DEAD");' ) ).toEqual( [1] )
+  } )
+
+  test( 'ignores hashes inside comments', () => {
+    expect( scan( '#1=IFCWALL(/* see #99 */#2);' ) ).toEqual( [1, 2] )
+  } )
+
+  test( 'skips #0', () => {
+    expect( scan( '#1=IFCWALL(#0,#2);' ) ).toEqual( [1, 2] )
+  } )
+} )

--- a/src/step/parsing/express_ref_scan.ts
+++ b/src/step/parsing/express_ref_scan.ts
@@ -1,0 +1,132 @@
+/**
+ * Lexical scan of a STEP record for `#<expressID>` references.
+ *
+ * Used to prefetch the source-byte closure a windowed extract will
+ * acquire: walking typed attributes requires those records to already
+ * be resident, so the walk has to happen on the raw text. Strings
+ * (`'...'` with `''` escapes), binary blobs (`"..."`) and C-style
+ * comments are skipped so a hash inside a string is not a ref.
+ */
+
+
+const HASH = 0x23
+const QUOTE = 0x27
+const DQUOTE = 0x22
+const ZERO = 0x30
+const NINE = 0x39
+const SLASH = 0x2F
+const STAR = 0x2A
+
+
+/**
+ * Collect the distinct express IDs referenced from a STEP record's
+ * bytes. Order is first-seen; `#0` is ignored (not a real entity).
+ *
+ * @param bytes The record text (or a view containing it).
+ * @param from Start offset within `bytes`.
+ * @param length Number of bytes to scan.
+ * @return {number[]} Distinct referenced express IDs.
+ */
+export function scanExpressRefs(
+    bytes: Uint8Array, from: number = 0, length: number = bytes.length - from ): number[] {
+
+  const refs: number[] = []
+  const seen = new Set<number>()
+  const end = Math.min( from + length, bytes.length )
+  let cursor = from
+
+  while ( cursor < end ) {
+
+    const byte = bytes[ cursor ]
+
+    if ( byte === QUOTE ) {
+
+      cursor = skipQuoted_( bytes, cursor + 1, end, QUOTE, true )
+      continue
+    }
+
+    if ( byte === DQUOTE ) {
+
+      cursor = skipQuoted_( bytes, cursor + 1, end, DQUOTE, false )
+      continue
+    }
+
+    if ( byte === SLASH && cursor + 1 < end && bytes[ cursor + 1 ] === STAR ) {
+
+      cursor += 2
+
+      while ( cursor + 1 < end &&
+          !( bytes[ cursor ] === STAR && bytes[ cursor + 1 ] === SLASH ) ) {
+
+        ++cursor
+      }
+
+      cursor += 2
+      continue
+    }
+
+    if ( byte === HASH ) {
+
+      let value = 0
+      let digit = cursor + 1
+
+      while ( digit < end && bytes[ digit ] >= ZERO && bytes[ digit ] <= NINE ) {
+
+        value = ( value * 10 ) + ( bytes[ digit ] - ZERO )
+        ++digit
+      }
+
+      if ( digit > cursor + 1 && value !== 0 && !seen.has( value ) ) {
+
+        seen.add( value )
+        refs.push( value )
+      }
+
+      cursor = digit
+      continue
+    }
+
+    ++cursor
+  }
+
+  return refs
+}
+
+
+/**
+ * Advance past a quoted span that started just before `from`.
+ *
+ * @param bytes Source bytes.
+ * @param from First byte after the opening quote.
+ * @param end Exclusive scan limit.
+ * @param quote The quote byte to match.
+ * @param doubledEscape True for STEP strings (`''` is one quote).
+ * @return {number} Index just after the closing quote (or `end`).
+ */
+function skipQuoted_(
+    bytes: Uint8Array,
+    from: number,
+    end: number,
+    quote: number,
+    doubledEscape: boolean ): number {
+
+  let cursor = from
+
+  while ( cursor < end ) {
+
+    if ( bytes[ cursor ] === quote ) {
+
+      if ( doubledEscape && cursor + 1 < end && bytes[ cursor + 1 ] === quote ) {
+
+        cursor += 2
+        continue
+      }
+
+      return cursor + 1
+    }
+
+    ++cursor
+  }
+
+  return end
+}

--- a/src/step/parsing/step_parser.ts
+++ b/src/step/parsing/step_parser.ts
@@ -476,7 +476,9 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
         return next.value
       }
 
-      onProgress?.( next.value )
+      if ( typeof next.value === 'number' ) {
+        onProgress?.( next.value )
+      }
     }
   }
 
@@ -489,7 +491,8 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
    *
    * @param input The input parsing buffer, positioned at the data section.
    * @param onRecordBoundary Called at each top-level record boundary with the
-   * buffer; the callback may rebase the buffer's window in place.
+   * buffer; the callback may rebase the buffer's window in place. Must be
+   * synchronous on this driver — a returned Promise is a caller bug.
    * @param onRecordIndexed Called as each top-level record is indexed, with
    * its localID, expressID and typeID (0 for external-mapping records) — the
    * seam for incremental semantic consumers (type index, roots registry,
@@ -500,7 +503,7 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
    */
   public parseDataBlockStreamed(
       input: ParsingBuffer,
-      onRecordBoundary: ( input: ParsingBuffer ) => void,
+      onRecordBoundary: ( input: ParsingBuffer ) => void | Promise<void>,
       onRecordIndexed?: ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
       onProgress?: ParseProgressCallback,
       sink?: StepIndexSink<TypeIDType> ): BlockParseResult<TypeIDType> {
@@ -516,6 +519,11 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
         return next.value
       }
 
+      if ( typeof next.value !== 'number' ) {
+        throw new Error(
+            'parseDataBlockStreamed: async window slide requires parseDataBlockStreamedAsync' )
+      }
+
       onProgress?.( next.value )
     }
   }
@@ -529,7 +537,9 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
    *
    * @param input The input parsing buffer, positioned at the data section.
    * @param onRecordBoundary Called at each top-level record boundary with the
-   * buffer; the callback may rebase the buffer's window in place.
+   * buffer; the callback may rebase the buffer's window in place. May return
+   * a Promise when the slide itself is I/O (an async ByteSource); this
+   * driver awaits it before the next record is lexed.
    * @param onRecordIndexed Called as each top-level record is indexed — see
    * parseDataBlockStreamed.
    * @param onProgress Optional byte-cursor progress callback.
@@ -540,7 +550,7 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
    */
   public async parseDataBlockStreamedAsync(
       input: ParsingBuffer,
-      onRecordBoundary: ( input: ParsingBuffer ) => void,
+      onRecordBoundary: ( input: ParsingBuffer ) => void | Promise<void>,
       onRecordIndexed?: ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
       onProgress?: ParseProgressCallback,
       sink?: StepIndexSink<TypeIDType>,
@@ -558,6 +568,11 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
 
       if ( next.done === true ) {
         return next.value
+      }
+
+      if ( typeof next.value !== 'number' ) {
+        await next.value
+        continue
       }
 
       onProgress?.( next.value )
@@ -599,7 +614,9 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
         return next.value
       }
 
-      onProgress?.( next.value )
+      if ( typeof next.value === 'number' ) {
+        onProgress?.( next.value )
+      }
 
       if ( Date.now() - lastYield >= yieldIntervalMs ) {
         await yieldToEventLoop()
@@ -620,10 +637,10 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
    */
   private* parseDataBlockIncremental(
       input: ParsingBuffer,
-      onRecordBoundary?: ( input: ParsingBuffer ) => void,
+      onRecordBoundary?: ( input: ParsingBuffer ) => void | Promise<void>,
       onRecordIndexed?: ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
       sink?: StepIndexSink<TypeIDType> ):
-      Generator<number, BlockParseResult<TypeIDType>, undefined> {
+      Generator<number | Promise<void>, BlockParseResult<TypeIDType>, undefined> {
 
     const indexResult: StepIndex<TypeIDType> = { elements: [] }
 
@@ -841,8 +858,14 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
       // Top-level record boundary: the rewind stack is empty and the cursor
       // sits at the next record's leading whitespace/`#`. A streaming driver
       // uses this to slide its moving window forward (see
-      // streaming_index_builder.ts). No-op on the resident path.
-      onRecordBoundary?.( input )
+      // streaming_index_builder.ts). No-op on the resident path. An async
+      // slide (OPFS File.slice / HTTP range) is yielded so the async
+      // driver can await it before the next record is lexed.
+      const slide = onRecordBoundary?.( input )
+
+      if ( slide !== void 0 && typeof ( slide as Promise<void> ).then === 'function' ) {
+        yield slide as Promise<void>
+      }
 
       if (!charws(HASH)) {
         if (tokenws(END_SECTION)) {

--- a/src/step/parsing/streaming_index_builder.ts
+++ b/src/step/parsing/streaming_index_builder.ts
@@ -1,5 +1,5 @@
 import ParsingBuffer from '../../parsing/parsing_buffer'
-import { ByteSource } from './byte_source'
+import { ByteSource, ReadableByteSource } from './byte_source'
 import { ColumnarIndexSink, StepIndexColumns } from './columnar_index'
 import StepParser, {
   ParseResult,
@@ -229,8 +229,31 @@ const MIN_WINDOW = 4 * 1024
  * @return {Promise<StreamingIndexResult>} The index, header, result and
  * diagnostics.
  */
+/**
+ * Fill `into` from either a sync or async byte source. A sync `read`
+ * resolves immediately; this is what lets the cooperative builder
+ * parse from an OPFS `File.slice()` store without a worker.
+ *
+ * @param source Sync or async positioned source.
+ * @param offset Absolute source offset.
+ * @param length Maximum bytes to copy.
+ * @param into Destination buffer.
+ * @param intoOffset Offset within `into`.
+ * @return {Promise<number>} Bytes copied.
+ */
+async function readSource(
+    source: ReadableByteSource,
+    offset: number,
+    length: number,
+    into: Uint8Array,
+    intoOffset: number ): Promise<number> {
+
+  return await source.read( offset, length, into, intoOffset )
+}
+
+
 export async function buildIndexStreamingAsync<TypeIDType>(
-    source: ByteSource,
+    source: ReadableByteSource,
     parser: StepParser<TypeIDType>,
     pool: number,
     onRecordIndexed?:
@@ -249,7 +272,7 @@ export async function buildIndexStreamingAsync<TypeIDType>(
     const window = new Uint8Array( windowBytes )
 
     let windowStartFile = 0
-    let windowLen = source.read( 0, windowBytes, window, 0 )
+    let windowLen = await readSource( source, 0, windowBytes, window, 0 )
     let bytesRead = windowLen
 
     const input = new ParsingBuffer( window, 0, windowLen )
@@ -271,7 +294,7 @@ export async function buildIndexStreamingAsync<TypeIDType>(
     let maxRecordLen = 0
     let prevBoundaryFile = windowStartFile + input.cursor
 
-    const onRecordBoundary = ( buffer: ParsingBuffer ): void => {
+    const onRecordBoundary = ( buffer: ParsingBuffer ): void | Promise<void> => {
 
       const cursor = buffer.cursor
       const recordFileStart = windowStartFile + cursor
@@ -297,15 +320,19 @@ export async function buildIndexStreamingAsync<TypeIDType>(
       window.copyWithin( 0, cursor, windowLen )
 
       const want = windowBytes - tail
-      const got = source.read( windowStartFile + windowLen, want, window, tail )
+      const fillAt = windowStartFile + windowLen
 
-      bytesRead += got
-      windowLen = tail + got
-      windowStartFile = recordFileStart
+      // Only return a Promise when this boundary actually slides —
+      // an `async` callback would force an await at every record
+      // (millions of hops on a PSB-class file).
+      return readSource( source, fillAt, want, window, tail ).then( ( got ) => {
 
-      buffer.rebaseWindow( window, 0, windowLen, windowStartFile )
-
-      ++slides
+        bytesRead += got
+        windowLen = tail + got
+        windowStartFile = recordFileStart
+        buffer.rebaseWindow( window, 0, windowLen, windowStartFile )
+        ++slides
+      } )
     }
 
     // Translate the parser's window-relative cursor to an absolute source
@@ -402,7 +429,7 @@ export function buildColumnarIndexStreaming<TypeIDType extends number>(
  * stats.
  */
 export async function buildColumnarIndexStreamingAsync<TypeIDType extends number>(
-    source: ByteSource,
+    source: ReadableByteSource,
     parser: StepParser<TypeIDType>,
     pool: number,
     onRecordIndexed?:

--- a/src/step/parsing/streaming_index_builder.ts
+++ b/src/step/parsing/streaming_index_builder.ts
@@ -211,25 +211,6 @@ const MIN_WINDOW = 4 * 1024
 
 
 /**
- * Cooperative twin of {@link buildIndexStreaming}: identical parse, window
- * and grow-and-restart behaviour (mirrored the same way the parser mirrors
- * parseDataBlock/parseDataBlockAsync), but the parse periodically yields to
- * the event loop so browsers repaint progress UI mid-parse instead of
- * flagging the tab as stalled (issue #301 §2 for the streamed path).
- *
- * @param source The byte source.
- * @param parser The STEP parser (typed to the schema).
- * @param pool Target window size in bytes.
- * @param onRecordIndexed Optional per-record event (see buildIndexStreaming).
- * @param sink Optional index sink (columnar builds).
- * @param onProgress Optional progress callback with the ABSOLUTE source byte
- * cursor (unlike the parser's window-relative cursor), so callers can report
- * `cursor / source.byteLength` directly.
- * @param yieldIntervalMs Minimum ms between event-loop yields.
- * @return {Promise<StreamingIndexResult>} The index, header, result and
- * diagnostics.
- */
-/**
  * Fill `into` from either a sync or async byte source. A sync `read`
  * resolves immediately; this is what lets the cooperative builder
  * parse from an OPFS `File.slice()` store without a worker.
@@ -252,6 +233,25 @@ async function readSource(
 }
 
 
+/**
+ * Cooperative twin of {@link buildIndexStreaming}: identical parse, window
+ * and grow-and-restart behaviour (mirrored the same way the parser mirrors
+ * parseDataBlock/parseDataBlockAsync), but the parse periodically yields to
+ * the event loop so browsers repaint progress UI mid-parse instead of
+ * flagging the tab as stalled (issue #301 §2 for the streamed path).
+ *
+ * @param source The byte source.
+ * @param parser The STEP parser (typed to the schema).
+ * @param pool Target window size in bytes.
+ * @param onRecordIndexed Optional per-record event (see buildIndexStreaming).
+ * @param sink Optional index sink (columnar builds).
+ * @param onProgress Optional progress callback with the ABSOLUTE source byte
+ * cursor (unlike the parser's window-relative cursor), so callers can report
+ * `cursor / source.byteLength` directly.
+ * @param yieldIntervalMs Minimum ms between event-loop yields.
+ * @return {Promise<StreamingIndexResult>} The index, header, result and
+ * diagnostics.
+ */
 export async function buildIndexStreamingAsync<TypeIDType>(
     source: ReadableByteSource,
     parser: StepParser<TypeIDType>,

--- a/src/step/parsing/streaming_index_builder_async.test.ts
+++ b/src/step/parsing/streaming_index_builder_async.test.ts
@@ -11,7 +11,8 @@ import fs from 'fs'
 import { describe, expect, test } from '@jest/globals'
 
 import IfcStepParser from '../../ifc/ifc_step_parser'
-import { BufferByteSource } from './byte_source'
+import { BufferByteSource, StoreByteSource } from './byte_source'
+import { InMemoryStepByteStore } from '../step_buffer_provider'
 import {
   buildColumnarIndexStreaming,
   buildColumnarIndexStreamingAsync,
@@ -73,6 +74,23 @@ describe( 'buildColumnarIndexStreamingAsync', () => {
     // Same window mechanics (slides prove the moving window really moved).
     expect( cooperative.stats.slides ).toBe( sync.stats.slides )
     expect( cooperative.stats.slides ).toBeGreaterThan( 0 )
+  }, 60000 )
+
+  test( 'StoreByteSource fills produce the same columns as a buffer source', async () => {
+
+    const bytes = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+    const parser = IfcStepParser.Instance
+    const fromBuffer = await buildColumnarIndexStreamingAsync(
+        new BufferByteSource( bytes ), parser, POOL, void 0, void 0, 0 )
+    const fromStore = await buildColumnarIndexStreamingAsync(
+        new StoreByteSource( new InMemoryStepByteStore( bytes ) ),
+        parser, POOL, void 0, void 0, 0 )
+
+    expect( fromStore.result ).toBe( ParseResult.COMPLETE )
+    expect( Array.from( fromStore.columns.address ) )
+        .toEqual( Array.from( fromBuffer.columns.address ) )
+    expect( Array.from( fromStore.columns.expressID ) )
+        .toEqual( Array.from( fromBuffer.columns.expressID ) )
   }, 60000 )
 
   test( 'yields to the event loop and reports absolute progress mid-parse', async () => {

--- a/src/step/step_buffer_provider.test.ts
+++ b/src/step/step_buffer_provider.test.ts
@@ -118,6 +118,25 @@ describe('WindowedStepBufferProvider', () => {
     expect(() => provider.acquire(32, 8)).toThrow(StepBufferNotResidentError)
   })
 
+  test('pinRange holds a chunk across later ensures that would evict it', async () => {
+    const bytes = makeBytes(160)
+    const provider = new WindowedStepBufferProvider(new InMemoryStepByteStore(bytes), 16, 2)
+
+    await provider.ensureResident(0, 8)
+    provider.pinRange(0, 8)
+    await provider.ensureResident(16, 8)
+    await provider.ensureResident(32, 8)
+    await provider.ensureResident(48, 8)
+
+    expect(() => provider.acquire(0, 8)).not.toThrow()
+
+    provider.unpinRange(0, 8)
+    await provider.ensureResident(64, 8)
+    await provider.ensureResident(80, 8)
+
+    expect(() => provider.acquire(0, 8)).toThrow(StepBufferNotResidentError)
+  })
+
   test('de-duplicates concurrent in-flight chunk loads', async () => {
     const bytes = makeBytes(64)
     let reads = 0

--- a/src/step/step_buffer_provider.ts
+++ b/src/step/step_buffer_provider.ts
@@ -210,6 +210,23 @@ export interface StepBufferProvider {
    * @return {Promise< void >} Resolves when resident.
    */
   ensureResident( address: number, length: number ): Promise< void >
+
+  /**
+   * Hold a range against LRU eviction until a matching
+   * {@link unpinRange}. No-op on a fully-resident source. Refcounted.
+   *
+   * @param address Absolute start of the range.
+   * @param length Length of the range.
+   */
+  pinRange?( address: number, length: number ): void
+
+  /**
+   * Drop one {@link pinRange} hold on a range.
+   *
+   * @param address Absolute start of the range.
+   * @param length Length of the range.
+   */
+  unpinRange?( address: number, length: number ): void
 }
 
 /**
@@ -441,7 +458,7 @@ export class WindowedStepBufferProvider implements StepBufferProvider {
     // until we return — the caller's synchronous acquire runs in its
     // continuation, which can interleave with other ensures' evictions.
     for ( let chunkIndex = firstChunk; chunkIndex <= lastChunk; ++chunkIndex ) {
-      this.ensurePins_.set( chunkIndex, ( this.ensurePins_.get( chunkIndex ) ?? 0 ) + 1 )
+      this.addPin_( chunkIndex, 1 )
     }
 
     try {
@@ -510,15 +527,72 @@ export class WindowedStepBufferProvider implements StepBufferProvider {
     } finally {
 
       for ( let chunkIndex = firstChunk; chunkIndex <= lastChunk; ++chunkIndex ) {
-
-        const pins = this.ensurePins_.get( chunkIndex ) ?? 0
-
-        if ( pins <= 1 ) {
-          this.ensurePins_.delete( chunkIndex )
-        } else {
-          this.ensurePins_.set( chunkIndex, pins - 1 )
-        }
+        this.addPin_( chunkIndex, -1 )
       }
+    }
+  }
+
+  /**
+   * Hold a range against LRU eviction until {@link unpinRange}.
+   *
+   * @param address Absolute start of the range.
+   * @param length Length of the range.
+   */
+  public pinRange( address: number, length: number ): void {
+
+    for ( const chunkIndex of this.chunkSpan_( address, length ) ) {
+      this.addPin_( chunkIndex, 1 )
+    }
+  }
+
+  /**
+   * Drop one {@link pinRange} hold.
+   *
+   * @param address Absolute start of the range.
+   * @param length Length of the range.
+   */
+  public unpinRange( address: number, length: number ): void {
+
+    for ( const chunkIndex of this.chunkSpan_( address, length ) ) {
+      this.addPin_( chunkIndex, -1 )
+    }
+  }
+
+  /**
+   * Chunk indices covering `[address, address + length)`.
+   *
+   * @param address Absolute start.
+   * @param length Length in bytes.
+   * @return {number[]} Inclusive chunk indices.
+   */
+  private chunkSpan_( address: number, length: number ): number[] {
+
+    const chunkBytes = this.chunkBytes_
+    const firstChunk = Math.floor( address / chunkBytes )
+    const lastChunk  = Math.floor( ( address + Math.max( length, 1 ) - 1 ) / chunkBytes )
+    const span: number[] = []
+
+    for ( let chunkIndex = firstChunk; chunkIndex <= lastChunk; ++chunkIndex ) {
+      span.push( chunkIndex )
+    }
+
+    return span
+  }
+
+  /**
+   * Adjust a chunk's pin count, deleting the entry at zero.
+   *
+   * @param chunkIndex The chunk.
+   * @param delta +1 pin or -1 unpin.
+   */
+  private addPin_( chunkIndex: number, delta: number ): void {
+
+    const pins = ( this.ensurePins_.get( chunkIndex ) ?? 0 ) + delta
+
+    if ( pins <= 0 ) {
+      this.ensurePins_.delete( chunkIndex )
+    } else {
+      this.ensurePins_.set( chunkIndex, pins )
     }
   }
 }

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -734,13 +734,13 @@ implements Iterable<BaseEntity>, Model {
    *
    * @param localID Seed record.
    * @param extraLocalIDs Additional seeds (voids, styles, materials).
+   * @param seen Optional set to extend (also skips already-pinned IDs).
    * @return {Promise<Set<number>>} The local IDs that were visited.
    */
   public async ensureResidentClosureByLocalID(
       localID: number,
-      extraLocalIDs?: Iterable<number> ): Promise< Set< number > > {
-
-    const seen = new Set< number >()
+      extraLocalIDs?: Iterable<number>,
+      seen: Set< number > = new Set< number >() ): Promise< Set< number > > {
 
     if ( !this.isSourceExternal ) {
       return seen
@@ -766,6 +766,7 @@ implements Iterable<BaseEntity>, Model {
       seen.add( id )
 
       await this.ensureResidentByLocalID( id )
+      this.pinByLocalID( id )
 
       for ( const expressID of this.scanRecordRefs_( id ) ) {
 
@@ -782,6 +783,54 @@ implements Iterable<BaseEntity>, Model {
 
 
   /**
+   * Hold a record's source range against windowed LRU eviction until
+   * {@link unpinByLocalID}. No-op while the source is fully resident.
+   *
+   * @param localID The record to pin.
+   */
+  public pinByLocalID( localID: number ): void {
+
+    if ( !this.isSourceExternal || localID >= this.count_ ) {
+      return
+    }
+
+    this.bufferProvider_.pinRange?.(
+        this.address_[ localID ], this.length_[ localID ] )
+  }
+
+
+  /**
+   * Drop one {@link pinByLocalID} hold.
+   *
+   * @param localID The record to unpin.
+   */
+  public unpinByLocalID( localID: number ): void {
+
+    if ( !this.isSourceExternal || localID >= this.count_ ) {
+      return
+    }
+
+    this.bufferProvider_.unpinRange?.(
+        this.address_[ localID ], this.length_[ localID ] )
+  }
+
+
+  /**
+   * Unpin every local ID in `localIDs` (best-effort; missing IDs are
+   * ignored). Use after {@link ensureResidentClosureByLocalID}, which
+   * pins as it walks.
+   *
+   * @param localIDs The records to unpin.
+   */
+  public unpinLocalIDs( localIDs: Iterable< number > ): void {
+
+    for ( const localID of localIDs ) {
+      this.unpinByLocalID( localID )
+    }
+  }
+
+
+  /**
    * Express-ID twin of {@link ensureResidentClosureByLocalID}. Unknown
    * IDs resolve to an empty visit set.
    *
@@ -791,19 +840,20 @@ implements Iterable<BaseEntity>, Model {
    */
   public async ensureResidentClosureByExpressID(
       expressID: number,
-      extraLocalIDs?: Iterable<number> ): Promise< Set< number > > {
+      extraLocalIDs?: Iterable<number>,
+      seen?: Set< number > ): Promise< Set< number > > {
 
     if ( !this.isSourceExternal ) {
-      return new Set< number >()
+      return seen ?? new Set< number >()
     }
 
     const localID = this.expressIDMap_.get( expressID )
 
     if ( localID === void 0 ) {
-      return new Set< number >()
+      return seen ?? new Set< number >()
     }
 
-    return this.ensureResidentClosureByLocalID( localID, extraLocalIDs )
+    return this.ensureResidentClosureByLocalID( localID, extraLocalIDs, seen )
   }
 
 

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -1,6 +1,7 @@
 import { StepIndexEntry } from './parsing/step_parser'
 import { StepIndexColumns } from './parsing/columnar_index'
 import { releaseScratchParsingBuffer } from './parsing/step_deserialization_functions'
+import { scanExpressRefs } from './parsing/express_ref_scan'
 import {
   ResidentStepBufferProvider,
   StepBufferProvider,
@@ -718,6 +719,134 @@ implements Iterable<BaseEntity>, Model {
     }
 
     await this.ensureResidentByLocalID( localID )
+  }
+
+
+  /**
+   * Page in the byte ranges a record *and every `#ref` reachable from
+   * its text* will need, so a following synchronous extract of that
+   * subgraph succeeds on a windowed source. Inverse relationships
+   * (not written in the record) are not discovered — callers that
+   * need them (rel-voids, styled items) pass their local IDs as
+   * `extraLocalIDs`.
+   *
+   * No-op while the source is fully resident.
+   *
+   * @param localID Seed record.
+   * @param extraLocalIDs Additional seeds (voids, styles, materials).
+   * @return {Promise<Set<number>>} The local IDs that were visited.
+   */
+  public async ensureResidentClosureByLocalID(
+      localID: number,
+      extraLocalIDs?: Iterable<number> ): Promise< Set< number > > {
+
+    const seen = new Set< number >()
+
+    if ( !this.isSourceExternal ) {
+      return seen
+    }
+
+    const stack: number[] = [ localID ]
+
+    if ( extraLocalIDs !== void 0 ) {
+
+      for ( const extra of extraLocalIDs ) {
+        stack.push( extra )
+      }
+    }
+
+    while ( stack.length > 0 ) {
+
+      const id = stack.pop() as number
+
+      if ( seen.has( id ) || id >= this.count_ ) {
+        continue
+      }
+
+      seen.add( id )
+
+      await this.ensureResidentByLocalID( id )
+
+      for ( const expressID of this.scanRecordRefs_( id ) ) {
+
+        const referenced = this.expressIDMap_.get( expressID )
+
+        if ( referenced !== void 0 && !seen.has( referenced ) ) {
+          stack.push( referenced )
+        }
+      }
+    }
+
+    return seen
+  }
+
+
+  /**
+   * Express-ID twin of {@link ensureResidentClosureByLocalID}. Unknown
+   * IDs resolve to an empty visit set.
+   *
+   * @param expressID Seed record.
+   * @param extraLocalIDs Additional seeds (local IDs).
+   * @return {Promise<Set<number>>} The local IDs that were visited.
+   */
+  public async ensureResidentClosureByExpressID(
+      expressID: number,
+      extraLocalIDs?: Iterable<number> ): Promise< Set< number > > {
+
+    if ( !this.isSourceExternal ) {
+      return new Set< number >()
+    }
+
+    const localID = this.expressIDMap_.get( expressID )
+
+    if ( localID === void 0 ) {
+      return new Set< number >()
+    }
+
+    return this.ensureResidentClosureByLocalID( localID, extraLocalIDs )
+  }
+
+
+  /**
+   * Scan a resident record's bytes for `#<expressID>` references.
+   *
+   * @param localID The record to scan.
+   * @return {number[]} Distinct referenced express IDs.
+   */
+  private scanRecordRefs_( localID: number ): number[] {
+
+    const address = this.address_[ localID ]
+    const length = this.length_[ localID ]
+    const acquisition = this.bufferProvider_.acquire( address, length )
+    const viewStart = address - acquisition.offset
+
+    const refs = scanExpressRefs( acquisition.buffer, viewStart, length )
+
+    const complex = this.complexEntries_?.get( localID )
+
+    if ( complex?.multiMapping === void 0 ) {
+      return refs
+    }
+
+    const seen = new Set< number >( refs )
+
+    for ( const mapped of complex.multiMapping ) {
+
+      const mappedAcquisition =
+        this.bufferProvider_.acquire( mapped.address, mapped.length )
+      const mappedStart = mapped.address - mappedAcquisition.offset
+
+      for ( const expressID of scanExpressRefs(
+          mappedAcquisition.buffer, mappedStart, mapped.length ) ) {
+
+        if ( !seen.has( expressID ) ) {
+          seen.add( expressID )
+          refs.push( expressID )
+        }
+      }
+    }
+
+    return refs
   }
 
 

--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -17,6 +17,8 @@
  */
 export {
   openStreamedIfcModel,
+  openStreamedIfcModelAsync,
+  openStreamedIfcModelFromStore,
   StreamedIfcOpen,
   StreamedIfcOpenOptions,
 } from '../ifc/ifc_stream_open'
@@ -26,7 +28,16 @@ export {
   StreamingColumnarIndexResult,
   StreamingIndexStats,
 } from '../step/parsing/streaming_index_builder'
-export { ByteSource, BufferByteSource } from '../step/parsing/byte_source'
+export {
+  ByteSource,
+  BufferByteSource,
+  AsyncByteSource,
+  ReadableByteSource,
+  StoreByteSource,
+  SyncAccessHandleByteSource,
+  SyncAccessHandleLike,
+} from '../step/parsing/byte_source'
+export { scanExpressRefs } from '../step/parsing/express_ref_scan'
 export {
   StepExternalByteStore,
   InMemoryStepByteStore,


### PR DESCRIPTION
## What

Two stacked increments on the same draft:

1. **Geometry progress:** deferred `ExtractGeometryBatch` resumes the parse tracker and ticks products so the load log splits Parsing from Geometry.
2. **M1b store-backed open:** `IfcAPI.OpenModelStream(store)` parses through `store.read()` windows and keeps the model windowed from birth — the source is never one JS `ArrayBuffer`. `ExtractGeometryBatchAsync` pages each product's `#ref` closure (plus voids/styles/materials) before the sync extract.

Also: `StoreByteSource`, `SyncAccessHandleByteSource`, `FileDescriptorByteSource`, `ensureResidentClosureByLocalID`, `openStreamedIfcModelFromStore`.

## Why

PSB cache-hit still pays `Buffering model bytes: +848 MB` for `file.arrayBuffer()`. M1b's exit is no full-source moment at parse. Geometry still pages a working set of windows (default 16 × 4 MiB); whole-file geometry residency waits on M3.

Share #1753 wires the new APIs behind feature-detect. The path is a no-op on 1.509.1435 and activates when this publishes.

## Testing

- `scanExpressRefs`, `ByteSource` impls, `openStreamedIfcModelFromStore` column parity
- `buildColumnarIndexStreamingAsync` via `StoreByteSource` matches a buffer source
- `OpenModelStream` + `ExtractGeometryBatchAsync` on `index.ifc`
- Incremental `tsc` clean

Full pre-commit `yarn test` still hits the local stale-Dist wasm OOB on packed facesets (pre-existing; same as the Geometry-progress commit).

Does not close #392 / Share #1602 — write-through of a network body and first-pixel M3 remain.
