### PR TITLE
Bound windowed source after extract; sparse parse AABB imposters

### DIFF
--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -38,6 +38,7 @@ import {
   ifcPreviewAdapter,
   StreamedPreviewChannel,
 } from './streamed_preview_channel'
+import { makeParseAabbImposter } from './parse_aabb_imposter'
 import EntityTypesIfc from '../../ifc/ifc4_gen/entity_types_ifc.gen'
 import { StepHeader } from '../../step/parsing/step_parser'
 import { ExtractResult } from '../../index'
@@ -65,6 +66,8 @@ const STREAMED_PARSE_POOL_BYTES = 1024 * 1024
  * is scratch — it does not stay resident after parse. */
 // eslint-disable-next-line no-magic-numbers
 const STORE_PARSE_POOL_BYTES = 16 * 1024 * 1024
+// eslint-disable-next-line no-magic-numbers
+const BYTES_PER_MIB = 1024 * 1024
 
 /**
  * Everything parse/extraction produces that the proxy constructor's tail
@@ -908,8 +911,9 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   /**
    * Windowed-from-birth twin of parseColumnarAndExtractAsync: the
    * source stays in `store`, parse windows are filled through it, and
-   * the model never holds a resident copy. Preview-during-parse is
-   * skipped (that channel needs a resident prefix). Deferred opens
+   * the model never holds a resident copy. The full prefix-extract
+   * preview channel is skipped (it needs a resident prefix); a sparse
+   * AABB imposter rides onRecordIndexed instead. Deferred opens
    * page prep closures before prepareDemandExtraction; non-deferred
    * opens drain the demand pump with per-product residency.
    *
@@ -956,11 +960,14 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     const parseStartTime = Date.now()
 
+    const onRecordIndexed = settings?.ON_PREVIEW_MESH !== void 0 ?
+      makeParseAabbImposter( settings.ON_PREVIEW_MESH ) : void 0
+
     const { result, columns } = await buildColumnarIndexStreamingAsync(
         new StoreByteSource( store ),
         parser,
         STORE_PARSE_POOL_BYTES,
-        void 0,
+        onRecordIndexed,
         parseTick )
 
     const parseEndTime = Date.now()
@@ -985,6 +992,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     try {
       conwayGeometry.prepareDemandExtraction()
     } finally {
+      model.releaseSourceViews( prepPins )
       model.unpinLocalIDs( prepPins )
     }
 
@@ -1030,11 +1038,14 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
             `Error extracting product ${product.expressID}: ` +
             `${error instanceof Error ? error.message : String( error )}` )
       } finally {
+        model.releaseSourceViews( pins )
         model.unpinLocalIDs( pins )
       }
 
       ++completed
-      tracker?.update( completed )
+      tracker?.update( completed, {
+        residentSourceMb: model.residentSourceBytes / BYTES_PER_MIB,
+      } )
     }
 
     for ( const relAggregate of model.types( IfcRelAggregates ) ) {
@@ -1049,11 +1060,14 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
             `Error extracting aggregate ${relAggregate.expressID}: ` +
             `${error instanceof Error ? error.message : String( error )}` )
       } finally {
+        model.releaseSourceViews( pins )
         model.unpinLocalIDs( pins )
       }
 
       ++completed
-      tracker?.update( completed )
+      tracker?.update( completed, {
+        residentSourceMb: model.residentSourceBytes / BYTES_PER_MIB,
+      } )
     }
 
     const endTime = Date.now()
@@ -1777,6 +1791,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
             `Error extracting product localID ${localID}: ` +
             `${error instanceof Error ? error.message : String(error)}`)
       } finally {
+        this.model[0].releaseSourceViews(pins)
         this.model[0].unpinLocalIDs(pins)
       }
     }
@@ -1804,6 +1819,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
               `Error extracting aggregate ${relAggregate.expressID}: ` +
               `${error instanceof Error ? error.message : String(error)}`)
         } finally {
+          this.model[0].releaseSourceViews(pins)
           this.model[0].unpinLocalIDs(pins)
         }
       }
@@ -1816,12 +1832,15 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     const remaining = (products.length - this.demandCursor_) +
         (aggregates.length - this.demandAggregatesCursor_)
 
+    const windowMb = this.model[0].residentSourceBytes / BYTES_PER_MIB
+
     if (this.progressTracker_ !== void 0) {
       const completed = totalWork - remaining
       if (remaining === 0) {
+        this.progressTracker_.update(completed, { residentSourceMb: windowMb })
         this.progressTracker_.endPhase(totalWork)
       } else {
-        this.progressTracker_.update(completed)
+        this.progressTracker_.update(completed, { residentSourceMb: windowMb })
       }
     }
 

--- a/src/compat/web-ifc/parse_aabb_imposter.test.ts
+++ b/src/compat/web-ifc/parse_aabb_imposter.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from '@jest/globals'
+import {
+  aabbFromStepReals,
+  aabbToPreviewMatrix,
+  makeParseAabbImposter,
+} from './parse_aabb_imposter'
+import EntityTypesIfc from '../../ifc/ifc4_gen/entity_types_ifc.gen'
+import type { PreviewMeshPayload } from './streamed_preview_channel'
+
+
+describe( 'parse_aabb_imposter', () => {
+
+  test( 'aabbFromStepReals reads IFCCARTESIANPOINTLIST3D triples', () => {
+
+    const text = '#10=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,2.,3.),(-1.,0.,1.),' +
+      '(4.,5.,6.),(0.,0.,1.),(0.,1.,0.),(1.,0.,0.),(2.,2.,2.)));'
+    const bytes = new TextEncoder().encode( text )
+    const aabb = aabbFromStepReals( bytes )
+
+    expect( aabb ).not.toBeNull()
+    expect( aabb!.min ).toEqual( [-1, 0, 0] )
+    expect( aabb!.max ).toEqual( [4, 5, 6] )
+  } )
+
+  test( 'aabbFromStepReals returns null for a short list', () => {
+
+    const text = '#1=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,1.,1.)));'
+    expect( aabbFromStepReals( new TextEncoder().encode( text ) ) ).toBeNull()
+  } )
+
+  test( 'aabbToPreviewMatrix is Z-up to Y-up and centres the box', () => {
+
+    const matrix = aabbToPreviewMatrix( { min: [0, 0, 0], max: [2, 4, 6] } )
+
+    expect( matrix[ 0 ] ).toBe( 2 )
+    expect( matrix[ 5 ] ).toBe( 6 )
+    expect( matrix[ 10 ] ).toBe( 4 )
+    expect( matrix[ 12 ] ).toBe( 1 )
+    expect( matrix[ 13 ] ).toBe( 3 )
+    expect( matrix[ 14 ] ).toBe( -2 )
+  } )
+
+  test( 'makeParseAabbImposter emits every 8th point list', () => {
+
+    const emitted: PreviewMeshPayload[] = []
+    const emit = makeParseAabbImposter( ( mesh ) => emitted.push( mesh ) )
+    const points = Array.from( { length: 8 }, ( _, i ) => `(${i}.,0.,0.)` ).join( ',' )
+    const bytes = new TextEncoder().encode(
+        `#1=IFCCARTESIANPOINTLIST3D((${points}));` )
+
+    for ( let i = 1; i <= 8; ++i ) {
+      emit( i, i * 10, EntityTypesIfc.IFCCARTESIANPOINTLIST3D, bytes )
+    }
+
+    expect( emitted ).toHaveLength( 1 )
+    expect( emitted[ 0 ].aabb ).toBeDefined()
+    expect( emitted[ 0 ].expressID ).toBe( 80 )
+  } )
+} )

--- a/src/compat/web-ifc/parse_aabb_imposter.ts
+++ b/src/compat/web-ifc/parse_aabb_imposter.ts
@@ -1,0 +1,267 @@
+import EntityTypesIfc from '../../ifc/ifc4_gen/entity_types_ifc.gen'
+import type { PreviewMeshPayload } from './streamed_preview_channel'
+
+/* eslint-disable no-magic-numbers */
+
+/** Emit every Nth point-list AABB — sparse on purpose. */
+const IMPOSTER_STRIDE = 8
+
+/** Skip lists with fewer than this many points (noise). */
+const MIN_POINTS = 8
+
+/** Pale cyan, see-through — reads as a ghost, not finished geom. */
+const IMPOSTER_COLOR = { x: 0.45, y: 0.75, z: 0.95, w: 0.35 }
+
+const CHAR_0 = 0x30
+const CHAR_9 = 0x39
+const CHAR_MINUS = 0x2d
+const CHAR_PLUS = 0x2b
+const CHAR_DOT = 0x2e
+const CHAR_E = 0x45
+const CHAR_e = 0x65
+const CHAR_HASH = 0x23
+const CHAR_EQ = 0x3d
+const CHAR_LPAREN = 0x28
+
+
+export interface Aabb3 {
+  min: [number, number, number]
+  max: [number, number, number]
+}
+
+
+/**
+ * Min/max of every STEP real triple in `bytes`. Used for
+ * IfcCartesianPointList3D bodies: the numbers live in the record, so a
+ * store-backed parse can emit an AABB without hydrating the entity or
+ * paging a closure.
+ *
+ * @param bytes The record's source bytes (window view; do not retain).
+ * @return {Aabb3 | null} Bounds, or null if fewer than MIN_POINTS triples.
+ */
+export function aabbFromStepReals( bytes: Uint8Array ): Aabb3 | null {
+
+  let minX = Infinity
+  let minY = Infinity
+  let minZ = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  let maxZ = -Infinity
+  let points = 0
+  let axis = 0
+  let x = 0
+  let y = 0
+
+  const end = bytes.length
+  // Skip `#id=TYPENAME(` so the express ID is not a phantom first real.
+  let cursor = 0
+
+  if ( bytes[ cursor ] === CHAR_HASH ) {
+
+    while ( cursor < end && bytes[ cursor ] !== CHAR_EQ ) {
+      ++cursor
+    }
+
+    if ( cursor < end ) {
+      ++cursor
+    }
+  }
+
+  while ( cursor < end && bytes[ cursor ] !== CHAR_LPAREN ) {
+    ++cursor
+  }
+
+  while ( cursor < end ) {
+
+    const parsed = parseStepReal_( bytes, cursor, end )
+
+    if ( parsed === null ) {
+      ++cursor
+      continue
+    }
+
+    cursor = parsed.next
+    const value = parsed.value
+
+    if ( axis === 0 ) {
+      x = value
+      axis = 1
+    } else if ( axis === 1 ) {
+      y = value
+      axis = 2
+    } else {
+      if ( x < minX ) {
+        minX = x
+      }
+      if ( y < minY ) {
+        minY = y
+      }
+      if ( value < minZ ) {
+        minZ = value
+      }
+      if ( x > maxX ) {
+        maxX = x
+      }
+      if ( y > maxY ) {
+        maxY = y
+      }
+      if ( value > maxZ ) {
+        maxZ = value
+      }
+      ++points
+      axis = 0
+    }
+  }
+
+  if ( points < MIN_POINTS || !Number.isFinite( minX ) ) {
+    return null
+  }
+
+  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] }
+}
+
+
+/**
+ * Column-major 4x4: IFC Z-up box → Y-up, translated to the box centre
+ * and scaled to its size. Share instances a shared unit cube with this.
+ *
+ * @param aabb The IFC-space bounds.
+ * @return {number[]} 16-element matrix.
+ */
+export function aabbToPreviewMatrix( aabb: Aabb3 ): number[] {
+
+  const sx = Math.max( aabb.max[ 0 ] - aabb.min[ 0 ], 1e-3 )
+  const sy = Math.max( aabb.max[ 1 ] - aabb.min[ 1 ], 1e-3 )
+  const sz = Math.max( aabb.max[ 2 ] - aabb.min[ 2 ], 1e-3 )
+  const cx = ( aabb.min[ 0 ] + aabb.max[ 0 ] ) * 0.5
+  const cy = ( aabb.min[ 1 ] + aabb.max[ 1 ] ) * 0.5
+  const cz = ( aabb.min[ 2 ] + aabb.max[ 2 ] ) * 0.5
+
+  // Z-up → Y-up (same as StreamedPreviewChannel.NORMALIZE_MAT).
+  return [
+    sx, 0, 0, 0,
+    0, sz, 0, 0,
+    0, 0, sy, 0,
+    cx, cz, -cy, 1,
+  ]
+}
+
+
+/**
+ * Stateful filter: every IMPOSTER_STRIDE-th IfcCartesianPointList3D
+ * becomes a tiny preview payload. Synchronous and allocation-light —
+ * safe on the parse's onRecordIndexed seam. The view `recordBytes`
+ * is into the sliding parse window; do not retain it.
+ *
+ * @param onMesh Preview consumer (Share's ON_PREVIEW_MESH).
+ * @return A callback matching onRecordIndexed.
+ */
+export function makeParseAabbImposter(
+    onMesh: ( mesh: PreviewMeshPayload ) => void ):
+    ( localID: number,
+      expressID: number,
+      typeID: number | undefined,
+      recordBytes?: Uint8Array ) => void {
+
+  let seen = 0
+
+  return ( _localID, expressID, typeID, recordBytes ) => {
+
+    if ( typeID !== EntityTypesIfc.IFCCARTESIANPOINTLIST3D ||
+        recordBytes === void 0 ) {
+      return
+    }
+
+    ++seen
+
+    if ( seen % IMPOSTER_STRIDE !== 0 ) {
+      return
+    }
+
+    try {
+
+      const aabb = aabbFromStepReals( recordBytes )
+
+      if ( aabb === null ) {
+        return
+      }
+
+      onMesh( {
+        expressID,
+        geometryExpressID: -1,
+        color: IMPOSTER_COLOR,
+        flatTransformation: aabbToPreviewMatrix( aabb ),
+        aabb,
+      } )
+    } catch {
+      // Preview must never break the parse.
+    }
+  }
+}
+
+
+/**
+ * @param bytes
+ * @param start
+ * @param end
+ * @return The real and the cursor after it, or null if `start` is not
+ * the start of a number.
+ */
+function parseStepReal_(
+    bytes: Uint8Array,
+    start: number,
+    end: number ): { value: number, next: number } | null {
+
+  let cursor = start
+  const first = bytes[ cursor ]
+
+  if ( first !== CHAR_MINUS && first !== CHAR_PLUS && first !== CHAR_DOT &&
+      ( first < CHAR_0 || first > CHAR_9 ) ) {
+    return null
+  }
+
+  if ( first === CHAR_MINUS || first === CHAR_PLUS ) {
+    ++cursor
+    if ( cursor >= end ) {
+      return null
+    }
+  }
+
+  const digitOrDot = bytes[ cursor ]
+
+  if ( digitOrDot !== CHAR_DOT && ( digitOrDot < CHAR_0 || digitOrDot > CHAR_9 ) ) {
+    return null
+  }
+
+  while ( cursor < end ) {
+
+    const ch = bytes[ cursor ]
+
+    if ( ( ch >= CHAR_0 && ch <= CHAR_9 ) || ch === CHAR_DOT ) {
+      ++cursor
+      continue
+    }
+
+    if ( ch === CHAR_E || ch === CHAR_e ) {
+      ++cursor
+      if ( cursor < end &&
+          ( bytes[ cursor ] === CHAR_MINUS || bytes[ cursor ] === CHAR_PLUS ) ) {
+        ++cursor
+      }
+      while ( cursor < end && bytes[ cursor ] >= CHAR_0 && bytes[ cursor ] <= CHAR_9 ) {
+        ++cursor
+      }
+    }
+
+    break
+  }
+
+  const value = Number.parseFloat(
+      String.fromCharCode( ...bytes.subarray( start, cursor ) ) )
+
+  if ( !Number.isFinite( value ) ) {
+    return null
+  }
+
+  return { value, next: cursor }
+}

