### PR TITLE
Speed store-backed open: 16 MiB parse window, no faceset prep pins

### DIFF
--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -60,6 +60,12 @@ const DEFERRED_DRAIN_BATCH = 256
 // eslint-disable-next-line no-magic-numbers
 const STREAMED_PARSE_POOL_BYTES = 1024 * 1024
 
+/* Store-backed open pays an await per window slide (`File.slice`).
+ * 1 MiB on an 860 MB IFC is ~1700 trips; 16 MiB is ~100. The window
+ * is scratch — it does not stay resident after parse. */
+// eslint-disable-next-line no-magic-numbers
+const STORE_PARSE_POOL_BYTES = 16 * 1024 * 1024
+
 /**
  * Everything parse/extraction produces that the proxy constructor's tail
  * (mesh vectors, statistics) consumes — precomputed by createAsync so the
@@ -928,7 +934,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     tracker?.beginPhase('headerParse', 'bytes', fileSize)
 
-    const headerLen = Math.min( fileSize, STREAMED_PARSE_POOL_BYTES )
+    const headerLen = Math.min( fileSize, STORE_PARSE_POOL_BYTES )
     const headerBytes = await store.read( 0, headerLen )
     const [stepHeader, result0] = parser.parseHeader( new ParsingBuffer( headerBytes ) )
 
@@ -953,7 +959,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     const { result, columns } = await buildColumnarIndexStreamingAsync(
         new StoreByteSource( store ),
         parser,
-        STREAMED_PARSE_POOL_BYTES,
+        STORE_PARSE_POOL_BYTES,
         void 0,
         parseTick )
 

--- a/src/ifc/ifc_demand_extraction.test.ts
+++ b/src/ifc/ifc_demand_extraction.test.ts
@@ -14,7 +14,7 @@ import IfcStepModel from './ifc_step_model'
 import ParsingBuffer from '../parsing/parsing_buffer'
 import { ConwayGeometry } from '../../dependencies/conway-geom'
 import { ExtractResult } from '../core/shared_constants'
-import { IfcProduct } from './ifc4_gen'
+import { IfcProduct, IfcStyledItem } from './ifc4_gen'
 
 let conwayGeometry: ConwayGeometry
 
@@ -151,5 +151,22 @@ describe( 'per-product demand extraction (Phase B2)', () => {
     expect( first instanceof IfcProduct ).toBe( false )
 
     expect( extraction.extractProductGeometryByLocalID( 0 ) ).toBe( false )
+  } )
+
+  test( 'styled-item Item local IDs resolve without hydrating the item', () => {
+
+    const model = freshModel()
+    let checked = 0
+
+    for ( const styledItem of model.types( IfcStyledItem ) ) {
+
+      const viaIndex = styledItem.extractReferenceLocalID( 0, 0, 1, true )
+      const viaItem = styledItem.Item?.localID ?? null
+
+      expect( viaIndex ).toBe( viaItem )
+      ++checked
+    }
+
+    expect( checked ).toBeGreaterThan( 0 )
   } )
 } )

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -6035,8 +6035,14 @@ export class IfcGeometryExtraction {
 
     for (const styledItem of styledItems) {
       try {
-        if (styledItem.Item !== null) {
-          this.materials.styledItemMap.set(styledItem.Item.localID, styledItem.localID)
+        // IfcStyledItem.Item — same vtable slot as the generated
+        // getter's extractElement(0, 0, 1, true, ...). Hydrating Item
+        // would acquire the faceset record (often the packed geometry
+        // itself) for every styled item at once.
+        const itemLocalID = styledItem.extractReferenceLocalID(0, 0, 1, true)
+
+        if (itemLocalID !== null) {
+          this.materials.styledItemMap.set(itemLocalID, styledItem.localID)
         }
       } catch (ex) {
         this.handleMapPrepError_('IfcStyledItem', styledItem.expressID, ex)
@@ -6402,6 +6408,12 @@ export class IfcGeometryExtraction {
    * the relationship sweeps succeed on a windowed source. Call before
    * the first prepare on a model whose source is external.
    *
+   * Pins the prep-type records themselves (and a 1-hop of product /
+   * material records the relationship getters hydrate). Does **not**
+   * BFS-pin styled-item Item closures — those are facesets, and
+   * walking them here pulled most of the file into the windowed LRU
+   * before the first product extract.
+   *
    * @return {Promise<Set<number>>} Pinned local IDs — caller must
    * {@link StepModelBase.unpinLocalIDs} after prepare/extract.
    */
@@ -6413,19 +6425,68 @@ export class IfcGeometryExtraction {
       return pinned
     }
 
