### PR TITLE
Rematerialise extract buffers; prefetch product-batch closures

### DIFF
--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -1034,25 +1034,28 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
       const pins = new Set< number >()
 
-      await Promise.all( pending.map( ( localID ) =>
-        conwayGeometry.ensureResidentForProductExtract( localID, pins ) ) )
+      try {
 
-      for ( const localID of pending ) {
+        await Promise.all( pending.map( ( localID ) =>
+          conwayGeometry.ensureResidentForProductExtract( localID, pins ) ) )
 
-        try {
-          conwayGeometry.extractProductGeometryByLocalID( localID )
-        } catch ( error ) {
-          Logger.error(
-              `Error extracting product localID ${localID}: ` +
-              `${error instanceof Error ? error.message : String( error )}` )
+        for ( const localID of pending ) {
+
+          try {
+            conwayGeometry.extractProductGeometryByLocalID( localID )
+          } catch ( error ) {
+            Logger.error(
+                `Error extracting product localID ${localID}: ` +
+                `${error instanceof Error ? error.message : String( error )}` )
+          }
+
+          ++completed
         }
-
-        ++completed
+      } finally {
+        model.releaseSourceViews( pins )
+        model.unpinLocalIDs( pins )
+        pending.length = 0
       }
-
-      model.releaseSourceViews( pins )
-      model.unpinLocalIDs( pins )
-      pending.length = 0
 
       tracker?.update( completed, {
         residentSourceMb: model.residentSourceBytes / BYTES_PER_MIB,
@@ -1805,31 +1808,33 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     if (batchIDs.length > 0) {
 
-      // One shared pin set for the batch: mapped/type geometry is
-      // paged once, then every product extracts against it. Per-product
-      // release was re-reading the same facesets from OPFS on every
-      // instance (the ~20s Geometry tax vs a resident buffer).
+      // One pin set for the batch so mapped geometry stays resident
+      // across the instances that share it.
       const pins = new Set<number>()
 
-      await Promise.all(batchIDs.map((localID) =>
-        this.conwayGeometry_.ensureResidentForProductExtract(localID, pins)))
+      try {
 
-      for (const localID of batchIDs) {
+        await Promise.all(batchIDs.map((localID) =>
+          this.conwayGeometry_.ensureResidentForProductExtract(localID, pins)))
 
-        try {
-          if (this.conwayGeometry_.extractProductGeometryByLocalID(localID)) {
-            ++extracted
+        for (const localID of batchIDs) {
+
+          try {
+            if (this.conwayGeometry_.extractProductGeometryByLocalID(localID)) {
+              ++extracted
+            }
+          } catch (error) {
+            Logger.error(
+                `Error extracting product localID ${localID}: ` +
+                `${error instanceof Error ? error.message : String(error)}`)
           }
-        } catch (error) {
-          Logger.error(
-              `Error extracting product localID ${localID}: ` +
-              `${error instanceof Error ? error.message : String(error)}`)
         }
-      }
 
-      this.model[0].releaseSourceViews(pins)
-      this.model[0].unpinLocalIDs(pins)
-      this.demandCursor_ = productEnd
+        this.demandCursor_ = productEnd
+      } finally {
+        this.model[0].releaseSourceViews(pins)
+        this.model[0].unpinLocalIDs(pins)
+      }
     }
 
     if (this.demandCursor_ >= products.length &&

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -1022,31 +1022,57 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     tracker?.setPhaseTotal( model.typeCount( IfcProduct ) )
 
+    // eslint-disable-next-line no-magic-numbers
+    const EXTRACT_BATCH = 8
+    const pending: number[] = []
+
+    const flushProductBatch = async () => {
+
+      if ( pending.length === 0 ) {
+        return
+      }
+
+      const pins = new Set< number >()
+
+      await Promise.all( pending.map( ( localID ) =>
+        conwayGeometry.ensureResidentForProductExtract( localID, pins ) ) )
+
+      for ( const localID of pending ) {
+
+        try {
+          conwayGeometry.extractProductGeometryByLocalID( localID )
+        } catch ( error ) {
+          Logger.error(
+              `Error extracting product localID ${localID}: ` +
+              `${error instanceof Error ? error.message : String( error )}` )
+        }
+
+        ++completed
+      }
+
+      model.releaseSourceViews( pins )
+      model.unpinLocalIDs( pins )
+      pending.length = 0
+
+      tracker?.update( completed, {
+        residentSourceMb: model.residentSourceBytes / BYTES_PER_MIB,
+      } )
+    }
+
     for ( const product of model.types( IfcProduct ) ) {
 
       if ( aggregateTargets.has( product.localID ) ) {
         continue
       }
 
-      const pins =
-        await conwayGeometry.ensureResidentForProductExtract( product.localID )
+      pending.push( product.localID )
 
-      try {
-        conwayGeometry.extractProductGeometryByLocalID( product.localID )
-      } catch ( error ) {
-        Logger.error(
-            `Error extracting product ${product.expressID}: ` +
-            `${error instanceof Error ? error.message : String( error )}` )
-      } finally {
-        model.releaseSourceViews( pins )
-        model.unpinLocalIDs( pins )
+      if ( pending.length >= EXTRACT_BATCH ) {
+        await flushProductBatch()
       }
-
-      ++completed
-      tracker?.update( completed, {
-        residentSourceMb: model.residentSourceBytes / BYTES_PER_MIB,
-      } )
     }
+
+    await flushProductBatch()
 
     for ( const relAggregate of model.types( IfcRelAggregates ) ) {
 
@@ -1775,25 +1801,35 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     }
 
     const productEnd = Math.min(this.demandCursor_ + budget, products.length)
+    const batchIDs = products.slice(this.demandCursor_, productEnd)
 
-    for (; this.demandCursor_ < productEnd; ++this.demandCursor_) {
+    if (batchIDs.length > 0) {
 
-      const localID = products[this.demandCursor_]
-      const pins =
-        await this.conwayGeometry_.ensureResidentForProductExtract(localID)
+      // One shared pin set for the batch: mapped/type geometry is
+      // paged once, then every product extracts against it. Per-product
+      // release was re-reading the same facesets from OPFS on every
+      // instance (the ~20s Geometry tax vs a resident buffer).
+      const pins = new Set<number>()
 
-      try {
-        if (this.conwayGeometry_.extractProductGeometryByLocalID(localID)) {
-          ++extracted
+      await Promise.all(batchIDs.map((localID) =>
+        this.conwayGeometry_.ensureResidentForProductExtract(localID, pins)))
+
+      for (const localID of batchIDs) {
+
+        try {
+          if (this.conwayGeometry_.extractProductGeometryByLocalID(localID)) {
+            ++extracted
+          }
+        } catch (error) {
+          Logger.error(
+              `Error extracting product localID ${localID}: ` +
+              `${error instanceof Error ? error.message : String(error)}`)
         }
-      } catch (error) {
-        Logger.error(
-            `Error extracting product localID ${localID}: ` +
-            `${error instanceof Error ? error.message : String(error)}`)
-      } finally {
-        this.model[0].releaseSourceViews(pins)
-        this.model[0].unpinLocalIDs(pins)
       }
+
+      this.model[0].releaseSourceViews(pins)
+      this.model[0].unpinLocalIDs(pins)
+      this.demandCursor_ = productEnd
     }
 
     if (this.demandCursor_ >= products.length &&

--- a/src/ifc/ifc_stream_open.test.ts
+++ b/src/ifc/ifc_stream_open.test.ts
@@ -123,6 +123,67 @@ describe( 'openStreamedIfcModel (Phase B3)', () => {
     expect( again!.extractLineArguments().length ).toBe( args.length )
   } )
 
+  test( 'extractParseBuffer rematerialises after releaseSourceViews', async () => {
+
+    const store = new InMemoryStepByteStore( bytes )
+    const fromStore = await openStreamedIfcModelFromStore( store, { pool: 4 * 1024 } )
+    const model = fromStore.model!
+    const expressID = [ ...model.expressIDsOfTypes( IfcRoot ) ][ 0 ] as number
+    const localID = model.resolveExpressID( expressID ) as number
+
+    await model.ensureResidentByLocalID( localID )
+    const first = model.getElementByExpressID( expressID )!
+
+    // Populate vtable + buffer the way a first extract does.
+    expect( first.extractLineArguments().length ).toBeGreaterThan( 0 )
+
+    const copied: number[] = []
+    const fakeResult = { resize: ( n: number ) => n }
+    const fakeModule = { HEAPU8: { set: ( src: Uint8Array ) => {
+
+      copied.push( src.length )
+    } } }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    first.extractParseBuffer( 0, 0, 0, fakeResult as any, fakeModule as any, true )
+    expect( copied[ 0 ] ).toBeGreaterThan( 0 )
+
+    model.releaseSourceViews( [ localID ] )
+    await model.ensureResidentByLocalID( localID )
+
+    // Same entity object — vtable kept, buffer dropped. This is the
+    // PSB "Cannot read properties of undefined (reading 'subarray')" path.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    first.extractParseBuffer( 0, 0, 0, fakeResult as any, fakeModule as any, true )
+    expect( copied[ 1 ] ).toBe( copied[ 0 ] )
+  } )
+
+  test( 'ensureResidentClosureByLocalID visits every #ref hop', async () => {
+
+    const store = new InMemoryStepByteStore( bytes )
+    const fromStore = await openStreamedIfcModelFromStore( store, { pool: 4 * 1024 } )
+    const model = fromStore.model!
+    const expressID = [ ...model.expressIDsOfTypes( IfcRoot ) ][ 0 ] as number
+    const localID = model.resolveExpressID( expressID ) as number
+
+    await model.ensureResidentByLocalID( localID )
+    const refs = model.referencedExpressIDs( localID )
+    expect( refs.length ).toBeGreaterThan( 0 )
+
+    const visited = await model.ensureResidentClosureByLocalID( localID )
+
+    expect( visited.has( localID ) ).toBe( true )
+
+    for ( const refExpressID of refs ) {
+
+      const refLocalID = model.resolveExpressID( refExpressID )
+
+      if ( refLocalID !== void 0 ) {
+        expect( visited.has( refLocalID ) ).toBe( true )
+      }
+    }
+  } )
+
   test( 'openStreamedIfcModelFromStore matches the sync open', async () => {
     const store = new InMemoryStepByteStore( bytes )
     const fromStore = await openStreamedIfcModelFromStore( store, { pool: 4 * 1024 } )

--- a/src/step/step_entity_base.ts
+++ b/src/step/step_entity_base.ts
@@ -897,7 +897,13 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
       module: WasmModule,
       optional: boolean ): boolean {
     
-    offset -= this.multiReference_ !== void 0 ? baseOffset : 0    
+    offset -= this.multiReference_ !== void 0 ? baseOffset : 0
+
+    // Rematerialise before the vtable walk: releaseSourceViews keeps
+    // vtables and drops `buffer`, and guaranteeVTable used to return
+    // the stale descriptor. HEAPU8.set then threw
+    // "Cannot read properties of undefined (reading 'subarray')".
+    this.guaranteeBuffer()
 
     const internalReference = this.guaranteeVTable( depth )
 
@@ -1224,6 +1230,10 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
         }
       }
 
+      if ( classReference.buffer === void 0 ) {
+        this.model.populateBufferEntry( this.localID )
+      }
+
       // Sync on EVERY access (not just first populate): generated
       // getters read `this.buffer` right after resolving a cursor for
       // this depth, and with a windowed provider each class reference
@@ -1242,6 +1252,10 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
       if (!populated) {
         throw new Error('Entity does not have matching table entry to read from model')
       }
+    }
+
+    if ( internalReference.buffer === void 0 ) {
+      this.guaranteeBuffer()
     }
 
     return internalReference as Required< StepEntityInternalReference<EntityTypeIDs> >

--- a/src/step/step_entity_base.ts
+++ b/src/step/step_entity_base.ts
@@ -899,10 +899,7 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
     
     offset -= this.multiReference_ !== void 0 ? baseOffset : 0
 
-    // Rematerialise before the vtable walk: releaseSourceViews keeps
-    // vtables and drops `buffer`, and guaranteeVTable used to return
-    // the stale descriptor. HEAPU8.set then threw
-    // "Cannot read properties of undefined (reading 'subarray')".
+    // releaseSourceViews keeps the vtable and drops `buffer`.
     this.guaranteeBuffer()
 
     const internalReference = this.guaranteeVTable( depth )

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -790,7 +790,10 @@ implements Iterable<BaseEntity>, Model {
           continue
         }
 
+        // Claim + pin before the await so a sibling ensure cannot
+        // evict this range once its own ensurePins_ drop.
         seen.add( id )
+        this.pinByLocalID( id )
         wave.push( id )
       }
 
@@ -803,8 +806,6 @@ implements Iterable<BaseEntity>, Model {
       await Promise.all( wave.map( ( id ) => this.ensureResidentByLocalID( id ) ) )
 
       for ( const id of wave ) {
-
-        this.pinByLocalID( id )
 
         for ( const expressID of this.scanRecordRefs_( id ) ) {
 

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -484,6 +484,10 @@ implements Iterable<BaseEntity>, Model {
       return void 0
     }
 
+    if ( element.buffer === void 0 ) {
+      this.populateBufferEntry( localID )
+    }
+
     const vtable = element.vtable
     const buffer = element.buffer
 
@@ -593,6 +597,14 @@ implements Iterable<BaseEntity>, Model {
 
     element.buffer =
       this.bufferProvider_.acquire( element.address, element.length ).buffer
+
+    if ( element.multiMapping !== void 0 ) {
+
+      for ( const mapped of element.multiMapping ) {
+        mapped.buffer =
+          this.bufferProvider_.acquire( mapped.address, mapped.length ).buffer
+      }
+    }
   }
 
 
@@ -746,34 +758,61 @@ implements Iterable<BaseEntity>, Model {
       return seen
     }
 
-    const stack: number[] = [ localID ]
+    // BFS by hop: page a whole frontier in parallel so a product whose
+    // #refs sit in different OPFS chunks is one round-trip, not one
+    // await per record. Claim `seen` before the await so overlapping
+    // walks (a batch of products sharing mapped geometry) pin once.
+    const frontier: number[] = []
+
+    const enqueue = ( id: number ) => {
+
+      if ( id < this.count_ && !seen.has( id ) ) {
+        frontier.push( id )
+      }
+    }
+
+    enqueue( localID )
 
     if ( extraLocalIDs !== void 0 ) {
 
       for ( const extra of extraLocalIDs ) {
-        stack.push( extra )
+        enqueue( extra )
       }
     }
 
-    while ( stack.length > 0 ) {
+    while ( frontier.length > 0 ) {
 
-      const id = stack.pop() as number
+      const wave: number[] = []
 
-      if ( seen.has( id ) || id >= this.count_ ) {
-        continue
+      for ( const id of frontier ) {
+
+        if ( seen.has( id ) || id >= this.count_ ) {
+          continue
+        }
+
+        seen.add( id )
+        wave.push( id )
       }
 
-      seen.add( id )
+      frontier.length = 0
 
-      await this.ensureResidentByLocalID( id )
-      this.pinByLocalID( id )
+      if ( wave.length === 0 ) {
+        break
+      }
 
-      for ( const expressID of this.scanRecordRefs_( id ) ) {
+      await Promise.all( wave.map( ( id ) => this.ensureResidentByLocalID( id ) ) )
 
-        const referenced = this.expressIDMap_.get( expressID )
+      for ( const id of wave ) {
 
-        if ( referenced !== void 0 && !seen.has( referenced ) ) {
-          stack.push( referenced )
+        this.pinByLocalID( id )
+
+        for ( const expressID of this.scanRecordRefs_( id ) ) {
+
+          const referenced = this.expressIDMap_.get( expressID )
+
+          if ( referenced !== void 0 && !seen.has( referenced ) ) {
+            frontier.push( referenced )
+          }
         }
       }
     }


### PR DESCRIPTION
## What

Store-backed extract follow-up from the 1.512.1444 PSB smoke (Share v1.1753.a562202: 60.7s, 1715 MB peak, `window=61`, six extract TypeErrors, leftover AABB cubes).

- `extractParseBuffer` / `guaranteeVTable` rematerialise `buffer` after `releaseSourceViews` (vtables are kept; the dropped view was the `Cannot read properties of undefined (reading 'subarray')` path on shared facesets).
- `populateBufferEntry` also restores multi-mapping views.
- `ensureResidentClosureByLocalID` pages each `#ref` hop in parallel. Each hop is pinned *before* `ensureResident` so a sibling LRU eviction cannot drop a just-loaded chunk.
- `ExtractGeometryBatchAsync` (and the non-deferred store extract) prefetches a whole product batch into one pin set, extracts, then releases in `finally` — shared facesets are read once per batch, not once per product.

## Why

1.512 Geometry was 37.6s / +411 MB vs 17s resident. The extra ~20s was serial OPFS: each product's closure awaited record-by-record, then `releaseSourceViews` dropped the shared tessellation so the next instance re-read it. The six extract errors were the same dropped-buffer view used by `extractParseBuffer`.

Placement of parse-time AABB imposters is not in this PR: `IfcCartesianPointList3D` has no product `ObjectPlacement` at parse time. Share teardown of leftover cubes is on Share #1753 (`d4bfa561`).

## Review

Handled: pin-before-ensure (LRU race); `try/finally` unpin so a rejected prefetch cannot leak holds.

## Tests

- `extractParseBuffer` on the same entity object after `releaseSourceViews` + re-`ensureResident`.
- `ensureResidentClosureByLocalID` visits every `#ref` hop.

Does not close #446 / #392.