--- a/src/compat/web-ifc/parse_aabb_imposter.ts
+++ b/src/compat/web-ifc/parse_aabb_imposter.ts
@@ -1,4 +1,5 @@
 import EntityTypesIfc from '../../ifc/ifc4_gen/entity_types_ifc.gen'
+import ParsingBuffer from '../../parsing/parsing_buffer'
 import type { PreviewMeshPayload } from './streamed_preview_channel'
 
 /* eslint-disable no-magic-numbers */
@@ -9,16 +10,11 @@ const IMPOSTER_STRIDE = 8
 /** Skip lists with fewer than this many points (noise). */
 const MIN_POINTS = 8
 
-/** Pale cyan, see-through — reads as a ghost, not finished geom. */
+/** Cap so one huge tessellation list cannot stall the parse yield. */
+const SCAN_BUDGET_BYTES = 128 * 1024
+
 const IMPOSTER_COLOR = { x: 0.45, y: 0.75, z: 0.95, w: 0.35 }
 
-const CHAR_0 = 0x30
-const CHAR_9 = 0x39
-const CHAR_MINUS = 0x2d
-const CHAR_PLUS = 0x2b
-const CHAR_DOT = 0x2e
-const CHAR_E = 0x45
-const CHAR_e = 0x65
 const CHAR_HASH = 0x23
 const CHAR_EQ = 0x3d
 const CHAR_LPAREN = 0x28