-    const prepTypes = [
-      IfcProject,
+    // Small trees: project units, material-definition style stacks.
+    for ( const type of [IfcProject, IfcMaterialDefinitionRepresentation] ) {
+
+      for ( const expressID of this.model.expressIDsOfTypes( type ) ) {
+        await this.model.ensureResidentClosureByExpressID( expressID, void 0, pinned )
+      }
+    }
+
+    const recordOnlyTypes = [
       IfcRelAssociatesMaterial,
-      IfcMaterialDefinitionRepresentation,
       IfcRelVoidsElement,
       IfcStyledItem,
       IfcRelAggregates,
     ]
 
-    for ( const type of prepTypes ) {
+    for ( const type of recordOnlyTypes ) {
 
       for ( const expressID of this.model.expressIDsOfTypes( type ) ) {
-        await this.model.ensureResidentClosureByExpressID( expressID, void 0, pinned )
+
+        const localID = this.model.resolveExpressID( expressID )
+
+        if ( localID === void 0 || pinned.has( localID ) ) {
+          continue
+        }
+
+        await this.model.ensureResidentByLocalID( localID )
+        this.model.pinByLocalID( localID )
+        pinned.add( localID )
+      }
+    }
+
+    // Relationship getters hydrate the related product / material
+    // records (not their geometry). Pin that 1-hop so populate can
+    // read `.localID` without a full closure walk.
+    const oneHopTypes = [
+      IfcRelAssociatesMaterial,
+      IfcRelVoidsElement,
+      IfcRelAggregates,
+    ]
+
+    for ( const type of oneHopTypes ) {
+
+      for ( const expressID of this.model.expressIDsOfTypes( type ) ) {
+
+        const localID = this.model.resolveExpressID( expressID )
+
+        if ( localID === void 0 ) {
+          continue
+        }
+
+        for ( const refExpressID of this.model.referencedExpressIDs( localID ) ) {
+
+          const refLocalID = this.model.resolveExpressID( refExpressID )
+
+          if ( refLocalID === void 0 || pinned.has( refLocalID ) ) {
+            continue
+          }
+
+          await this.model.ensureResidentByLocalID( refLocalID )
+          this.model.pinByLocalID( refLocalID )
+          pinned.add( refLocalID )
+        }
       }
     }
 

--- a/src/step/step_entity_base.ts
+++ b/src/step/step_entity_base.ts
@@ -439,6 +439,52 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
   }
 
   /**
+   * Resolve a single reference field to its local ID without
+   * constructing the target entity. Prep maps that only store
+   * `Item.localID` (IfcStyledItem → faceset) must not hydrate the
+   * target: on a windowed source that would pin the faceset record
+   * (often megabytes) for every styled item at once.
+   *
+   * @param offset The offset in the vtable to extract from.
+   * @param baseOffset The base offset of the class in the vtable.
+   * @param depth The depth in the inheritance hierarchy.
+   * @param optional Is this an optional field?
+   * @return {number | null} The referenced local ID, or null if the
+   * field is unset/optional-null.
+   */
+  public extractReferenceLocalID(
+      offset: number,
+      baseOffset: number,
+      depth: number,
+      optional: boolean ): number | null {
+
+    const [cursor, endCursor, buffer] = this.getOffsetAndEndCursor( offset, baseOffset, depth )
+    const expressID = stepExtractReference( buffer, cursor, endCursor )
+
+    if ( expressID !== void 0 ) {
+      return this.model.resolveExpressID( expressID ) ?? null
+    }
+
+    const inline = this.model.getInlineElementByAddress(
+        extractInlineElementAddress( buffer, cursor, endCursor ) )
+
+    if ( inline !== void 0 ) {
+      return inline.localID
+    }
+
+    if ( !optional ) {
+      throw new Error( 'Value in STEP was incorrectly typed' )
+    }
+
+    if ( !this.model.nullOnErrors &&
+        stepExtractOptional( buffer, cursor, endCursor ) !== null ) {
+      throw new Error( 'Value in STEP was incorrectly typed' )
+    }
+
+    return null
+  }
+
+  /**
    *
    * @param buffer
    * @param cursor

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -858,6 +858,19 @@ implements Iterable<BaseEntity>, Model {
 
 
   /**
+   * Express IDs referenced by a resident record (`#<id>` tokens in its
+   * text, including multi-mapped class records). The record itself
+   * must already be resident.
+   *
+   * @param localID The record to scan.
+   * @return {number[]} Distinct referenced express IDs.
+   */
+  public referencedExpressIDs( localID: number ): number[] {
+    return this.scanRecordRefs_( localID )
+  }
+
+
+  /**
    * Scan a resident record's bytes for `#<expressID>` references.
    *
    * @param localID The record to scan.


### PR DESCRIPTION
## Summary

Smoke of Share v1.1753 + Conway 1.510.1439 on the 860 MB PSB IFC showed Parsing at 66s / +1269 MB (was 16s / +418 with a resident buffer). Two causes:

1. **Store parse window was 1 MiB** — ~1700 `File.slice` trips. Now **16 MiB** (~100 trips). Scratch only; not held after parse.
2. **`ensureResidentForDemandPrep` BFS-pinned every styled-item Item closure.** Those Items are facesets, so prep pulled most of the file into the windowed LRU before the first product extract. Prep now pins the relationship records themselves (plus a 1-hop of product/material rows the getters hydrate) and resolves `IfcStyledItem.Item.localID` from the express-ID index without constructing the faceset.

Share-side hash + first-pixel batch size land in bldrs-ai/Share#1753 (works against 1.510.1439; this PR is the parse/prep half).

## Test plan

- [x] `yarn build-incremental`
- [x] `ifc_api_streamed_open` + `step_buffer_provider` tests
- [x] New demand-extraction test: `extractReferenceLocalID` matches `Item.localID`
- [ ] Deploy-preview smoke on PSB after this publishes and Share bumps: Parsing should drop well below 66s / +1269 MB, Geometry first pixels in file order