@@ -52,36 +48,35 @@ export function aabbFromStepReals( bytes: Uint8Array ): Aabb3 | null {
   let x = 0
   let y = 0
 
-  const end = bytes.length
   // Skip `#id=TYPENAME(` so the express ID is not a phantom first real.
-  let cursor = 0
+  let start = 0
+  const end = Math.min( bytes.length, SCAN_BUDGET_BYTES )
 
-  if ( bytes[ cursor ] === CHAR_HASH ) {
+  if ( bytes[ start ] === CHAR_HASH ) {
 
-    while ( cursor < end && bytes[ cursor ] !== CHAR_EQ ) {
-      ++cursor
+    while ( start < end && bytes[ start ] !== CHAR_EQ ) {
+      ++start
     }
 
-    if ( cursor < end ) {
-      ++cursor
+    if ( start < end ) {
+      ++start
     }
   }
 
-  while ( cursor < end && bytes[ cursor ] !== CHAR_LPAREN ) {
-    ++cursor
+  while ( start < end && bytes[ start ] !== CHAR_LPAREN ) {
+    ++start
   }
 
-  while ( cursor < end ) {
+  const input = new ParsingBuffer( bytes, start, end )
 
-    const parsed = parseStepReal_( bytes, cursor, end )
+  while ( !input.finished ) {
 
-    if ( parsed === null ) {
-      ++cursor
+    const value = input.readReal()
+
+    if ( value === void 0 ) {
+      input.step()
       continue
     }
-
-    cursor = parsed.next
-    const value = parsed.value
 
     if ( axis === 0 ) {
       x = value
@@ -137,7 +132,7 @@ export function aabbToPreviewMatrix( aabb: Aabb3 ): number[] {
   const cy = ( aabb.min[ 1 ] + aabb.max[ 1 ] ) * 0.5
   const cz = ( aabb.min[ 2 ] + aabb.max[ 2 ] ) * 0.5
 
-  // Z-up → Y-up (same as StreamedPreviewChannel.NORMALIZE_MAT).
+  // Z-up → Y-up, then scale/centre for a unit cube.
   return [
     sx, 0, 0, 0,
     0, sz, 0, 0,
@@ -149,9 +144,8 @@ export function aabbToPreviewMatrix( aabb: Aabb3 ): number[] {
 
 /**
  * Stateful filter: every IMPOSTER_STRIDE-th IfcCartesianPointList3D
- * becomes a tiny preview payload. Synchronous and allocation-light —
- * safe on the parse's onRecordIndexed seam. The view `recordBytes`
- * is into the sliding parse window; do not retain it.
+ * becomes a tiny preview payload. The view `recordBytes` is into the
+ * sliding parse window; do not retain it.
  *
  * @param onMesh Preview consumer (Share's ON_PREVIEW_MESH).
  * @return A callback matching onRecordIndexed.
@@ -197,71 +191,4 @@ export function makeParseAabbImposter(
       // Preview must never break the parse.
     }
   }
-}
-
-
-/**
- * @param bytes
- * @param start
- * @param end
- * @return The real and the cursor after it, or null if `start` is not
- * the start of a number.
- */
-function parseStepReal_(
-    bytes: Uint8Array,
-    start: number,
-    end: number ): { value: number, next: number } | null {
-
-  let cursor = start
-  const first = bytes[ cursor ]
-
-  if ( first !== CHAR_MINUS && first !== CHAR_PLUS && first !== CHAR_DOT &&
-      ( first < CHAR_0 || first > CHAR_9 ) ) {
-    return null
-  }
-
-  if ( first === CHAR_MINUS || first === CHAR_PLUS ) {
-    ++cursor
-    if ( cursor >= end ) {
-      return null
-    }
-  }
-
-  const digitOrDot = bytes[ cursor ]
-
-  if ( digitOrDot !== CHAR_DOT && ( digitOrDot < CHAR_0 || digitOrDot > CHAR_9 ) ) {
-    return null
-  }
-
-  while ( cursor < end ) {
-
-    const ch = bytes[ cursor ]
-
-    if ( ( ch >= CHAR_0 && ch <= CHAR_9 ) || ch === CHAR_DOT ) {
-      ++cursor
-      continue
-    }
-
-    if ( ch === CHAR_E || ch === CHAR_e ) {
-      ++cursor
-      if ( cursor < end &&
-          ( bytes[ cursor ] === CHAR_MINUS || bytes[ cursor ] === CHAR_PLUS ) ) {
-        ++cursor
-      }
-      while ( cursor < end && bytes[ cursor ] >= CHAR_0 && bytes[ cursor ] <= CHAR_9 ) {
-        ++cursor
-      }
-    }
-
-    break
-  }
-
-  const value = Number.parseFloat(
-      String.fromCharCode( ...bytes.subarray( start, cursor ) ) )
-
-  if ( !Number.isFinite( value ) ) {
-    return null
-  }
-
-  return { value, next: cursor }
 }

--- a/src/compat/web-ifc/streamed_preview_channel.ts
+++ b/src/compat/web-ifc/streamed_preview_channel.ts
@@ -74,6 +74,8 @@ export interface PreviewMeshPayload {
   flatTransformation: number[]
   vertexData?: Float32Array
   indexData?: Uint32Array
+  /** Parse-time AABB imposter (no vertex payload; Share instances a unit cube). */
+  aabb?: { min: [number, number, number], max: [number, number, number] }
 }
 
 /**

--- a/src/core/progress.ts
+++ b/src/core/progress.ts
@@ -158,13 +158,13 @@ export class ProgressTracker {
   public update(
       completed: number,
       extras?: { residentSourceMb?: number } ): void {
+    this.extras_ = extras
     const now = Date.now()
 
     if ( now - this.lastEmitTime < this.minIntervalMs ) {
       return
     }
 
-    this.extras_ = extras
     this.emit( completed, now, extras )
   }
 

--- a/src/core/progress.ts
+++ b/src/core/progress.ts
@@ -33,6 +33,8 @@ export interface ProgressEvent {
   readonly elapsedMs: number
   /** Coarse used-JS-heap sample in MB, when the environment exposes one. */
   readonly memoryMb?: number
+  /** Windowed source bytes currently resident, in MB (Geometry phase). */
+  readonly residentSourceMb?: number
 }
 
 export type ProgressCallback = ( event: ProgressEvent ) => void
@@ -101,6 +103,7 @@ export class ProgressTracker {
   private phase_: ProgressPhase | undefined
   private unit_: ProgressUnit = 'elements'
   private total_: number | undefined
+  private extras_: { residentSourceMb?: number } | undefined
 
   /**
    * Construct this with the callback progress events are forwarded to.
@@ -150,15 +153,19 @@ export class ProgressTracker {
    * Report progress within the current phase; throttled.
    *
    * @param completed Units completed so far.
+   * @param extras Optional extras (window residency) merged into the event.
    */
-  public update( completed: number ): void {
+  public update(
+      completed: number,
+      extras?: { residentSourceMb?: number } ): void {
     const now = Date.now()
 
     if ( now - this.lastEmitTime < this.minIntervalMs ) {
       return
     }
 
-    this.emit( completed, now )
+    this.extras_ = extras
+    this.emit( completed, now, extras )
   }
 
   /**
@@ -168,8 +175,9 @@ export class ProgressTracker {
    * @param completed Final completed units (defaults to the phase total).
    */
   public endPhase( completed?: number ): void {
-    this.emit( completed ?? this.total_ ?? 0 )
+    this.emit( completed ?? this.total_ ?? 0, Date.now(), this.extras_ )
     this.phase_ = void 0
+    this.extras_ = void 0
   }
 
   /**
@@ -177,8 +185,12 @@ export class ProgressTracker {
    *
    * @param completed Units completed so far.
    * @param now Current time in ms (defaults to Date.now()).
+   * @param extras Optional extras merged into the event.
    */
-  private emit( completed: number, now: number = Date.now() ): void {
+  private emit(
+      completed: number,
+      now: number = Date.now(),
+      extras?: { residentSourceMb?: number } ): void {
     if ( this.phase_ === void 0 ) {
       return
     }
@@ -194,6 +206,7 @@ export class ProgressTracker {
       unit: this.unit_,
       elapsedMs: now - this.startTime,
       memoryMb: Memory.usedHeapMb(),
+      residentSourceMb: extras?.residentSourceMb,
     } )
   }
 }

--- a/src/core/progress_log.test.ts
+++ b/src/core/progress_log.test.ts
@@ -121,6 +121,32 @@ describe( 'LoadLogAccumulator', () => {
     expect( log.totalLine() ).toBe( 'Total: 16.500s, 500.000000 → 720.000000 MB heap' )
   } )
 
+  test( 'appends window residency on the Geometry line when provided', () => {
+
+    const log = new LoadLogAccumulator()
+
+    log.onProgress( {
+      phase: 'geometry',
+      completed: 0,
+      total: 10,
+      elapsedMs: 0,
+      memoryMb: 100,
+      residentSourceMb: 64,
+    } )
+    log.onProgress( {
+      phase: 'geometry',
+      completed: 10,
+      total: 10,
+      elapsedMs: 1000,
+      memoryMb: 120,
+      residentSourceMb: 64,
+    } )
+    log.closeCurrentStage()
+
+    expect( log.finishedLines()[ 0 ] ).toBe(
+        'Geometry: 1.000s, +20.000000 MB heap, window=64.000000 MB' )
+  } )
+
   test( 'handles indeterminate stages and missing memory', () => {
 
     const log = new LoadLogAccumulator()

--- a/src/core/progress_log.ts
+++ b/src/core/progress_log.ts
@@ -40,6 +40,7 @@ export interface ProgressEventLike {
   total?: number
   elapsedMs: number
   memoryMb?: number
+  residentSourceMb?: number
 }
 
 /** Display labels for the phase taxonomy; unknown phases title-case as-is. */
@@ -159,6 +160,7 @@ interface StageState {
   startHeapMb?: number
   lastHeapMb?: number
   percent?: number
+  residentSourceMb?: number
 }
 
 /**
@@ -195,17 +197,19 @@ function heapDeltaSuffix( state: StageState ): string {
 function formatStageLine( state: StageState, final: boolean ): string {
   const duration = state.lastElapsedMs - state.startElapsedMs
   const heap = heapDeltaSuffix( state )
+  const window = state.residentSourceMb !== void 0 ?
+    `, window=${formatMb( state.residentSourceMb )} MB` : ''
   const determinate = state.percent !== void 0
 
   // Completed: no bar, colon-separated. A determinate stage that stopped
   // short of 100% is a failure — keep its bar to show the reach.
   if ( final && !( determinate && ( state.percent as number ) < PERCENT ) ) {
-    return `${state.label}: ${formatSeconds( duration )}${heap}`
+    return `${state.label}: ${formatSeconds( duration )}${heap}${window}`
   }
 
   const bar = formatBar( determinate ? state.percent : void 0 )
 
-  return `${state.label} ${bar} ${formatSeconds( duration )}${heap}`
+  return `${state.label} ${bar} ${formatSeconds( duration )}${heap}${window}`
 }
 
 /**
@@ -282,6 +286,10 @@ export class LoadLogAccumulator {
     if ( event.memoryMb !== void 0 ) {
       current.startHeapMb ??= event.memoryMb
       current.lastHeapMb = event.memoryMb
+    }
+
+    if ( event.residentSourceMb !== void 0 ) {
+      current.residentSourceMb = event.residentSourceMb
     }
 
     if ( event.total !== void 0 && event.total > 0 ) {

--- a/src/ifc/ifc_stream_open.test.ts
+++ b/src/ifc/ifc_stream_open.test.ts
@@ -102,6 +102,25 @@ describe( 'openStreamedIfcModel (Phase B3)', () => {
         .toThrow( /does not match/ )
   } )
 
+  test( 'releaseSourceViews still lets a later read re-acquire', async () => {
+
+    const store = new InMemoryStepByteStore( bytes )
+    const fromStore = await openStreamedIfcModelFromStore( store, { pool: 4 * 1024 } )
+    const model = fromStore.model!
+    const expressID = [ ...model.expressIDsOfTypes( IfcRoot ) ][ 0 ] as number
+    const localID = model.resolveExpressID( expressID ) as number
+
+    await model.ensureResidentByLocalID( localID )
+    const first = model.getElementByExpressID( expressID )
+    expect( first?.expressID ).toBe( expressID )
+
+    model.releaseSourceViews( [ localID ] )
+
+    await model.ensureResidentByLocalID( localID )
+    const again = model.getElementByExpressID( expressID )
+    expect( again?.expressID ).toBe( expressID )
+  } )
+
   test( 'openStreamedIfcModelFromStore matches the sync open', async () => {
     const store = new InMemoryStepByteStore( bytes )
     const fromStore = await openStreamedIfcModelFromStore( store, { pool: 4 * 1024 } )

--- a/src/ifc/ifc_stream_open.test.ts
+++ b/src/ifc/ifc_stream_open.test.ts
@@ -112,13 +112,15 @@ describe( 'openStreamedIfcModel (Phase B3)', () => {
 
     await model.ensureResidentByLocalID( localID )
     const first = model.getElementByExpressID( expressID )
-    expect( first?.expressID ).toBe( expressID )
+    expect( first ).toBeDefined()
+    const args = first!.extractLineArguments()
+    expect( args.length ).toBeGreaterThan( 0 )
 
     model.releaseSourceViews( [ localID ] )
 
     await model.ensureResidentByLocalID( localID )
     const again = model.getElementByExpressID( expressID )
-    expect( again?.expressID ).toBe( expressID )
+    expect( again!.extractLineArguments().length ).toBe( args.length )
   } )
 
   test( 'openStreamedIfcModelFromStore matches the sync open', async () => {

--- a/src/step/parsing/step_parser.ts
+++ b/src/step/parsing/step_parser.ts
@@ -504,7 +504,11 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
   public parseDataBlockStreamed(
       input: ParsingBuffer,
       onRecordBoundary: ( input: ParsingBuffer ) => void | Promise<void>,
-      onRecordIndexed?: ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
+      onRecordIndexed?: (
+        localID: number,
+        expressID: number,
+        typeID: TypeIDType | undefined,
+        recordBytes?: Uint8Array ) => void,
       onProgress?: ParseProgressCallback,
       sink?: StepIndexSink<TypeIDType> ): BlockParseResult<TypeIDType> {
 
@@ -551,7 +555,11 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
   public async parseDataBlockStreamedAsync(
       input: ParsingBuffer,
       onRecordBoundary: ( input: ParsingBuffer ) => void | Promise<void>,
-      onRecordIndexed?: ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
+      onRecordIndexed?: (
+        localID: number,
+        expressID: number,
+        typeID: TypeIDType | undefined,
+        recordBytes?: Uint8Array ) => void,
       onProgress?: ParseProgressCallback,
       sink?: StepIndexSink<TypeIDType>,
       yieldIntervalMs: number = DEFAULT_PARSE_YIELD_INTERVAL_MS ):
@@ -638,7 +646,11 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
   private* parseDataBlockIncremental(
       input: ParsingBuffer,
       onRecordBoundary?: ( input: ParsingBuffer ) => void | Promise<void>,
-      onRecordIndexed?: ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
+      onRecordIndexed?: (
+        localID: number,
+        expressID: number,
+        typeID: TypeIDType | undefined,
+        recordBytes?: Uint8Array ) => void,
       sink?: StepIndexSink<TypeIDType> ):
       Generator<number | Promise<void>, BlockParseResult<TypeIDType>, undefined> {
 
@@ -927,7 +939,14 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
           return syntaxError()
         }
 
-        onRecordIndexed?.( topLevelCount, expressID, 0 as TypeIDType )
+        {
+          const recordLen = input.address - startElement
+          onRecordIndexed?.(
+              topLevelCount,
+              expressID,
+              0 as TypeIDType,
+              input.buffer.subarray( input.cursor - recordLen, input.cursor ) )
+        }
         ++topLevelCount
 
         pushEntry(
@@ -1097,7 +1116,14 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
         return syntaxError()
       }
 
-      onRecordIndexed?.( topLevelCount, expressID, foundItem )
+      {
+        const recordLen = input.address - startElement
+        onRecordIndexed?.(
+            topLevelCount,
+            expressID,
+            foundItem,
+            input.buffer.subarray( input.cursor - recordLen, input.cursor ) )
+      }
       ++topLevelCount
 
       pushEntry(

--- a/src/step/parsing/streaming_index_builder.ts
+++ b/src/step/parsing/streaming_index_builder.ts
@@ -88,8 +88,11 @@ export function buildIndexStreaming<TypeIDType>(
     source: ByteSource,
     parser: StepParser<TypeIDType>,
     pool: number,
-    onRecordIndexed?:
-      ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
+    onRecordIndexed?: (
+      localID: number,
+      expressID: number,
+      typeID: TypeIDType | undefined,
+      recordBytes?: Uint8Array ) => void,
     sink?: StepIndexSink<TypeIDType> ):
     StreamingIndexResult<TypeIDType> {
 
@@ -256,8 +259,11 @@ export async function buildIndexStreamingAsync<TypeIDType>(
     source: ReadableByteSource,
     parser: StepParser<TypeIDType>,
     pool: number,
-    onRecordIndexed?:
-      ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
+    onRecordIndexed?: (
+      localID: number,
+      expressID: number,
+      typeID: TypeIDType | undefined,
+      recordBytes?: Uint8Array ) => void,
     sink?: StepIndexSink<TypeIDType>,
     onProgress?: ( absoluteByteCursor: number ) => void,
     yieldIntervalMs?: number ):
@@ -400,8 +406,11 @@ export function buildColumnarIndexStreaming<TypeIDType extends number>(
     source: ByteSource,
     parser: StepParser<TypeIDType>,
     pool: number,
-    onRecordIndexed?:
-      ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void ):
+    onRecordIndexed?: (
+      localID: number,
+      expressID: number,
+      typeID: TypeIDType | undefined,
+      recordBytes?: Uint8Array ) => void ):
     StreamingColumnarIndexResult<TypeIDType> {
 
   const sink = new ColumnarIndexSink<TypeIDType>()
@@ -432,8 +441,11 @@ export async function buildColumnarIndexStreamingAsync<TypeIDType extends number
     source: ReadableByteSource,
     parser: StepParser<TypeIDType>,
     pool: number,
-    onRecordIndexed?:
-      ( localID: number, expressID: number, typeID: TypeIDType | undefined ) => void,
+    onRecordIndexed?: (
+      localID: number,
+      expressID: number,
+      typeID: TypeIDType | undefined,
+      recordBytes?: Uint8Array ) => void,
     onProgress?: ( absoluteByteCursor: number ) => void,
     yieldIntervalMs?: number ):
     Promise<StreamingColumnarIndexResult<TypeIDType>> {

--- a/src/step/step_buffer_provider.ts
+++ b/src/step/step_buffer_provider.ts
@@ -34,9 +34,10 @@
  *    a {@link StepExternalByteStore} with an LRU residency cap.
  *    Records contained in one chunk are served as a view over it;
  *    records straddling chunks get a per-record merged copy. Eviction
- *    is advisory — descriptors that captured a chunk keep it alive
- *    via their own reference, so correctness never depends on the
- *    residency set; only memory does.
+ *    is advisory while a descriptor still holds a chunk view.
+ *    {@link StepModelBase.releaseSourceViews} drops those views so
+ *    the LRU can evict; the next sync read must `ensureResident`
+ *    first (same as any other miss).
  *
  * The external store itself is environment-provided (OPFS in the
  * browser, a file or memory in node) — this module only defines the

--- a/src/step/step_entity_base.ts
+++ b/src/step/step_entity_base.ts
@@ -1093,6 +1093,8 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
    */
   protected get buffer(): Uint8Array {
 
+    this.guaranteeBuffer()
+
     return this.internalReference_.buffer as Uint8Array
   }
 

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -816,6 +816,57 @@ implements Iterable<BaseEntity>, Model {
 
 
   /**
+   * Drop captured source-window views on `localIDs` so the windowed
+   * LRU can actually evict those chunks. Descriptors keep SoA columns
+   * and (if present) the entity object; the next field read
+   * re-acquires. Call after a product extract, once the closure is
+   * unpin-able — otherwise every extracted entity pins its 4 MiB
+   * chunk for the rest of the load.
+   *
+   * @param localIDs Records whose `buffer` views to drop.
+   */
+  public releaseSourceViews( localIDs: Iterable< number > ): void {
+
+    if ( !this.isSourceExternal ) {
+      return
+    }
+
+    for ( const localID of localIDs ) {
+
+      if ( localID >= this.count_ ) {
+        continue
+      }
+
+      const item =
+        this.complexEntries_?.get( localID ) ?? this.descriptorCache_[ localID ]
+
+      if ( item === void 0 ) {
+        continue
+      }
+
+      // Drop the view AND the vtable: vtable slots are view-relative,
+      // so they are stale against the next acquire of a different window.
+      item.buffer      = void 0
+      item.vtable      = void 0
+      item.vtableCount = void 0
+      item.vtableIndex = void 0
+
+      if ( item.multiMapping !== void 0 ) {
+
+        for ( const mapped of item.multiMapping ) {
+          mapped.buffer      = void 0
+          mapped.vtable      = void 0
+          mapped.vtableCount = void 0
+          mapped.vtableIndex = void 0
+        }
+      }
+    }
+
+    releaseScratchParsingBuffer()
+  }
+
+
+  /**
    * Unpin every local ID in `localIDs` (best-effort; missing IDs are
    * ignored). Use after {@link ensureResidentClosureByLocalID}, which
    * pins as it walks.

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -816,12 +816,10 @@ implements Iterable<BaseEntity>, Model {
 
 
   /**
-   * Drop captured source-window views on `localIDs` so the windowed
-   * LRU can actually evict those chunks. Descriptors keep SoA columns
-   * and (if present) the entity object; the next field read
-   * re-acquires. Call after a product extract, once the closure is
-   * unpin-able — otherwise every extracted entity pins its 4 MiB
-   * chunk for the rest of the load.
+   * Drop captured source-window views on `localIDs` so the LRU can
+   * evict those chunks. Vtables stay — `acquire` of the same
+   * `(address, length)` is at a stable base. The next
+   * `ensureResident` + field read rematerialises the view.
    *
    * @param localIDs Records whose `buffer` views to drop.
    */
@@ -844,20 +842,12 @@ implements Iterable<BaseEntity>, Model {
         continue
       }
 
-      // Drop the view AND the vtable: vtable slots are view-relative,
-      // so they are stale against the next acquire of a different window.
-      item.buffer      = void 0
-      item.vtable      = void 0
-      item.vtableCount = void 0
-      item.vtableIndex = void 0
+      item.buffer = void 0
 
       if ( item.multiMapping !== void 0 ) {
 
         for ( const mapped of item.multiMapping ) {
-          mapped.buffer      = void 0
-          mapped.vtable      = void 0
-          mapped.vtableCount = void 0
-          mapped.vtableIndex = void 0
+          mapped.buffer = void 0
         }
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to the 1.511.1441 smoke (58s, 3821 MB peak). Two memory levers plus a parse-time ghost:

1. **`releaseSourceViews`** after demand prep and each product extract. Entity descriptors were keeping 4 MiB chunk views alive, so the LRU never actually bounded the source. The buffer getter re-acquires; vtables are dropped with the view (they are view-relative). Geometry progress reports `window=N MB` so we can see whether residency stays near 16×4 MiB.

2. **Sparse AABB imposters** on store-backed parse. The prefix-extract preview channel needs a resident prefix; this path does not. Every 8th `IfcCartesianPointList3D` is scanned in-window (min/max of the STEP reals, no entity hydrate) and emitted as a `PreviewMeshPayload.aabb`. Share instances one unit cube and keeps the last 100.

## Test plan

- [x] `yarn build-incremental`
- [x] `parse_aabb_imposter`, `progress_log`, `ifc_stream_open`, `ifc_api_streamed_open`
- [ ] PSB smoke after publish + Share bump: Hashing heap vs +410; Geometry line shows `window=`; cyan wire boxes during parse; peak vs 3821