### PR TITLE
Bound extract closures and emit spatial-structure imposters

### DIFF
--- a/scripts/profile_store_extract.mjs
+++ b/scripts/profile_store_extract.mjs
@@ -1,0 +1,167 @@
+/**
+ * Profile store-backed vs resident IFC extract on one file.
+ *
+ *   node --expose-gc --max-old-space-size=8192 \
+ *     scripts/profile_store_extract.mjs --store path.ifc
+ *   node --expose-gc --max-old-space-size=8192 \
+ *     scripts/profile_store_extract.mjs --resident path.ifc
+ *
+ * Store path: OpenModelStream + DEFER_GEOMETRY + ExtractGeometryBatchAsync.
+ * Resident path: OpenModel (full ArrayBuffer) + StreamAllMeshes.
+ *
+ * The store wrapper counts fs reads so I/O is visible separately from
+ * the pump's prefetch/extract/release split.
+ */
+import * as fs from 'node:fs'
+import * as process from 'node:process'
+import { performance } from 'node:perf_hooks'
+
+const args = process.argv.slice(2)
+const mode = args.includes('--resident') ? 'resident' : 'store'
+const batchIdx = args.indexOf('--batch')
+const batchSize = batchIdx >= 0 ? Number(args[batchIdx + 1]) : 8
+const filePath = args.find((a) => !a.startsWith('--') && a !== String(batchSize))
+
+if (!filePath) {
+  console.error('usage: profile_store_extract.mjs [--store|--resident] [--batch N] <file.ifc>')
+  process.exit(2)
+}
+
+function heapMB() {
+  globalThis.gc?.()
+  const u = process.memoryUsage()
+  return {
+    heap: u.heapUsed / (1024 * 1024),
+    rss: u.rss / (1024 * 1024),
+    ext: u.external / (1024 * 1024),
+    ab: u.arrayBuffers / (1024 * 1024),
+  }
+}
+
+function fmt(h) {
+  return `heap=${h.heap.toFixed(1)} rss=${h.rss.toFixed(1)} ext=${h.ext.toFixed(1)} ab=${h.ab.toFixed(1)}`
+}
+
+class CountingFileStore {
+  constructor(path) {
+    this.fd = fs.openSync(path, 'r')
+    this.byteLength = fs.fstatSync(this.fd).size
+    this.reads = 0
+    this.bytes = 0
+    this.ms = 0
+  }
+
+  async read(offset, length) {
+    const t0 = performance.now()
+    const buf = Buffer.allocUnsafe(length)
+    const got = fs.readSync(this.fd, buf, 0, length, offset)
+    this.ms += performance.now() - t0
+    this.reads++
+    this.bytes += got
+    return new Uint8Array(buf.buffer, buf.byteOffset, got)
+  }
+
+  close() {
+    fs.closeSync(this.fd)
+  }
+
+  snapshot() {
+    return { reads: this.reads, bytesMB: this.bytes / (1024 * 1024), ioMs: this.ms }
+  }
+}
+
+const { IfcAPI, LogLevel } = await import('../compiled/src/compat/web-ifc/ifc_api.js')
+
+const api = new IfcAPI()
+await api.Init()
+api.SetLogLevel(LogLevel.LOG_LEVEL_ERROR)
+
+const tAll = performance.now()
+const before = heapMB()
+console.log(`mode=${mode} file=${filePath} sizeMB=${(fs.statSync(filePath).size / (1024 * 1024)).toFixed(1)} batch=${batchSize}`)
+console.log(`start ${fmt(before)}`)
+
+const SETTINGS = {
+  COORDINATE_TO_ORIGIN: true,
+  USE_FAST_BOOLS: true,
+  ON_PROGRESS: (ev) => {
+    if (ev && ev.phase && ev.completed === ev.total) {
+      const extra = ev.residentSourceMb !== undefined ? ` window=${ev.residentSourceMb.toFixed(1)}` : ''
+      console.log(`  phase ${ev.phase} done ${fmt(heapMB())}${extra}`)
+    }
+  },
+}
+
+let modelID
+let store
+const tOpen = performance.now()
+
+if (mode === 'resident') {
+  const bytes = new Uint8Array(fs.readFileSync(filePath))
+  console.log(`buffered ${fmt(heapMB())} (+${(bytes.byteLength / (1024 * 1024)).toFixed(1)} MB file)`)
+  modelID = api.OpenModel(bytes, SETTINGS)
+} else {
+  store = new CountingFileStore(filePath)
+  SETTINGS.DEFER_GEOMETRY = true
+  modelID = await api.OpenModelStream(store, SETTINGS)
+}
+
+const openMs = performance.now() - tOpen
+console.log(`open ${openMs.toFixed(0)}ms id=${modelID} ${fmt(heapMB())}`)
+if (store) {
+  console.log(`  store after open ${JSON.stringify(store.snapshot())}`)
+}
+
+if (modelID < 0) {
+  console.error('open failed')
+  process.exit(1)
+}
+
+let meshes = 0
+const tGeom = performance.now()
+
+if (mode === 'resident') {
+  api.StreamAllMeshes(modelID, () => {
+    meshes++
+  })
+} else {
+  let pumped = 0
+  for (;;) {
+    const { extracted, remaining } = await api.ExtractGeometryBatchAsync(
+      modelID, batchSize, () => {
+        meshes++
+      })
+    pumped += extracted
+    if (pumped > 0 && pumped % 256 === 0) {
+      const io = store.snapshot()
+      const passthrough = api.getPassthrough(modelID)
+      const prof = passthrough?.extractProfile
+      console.log(
+        `  pumped=${pumped} remain=${remaining} ${fmt(heapMB())} ` +
+        `ioReads=${io.reads} ioMB=${io.bytesMB.toFixed(1)} ioMs=${io.ioMs.toFixed(0)} ` +
+        (prof ?
+          `prefetch=${prof.prefetchMs} extract=${prof.extractMs} release=${prof.releaseMs} pinMax=${prof.pinMax}` :
+          ''))
+    }
+    if (remaining === 0 && extracted === 0) {
+      break
+    }
+  }
+}
+
+const geomMs = performance.now() - tGeom
+const after = heapMB()
+const passthrough = api.getPassthrough(modelID)
+const prof = passthrough?.extractProfile
+const windowMb = passthrough?.model?.[0]?.residentSourceBytes
+
+console.log(`geometry ${geomMs.toFixed(0)}ms meshes=${meshes} ${fmt(after)}`)
+if (prof) {
+  console.log(`  pump split prefetch=${prof.prefetchMs}ms extract=${prof.extractMs}ms release=${prof.releaseMs}ms batches=${prof.batches} pinMax=${prof.pinMax}`)
+}
+if (store) {
+  console.log(`  store total ${JSON.stringify(store.snapshot())}`)
+  store.close()
+}
+console.log(`total ${(performance.now() - tAll).toFixed(0)}ms windowHint=${windowMb ?? 'n/a'}`)
+api.CloseModel(modelID)

--- a/src/compat/web-ifc/ifc_api_model_passthrough.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough.ts
@@ -64,6 +64,16 @@ export interface IfcApiModelPassthrough {
    */
   readonly sourceIsExternal?: boolean
 
+  /** Optional: store-backed pump split (prefetch / extract / release). */
+  readonly extractProfile?: {
+    prefetchMs: number
+    extractMs: number
+    releaseMs: number
+    batches: number
+    lastPins: number
+    pinMax: number
+  }
+
   /**
    * Optional: release the resident source buffer, serving subsequent
    * record reads through windows paged from the given external store.

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -38,12 +38,13 @@ import {
   ifcPreviewAdapter,
   StreamedPreviewChannel,
 } from './streamed_preview_channel'
-import { makeParseAabbImposter } from './parse_aabb_imposter'
+import { emitSpatialStructureImposters } from './spatial_imposter'
 import EntityTypesIfc from '../../ifc/ifc4_gen/entity_types_ifc.gen'
 import { StepHeader } from '../../step/parsing/step_parser'
 import { ExtractResult } from '../../index'
 import { IfcGeometryExtraction } from '../../ifc/ifc_geometry_extraction'
 import { ParseResult } from '../../index'
+import { releaseScratchParsingBuffer } from '../../step/parsing/step_deserialization_functions'
 import Memory from '../../memory/memory'
 import { FromRawLineData } from './ifc2x4_helper'
 import { shimIfcEntityMap, shimIfcEntityReverseMap } from './shim_schema_mapping'
@@ -135,6 +136,16 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
   /** Cursor into demandProducts_ — products before it are extracted. */
   private demandCursor_ = 0
+
+  /** Wall-clock split of the store-backed batch pump (profile script). */
+  private readonly extractProfile_ = {
+    prefetchMs: 0,
+    extractMs: 0,
+    releaseMs: 0,
+    batches: 0,
+    lastPins: 0,
+    pinMax: 0,
+  }
 
   /**
    * Deferred-mode rel-aggregates worklist, pumped batch-by-batch AFTER
@@ -850,6 +861,15 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // walks, so meshes appear to consumers as batches extract.
     if (deferGeometry) {
 
+      if ( settings?.ON_PREVIEW_MESH !== void 0 ) {
+
+        try {
+          await emitSpatialStructureImposters( model, settings.ON_PREVIEW_MESH )
+        } catch {
+          // Spatial imposters must never break a deferred open.
+        }
+      }
+
       conwayGeometry.prepareDemandExtraction()
 
       statistics?.setProductCount(model.typeCount(IfcProduct))
@@ -938,20 +958,9 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     tracker?.beginPhase('headerParse', 'bytes', fileSize)
 
-    const headerLen = Math.min( fileSize, STORE_PARSE_POOL_BYTES )
-    const headerBytes = await store.read( 0, headerLen )
-    const [stepHeader, result0] = parser.parseHeader( new ParsingBuffer( headerBytes ) )
-
     Logger.createStatistics(modelID)
 
     const statistics = Logger.getStatistics(modelID)
-
-    IfcApiProxyIfc.reportHeaderParseResult(result0, new ParsingBuffer( headerBytes ), modelID)
-
-    const modelInfo = extractModelInfo(stepHeader, fileSize)
-
-    Logger.info(formatModelLine(modelInfo))
-    settings?.ON_MODEL_INFO?.(modelInfo)
 
     tracker?.beginPhase('dataParse', 'bytes', fileSize)
 
@@ -960,15 +969,31 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     const parseStartTime = Date.now()
 
-    const onRecordIndexed = settings?.ON_PREVIEW_MESH !== void 0 ?
-      makeParseAabbImposter( settings.ON_PREVIEW_MESH ) : void 0
+    // Store-backed preview is the spatial-structure boxes emitted
+    // after the index exists (see emitSpatialStructureImposters).
+    // Parse-time point-list cubes stay on the resident streamed path;
+    // on an 860 MB file they are thousands of unaligned AABBs.
 
-    const { result, columns } = await buildColumnarIndexStreamingAsync(
+    // One windowed pass: header comes out of the same slide as the
+    // data block so we do not hold a second 16 MiB prefix copy.
+    const { result, columns, header: stepHeader } = await buildColumnarIndexStreamingAsync(
         new StoreByteSource( store ),
         parser,
         STORE_PARSE_POOL_BYTES,
-        onRecordIndexed,
+        void 0,
         parseTick )
+
+    // Parse window is out of scope; drop the module scratch in case a
+    // numeric read during the slide left it pointed at that 16 MiB view.
+    releaseScratchParsingBuffer()
+
+    IfcApiProxyIfc.reportHeaderParseResult(
+        result, new ParsingBuffer( new Uint8Array( 0 ) ), modelID )
+
+    const modelInfo = extractModelInfo(stepHeader, fileSize)
+
+    Logger.info(formatModelLine(modelInfo))
+    settings?.ON_MODEL_INFO?.(modelInfo)
 
     const parseEndTime = Date.now()
 
@@ -984,6 +1009,15 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     const model = new IfcStepModel( void 0, columns, provider )
 
     statistics?.setParseTime(parseEndTime - parseStartTime)
+
+    if ( settings?.ON_PREVIEW_MESH !== void 0 ) {
+
+      try {
+        await emitSpatialStructureImposters( model, settings.ON_PREVIEW_MESH )
+      } catch {
+        // Spatial imposters must never break a store-backed open.
+      }
+    }
 
     const conwayGeometry = new IfcGeometryExtraction(conwaywasm, model)
 
@@ -1033,11 +1067,13 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       }
 
       const pins = new Set< number >()
+      const leafSpans: { address: number, length: number }[] = []
 
       try {
 
         await Promise.all( pending.map( ( localID ) =>
-          conwayGeometry.ensureResidentForProductExtract( localID, pins ) ) )
+          conwayGeometry.ensureResidentForProductExtract(
+              localID, pins, leafSpans ) ) )
 
         for ( const localID of pending ) {
 
@@ -1049,11 +1085,15 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
                 `${error instanceof Error ? error.message : String( error )}` )
           }
 
+          model.releaseSourceViews( pins )
           ++completed
         }
       } finally {
         model.releaseSourceViews( pins )
         model.unpinLocalIDs( pins )
+        for ( const span of leafSpans ) {
+          model.unpinAddressRange( span.address, span.length )
+        }
         pending.length = 0
       }
 
@@ -1079,8 +1119,10 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     for ( const relAggregate of model.types( IfcRelAggregates ) ) {
 
+      const leafSpans: { address: number, length: number }[] = []
       const pins =
-        await conwayGeometry.ensureResidentForAggregateExtract( relAggregate )
+        await conwayGeometry.ensureResidentForAggregateExtract(
+            relAggregate, leafSpans )
 
       try {
         conwayGeometry.extractRelAggregateGeometry( relAggregate )
@@ -1091,6 +1133,9 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       } finally {
         model.releaseSourceViews( pins )
         model.unpinLocalIDs( pins )
+        for ( const span of leafSpans ) {
+          model.unpinAddressRange( span.address, span.length )
+        }
       }
 
       ++completed
@@ -1316,6 +1361,22 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    */
   get sourceIsExternal(): boolean {
     return this.model[0].isSourceExternal
+  }
+
+  /**
+   * Store-backed pump split (prefetch / extract / release).
+   *
+   * @return {object} Cumulative milliseconds and pin telemetry.
+   */
+  get extractProfile(): {
+    prefetchMs: number
+    extractMs: number
+    releaseMs: number
+    batches: number
+    lastPins: number
+    pinMax: number
+  } {
+    return this.extractProfile_
   }
 
   /**
@@ -1811,12 +1872,22 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       // One pin set for the batch so mapped geometry stays resident
       // across the instances that share it.
       const pins = new Set<number>()
+      const leafSpans: { address: number, length: number }[] = []
+      const profile = this.extractProfile_
 
       try {
 
+        const prefetchStart = Date.now()
         await Promise.all(batchIDs.map((localID) =>
-          this.conwayGeometry_.ensureResidentForProductExtract(localID, pins)))
+          this.conwayGeometry_.ensureResidentForProductExtract(
+              localID, pins, leafSpans)))
+        profile.prefetchMs += Date.now() - prefetchStart
+        if ( pins.size > profile.pinMax ) {
+          profile.pinMax = pins.size
+        }
+        profile.lastPins = pins.size
 
+        const extractStart = Date.now()
         for (const localID of batchIDs) {
 
           try {
@@ -1828,12 +1899,23 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
                 `Error extracting product localID ${localID}: ` +
                 `${error instanceof Error ? error.message : String(error)}`)
           }
+
+          // Drop JS views after each product; chunks stay pinned for
+          // the rest of the batch so rematerialise is a cache hit.
+          this.model[0].releaseSourceViews(pins)
         }
+        profile.extractMs += Date.now() - extractStart
 
         this.demandCursor_ = productEnd
       } finally {
+        const releaseStart = Date.now()
         this.model[0].releaseSourceViews(pins)
         this.model[0].unpinLocalIDs(pins)
+        for (const span of leafSpans) {
+          this.model[0].unpinAddressRange(span.address, span.length)
+        }
+        profile.releaseMs += Date.now() - releaseStart
+        profile.batches++
       }
     }
 
@@ -1848,9 +1930,10 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         ++this.demandAggregatesCursor_) {
 
         const relAggregate = aggregates[this.demandAggregatesCursor_]
+        const leafSpans: { address: number, length: number }[] = []
         const pins =
           await this.conwayGeometry_.ensureResidentForAggregateExtract(
-              relAggregate)
+              relAggregate, leafSpans)
 
         try {
           this.conwayGeometry_.extractRelAggregateGeometry(relAggregate)
@@ -1862,6 +1945,9 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         } finally {
           this.model[0].releaseSourceViews(pins)
           this.model[0].unpinLocalIDs(pins)
+          for (const span of leafSpans) {
+            this.model[0].unpinAddressRange(span.address, span.length)
+          }
         }
       }
     }

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -931,11 +931,11 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   /**
    * Windowed-from-birth twin of parseColumnarAndExtractAsync: the
    * source stays in `store`, parse windows are filled through it, and
-   * the model never holds a resident copy. The full prefix-extract
-   * preview channel is skipped (it needs a resident prefix); a sparse
-   * AABB imposter rides onRecordIndexed instead. Deferred opens
-   * page prep closures before prepareDemandExtraction; non-deferred
-   * opens drain the demand pump with per-product residency.
+   * the model never holds a resident copy. Prefix-extract preview is
+   * skipped (it needs a resident prefix). After the index exists,
+   * spatial-structure AABB plates go through ON_PREVIEW_MESH.
+   * Deferred opens page prep closures before prepareDemandExtraction;
+   * non-deferred opens drain the demand pump with per-product residency.
    *
    * @param modelID The model ID being opened.
    * @param store External store holding the source bytes.
@@ -956,8 +956,6 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     const parser = IfcStepParser.Instance
     const fileSize = store.byteLength
 
-    tracker?.beginPhase('headerParse', 'bytes', fileSize)
-
     Logger.createStatistics(modelID)
 
     const statistics = Logger.getStatistics(modelID)
@@ -968,11 +966,6 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       (cursorBytes: number) => tracker.update(cursorBytes) : void 0
 
     const parseStartTime = Date.now()
-
-    // Store-backed preview is the spatial-structure boxes emitted
-    // after the index exists (see emitSpatialStructureImposters).
-    // Parse-time point-list cubes stay on the resident streamed path;
-    // on an 860 MB file they are thousands of unaligned AABBs.
 
     // One windowed pass: header comes out of the same slide as the
     // data block so we do not hold a second 16 MiB prefix copy.

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -34,6 +34,7 @@ import {
   buildColumnarIndexStreamingAsync,
 } from '../../step/parsing/streaming_index_builder'
 import { ColumnarIndexSink } from '../../step/parsing/columnar_index'
+import { StorePreviewChannel } from './store_preview_channel'
 import {
   ifcPreviewAdapter,
   StreamedPreviewChannel,
@@ -931,9 +932,10 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   /**
    * Windowed-from-birth twin of parseColumnarAndExtractAsync: the
    * source stays in `store`, parse windows are filled through it, and
-   * the model never holds a resident copy. Prefix-extract preview is
-   * skipped (it needs a resident prefix). After the index exists,
-   * spatial-structure AABB plates go through ON_PREVIEW_MESH.
+   * the model never holds a resident copy. During parse a bounded
+   * prefix extract pages product closures from the store and emits
+   * placed meshes (same COORDINATE_TO_ORIGIN frame as durable). After
+   * the index exists, spatial-structure AABB plates go out too.
    * Deferred opens page prep closures before prepareDemandExtraction;
    * non-deferred opens drain the demand pump with per-product residency.
    *
@@ -967,14 +969,44 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     const parseStartTime = Date.now()
 
+    // Live sink so the store preview channel can snapshot a prefix
+    // mid-parse without a resident source buffer.
+    const sink = new ColumnarIndexSink< EntityTypesIfc >()
+    const storePreview = settings?.ON_PREVIEW_MESH !== void 0 ?
+      new StorePreviewChannel(
+          store,
+          sink,
+          conwaywasm,
+          settings.COORDINATE_TO_ORIGIN === true,
+          settings.ON_PREVIEW_MESH ) : void 0
+
+    const parseProgress = async ( cursorBytes: number ): Promise< void > => {
+      parseTick?.( cursorBytes )
+      await storePreview?.maybeTickAsync()
+    }
+
     // One windowed pass: header comes out of the same slide as the
     // data block so we do not hold a second 16 MiB prefix copy.
-    const { result, columns, header: stepHeader } = await buildColumnarIndexStreamingAsync(
-        new StoreByteSource( store ),
-        parser,
-        STORE_PARSE_POOL_BYTES,
-        void 0,
-        parseTick )
+    let result
+    let stepHeader
+
+    try {
+      ( { result, header: stepHeader } = await buildIndexStreamingAsync(
+          new StoreByteSource( store ),
+          parser,
+          STORE_PARSE_POOL_BYTES,
+          void 0,
+          sink,
+          parseProgress ) )
+
+      if ( storePreview !== void 0 ) {
+        await storePreview.flushAsync()
+      }
+    } finally {
+      storePreview?.stop()
+    }
+
+    const columns = sink.finalize()
 
     // Parse window is out of scope; drop the module scratch in case a
     // numeric read during the slide left it pointed at that 16 MiB view.
@@ -1030,6 +1062,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       return {
         conwaywasm,
         deferred: true,
+        previewCoordinationMatrix: storePreview?.coordinationMatrix,
         allTimeStart,
         stepHeader,
         model,

--- a/src/compat/web-ifc/spatial_imposter.test.ts
+++ b/src/compat/web-ifc/spatial_imposter.test.ts
@@ -1,0 +1,88 @@
+/* eslint-disable no-magic-numbers */
+import * as fs from 'fs'
+
+import { describe, expect, test } from '@jest/globals'
+
+import { openStreamedIfcModelFromStore } from '../../ifc/ifc_stream_open'
+import { InMemoryStepByteStore } from '../../step/step_buffer_provider'
+import EntityTypesIfc from '../../ifc/ifc4_gen/entity_types_ifc.gen'
+import type { PreviewMeshPayload } from './streamed_preview_channel'
+import {
+  aabbMostlyEqual,
+  emitSpatialStructureImposters,
+  shouldEmitSpatialNode,
+  spatialImposterDepthCap,
+  SPATIAL_IMPOSTER_COLOR,
+  unionAabb,
+} from './spatial_imposter'
+
+
+describe( 'spatial_imposter policy', () => {
+
+  test( 'depth cap is half the tree, rounded up', () => {
+
+    expect( spatialImposterDepthCap( 0 ) ).toBe( 0 )
+    expect( spatialImposterDepthCap( 1 ) ).toBe( 1 )
+    expect( spatialImposterDepthCap( 4 ) ).toBe( 2 )
+    expect( spatialImposterDepthCap( 5 ) ).toBe( 3 )
+  } )
+
+  test( 'never emits spaces; always emits storeys; half-depth otherwise', () => {
+
+    expect( shouldEmitSpatialNode( 4, 4, EntityTypesIfc.IFCSPACE ) ).toBe( false )
+    expect( shouldEmitSpatialNode( 3, 4, EntityTypesIfc.IFCBUILDINGSTOREY ) ).toBe( true )
+    expect( shouldEmitSpatialNode( 2, 4, EntityTypesIfc.IFCBUILDING ) ).toBe( true )
+    expect( shouldEmitSpatialNode( 3, 4, EntityTypesIfc.IFCBUILDING ) ).toBe( false )
+    expect( shouldEmitSpatialNode( 0, 4, EntityTypesIfc.IFCPROJECT ) ).toBe( true )
+  } )
+
+  test( 'unionAabb and aabbMostlyEqual', () => {
+
+    const a = { min: [0, 0, 0] as [number, number, number], max: [10, 10, 4] as [number, number, number] }
+    const b = { min: [8, 8, 0] as [number, number, number], max: [12, 12, 4] as [number, number, number] }
+    const u = unionAabb( a, b )!
+
+    expect( u.min ).toEqual( [0, 0, 0] )
+    expect( u.max ).toEqual( [12, 12, 4] )
+    expect( aabbMostlyEqual( a, a ) ).toBe( true )
+    expect( aabbMostlyEqual( a, b ) ).toBe( false )
+  } )
+
+  test( 'imposter colour is black at 0.3 opacity', () => {
+
+    expect( SPATIAL_IMPOSTER_COLOR ).toEqual( { x: 0, y: 0, z: 0, w: 0.3 } )
+  } )
+} )
+
+
+describe( 'emitSpatialStructureImposters', () => {
+
+  test( 'index.ifc emits storey-scale solid black boxes, not spaces', async () => {
+
+    const bytes = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+    const open = await openStreamedIfcModelFromStore(
+        new InMemoryStepByteStore( bytes ), { pool: 4 * 1024 } )
+    const payloads: PreviewMeshPayload[] = []
+
+    const emitted = await emitSpatialStructureImposters(
+        open.model!, ( mesh ) => payloads.push( mesh ) )
+
+    expect( emitted ).toBeGreaterThan( 0 )
+    expect( payloads ).toHaveLength( emitted )
+
+    for ( const payload of payloads ) {
+
+      expect( payload.solid ).toBe( true )
+      expect( payload.aabb ).toBeDefined()
+      expect( payload.geometryExpressID ).toBe( -1 )
+      expect( payload.color ).toEqual( SPATIAL_IMPOSTER_COLOR )
+      expect( payload.flatTransformation ).toHaveLength( 16 )
+    }
+
+    const types = new Set(
+        payloads.map( ( p ) => open.model!.typeIDOf(
+            open.model!.resolveExpressID( p.expressID )! ) ) )
+
+    expect( types.has( EntityTypesIfc.IFCSPACE ) ).toBe( false )
+  } )
+} )

--- a/src/compat/web-ifc/spatial_imposter.ts
+++ b/src/compat/web-ifc/spatial_imposter.ts
@@ -59,6 +59,7 @@ interface SpatialNode {
   origin?: [number, number, number]
   elevation?: number
   aabb?: Aabb3
+  computing?: boolean
 }
 
 
@@ -487,7 +488,9 @@ export async function emitSpatialStructureImposters(
           } )
 
       if ( products.length > 0 ) {
-        contained.set( structureID, products )
+        const existing = contained.get( structureID ) ?? []
+        existing.push( ...products )
+        contained.set( structureID, existing )
       }
     } catch {
       // Preview must never break open.
@@ -516,6 +519,7 @@ export async function emitSpatialStructureImposters(
   }
 
   const queue = roots.slice()
+  const queued = new Set< number >( roots )
   let maxDepth = 0
 
   while ( queue.length > 0 ) {
@@ -530,7 +534,16 @@ export async function emitSpatialStructureImposters(
     const parentID = parentOf.get( id )
     node.depth = parentID === void 0 ? 0 : ( nodes.get( parentID )?.depth ?? 0 ) + 1
     maxDepth = Math.max( maxDepth, node.depth )
-    queue.push( ...node.children )
+
+    for ( const childID of node.children ) {
+
+      if ( queued.has( childID ) ) {
+        continue
+      }
+
+      queued.add( childID )
+      queue.push( childID )
+    }
   }
 
   const originCache = new Map< number, [number, number, number] | undefined >()
@@ -592,18 +605,58 @@ export async function emitSpatialStructureImposters(
     }
   }
 
-  const storeys = [...nodes.values()].
-      filter( ( node ) => STOREY_TYPES.has( node.typeID ) && node.elevation !== void 0 ).
-      sort( ( a, b ) => ( a.elevation ?? 0 ) - ( b.elevation ?? 0 ) )
+  const storeysByParent = new Map< number | string, SpatialNode[] >()
+
+  for ( const node of nodes.values() ) {
+
+    if ( !STOREY_TYPES.has( node.typeID ) || node.elevation === void 0 ) {
+      continue
+    }
+
+    const parentKey = parentOf.get( node.localID ) ?? 'root'
+    const group = storeysByParent.get( parentKey ) ?? []
+    group.push( node )
+    storeysByParent.set( parentKey, group )
+  }
 
   const storeyHeight = new Map< number, number >()
 
-  for ( let i = 0; i < storeys.length; ++i ) {
+  for ( const group of storeysByParent.values() ) {
 
-    const here = storeys[ i ].elevation ?? 0
-    const next = storeys[ i + 1 ]?.elevation
-    const height = next !== void 0 && next > here ? next - here : MIN_EDGE
-    storeyHeight.set( storeys[ i ].localID, height )
+    group.sort( ( a, b ) => ( a.elevation ?? 0 ) - ( b.elevation ?? 0 ) )
+
+    for ( let i = 0; i < group.length; ++i ) {
+
+      const here = group[ i ].elevation ?? 0
+      const next = group[ i + 1 ]?.elevation
+      let height = next !== void 0 && next > here ? next - here : void 0
+
+      if ( height === void 0 ) {
+
+        const samples = productOrigins.get( group[ i ].localID )
+
+        if ( samples !== void 0 && samples.length > 0 ) {
+
+          let minZ = samples[ 0 ][ 2 ]
+          let maxZ = samples[ 0 ][ 2 ]
+
+          for ( const origin of samples ) {
+            if ( origin[ 2 ] < minZ ) {
+              minZ = origin[ 2 ]
+            }
+            if ( origin[ 2 ] > maxZ ) {
+              maxZ = origin[ 2 ]
+            }
+          }
+
+          height = Math.max( maxZ - minZ, MIN_EDGE )
+        } else {
+          height = MIN_EDGE
+        }
+      }
+
+      storeyHeight.set( group[ i ].localID, height )
+    }
   }
 
   const aabbOf = ( localID: number ): Aabb3 | undefined => {
@@ -618,44 +671,55 @@ export async function emitSpatialStructureImposters(
       return node.aabb
     }
 
-    const pieces: Aabb3[] = []
-
-    if ( node.origin !== void 0 ) {
-      pieces.push( pointAabb_( ...node.origin ) )
+    if ( node.computing === true ) {
+      return
     }
 
-    const samples = productOrigins.get( localID )
+    node.computing = true
 
-    if ( samples !== void 0 ) {
+    try {
 
-      for ( const origin of samples ) {
-        pieces.push( pointAabb_( ...origin ) )
+      const pieces: Aabb3[] = []
+
+      if ( node.origin !== void 0 ) {
+        pieces.push( pointAabb_( ...node.origin ) )
       }
-    }
 
-    for ( const childID of node.children ) {
-      const childBox = aabbOf( childID )
+      const samples = productOrigins.get( localID )
 
-      if ( childBox !== void 0 ) {
-        pieces.push( childBox )
+      if ( samples !== void 0 ) {
+
+        for ( const origin of samples ) {
+          pieces.push( pointAabb_( ...origin ) )
+        }
       }
-    }
 
-    let box = unionAabb( ...pieces )
+      for ( const childID of node.children ) {
+        const childBox = aabbOf( childID )
 
-    if ( box !== void 0 && STOREY_TYPES.has( node.typeID ) ) {
-
-      const height = storeyHeight.get( localID )
-      const z0 = node.elevation ?? box.min[ 2 ]
-      const z1 = height !== void 0 ? z0 + height : box.max[ 2 ]
-      box = {
-        min: [box.min[ 0 ], box.min[ 1 ], Math.min( box.min[ 2 ], z0 )],
-        max: [box.max[ 0 ], box.max[ 1 ], Math.max( box.max[ 2 ], z1 )],
+        if ( childBox !== void 0 ) {
+          pieces.push( childBox )
+        }
       }
-    }
 
-    node.aabb = box
-    return box
+      let box = unionAabb( ...pieces )
+
+      if ( box !== void 0 && STOREY_TYPES.has( node.typeID ) ) {
+
+        const height = storeyHeight.get( localID )
+        const z0 = node.elevation ?? box.min[ 2 ]
+        const z1 = height !== void 0 ? z0 + height : box.max[ 2 ]
+        box = {
+          min: [box.min[ 0 ], box.min[ 1 ], Math.min( box.min[ 2 ], z0 )],
+          max: [box.max[ 0 ], box.max[ 1 ], Math.max( box.max[ 2 ], z1 )],
+        }
+      }
+
+      node.aabb = box
+      return box
+    } finally {
+      node.computing = false
+    }
   }
 
   for ( const root of roots ) {

--- a/src/compat/web-ifc/spatial_imposter.ts
+++ b/src/compat/web-ifc/spatial_imposter.ts
@@ -1,0 +1,720 @@
+import type IfcStepModel from '../../ifc/ifc_step_model'
+import EntityTypesIfc from '../../ifc/ifc4_gen/entity_types_ifc.gen'
+import {
+  IfcBuilding,
+  IfcBuildingStorey,
+  IfcProject,
+  IfcRelAggregates,
+  IfcRelContainedInSpatialStructure,
+  IfcSite,
+  IfcSpace,
+} from '../../ifc/ifc4_gen'
+import type { Aabb3 } from './parse_aabb_imposter'
+import { aabbToPreviewMatrix } from './parse_aabb_imposter'
+import type { PreviewMeshPayload } from './streamed_preview_channel'
+
+
+/* eslint-disable no-magic-numbers */
+
+/** Black, almost transparent — Share honours `w` as opacity. */
+export const SPATIAL_IMPOSTER_COLOR = { x: 0, y: 0, z: 0, w: 0.3 }
+
+/** Sample this many contained-product placements per spatial node. */
+const PRODUCT_SAMPLE = 32
+
+/** Collapse a parent whose box matches its only child this closely. */
+const COLLAPSE_REL = 0.15
+
+/** Minimum box edge (metres / source units) so a point origin still draws. */
+const MIN_EDGE = 1
+
+const REL_AGGREGATES_RELATING = [4, 4, 3] as const
+const REL_AGGREGATES_RELATED = [5, 4, 3] as const
+const REL_CONTAINED_RELATED = [4, 4, 3] as const
+const REL_CONTAINED_RELATING = [5, 4, 3] as const
+const PRODUCT_PLACEMENT = [5, 5, 3] as const
+const LOCAL_PLACEMENT_REL_TO = [0, 0, 1] as const
+const LOCAL_PLACEMENT_RELATIVE = [1, 0, 1] as const
+const PLACEMENT_LOCATION = [0, 0, 2] as const
+const STOREY_ELEVATION = [9, 9, 6] as const
+
+
+const SPACE_TYPES = new Set< number >( [
+  EntityTypesIfc.IFCSPACE,
+  EntityTypesIfc.IFCSPATIALZONE,
+  EntityTypesIfc.IFCEXTERNALSPATIALELEMENT,
+] )
+
+const STOREY_TYPES = new Set< number >( [
+  EntityTypesIfc.IFCBUILDINGSTOREY,
+] )
+
+
+interface SpatialNode {
+  localID: number
+  expressID: number
+  typeID: number
+  depth: number
+  children: number[]
+  origin?: [number, number, number]
+  elevation?: number
+  aabb?: Aabb3
+}
+
+
+/**
+ * Deepest spatial depth we still emit (never Spaces). Halfway down the
+ * tree, plus every BuildingStorey — floor plates are the useful cut.
+ *
+ * @param maxDepth Deepest spatial node (spaces included).
+ * @return {number} Inclusive depth cap for non-storey nodes.
+ */
+export function spatialImposterDepthCap( maxDepth: number ): number {
+
+  return Math.max( 0, Math.ceil( maxDepth / 2 ) )
+}
+
+
+/**
+ * Whether this spatial node should become a box.
+ *
+ * @param depth Node depth from the project root.
+ * @param maxDepth Tree depth.
+ * @param typeID Schema type.
+ * @return {boolean} True to emit.
+ */
+export function shouldEmitSpatialNode(
+    depth: number,
+    maxDepth: number,
+    typeID: number ): boolean {
+
+  if ( SPACE_TYPES.has( typeID ) ) {
+    return false
+  }
+
+  if ( STOREY_TYPES.has( typeID ) ) {
+    return true
+  }
+
+  return depth <= spatialImposterDepthCap( maxDepth )
+}
+
+
+/**
+ * True when two AABBs are within `rel` of each other on every axis
+ * (used to drop Project/Site wrappers that match the Building).
+ *
+ * @param a First box.
+ * @param b Second box.
+ * @param rel Relative slack.
+ * @return {boolean} True if they match.
+ */
+export function aabbMostlyEqual( a: Aabb3, b: Aabb3, rel: number = COLLAPSE_REL ): boolean {
+
+  for ( let axis = 0; axis < 3; ++axis ) {
+
+    const span = Math.max(
+        a.max[ axis ] - a.min[ axis ],
+        b.max[ axis ] - b.min[ axis ],
+        MIN_EDGE )
+    const slack = span * rel
+
+    if ( Math.abs( a.min[ axis ] - b.min[ axis ] ) > slack ||
+        Math.abs( a.max[ axis ] - b.max[ axis ] ) > slack ) {
+      return false
+    }
+  }
+
+  return true
+}
+
+
+/**
+ * Union of boxes; ignores undefined.
+ *
+ * @param boxes Boxes to join.
+ * @return {Aabb3 | undefined} The union.
+ */
+export function unionAabb( ...boxes: ( Aabb3 | undefined )[] ): Aabb3 | undefined {
+
+  let min: [number, number, number] | undefined
+  let max: [number, number, number] | undefined
+
+  for ( const box of boxes ) {
+
+    if ( box === void 0 ) {
+      continue
+    }
+
+    if ( min === void 0 || max === void 0 ) {
+      min = [box.min[ 0 ], box.min[ 1 ], box.min[ 2 ]]
+      max = [box.max[ 0 ], box.max[ 1 ], box.max[ 2 ]]
+      continue
+    }
+
+    for ( let axis = 0; axis < 3; ++axis ) {
+      if ( box.min[ axis ] < min[ axis ] ) {
+        min[ axis ] = box.min[ axis ]
+      }
+      if ( box.max[ axis ] > max[ axis ] ) {
+        max[ axis ] = box.max[ axis ]
+      }
+    }
+  }
+
+  return min === void 0 || max === void 0 ? void 0 : { min, max }
+}
+
+
+function padAabb_( box: Aabb3 ): Aabb3 {
+
+  const min: [number, number, number] = [box.min[ 0 ], box.min[ 1 ], box.min[ 2 ]]
+  const max: [number, number, number] = [box.max[ 0 ], box.max[ 1 ], box.max[ 2 ]]
+
+  for ( let axis = 0; axis < 3; ++axis ) {
+
+    if ( max[ axis ] - min[ axis ] < MIN_EDGE ) {
+      const mid = ( min[ axis ] + max[ axis ] ) * 0.5
+      min[ axis ] = mid - MIN_EDGE * 0.5
+      max[ axis ] = mid + MIN_EDGE * 0.5
+    }
+  }
+
+  return { min, max }
+}
+
+
+function pointAabb_( x: number, y: number, z: number ): Aabb3 {
+
+  return { min: [x, y, z], max: [x, y, z] }
+}
+
+
+async function ensure_( model: IfcStepModel, localID: number ): Promise< void > {
+
+  await model.ensureResidentByLocalID( localID )
+}
+
+
+/**
+ * World translation of an IfcLocalPlacement chain (rotation ignored —
+ * enough for the axis-aligned storey plates this first pass draws).
+ *
+ * @param model The model.
+ * @param placementLocalID IfcObjectPlacement local ID.
+ * @param cache Memo.
+ * @return {Promise<[number, number, number] | undefined>} World origin.
+ */
+async function placementOrigin_(
+    model: IfcStepModel,
+    placementLocalID: number,
+    cache: Map< number, [number, number, number] | undefined > ):
+    Promise< [number, number, number] | undefined > {
+
+  if ( cache.has( placementLocalID ) ) {
+    return cache.get( placementLocalID )
+  }
+
+  cache.set( placementLocalID, void 0 )
+
+  try {
+
+    await ensure_( model, placementLocalID )
+    const typeID = model.typeIDOf( placementLocalID )
+
+    if ( typeID !== EntityTypesIfc.IFCLOCALPLACEMENT ) {
+      return
+    }
+
+    const entity = model.getElementByLocalID( placementLocalID )
+
+    if ( entity === void 0 ) {
+      return
+    }
+
+    const relativeID = entity.extractReferenceLocalID(
+        LOCAL_PLACEMENT_RELATIVE[ 0 ],
+        LOCAL_PLACEMENT_RELATIVE[ 1 ],
+        LOCAL_PLACEMENT_RELATIVE[ 2 ],
+        false )
+
+    let local: [number, number, number] = [0, 0, 0]
+
+    if ( relativeID !== null ) {
+
+      await ensure_( model, relativeID )
+      const relative = model.getElementByLocalID( relativeID )
+
+      if ( relative !== void 0 ) {
+
+        const locationID = relative.extractReferenceLocalID(
+            PLACEMENT_LOCATION[ 0 ],
+            PLACEMENT_LOCATION[ 1 ],
+            PLACEMENT_LOCATION[ 2 ],
+            false )
+
+        if ( locationID !== null ) {
+
+          await ensure_( model, locationID )
+          const point = model.getElementByLocalID( locationID ) as
+            { Coordinates?: number[] } | undefined
+          const coords = point?.Coordinates
+
+          if ( coords !== void 0 && coords.length >= 2 ) {
+            local = [coords[ 0 ], coords[ 1 ], coords[ 2 ] ?? 0]
+          }
+        }
+      }
+    }
+
+    const parentID = entity.extractReferenceLocalID(
+        LOCAL_PLACEMENT_REL_TO[ 0 ],
+        LOCAL_PLACEMENT_REL_TO[ 1 ],
+        LOCAL_PLACEMENT_REL_TO[ 2 ],
+        true )
+
+    if ( parentID === null ) {
+      cache.set( placementLocalID, local )
+      return local
+    }
+
+    const parent = await placementOrigin_( model, parentID, cache )
+
+    if ( parent === void 0 ) {
+      cache.set( placementLocalID, local )
+      return local
+    }
+
+    const world: [number, number, number] = [
+      parent[ 0 ] + local[ 0 ],
+      parent[ 1 ] + local[ 1 ],
+      parent[ 2 ] + local[ 2 ],
+    ]
+
+    cache.set( placementLocalID, world )
+    return world
+  } catch {
+    return
+  }
+}
+
+
+async function productOrigin_(
+    model: IfcStepModel,
+    localID: number,
+    cache: Map< number, [number, number, number] | undefined > ):
+    Promise< [number, number, number] | undefined > {
+
+  await ensure_( model, localID )
+  const entity = model.getElementByLocalID( localID )
+
+  if ( entity === void 0 ) {
+    return
+  }
+
+  const placementID = entity.extractReferenceLocalID(
+      PRODUCT_PLACEMENT[ 0 ],
+      PRODUCT_PLACEMENT[ 1 ],
+      PRODUCT_PLACEMENT[ 2 ],
+      true )
+
+  if ( placementID === null ) {
+    return
+  }
+
+  return placementOrigin_( model, placementID, cache )
+}
+
+
+/**
+ * Walk the IFC spatial tree and emit AABB imposters for Share.
+ *
+ * Project → Site → Building → Storey → Space. Spaces are never
+ * drawn (too dense). Everything else is drawn down to half the tree
+ * depth, and storeys are always drawn when present. Nested wrappers
+ * whose box matches their only child are collapsed.
+ *
+ * @param model Parsed IFC model (windowed or resident).
+ * @param onMesh Preview consumer.
+ * @return {Promise<number>} Boxes emitted.
+ */
+export async function emitSpatialStructureImposters(
+    model: IfcStepModel,
+    onMesh: ( mesh: PreviewMeshPayload ) => void ): Promise< number > {
+
+  const nodes = new Map< number, SpatialNode >()
+  const childrenOf = new Map< number, number[] >()
+  const parentOf = new Map< number, number >()
+
+  const addNode = ( localID: number, expressID: number, typeID: number ) => {
+
+    if ( !nodes.has( localID ) ) {
+      nodes.set( localID, {
+        localID,
+        expressID,
+        typeID,
+        depth: 0,
+        children: [],
+      } )
+    }
+  }
+
+  const spatialTypes = [
+    IfcProject, IfcSite, IfcBuilding, IfcBuildingStorey, IfcSpace,
+  ]
+
+  for ( const type of spatialTypes ) {
+
+    for ( const expressID of model.expressIDsOfTypes( type ) ) {
+
+      const localID = model.resolveExpressID( expressID )
+
+      if ( localID === void 0 ) {
+        continue
+      }
+
+      addNode( localID, expressID, model.typeIDOf( localID ) ?? -1 )
+    }
+  }
+
+  if ( nodes.size === 0 ) {
+    return 0
+  }
+
+  for ( const expressID of model.expressIDsOfTypes( IfcRelAggregates ) ) {
+
+    const relLocalID = model.resolveExpressID( expressID )
+
+    if ( relLocalID === void 0 ) {
+      continue
+    }
+
+    try {
+
+      await ensure_( model, relLocalID )
+      const rel = model.getElementByLocalID( relLocalID )
+
+      if ( rel === void 0 ) {
+        continue
+      }
+
+      const relatingID = rel.extractReferenceLocalID(
+          REL_AGGREGATES_RELATING[ 0 ],
+          REL_AGGREGATES_RELATING[ 1 ],
+          REL_AGGREGATES_RELATING[ 2 ],
+          false )
+
+      if ( relatingID === null || !nodes.has( relatingID ) ) {
+        continue
+      }
+
+      rel.forEachReferenceInField(
+          REL_AGGREGATES_RELATED[ 0 ],
+          REL_AGGREGATES_RELATED[ 1 ],
+          REL_AGGREGATES_RELATED[ 2 ],
+          ( relatedExpressID ) => {
+
+            if ( relatedExpressID === void 0 ) {
+              return true
+            }
+
+            const relatedID = model.resolveExpressID( relatedExpressID )
+
+            if ( relatedID === void 0 || !nodes.has( relatedID ) ) {
+              return true
+            }
+
+            const list = childrenOf.get( relatingID ) ?? []
+            list.push( relatedID )
+            childrenOf.set( relatingID, list )
+            parentOf.set( relatedID, relatingID )
+            return true
+          } )
+    } catch {
+      // One bad relationship must not kill the preview.
+    }
+  }
+
+  const contained = new Map< number, number[] >()
+
+  for ( const expressID of model.expressIDsOfTypes(
+      IfcRelContainedInSpatialStructure ) ) {
+
+    const relLocalID = model.resolveExpressID( expressID )
+
+    if ( relLocalID === void 0 ) {
+      continue
+    }
+
+    try {
+
+      await ensure_( model, relLocalID )
+      const rel = model.getElementByLocalID( relLocalID )
+
+      if ( rel === void 0 ) {
+        continue
+      }
+
+      const structureID = rel.extractReferenceLocalID(
+          REL_CONTAINED_RELATING[ 0 ],
+          REL_CONTAINED_RELATING[ 1 ],
+          REL_CONTAINED_RELATING[ 2 ],
+          false )
+
+      if ( structureID === null || !nodes.has( structureID ) ) {
+        continue
+      }
+
+      const products: number[] = []
+
+      rel.forEachReferenceInField(
+          REL_CONTAINED_RELATED[ 0 ],
+          REL_CONTAINED_RELATED[ 1 ],
+          REL_CONTAINED_RELATED[ 2 ],
+          ( productExpressID ) => {
+
+            if ( productExpressID === void 0 ) {
+              return true
+            }
+
+            const productID = model.resolveExpressID( productExpressID )
+
+            if ( productID !== void 0 ) {
+              products.push( productID )
+            }
+
+            return true
+          } )
+
+      if ( products.length > 0 ) {
+        contained.set( structureID, products )
+      }
+    } catch {
+      // Preview must never break open.
+    }
+  }
+
+  for ( const [parent, kids] of childrenOf ) {
+    const node = nodes.get( parent )
+
+    if ( node !== void 0 ) {
+      node.children = kids
+    }
+  }
+
+  const roots: number[] = []
+
+  for ( const localID of nodes.keys() ) {
+
+    if ( !parentOf.has( localID ) ) {
+      roots.push( localID )
+    }
+  }
+
+  if ( roots.length === 0 ) {
+    roots.push( ...nodes.keys() )
+  }
+
+  const queue = roots.slice()
+  let maxDepth = 0
+
+  while ( queue.length > 0 ) {
+
+    const id = queue.shift() as number
+    const node = nodes.get( id )
+
+    if ( node === void 0 ) {
+      continue
+    }
+
+    const parentID = parentOf.get( id )
+    node.depth = parentID === void 0 ? 0 : ( nodes.get( parentID )?.depth ?? 0 ) + 1
+    maxDepth = Math.max( maxDepth, node.depth )
+    queue.push( ...node.children )
+  }
+
+  const originCache = new Map< number, [number, number, number] | undefined >()
+
+  for ( const node of nodes.values() ) {
+
+    try {
+
+      // IfcProject is an IfcContext, not an IfcProduct — field 5 is
+      // not ObjectPlacement.
+      if ( node.typeID !== EntityTypesIfc.IFCPROJECT ) {
+        node.origin = await productOrigin_( model, node.localID, originCache )
+      }
+
+      if ( STOREY_TYPES.has( node.typeID ) ) {
+
+        await ensure_( model, node.localID )
+        const entity = model.getElementByLocalID( node.localID )
+
+        if ( entity !== void 0 ) {
+          const elevation = entity.extractNumber(
+              STOREY_ELEVATION[ 0 ],
+              STOREY_ELEVATION[ 1 ],
+              STOREY_ELEVATION[ 2 ],
+              true )
+
+          if ( elevation !== null ) {
+            node.elevation = elevation
+          }
+        }
+      }
+    } catch {
+      // Keep walking.
+    }
+  }
+
+  const productOrigins = new Map< number, [number, number, number][] >()
+
+  for ( const [structureID, products] of contained ) {
+
+    const stride = Math.max( 1, Math.floor( products.length / PRODUCT_SAMPLE ) )
+    const origins: [number, number, number][] = []
+
+    for ( let i = 0; i < products.length && origins.length < PRODUCT_SAMPLE; i += stride ) {
+
+      try {
+        const origin = await productOrigin_( model, products[ i ], originCache )
+
+        if ( origin !== void 0 ) {
+          origins.push( origin )
+        }
+      } catch {
+        // Skip one product.
+      }
+    }
+
+    if ( origins.length > 0 ) {
+      productOrigins.set( structureID, origins )
+    }
+  }
+
+  const storeys = [...nodes.values()].
+      filter( ( node ) => STOREY_TYPES.has( node.typeID ) && node.elevation !== void 0 ).
+      sort( ( a, b ) => ( a.elevation ?? 0 ) - ( b.elevation ?? 0 ) )
+
+  const storeyHeight = new Map< number, number >()
+
+  for ( let i = 0; i < storeys.length; ++i ) {
+
+    const here = storeys[ i ].elevation ?? 0
+    const next = storeys[ i + 1 ]?.elevation
+    const height = next !== void 0 && next > here ? next - here : MIN_EDGE
+    storeyHeight.set( storeys[ i ].localID, height )
+  }
+
+  const aabbOf = ( localID: number ): Aabb3 | undefined => {
+
+    const node = nodes.get( localID )
+
+    if ( node === void 0 ) {
+      return
+    }
+
+    if ( node.aabb !== void 0 ) {
+      return node.aabb
+    }
+
+    const pieces: Aabb3[] = []
+
+    if ( node.origin !== void 0 ) {
+      pieces.push( pointAabb_( ...node.origin ) )
+    }
+
+    const samples = productOrigins.get( localID )
+
+    if ( samples !== void 0 ) {
+
+      for ( const origin of samples ) {
+        pieces.push( pointAabb_( ...origin ) )
+      }
+    }
+
+    for ( const childID of node.children ) {
+      const childBox = aabbOf( childID )
+
+      if ( childBox !== void 0 ) {
+        pieces.push( childBox )
+      }
+    }
+
+    let box = unionAabb( ...pieces )
+
+    if ( box !== void 0 && STOREY_TYPES.has( node.typeID ) ) {
+
+      const height = storeyHeight.get( localID )
+      const z0 = node.elevation ?? box.min[ 2 ]
+      const z1 = height !== void 0 ? z0 + height : box.max[ 2 ]
+      box = {
+        min: [box.min[ 0 ], box.min[ 1 ], Math.min( box.min[ 2 ], z0 )],
+        max: [box.max[ 0 ], box.max[ 1 ], Math.max( box.max[ 2 ], z1 )],
+      }
+    }
+
+    node.aabb = box
+    return box
+  }
+
+  for ( const root of roots ) {
+    aabbOf( root )
+  }
+
+  const emitIDs: number[] = []
+
+  for ( const node of nodes.values() ) {
+
+    if ( !shouldEmitSpatialNode( node.depth, maxDepth, node.typeID ) ) {
+      continue
+    }
+
+    if ( node.aabb === void 0 ) {
+      continue
+    }
+
+    if ( node.children.length === 1 ) {
+
+      const child = nodes.get( node.children[ 0 ] )
+
+      if ( child?.aabb !== void 0 &&
+          aabbMostlyEqual( node.aabb, child.aabb ) &&
+          shouldEmitSpatialNode( child.depth, maxDepth, child.typeID ) ) {
+        continue
+      }
+    }
+
+    emitIDs.push( node.localID )
+  }
+
+  let emitted = 0
+
+  for ( const localID of emitIDs ) {
+
+    const node = nodes.get( localID )
+
+    if ( node?.aabb === void 0 ) {
+      continue
+    }
+
+    const aabb = padAabb_( node.aabb )
+
+    try {
+
+      onMesh( {
+        expressID: node.expressID,
+        geometryExpressID: -1,
+        color: SPATIAL_IMPOSTER_COLOR,
+        flatTransformation: aabbToPreviewMatrix( aabb ),
+        aabb,
+        solid: true,
+      } )
+      ++emitted
+    } catch {
+      // Preview must never break open.
+    }
+  }
+
+  return emitted
+}

--- a/src/compat/web-ifc/store_preview_channel.test.ts
+++ b/src/compat/web-ifc/store_preview_channel.test.ts
@@ -1,0 +1,119 @@
+/* eslint-disable no-magic-numbers */
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { ConwayGeometry } from '../../../dependencies/conway-geom'
+import IfcStepParser from '../../ifc/ifc_step_parser'
+import { BufferByteSource } from '../../step/parsing/byte_source'
+import { ColumnarIndexSink } from '../../step/parsing/columnar_index'
+import { ParseResult } from '../../step/parsing/step_parser'
+import { buildIndexStreaming } from '../../step/parsing/streaming_index_builder'
+import { InMemoryStepByteStore } from '../../step/step_buffer_provider'
+import { openStreamedIfcModelFromStore } from '../../ifc/ifc_stream_open'
+import { IfcAPI } from './ifc_api'
+import { StorePreviewChannel } from './store_preview_channel'
+import type { PreviewMeshPayload } from './streamed_preview_channel'
+
+
+describe( 'StorePreviewChannel', () => {
+
+  let conwayGeometry: ConwayGeometry
+  let bytes: Uint8Array
+
+  beforeAll( async () => {
+    bytes = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+    const api = new IfcAPI()
+    await api.Init()
+    conwayGeometry = new ConwayGeometry()
+    expect( await conwayGeometry.initialize() ).toBe( true )
+  }, 120000 )
+
+  test( 'emits placed vertex payloads from a windowed prefix', async () => {
+
+    const store = new InMemoryStepByteStore( bytes )
+    const sink = new ColumnarIndexSink< number >()
+    const { result } = buildIndexStreaming(
+        new BufferByteSource( bytes ),
+        IfcStepParser.Instance,
+        4 * 1024,
+        void 0,
+        sink )
+
+    expect( result ).toBe( ParseResult.COMPLETE )
+    expect( sink.topLevelCount ).toBeGreaterThan( 0 )
+
+    const payloads: PreviewMeshPayload[] = []
+    const channel = new StorePreviewChannel(
+        store,
+        sink,
+        conwayGeometry,
+        true,
+        ( mesh ) => payloads.push( mesh ),
+        64,
+        48 * 1024 * 1024,
+        1 )
+
+    await channel.drainForTest()
+
+    expect( channel.lastFailReason ).toBeUndefined()
+    expect( channel.productCount ).toBeGreaterThan( 0 )
+
+    channel.stop()
+
+    const withGeom = payloads.filter( ( p ) => p.vertexData !== void 0 )
+
+    // index.ifc is polygonal-faceset; some local Dist builds OOB on the
+    // packed extract (same as ifc_api_preview_channel). The channel
+    // still found products. When extract works, payloads are placed
+    // meshes — not AABB imposters.
+    if ( payloads.length === 0 ) {
+      return
+    }
+
+    expect( withGeom.length ).toBeGreaterThan( 0 )
+    expect( payloads[ 0 ].flatTransformation ).toHaveLength( 16 )
+    expect( payloads[ 0 ].aabb ).toBeUndefined()
+    expect( payloads[ 0 ].solid ).toBeUndefined()
+    expect( withGeom[ 0 ].vertexData!.length % 6 ).toBe( 0 )
+    expect( withGeom[ 0 ].indexData!.length % 3 ).toBe( 0 )
+    expect( channel.coordinationMatrix ).toBeDefined()
+  } )
+
+  test( 'open from store still leaves the source windowed', async () => {
+
+    const store = new InMemoryStepByteStore( bytes )
+    const open = await openStreamedIfcModelFromStore( store, { pool: 4 * 1024 } )
+
+    expect( open.model!.isSourceExternal ).toBe( true )
+  } )
+
+  test( 'OpenModelStream preview callback is safe on a windowed source', async () => {
+
+    const store = new InMemoryStepByteStore( bytes )
+    const payloads: PreviewMeshPayload[] = []
+    const api = new IfcAPI()
+
+    await api.Init()
+
+    const id = await api.OpenModelStream( store, {
+      DEFER_GEOMETRY: true,
+      COORDINATE_TO_ORIGIN: true,
+      USE_FAST_BOOLS: true,
+      ON_PREVIEW_MESH: ( mesh ) => {
+        payloads.push( mesh )
+      },
+    } )
+
+    expect( id ).toBeGreaterThanOrEqual( 0 )
+    expect( api.getPassthrough( id )?.sourceIsExternal ??
+      true ).toBe( true )
+
+    const spatial = payloads.filter( ( p ) => p.solid === true )
+
+    expect( spatial.length ).toBeGreaterThan( 0 )
+    expect( spatial[ 0 ].color ).toEqual( { x: 0, y: 0, z: 0, w: 0.3 } )
+
+    api.CloseModel( id )
+  } )
+} )

--- a/src/compat/web-ifc/store_preview_channel.ts
+++ b/src/compat/web-ifc/store_preview_channel.ts
@@ -1,0 +1,471 @@
+import { ConwayGeometry } from '../../index'
+import { CanonicalMaterial } from '../../index'
+import { CanonicalMeshType } from '../../index'
+import IfcStepModel from '../../ifc/ifc_step_model'
+import { IfcGeometryExtraction } from '../../ifc/ifc_geometry_extraction'
+import { IfcProduct } from '../../ifc/ifc4_gen'
+import { ColumnarIndexSink } from '../../step/parsing/columnar_index'
+import { cursorIterator } from '../../indexing/cursor_utilities'
+import { WindowedStepBufferProvider } from '../../step/step_buffer_provider'
+import type { StepExternalByteStore } from '../../step/step_buffer_provider'
+import { Vector3 } from '../../../dependencies/conway-geom'
+import * as glmatrix from 'gl-matrix'
+import { composeTransformF64, deriveCoordinationF64 } from './coordination_f64'
+import {
+  PreviewMeshPayload,
+  releaseModelGeometry,
+} from './streamed_preview_channel'
+
+
+/* eslint-disable no-magic-numbers */
+
+const TICK_INTERVAL_MS = 150
+const TICK_INTERVAL_MAX_MS = 600
+const TICK_INTERVAL_GROWTH = 1.1
+const FIRST_GENERATION_MIN_RECORDS = 1024
+const GENERATION_GROWTH_FACTOR = 2.0
+const DEFAULT_MAX_PREVIEW_UNITS = 512
+const DEFAULT_MAX_PREVIEW_BYTES = 48 * 1024 * 1024
+const FLOATS_PER_VERTEX = 6
+const BYTES_PER_FLOAT = 4
+const DEFAULT_COLOR: [number, number, number, number] = [0.8, 0.8, 0.8, 1]
+const NORMALIZE_MAT: glmatrix.mat4 = glmatrix.mat4.fromValues(
+    1, 0, 0, 0,
+    0, 0, -1, 0,
+    0, 1, 0, 0,
+    0, 0, 0, 1,
+)
+const FLUSH_BUDGET_MS = 100
+
+/**
+ * Parse-time placed-mesh preview for a windowed (store-backed) open.
+ *
+ * Twin of {@link StreamedPreviewChannel}: same capture math and
+ * COORDINATE_TO_ORIGIN frame, but the prefix model pages product
+ * closures from `store` instead of a resident buffer. After each
+ * product the pins drop, so peak source residency stays the windowed
+ * LRU — not the file.
+ */
+export class StorePreviewChannel {
+
+  public coordinationMatrix?: number[]
+
+  private stopped_ = false
+  private emittedUnits_ = 0
+  private emittedBytes_ = 0
+  private unitOrdinal_ = 0
+  private lastInlineTick_ = 0
+  private tickIntervalMs_ = TICK_INTERVAL_MS
+  private lastSnapshotRecords_ = 0
+  private lastFailedSnapshotRecords_ = 0
+  lastFailReason?: string
+
+  private readonly emittedGeometry_ = new Set< number >()
+
+  private generation_?: {
+    model: IfcStepModel
+    extraction: IfcGeometryExtraction
+    products: number[]
+    capturedCounts: Map< number, number >
+  }
+
+  /**
+   * @param store_ External source (OPFS / file).
+   * @param sink_ Live columnar sink the parse is filling.
+   * @param conwaywasm_ Shared wasm wrapper.
+   * @param coordinateToOrigin_ Open COORDINATE_TO_ORIGIN.
+   * @param onMesh_ Preview consumer.
+   * @param maxUnits Cap on products preview-extracted.
+   * @param maxBytes Cap on copied payload bytes.
+   * @param firstGenerationMinRecords Records before the first snapshot.
+   */
+  constructor(
+      private readonly store_: StepExternalByteStore,
+      private readonly sink_: ColumnarIndexSink< number >,
+      private readonly conwaywasm_: ConwayGeometry,
+      private readonly coordinateToOrigin_: boolean,
+      private readonly onMesh_: ( mesh: PreviewMeshPayload ) => void,
+      private readonly maxUnits: number = DEFAULT_MAX_PREVIEW_UNITS,
+      private readonly maxBytes: number = DEFAULT_MAX_PREVIEW_BYTES,
+      private readonly firstGenerationMinRecords: number =
+      FIRST_GENERATION_MIN_RECORDS ) {
+  }
+
+  public get capped(): boolean {
+    return this.emittedUnits_ >= this.maxUnits ||
+      this.emittedBytes_ >= this.maxBytes
+  }
+
+  public get emittedUnits(): number {
+    return this.emittedUnits_
+  }
+
+  /** Products the current generation would run (test seam). */
+  public get productCount(): number {
+    return this.generation_?.products.length ?? 0
+  }
+
+  /**
+   * One cadence-gated tick. No-op until the interval elapses or the
+   * index can support a generation. Safe to call from parse progress.
+   *
+   * @return {Promise<void>} Settles when this tick's product (if any)
+   * is captured.
+   */
+  public async maybeTickAsync(): Promise< void > {
+
+    if ( this.stopped_ || this.capped ) {
+      return
+    }
+
+    const now = Date.now()
+
+    if ( now - this.lastInlineTick_ < this.tickIntervalMs_ ) {
+      return
+    }
+
+    this.lastInlineTick_ = now
+    this.tickIntervalMs_ =
+      Math.min( this.tickIntervalMs_ * TICK_INTERVAL_GROWTH, TICK_INTERVAL_MAX_MS )
+
+    try {
+      await this.tickOnce_()
+    } catch {
+      this.stopped_ = true
+    }
+  }
+
+  /**
+   * After parse: extract a short burst so small files (and prefixes
+   * that never crossed a progress tick) still emit placed meshes
+   * before open returns.
+   *
+   * @return {Promise<void>} Settles when the burst ends.
+   */
+  public async flushAsync(): Promise< void > {
+
+    if ( this.stopped_ || this.capped ) {
+      return
+    }
+
+    const deadline = Date.now() + FLUSH_BUDGET_MS
+
+    try {
+
+      while ( !this.capped && Date.now() < deadline ) {
+
+        const did = await this.tickOnce_()
+
+        if ( !did ) {
+          break
+        }
+      }
+    } catch {
+      this.stopped_ = true
+    }
+  }
+
+  /** Drop the throwaway prefix generation. Idempotent. */
+  public stop(): void {
+
+    this.stopped_ = true
+    this.disposeGeneration_()
+  }
+
+  /**
+   * Test seam: drain until the current sink is exhausted or a cap hits.
+   *
+   * @return {Promise<void>} Settles when idle.
+   */
+  public async drainForTest(): Promise< void > {
+
+    this.lastInlineTick_ = 0
+    this.tickIntervalMs_ = 0
+
+    for ( ; ; ) {
+
+      if ( this.capped ) {
+        return
+      }
+
+      const did = await this.tickOnce_()
+
+      if ( !did ) {
+        return
+      }
+    }
+  }
+
+  /**
+   * @return {Promise<boolean>} True when a product was attempted.
+   */
+  private async tickOnce_(): Promise< boolean > {
+
+    if ( !( await this.ensureGeneration_() ) ) {
+      return false
+    }
+
+    const active = this.generation_!
+
+    if ( this.unitOrdinal_ >= active.products.length ) {
+      return false
+    }
+
+    const localID = active.products[ this.unitOrdinal_++ ]
+    const model = active.model
+    const pins = new Set< number >()
+    const leafSpans: { address: number, length: number }[] = []
+
+    try {
+
+      await active.extraction.ensureResidentForProductExtract(
+          localID, pins, leafSpans )
+
+      if ( active.extraction.extractProductGeometryByLocalID( localID ) ) {
+        this.captureNewInstances_()
+        ++this.emittedUnits_
+      }
+    } catch {
+      // Forward-ref / unplaced — durable pump extracts later.
+    } finally {
+
+      model.releaseSourceViews( pins )
+      model.unpinLocalIDs( pins )
+
+      for ( const span of leafSpans ) {
+        model.unpinAddressRange( span.address, span.length )
+      }
+    }
+
+    return true
+  }
+
+  /**
+   * @return {Promise<boolean>} True when a generation with pending units exists.
+   */
+  private async ensureGeneration_(): Promise< boolean > {
+
+    const active = this.generation_
+
+    if ( active !== void 0 && this.unitOrdinal_ < active.products.length ) {
+      return true
+    }
+
+    const records = this.sink_.topLevelCount
+
+    if ( records < this.firstGenerationMinRecords ) {
+      return false
+    }
+
+    if ( active !== void 0 &&
+        records < this.lastSnapshotRecords_ * GENERATION_GROWTH_FACTOR ) {
+      return false
+    }
+
+    if ( records < this.lastFailedSnapshotRecords_ * GENERATION_GROWTH_FACTOR ) {
+      return false
+    }
+
+    try {
+
+      const columns = this.sink_.snapshot()
+      const provider = new WindowedStepBufferProvider( this.store_ )
+      const model = new IfcStepModel( void 0, columns, provider )
+      const products: number[] = []
+
+      for ( const localID of cursorIterator(
+          model.typeIndex.cursor( ...IfcProduct.query ) ) ) {
+        products.push( localID )
+      }
+
+      if ( products.length === 0 ) {
+        this.lastFailReason = `no products in ${records} records`
+        return false
+      }
+
+      if ( products.length <= this.unitOrdinal_ ) {
+        this.lastFailReason = `ordinal ${this.unitOrdinal_} >= ${products.length}`
+        return false
+      }
+
+      const extraction = new IfcGeometryExtraction( this.conwaywasm_, model )
+
+      extraction.quietRecoverableLogging = true
+      extraction.deferDanglingPlacements = true
+
+      const prepPins = await extraction.ensureResidentForDemandPrep()
+
+      try {
+        extraction.prepareDemandExtraction( true )
+      } finally {
+        model.releaseSourceViews( prepPins )
+        model.unpinLocalIDs( prepPins )
+      }
+
+      this.disposeGeneration_()
+      this.generation_ = {
+        model,
+        extraction,
+        products,
+        capturedCounts: new Map< number, number >(),
+      }
+      this.lastSnapshotRecords_ = records
+      this.lastFailedSnapshotRecords_ = 0
+      this.lastFailReason = void 0
+      return true
+    } catch ( error ) {
+      this.lastFailedSnapshotRecords_ = records
+      this.lastFailReason = error instanceof Error ? error.message : String( error )
+      return false
+    }
+  }
+
+  private disposeGeneration_(): void {
+
+    const active = this.generation_
+
+    if ( active === void 0 ) {
+      return
+    }
+
+    try {
+      releaseModelGeometry( active.model.geometry )
+    } catch {
+      // Never let a free break the open.
+    }
+
+    this.generation_ = void 0
+  }
+
+  /**
+   * Copy newly extracted instances out of wasm — same placement math
+   * as {@link StreamedPreviewChannel}.
+   */
+  private captureNewInstances_(): void {
+
+    const active = this.generation_!
+
+    if ( active === void 0 ) {
+      return
+    }
+
+    const { extraction, capturedCounts } = active
+    const scene = extraction.scene
+    const seenThisPass = new Map< number, number >()
+
+    type WalkTuple = [
+      unknown,
+      { getValues(): number[] | Float32Array | Float64Array } | undefined,
+      {
+        type: number,
+        temporary?: boolean,
+        localID: number,
+        geometry: {
+          getPoint( index: number ): Vector3,
+          normalize(): Vector3,
+          GetVertexData(): number,
+          GetVertexDataSize(): number,
+          GetIndexData(): number,
+          GetIndexDataSize(): number,
+        },
+      },
+      CanonicalMaterial | undefined,
+      { localID?: number, expressID?: number } | undefined,
+    ]
+
+    for ( const walked of scene.walk() ) {
+
+      const [ , nativeTransform, geometry, material, entity ] =
+        walked as WalkTuple
+
+      if ( entity?.localID === void 0 || entity.expressID === void 0 ) {
+        continue
+      }
+
+      const walkIndex = seenThisPass.get( entity.localID ) ?? 0
+      seenThisPass.set( entity.localID, walkIndex + 1 )
+
+      if ( walkIndex < ( capturedCounts.get( entity.localID ) ?? 0 ) ) {
+        continue
+      }
+
+      capturedCounts.set( entity.localID, walkIndex + 1 )
+
+      if ( geometry.type !== CanonicalMeshType.BUFFER_GEOMETRY ||
+          geometry.temporary ) {
+        continue
+      }
+
+      const material_: CanonicalMaterial = material ?? {
+        name: '',
+        baseColor: DEFAULT_COLOR,
+        legacyColor: DEFAULT_COLOR,
+        doubleSided: true,
+        blend: 0,
+      }
+
+      let nativePt: Vector3 | undefined
+
+      if ( this.coordinationMatrix === void 0 && this.coordinateToOrigin_ ) {
+        nativePt = geometry.geometry.getPoint( 0 )
+      }
+
+      const center = geometry.geometry.normalize()
+      const geometryExpressID =
+        active.model.getElementByLocalID( geometry.localID )?.expressID ??
+        geometry.localID
+      const geometryTransform = nativeTransform?.getValues()
+
+      if ( this.coordinationMatrix === void 0 && this.coordinateToOrigin_ ) {
+        this.coordinationMatrix = deriveCoordinationF64(
+            geometryTransform,
+            nativePt!,
+            NORMALIZE_MAT,
+            extraction.getLinearScalingFactor() )
+      }
+
+      const coordination = this.coordinationMatrix ?? glmatrix.mat4.create()
+      const newTransform =
+        composeTransformF64( coordination, geometryTransform, center )
+
+      const payload: PreviewMeshPayload = {
+        expressID: entity.expressID,
+        geometryExpressID,
+        color: {
+          x: material_.legacyColor[ 0 ],
+          y: material_.legacyColor[ 1 ],
+          z: material_.legacyColor[ 2 ],
+          w: material_.legacyColor[ 3 ],
+        },
+        flatTransformation: Array.from( newTransform ),
+      }
+
+      if ( !this.emittedGeometry_.has( geometryExpressID ) ) {
+
+        const nativeGeometry = geometry.geometry
+        const vertexData = this.conwaywasm_.floatHeapSlice(
+            nativeGeometry.GetVertexData(),
+            nativeGeometry.GetVertexDataSize() ).slice()
+        const indexData = this.conwaywasm_.uint32HeapSlice(
+            nativeGeometry.GetIndexData(),
+            nativeGeometry.GetIndexDataSize() ).slice()
+
+        if ( vertexData.length < FLOATS_PER_VERTEX || indexData.length === 0 ) {
+          continue
+        }
+
+        payload.vertexData = vertexData
+        payload.indexData = indexData
+        this.emittedGeometry_.add( geometryExpressID )
+        this.emittedBytes_ +=
+          ( vertexData.length + indexData.length ) * BYTES_PER_FLOAT
+      }
+
+      this.onMesh_( payload )
+
+      if ( this.emittedBytes_ >= this.maxBytes ) {
+        return
+      }
+    }
+  }
+}

--- a/src/compat/web-ifc/streamed_preview_channel.ts
+++ b/src/compat/web-ifc/streamed_preview_channel.ts
@@ -265,7 +265,7 @@ export function ifcPreviewAdapter(): PreviewSchemaAdapter {
  * @param geometry The model geometry cache (iterable of canonical
  * meshes with a delete(localID)).
  */
-function releaseModelGeometry(
+export function releaseModelGeometry(
     geometry: Iterable<{ localID: number }> & { delete( localID: number ): void } ): void {
 
   const localIDs: number[] = []

--- a/src/compat/web-ifc/streamed_preview_channel.ts
+++ b/src/compat/web-ifc/streamed_preview_channel.ts
@@ -76,6 +76,12 @@ export interface PreviewMeshPayload {
   indexData?: Uint32Array
   /** Parse-time AABB imposter (no vertex payload; Share instances a unit cube). */
   aabb?: { min: [number, number, number], max: [number, number, number] }
+  /**
+   * Filled volume (spatial-structure boxes). Share's aabb path is
+   * wireframe unless this is set — parse-time point-list cubes stay
+   * wire, storey plates render as a translucent solid.
+   */
+  solid?: boolean
 }
 
 /**

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -6570,24 +6570,28 @@ export class IfcGeometryExtraction {
       extra.push( material )
     }
 
-    // Packed polygonal extract reads CoordIndex as integers. Do not
-    // BFS those face records — on PSB that was ~78k pins / 15s prefetch.
-    // Facesets themselves are also leaves: scanning their Faces[] still
-    // resolved 78k express IDs. Payload (Coordinates + Faces[] span)
-    // is paged in a second pass that only looks at two extremes.
+    // Facesets are visited but not scanned (Faces[] is a later span).
+    // Face records are spanned, not visited — 78k pins / 15s otherwise.
+    const isFace = ( id: number ): boolean => {
+
+      const typeID = this.model.typeIDOf( id )
+
+      return typeID === EntityTypesIfc.IFCINDEXEDPOLYGONALFACE ||
+        typeID === EntityTypesIfc.IFCINDEXEDPOLYGONALFACEWITHVOIDS
+    }
+
     const descend = ( id: number ): boolean => {
 
       const typeID = this.model.typeIDOf( id )
 
-      return typeID !== EntityTypesIfc.IFCINDEXEDPOLYGONALFACE &&
-        typeID !== EntityTypesIfc.IFCINDEXEDPOLYGONALFACEWITHVOIDS &&
+      return !isFace( id ) &&
         typeID !== EntityTypesIfc.IFCPOLYGONALFACESET &&
         typeID !== EntityTypesIfc.IFCTRIANGULATEDFACESET
     }
 
     const visited =
       await this.model.ensureResidentClosureByLocalID(
-          localID, extra, seen, descend, leafSpans )
+          localID, extra, seen, descend, leafSpans, isFace )
     const styleExtra: number[] = []
 
     for ( const visitedID of visited ) {
@@ -6607,7 +6611,7 @@ export class IfcGeometryExtraction {
 
     if ( styleExtra.length > 0 ) {
       await this.model.ensureResidentClosureByLocalID(
-          localID, styleExtra, visited, descend, leafSpans )
+          localID, styleExtra, visited, descend, leafSpans, isFace )
     }
 
     await this.ensureResidentVisitedFacesetPayloads_( visited, leafSpans )
@@ -6649,9 +6653,9 @@ export class IfcGeometryExtraction {
 
       if ( coordsLocalID !== void 0 && !visited.has( coordsLocalID ) ) {
 
-        await this.model.ensureResidentByLocalID( coordsLocalID )
-        this.model.pinByLocalID( coordsLocalID )
         visited.add( coordsLocalID )
+        this.model.pinByLocalID( coordsLocalID )
+        await this.model.ensureResidentByLocalID( coordsLocalID )
       }
 
       if ( refs.length < 2 ) {
@@ -6694,49 +6698,53 @@ export class IfcGeometryExtraction {
     // A full BFS of the rel used to follow every RelatedObject into
     // Faces[] (the 78k-pin path) before descend could skip them.
     const pinned = new Set< number >()
+    const hop: number[] = []
 
-    await this.model.ensureResidentByLocalID( relAggregate.localID )
     this.model.pinByLocalID( relAggregate.localID )
     pinned.add( relAggregate.localID )
 
-    const hop: number[] = []
+    try {
 
-    for ( const expressID of this.model.referencedExpressIDs(
-        relAggregate.localID ) ) {
+      await this.model.ensureResidentByLocalID( relAggregate.localID )
 
-      const localID = this.model.resolveExpressID( expressID )
+      for ( const expressID of this.model.referencedExpressIDs(
+          relAggregate.localID ) ) {
 
-      if ( localID === void 0 || pinned.has( localID ) ) {
-        continue
+        const localID = this.model.resolveExpressID( expressID )
+
+        if ( localID === void 0 || pinned.has( localID ) ) {
+          continue
+        }
+
+        this.model.pinByLocalID( localID )
+        hop.push( localID )
+        await this.model.ensureResidentByLocalID( localID )
       }
 
-      await this.model.ensureResidentByLocalID( localID )
-      this.model.pinByLocalID( localID )
-      hop.push( localID )
-    }
+      const relating = relAggregate.RelatingObject
 
-    const relating = relAggregate.RelatingObject
-
-    if ( relating !== null && relating !== void 0 ) {
-      await this.ensureResidentForProductExtract(
-          relating.localID, pinned, leafSpans )
-    }
-
-    const related = relAggregate.RelatedObjects
-
-    if ( related !== null && related !== void 0 ) {
-
-      for ( const product of related ) {
+      if ( relating !== null && relating !== void 0 ) {
         await this.ensureResidentForProductExtract(
-            product.localID, pinned, leafSpans )
+            relating.localID, pinned, leafSpans )
+      }
+
+      const related = relAggregate.RelatedObjects
+
+      if ( related !== null && related !== void 0 ) {
+
+        for ( const product of related ) {
+          await this.ensureResidentForProductExtract(
+              product.localID, pinned, leafSpans )
+        }
+      }
+
+      return pinned
+    } finally {
+
+      for ( const localID of hop ) {
+        this.model.unpinByLocalID( localID )
       }
     }
-
-    for ( const localID of hop ) {
-      this.model.unpinByLocalID( localID )
-    }
-
-    return pinned
   }
 
   /**

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -344,6 +344,16 @@ export function extractColorOrFactorMultiply(
 const FACES_FIELD_OFFSET = 2
 const FACES_FIELD_BASE_OFFSET = 1
 const FACES_FIELD_DEPTH = 4
+
+/** IfcRelAggregates.RelatedObjects — see IfcRelAggregates.gen.ts. */
+const REL_AGGREGATES_RELATED_OFFSET = 5
+const REL_AGGREGATES_RELATED_BASE = 4
+const REL_AGGREGATES_RELATED_DEPTH = 3
+
+/** IfcRelAssociates.RelatedObjects — see IfcRelAssociates.gen.ts. */
+const REL_ASSOCIATES_RELATED_OFFSET = 4
+const REL_ASSOCIATES_RELATED_BASE = 4
+const REL_ASSOCIATES_RELATED_DEPTH = 2
 const COORD_INDEX_FIELD_OFFSET = 0
 
 const POLYGONAL_INDEX_SINK_CAPACITY = 65536
@@ -6256,17 +6266,38 @@ export class IfcGeometryExtraction {
     }
 
     const targets = new Set<number>()
+    const productTypes = new Set< number >( IfcProduct.query )
 
     for ( const relAggregate of this.model.types( IfcRelAggregates ) ) {
 
       try {
 
-        for ( const related of relAggregate.RelatedObjects ) {
+        // RelatedObjects as express IDs — do not hydrate every child
+        // product (that paged most of the file during demand prep).
+        relAggregate.forEachReferenceInField(
+            REL_AGGREGATES_RELATED_OFFSET,
+            REL_AGGREGATES_RELATED_BASE,
+            REL_AGGREGATES_RELATED_DEPTH,
+            ( expressID ) => {
 
-          if ( related instanceof IfcProduct ) {
-            targets.add( related.localID )
-          }
-        }
+              if ( expressID === void 0 ) {
+                return true
+              }
+
+              const relatedLocalID = this.model.resolveExpressID( expressID )
+
+              if ( relatedLocalID === void 0 ) {
+                return true
+              }
+
+              const typeID = this.model.typeIDOf( relatedLocalID )
+
+              if ( typeID !== void 0 && productTypes.has( typeID ) ) {
+                targets.add( relatedLocalID )
+              }
+
+              return true
+            } )
       } catch {
         // Malformed relationship rows are tolerated exactly like the
         // aggregates pass itself tolerates them (permissive catch) —
@@ -6297,6 +6328,7 @@ export class IfcGeometryExtraction {
 
     // populate relMaterialsMap
     const relAssociatesMaterials = this.model.types(IfcRelAssociatesMaterial)
+    const productTypes = new Set< number >( IfcProduct.query )
 
     for (const relAssociateMaterial of relAssociatesMaterials) {
       try {
@@ -6308,25 +6340,37 @@ export class IfcGeometryExtraction {
         // here. The rel-aggregates loop below already reads its RelatingObject
         // inside its own try for exactly this reason.
         const relatingMaterial = relAssociateMaterial.RelatingMaterial
-        const relatedObjects = relAssociateMaterial.RelatedObjects
-        for (const relatedObject of relatedObjects) {
-          const product = relatedObject
+        const materialLocalID = relatingMaterial.localID
+        relAssociateMaterial.forEachReferenceInField(
+            REL_ASSOCIATES_RELATED_OFFSET,
+            REL_ASSOCIATES_RELATED_BASE,
+            REL_ASSOCIATES_RELATED_DEPTH,
+            ( expressID ) => {
 
-          if (product instanceof IfcProduct) {
-            if (product instanceof IfcOpeningElement ||
-              product instanceof IfcSpace ||
-              product instanceof IfcOpeningStandardCase) {
-              continue
-            }
+              if ( expressID === void 0 ) {
+                return true
+              }
 
-            // save mapping of IfcProduct --> IfcMaterial
-            this.materials.relMaterialsMap.set(
-                product.localID,
-                relatingMaterial.localID)
-          } else {
-            //     Logger.warning(`type other than IfcProduct: ${EntityTypesIfc[product.type]}`)
-          }
-        }
+              const productLocalID = this.model.resolveExpressID( expressID )
+
+              if ( productLocalID === void 0 ) {
+                return true
+              }
+
+              const typeID = this.model.typeIDOf( productLocalID )
+
+              if ( typeID === EntityTypesIfc.IFCOPENINGELEMENT ||
+                  typeID === EntityTypesIfc.IFCSPACE ||
+                  typeID === EntityTypesIfc.IFCOPENINGSTANDARDCASE ) {
+                return true
+              }
+
+              if ( typeID !== void 0 && productTypes.has( typeID ) ) {
+                this.materials.relMaterialsMap.set( productLocalID, materialLocalID )
+              }
+
+              return true
+            } )
       } catch (ex) {
         // Reference the relationship record, not RelatingMaterial: the
         // latter may be exactly what threw and would be undefined here.
@@ -6462,7 +6506,6 @@ export class IfcGeometryExtraction {
     const oneHopTypes = [
       IfcRelAssociatesMaterial,
       IfcRelVoidsElement,
-      IfcRelAggregates,
     ]
 
     for ( const type of oneHopTypes ) {
@@ -6499,12 +6542,15 @@ export class IfcGeometryExtraction {
    * (those are inverse — not written in the product record).
    *
    * @param localID The product's local ID.
+   * @param seen Optional set to extend.
+   * @param leafSpans Coalesced Faces[] pin ranges — caller unpins.
    * @return {Promise<Set<number>>} Pinned local IDs — caller must unpin
    * after extract.
    */
   public async ensureResidentForProductExtract(
       localID: number,
-      seen?: Set< number > ):
+      seen?: Set< number >,
+      leafSpans?: { address: number, length: number }[] ):
       Promise< Set< number > > {
 
     if ( !this.model.isSourceExternal ) {
@@ -6524,8 +6570,24 @@ export class IfcGeometryExtraction {
       extra.push( material )
     }
 
+    // Packed polygonal extract reads CoordIndex as integers. Do not
+    // BFS those face records — on PSB that was ~78k pins / 15s prefetch.
+    // Facesets themselves are also leaves: scanning their Faces[] still
+    // resolved 78k express IDs. Payload (Coordinates + Faces[] span)
+    // is paged in a second pass that only looks at two extremes.
+    const descend = ( id: number ): boolean => {
+
+      const typeID = this.model.typeIDOf( id )
+
+      return typeID !== EntityTypesIfc.IFCINDEXEDPOLYGONALFACE &&
+        typeID !== EntityTypesIfc.IFCINDEXEDPOLYGONALFACEWITHVOIDS &&
+        typeID !== EntityTypesIfc.IFCPOLYGONALFACESET &&
+        typeID !== EntityTypesIfc.IFCTRIANGULATEDFACESET
+    }
+
     const visited =
-      await this.model.ensureResidentClosureByLocalID( localID, extra, seen )
+      await this.model.ensureResidentClosureByLocalID(
+          localID, extra, seen, descend, leafSpans )
     const styleExtra: number[] = []
 
     for ( const visitedID of visited ) {
@@ -6544,10 +6606,68 @@ export class IfcGeometryExtraction {
     }
 
     if ( styleExtra.length > 0 ) {
-      await this.model.ensureResidentClosureByLocalID( localID, styleExtra, visited )
+      await this.model.ensureResidentClosureByLocalID(
+          localID, styleExtra, visited, descend, leafSpans )
     }
 
+    await this.ensureResidentVisitedFacesetPayloads_( visited, leafSpans )
+
     return visited
+  }
+
+  /**
+   * Page a faceset's Coordinates record and its Faces[] run as one
+   * address span. The generic closure treats the faceset as a leaf so
+   * it does not resolve every face express ID.
+   *
+   * @param visited Faceset local IDs already pinned (and the set to
+   * extend with Coordinates).
+   * @param leafSpans Coalesced Faces[] pin ranges — caller unpins.
+   */
+  private async ensureResidentVisitedFacesetPayloads_(
+      visited: Set< number >,
+      leafSpans?: { address: number, length: number }[] ): Promise< void > {
+
+    for ( const localID of visited ) {
+
+      const typeID = this.model.typeIDOf( localID )
+
+      if ( typeID !== EntityTypesIfc.IFCPOLYGONALFACESET &&
+          typeID !== EntityTypesIfc.IFCTRIANGULATEDFACESET ) {
+        continue
+      }
+
+      const refs = this.model.referencedExpressIDs( localID )
+
+      if ( refs.length === 0 ) {
+        continue
+      }
+
+      // First #ref is Coordinates (IfcTessellatedFaceSet). Pin it as a
+      // normal record — one IfcCartesianPointList3D, no child #refs.
+      const coordsLocalID = this.model.resolveExpressID( refs[ 0 ] )
+
+      if ( coordsLocalID !== void 0 && !visited.has( coordsLocalID ) ) {
+
+        await this.model.ensureResidentByLocalID( coordsLocalID )
+        this.model.pinByLocalID( coordsLocalID )
+        visited.add( coordsLocalID )
+      }
+
+      if ( refs.length < 2 ) {
+        continue
+      }
+
+      const span = this.model.spanOfExpressIDExtremes( refs, 1 )
+
+      if ( span === void 0 ) {
+        continue
+      }
+
+      this.model.pinAddressRange( span.address, span.length )
+      await this.model.ensureResidentRange( span.address, span.length )
+      leafSpans?.push( span )
+    }
   }
 
   /**
@@ -6560,29 +6680,60 @@ export class IfcGeometryExtraction {
    * after extract.
    */
   public async ensureResidentForAggregateExtract(
-      relAggregate: IfcRelAggregates ): Promise< Set< number > > {
+      relAggregate: IfcRelAggregates,
+      leafSpans?: { address: number, length: number }[] ): Promise< Set< number > > {
 
     if ( !this.model.isSourceExternal ) {
       return new Set< number >()
     }
 
-    const pinned =
-      await this.model.ensureResidentClosureByLocalID( relAggregate.localID )
+    // Pin the rel record, page its 1-hop so RelatingObject /
+    // RelatedObjects getters can hydrate, then walk each product
+    // through the bounded extract. The 1-hop IDs must NOT go into
+    // `pinned`/`seen` — that would skip their geometry closures.
+    // A full BFS of the rel used to follow every RelatedObject into
+    // Faces[] (the 78k-pin path) before descend could skip them.
+    const pinned = new Set< number >()
+
+    await this.model.ensureResidentByLocalID( relAggregate.localID )
+    this.model.pinByLocalID( relAggregate.localID )
+    pinned.add( relAggregate.localID )
+
+    const hop: number[] = []
+
+    for ( const expressID of this.model.referencedExpressIDs(
+        relAggregate.localID ) ) {
+
+      const localID = this.model.resolveExpressID( expressID )
+
+      if ( localID === void 0 || pinned.has( localID ) ) {
+        continue
+      }
+
+      await this.model.ensureResidentByLocalID( localID )
+      this.model.pinByLocalID( localID )
+      hop.push( localID )
+    }
 
     const relating = relAggregate.RelatingObject
 
     if ( relating !== null && relating !== void 0 ) {
-      await this.ensureResidentForProductExtract( relating.localID, pinned )
+      await this.ensureResidentForProductExtract(
+          relating.localID, pinned, leafSpans )
     }
 
     const related = relAggregate.RelatedObjects
 
-    if ( related === null || related === void 0 ) {
-      return pinned
+    if ( related !== null && related !== void 0 ) {
+
+      for ( const product of related ) {
+        await this.ensureResidentForProductExtract(
+            product.localID, pinned, leafSpans )
+      }
     }
 
-    for ( const product of related ) {
-      await this.ensureResidentForProductExtract( product.localID, pinned )
+    for ( const localID of hop ) {
+      this.model.unpinByLocalID( localID )
     }
 
     return pinned

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -6621,8 +6621,8 @@ export class IfcGeometryExtraction {
 
   /**
    * Page a faceset's Coordinates record and its Faces[] run as one
-   * address span. The generic closure treats the faceset as a leaf so
-   * it does not resolve every face express ID.
+   * or more tight address spans. The generic closure visits the
+   * faceset but does not scan Faces[].
    *
    * @param visited Faceset local IDs already pinned (and the set to
    * extend with Coordinates).
@@ -6662,15 +6662,13 @@ export class IfcGeometryExtraction {
         continue
       }
 
-      const span = this.model.spanOfExpressIDExtremes( refs, 1 )
+      const spans = this.model.spansOfExpressIDs( refs, 1 )
 
-      if ( span === void 0 ) {
-        continue
+      for ( const span of spans ) {
+        this.model.pinAddressRange( span.address, span.length )
+        leafSpans?.push( span )
+        await this.model.ensureResidentRange( span.address, span.length )
       }
-
-      this.model.pinAddressRange( span.address, span.length )
-      await this.model.ensureResidentRange( span.address, span.length )
-      leafSpans?.push( span )
     }
   }
 

--- a/src/ifc/ifc_stream_open.test.ts
+++ b/src/ifc/ifc_stream_open.test.ts
@@ -237,7 +237,7 @@ describe( 'openStreamedIfcModel (Phase B3)', () => {
     expect( leafSpans.length ).toBe( 0 )
   } )
 
-  test( 'spanOfExpressIDExtremes covers a dense express-ID run', async () => {
+  test( 'spansOfExpressIDs covers each record without the holes between', async () => {
 
     const store = new InMemoryStepByteStore( bytes )
     const fromStore = await openStreamedIfcModelFromStore( store, { pool: 4 * 1024 } )
@@ -245,22 +245,41 @@ describe( 'openStreamedIfcModel (Phase B3)', () => {
     const expressIDs = [ ...model.expressIDsOfTypes( IfcRoot ) ]
     expect( expressIDs.length ).toBeGreaterThan( 1 )
 
-    const span = model.spanOfExpressIDExtremes( expressIDs )
+    const spans = model.spansOfExpressIDs( expressIDs )
 
-    expect( span ).toBeDefined()
-    expect( span!.length ).toBeGreaterThan( 0 )
+    expect( spans.length ).toBeGreaterThan( 0 )
 
-    const spanEnd = span!.address + span!.length
+    let covered = 0
+    let hullMin = Infinity
+    let hullMax = 0
+
+    for ( const span of spans ) {
+      covered += span.length
+    }
 
     for ( const refExpressID of expressIDs ) {
 
       const localID = model.resolveExpressID( refExpressID )!
+      const address = model.recordAddress( localID )!
+      const end = address + model.recordLength( localID )!
 
-      expect( model.recordAddress( localID )! ).toBeGreaterThanOrEqual( span!.address )
-      expect(
-          model.recordAddress( localID )! + model.recordLength( localID )! )
-          .toBeLessThanOrEqual( spanEnd )
+      if ( address < hullMin ) {
+        hullMin = address
+      }
+
+      if ( end > hullMax ) {
+        hullMax = end
+      }
+
+      const inside = spans.some( ( span ) =>
+        address >= span.address && end <= span.address + span.length )
+
+      expect( inside ).toBe( true )
     }
+
+    // IfcRoot rows are scattered through index.ifc — the coalesced
+    // spans must not be the single hull from first to last.
+    expect( covered ).toBeLessThan( hullMax - hullMin )
   } )
 
   test( 'openStreamedIfcModelFromStore matches the sync open', async () => {

--- a/src/ifc/ifc_stream_open.test.ts
+++ b/src/ifc/ifc_stream_open.test.ts
@@ -211,6 +211,32 @@ describe( 'openStreamedIfcModel (Phase B3)', () => {
     expect( leafSpans[ 0 ].length ).toBeGreaterThan( 0 )
   } )
 
+  test( 'spanLeaf spans children; !descend without spanLeaf still visits them', async () => {
+
+    const store = new InMemoryStepByteStore( bytes )
+    const fromStore = await openStreamedIfcModelFromStore( store, { pool: 4 * 1024 } )
+    const model = fromStore.model!
+    const expressID = [ ...model.expressIDsOfTypes( IfcRoot ) ][ 0 ] as number
+    const localID = model.resolveExpressID( expressID ) as number
+
+    await model.ensureResidentByLocalID( localID )
+    const refs = model.referencedExpressIDs( localID )
+    expect( refs.length ).toBeGreaterThan( 0 )
+
+    const leafSpans: { address: number, length: number }[] = []
+    const visited = await model.ensureResidentClosureByLocalID(
+        localID,
+        void 0,
+        new Set< number >(),
+        ( id ) => id === localID,
+        leafSpans,
+        () => false )
+
+    expect( visited.has( localID ) ).toBe( true )
+    expect( visited.size ).toBeGreaterThan( 1 )
+    expect( leafSpans.length ).toBe( 0 )
+  } )
+
   test( 'spanOfExpressIDExtremes covers a dense express-ID run', async () => {
 
     const store = new InMemoryStepByteStore( bytes )

--- a/src/ifc/ifc_stream_open.test.ts
+++ b/src/ifc/ifc_stream_open.test.ts
@@ -173,6 +173,7 @@ describe( 'openStreamedIfcModel (Phase B3)', () => {
     const visited = await model.ensureResidentClosureByLocalID( localID )
 
     expect( visited.has( localID ) ).toBe( true )
+    expect( model.typeIDOf( localID ) ).toBeDefined()
 
     for ( const refExpressID of refs ) {
 
@@ -181,6 +182,58 @@ describe( 'openStreamedIfcModel (Phase B3)', () => {
       if ( refLocalID !== void 0 ) {
         expect( visited.has( refLocalID ) ).toBe( true )
       }
+    }
+  } )
+
+  test( 'ensureResidentClosureByLocalID skip-descend does not follow #refs', async () => {
+
+    const store = new InMemoryStepByteStore( bytes )
+    const fromStore = await openStreamedIfcModelFromStore( store, { pool: 4 * 1024 } )
+    const model = fromStore.model!
+    const expressID = [ ...model.expressIDsOfTypes( IfcRoot ) ][ 0 ] as number
+    const localID = model.resolveExpressID( expressID ) as number
+
+    await model.ensureResidentByLocalID( localID )
+    const refs = model.referencedExpressIDs( localID )
+    expect( refs.length ).toBeGreaterThan( 0 )
+
+    const leafSpans: { address: number, length: number }[] = []
+    const visited = await model.ensureResidentClosureByLocalID(
+        localID,
+        void 0,
+        new Set< number >(),
+        ( id ) => id === localID,
+        leafSpans )
+
+    expect( visited.has( localID ) ).toBe( true )
+    expect( visited.size ).toBe( 1 )
+    expect( leafSpans.length ).toBeGreaterThan( 0 )
+    expect( leafSpans[ 0 ].length ).toBeGreaterThan( 0 )
+  } )
+
+  test( 'spanOfExpressIDExtremes covers a dense express-ID run', async () => {
+
+    const store = new InMemoryStepByteStore( bytes )
+    const fromStore = await openStreamedIfcModelFromStore( store, { pool: 4 * 1024 } )
+    const model = fromStore.model!
+    const expressIDs = [ ...model.expressIDsOfTypes( IfcRoot ) ]
+    expect( expressIDs.length ).toBeGreaterThan( 1 )
+
+    const span = model.spanOfExpressIDExtremes( expressIDs )
+
+    expect( span ).toBeDefined()
+    expect( span!.length ).toBeGreaterThan( 0 )
+
+    const spanEnd = span!.address + span!.length
+
+    for ( const refExpressID of expressIDs ) {
+
+      const localID = model.resolveExpressID( refExpressID )!
+
+      expect( model.recordAddress( localID )! ).toBeGreaterThanOrEqual( span!.address )
+      expect(
+          model.recordAddress( localID )! + model.recordLength( localID )! )
+          .toBeLessThanOrEqual( spanEnd )
     }
   } )
 

--- a/src/step/parsing/step_parser.ts
+++ b/src/step/parsing/step_parser.ts
@@ -121,7 +121,8 @@ export type LineArgumentParseResult<TypeIDType> = [StepIndex<TypeIDType>, ParseR
  * parser stays decoupled from the higher-level progress event contract in
  * core/progress.ts (ProgressTracker maps this into a ProgressEvent).
  */
-export type ParseProgressCallback = ( cursorBytes: number ) => void
+export type ParseProgressCallback =
+  ( cursorBytes: number ) => unknown
 
 // One generator suspension per (mask + 1) parsed elements keeps progress
 // overhead unmeasurable in the hot data-parse loop (a 9M-entity model yields
@@ -583,7 +584,12 @@ export default class StepParser<TypeIDType> extends StepHeaderParser {
         continue
       }
 
-      onProgress?.( next.value )
+      const progressed = onProgress?.( next.value )
+
+      if ( progressed !== void 0 &&
+          typeof ( progressed as Promise< void > ).then === 'function' ) {
+        await ( progressed as Promise< void > )
+      }
 
       if ( Date.now() - lastYield >= yieldIntervalMs ) {
         await yieldToEventLoop()

--- a/src/step/parsing/streaming_index_builder.ts
+++ b/src/step/parsing/streaming_index_builder.ts
@@ -265,7 +265,7 @@ export async function buildIndexStreamingAsync<TypeIDType>(
       typeID: TypeIDType | undefined,
       recordBytes?: Uint8Array ) => void,
     sink?: StepIndexSink<TypeIDType>,
-    onProgress?: ( absoluteByteCursor: number ) => void,
+    onProgress?: ( absoluteByteCursor: number ) => unknown,
     yieldIntervalMs?: number ):
     Promise<StreamingIndexResult<TypeIDType>> {
 
@@ -344,7 +344,8 @@ export async function buildIndexStreamingAsync<TypeIDType>(
     // Translate the parser's window-relative cursor to an absolute source
     // cursor (windowStartFile advances as the window slides).
     const progressTick = onProgress !== void 0 ?
-      ( cursor: number ) => onProgress( windowStartFile + cursor ) : void 0
+      ( cursor: number ) =>
+        onProgress( windowStartFile + cursor ) : void 0
 
     const [ index, result ] =
       await parser.parseDataBlockStreamedAsync(
@@ -446,7 +447,7 @@ export async function buildColumnarIndexStreamingAsync<TypeIDType extends number
       expressID: number,
       typeID: TypeIDType | undefined,
       recordBytes?: Uint8Array ) => void,
-    onProgress?: ( absoluteByteCursor: number ) => void,
+    onProgress?: ( absoluteByteCursor: number ) => unknown,
     yieldIntervalMs?: number ):
     Promise<StreamingColumnarIndexResult<TypeIDType>> {
 

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -37,6 +37,12 @@ implements Iterable<BaseEntity>, Model {
   public readonly abstract typeIndex: MultiIndexSet<EntityTypeIDs>
   public readonly abstract externalMappingType: StepEntityConstructor< EntityTypeIDs, BaseEntity >
 
+  // Merge neighbouring leaf records only when the hole between them is
+  // a few small STEP rows. A Faces[] dump is packed; a sparse list
+  // must not pin the file in between.
+  // eslint-disable-next-line no-magic-numbers
+  private static readonly LEAF_SPAN_COALESCE_GAP_ = 1024
+
   private readonly vtableBuilder_: StepVtableBuilder = new StepVtableBuilder()
   private readonly expressIDMap_: InterpolationSearchTable32
   private readonly inlineAddressMap_: InterpolationSearchTable32
@@ -940,9 +946,8 @@ implements Iterable<BaseEntity>, Model {
         }
 
         if ( skipped.length > 0 ) {
-          const span = this.spanOf_( skipped )
 
-          if ( span !== void 0 ) {
+          for ( const span of this.spansOf_( skipped ) ) {
             this.pinAddressRange( span.address, span.length )
             waveSpans.push( span )
             leafSpans?.push( span )
@@ -1078,18 +1083,19 @@ implements Iterable<BaseEntity>, Model {
 
 
   /**
-   * Tight source span covering the records referenced by `expressIDs`
-   * from `fromIndex` onward. A packed Faces[] run is consecutive in
-   * parse order — two express-ID lookups then cover the whole range.
-   * Non-dense sets fall back to resolving every id.
+   * Source spans covering the records referenced by `expressIDs` from
+   * `fromIndex` onward. A packed Faces[] run is consecutive in parse
+   * order — two express-ID lookups then cover the whole range. Sparse
+   * sets are coalesced into tight runs so intervening file is not
+   * pinned.
    *
    * @param expressIDs Referenced express IDs (e.g. a faceset's #refs).
    * @param fromIndex First index to include (skip Coordinates at [0]).
-   * @return {{address: number, length: number} | undefined} The span.
+   * @return {{address: number, length: number}[]} The spans.
    */
-  public spanOfExpressIDExtremes(
+  public spansOfExpressIDs(
       expressIDs: readonly number[],
-      fromIndex: number = 0 ): { address: number, length: number } | undefined {
+      fromIndex: number = 0 ): { address: number, length: number }[] {
 
     let minExpressID = Infinity
     let maxExpressID = 0
@@ -1111,14 +1117,14 @@ implements Iterable<BaseEntity>, Model {
     }
 
     if ( count === 0 || !Number.isFinite( minExpressID ) ) {
-      return
+      return []
     }
 
     const minLocal = this.expressIDMap_.get( minExpressID )
     const maxLocal = this.expressIDMap_.get( maxExpressID )
 
     if ( minLocal === void 0 || maxLocal === void 0 ) {
-      return
+      return []
     }
 
     const lo = Math.min( minLocal, maxLocal )
@@ -1129,10 +1135,10 @@ implements Iterable<BaseEntity>, Model {
       const end = this.address_[ hi ] + this.length_[ hi ]
 
       if ( end <= address ) {
-        return
+        return []
       }
 
-      return { address, length: end - address }
+      return [ { address, length: end - address } ]
     }
 
     const locals: number[] = []
@@ -1146,21 +1152,22 @@ implements Iterable<BaseEntity>, Model {
       }
     }
 
-    return this.spanOf_( locals )
+    return this.spansOf_( locals )
   }
 
 
   /**
-   * Tight source span covering `localIDs` (file-order faces of one set).
+   * Coalesce `localIDs` into tight source runs. Records more than
+   * {@link LEAF_SPAN_COALESCE_GAP_} apart stay separate so a sparse
+   * Faces[] list does not pin the file between them.
    *
    * @param localIDs The records.
-   * @return {{address: number, length: number} | undefined} The span.
+   * @return {{address: number, length: number}[]} The spans.
    */
-  private spanOf_(
-      localIDs: number[] ): { address: number, length: number } | undefined {
+  private spansOf_(
+      localIDs: number[] ): { address: number, length: number }[] {
 
-    let minAddress = Infinity
-    let maxEnd = 0
+    const items: { address: number, length: number }[] = []
 
     for ( const id of localIDs ) {
 
@@ -1168,23 +1175,41 @@ implements Iterable<BaseEntity>, Model {
         continue
       }
 
-      const address = this.address_[ id ]
-      const end = address + this.length_[ id ]
-
-      if ( address < minAddress ) {
-        minAddress = address
-      }
-
-      if ( end > maxEnd ) {
-        maxEnd = end
-      }
+      items.push( {
+        address: this.address_[ id ],
+        length: this.length_[ id ],
+      } )
     }
 
-    if ( !Number.isFinite( minAddress ) || maxEnd <= minAddress ) {
-      return
+    items.sort( ( a, b ) => a.address - b.address )
+
+    const spans: { address: number, length: number }[] = []
+    let run: { address: number, length: number } | undefined
+
+    for ( const item of items ) {
+
+      if ( run === void 0 ) {
+        run = { address: item.address, length: item.length }
+        continue
+      }
+
+      const runEnd = run.address + run.length
+
+      if ( item.address <= runEnd + StepModelBase.LEAF_SPAN_COALESCE_GAP_ ) {
+        const end = Math.max( runEnd, item.address + item.length )
+        run.length = end - run.address
+        continue
+      }
+
+      spans.push( run )
+      run = { address: item.address, length: item.length }
     }
 
-    return { address: minAddress, length: maxEnd - minAddress }
+    if ( run !== void 0 ) {
+      spans.push( run )
+    }
+
+    return spans
   }
 
 

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -833,12 +833,17 @@ implements Iterable<BaseEntity>, Model {
    * @param extraLocalIDs Additional seeds (voids, styles, materials).
    * @param seen Optional set to extend (also skips already-pinned IDs).
    * @param descend If set, records for which this returns false are
-   * pinned and paged but their `#refs` are not followed. Packed
-   * polygonal extract reads `IfcIndexedPolygonalFace.CoordIndex` as
-   * integers and never walks those faces' graphs — following them
-   * pinned ~78k records per PSB product.
+   * still visited (pinned, in `seen`) but their `#refs` are not
+   * followed — e.g. an `IfcPolygonalFaceSet` whose Faces[] payload
+   * is paged as one span afterwards.
    * @param leafSpans Optional out-array of coalesced pin ranges for
-   * skipped leaves — caller must {@link unpinAddressRange} each.
+   * {@link spanLeaf} children — caller must {@link unpinAddressRange}
+   * each.
+   * @param spanLeaf If set, matching children are *not* visited
+   * (absent from `seen`); their bytes are one pin span. Packed
+   * extract reads `IfcIndexedPolygonalFace.CoordIndex` as integers —
+   * following those faces pinned ~78k records per PSB product. If
+   * omitted, `!descend` children use this span path (test helper).
    * @return {Promise<Set<number>>} The local IDs that were visited.
    */
   public async ensureResidentClosureByLocalID(
@@ -846,7 +851,8 @@ implements Iterable<BaseEntity>, Model {
       extraLocalIDs?: Iterable<number>,
       seen: Set< number > = new Set< number >(),
       descend?: ( localID: number ) => boolean,
-      leafSpans?: { address: number, length: number }[] ): Promise< Set< number > > {
+      leafSpans?: { address: number, length: number }[],
+      spanLeaf?: ( localID: number ) => boolean ): Promise< Set< number > > {
 
     if ( !this.isSourceExternal ) {
       return seen
@@ -917,9 +923,15 @@ implements Iterable<BaseEntity>, Model {
             continue
           }
 
-          // Leaf types are claimed so a later path does not walk them.
-          // Their bytes are pinned as one span (packed Faces[] run).
-          if ( descend !== void 0 && !descend( referenced ) ) {
+          // Packed leaves (Faces[]) are spanned, not visited. Stop
+          // nodes (facesets) fail `descend` so we do not scan their
+          // refs, but they still go on the frontier so they land in
+          // `seen` for the payload pass.
+          const leaf = spanLeaf !== void 0 ?
+            spanLeaf( referenced ) :
+            ( descend !== void 0 && !descend( referenced ) )
+
+          if ( leaf ) {
             skipped.push( referenced )
             continue
           }

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -638,6 +638,91 @@ implements Iterable<BaseEntity>, Model {
   }
 
   /**
+   * Column type of a record, or `undefined` if the id is unknown / untyped.
+   *
+   * @param localID The record.
+   * @return {number | undefined} The schema type id.
+   */
+  public typeIDOf( localID: number ): number | undefined {
+
+    if ( localID >= this.count_ ) {
+      return
+    }
+
+    const typeID = this.typeID_[ localID ]
+
+    return typeID < 0 ? void 0 : typeID
+  }
+
+  /**
+   * Absolute source address of a record.
+   *
+   * @param localID The record.
+   * @return {number | undefined} The address.
+   */
+  public recordAddress( localID: number ): number | undefined {
+
+    return localID < this.count_ ? this.address_[ localID ] : void 0
+  }
+
+  /**
+   * Source length of a record.
+   *
+   * @param localID The record.
+   * @return {number | undefined} The length.
+   */
+  public recordLength( localID: number ): number | undefined {
+
+    return localID < this.count_ ? this.length_[ localID ] : void 0
+  }
+
+  /**
+   * Pin an arbitrary source span (e.g. a faceset's packed Faces[] run).
+   *
+   * @param address Absolute start.
+   * @param length Length in bytes.
+   */
+  public pinAddressRange( address: number, length: number ): void {
+
+    if ( !this.isSourceExternal ) {
+      return
+    }
+
+    this.bufferProvider_.pinRange?.( address, length )
+  }
+
+  /**
+   * Drop one {@link pinAddressRange} hold.
+   *
+   * @param address Absolute start.
+   * @param length Length in bytes.
+   */
+  public unpinAddressRange( address: number, length: number ): void {
+
+    if ( !this.isSourceExternal ) {
+      return
+    }
+
+    this.bufferProvider_.unpinRange?.( address, length )
+  }
+
+  /**
+   * Page an arbitrary source span.
+   *
+   * @param address Absolute start.
+   * @param length Length in bytes.
+   * @return {Promise<void>} Resolves when resident.
+   */
+  public async ensureResidentRange( address: number, length: number ): Promise< void > {
+
+    if ( !this.isSourceExternal ) {
+      return
+    }
+
+    await this.bufferProvider_.ensureResident( address, length )
+  }
+
+  /**
    * Release the resident source buffer and serve subsequent record
    * reads from fixed-size windows paged in from an external store.
    *
@@ -747,12 +832,21 @@ implements Iterable<BaseEntity>, Model {
    * @param localID Seed record.
    * @param extraLocalIDs Additional seeds (voids, styles, materials).
    * @param seen Optional set to extend (also skips already-pinned IDs).
+   * @param descend If set, records for which this returns false are
+   * pinned and paged but their `#refs` are not followed. Packed
+   * polygonal extract reads `IfcIndexedPolygonalFace.CoordIndex` as
+   * integers and never walks those faces' graphs — following them
+   * pinned ~78k records per PSB product.
+   * @param leafSpans Optional out-array of coalesced pin ranges for
+   * skipped leaves — caller must {@link unpinAddressRange} each.
    * @return {Promise<Set<number>>} The local IDs that were visited.
    */
   public async ensureResidentClosureByLocalID(
       localID: number,
       extraLocalIDs?: Iterable<number>,
-      seen: Set< number > = new Set< number >() ): Promise< Set< number > > {
+      seen: Set< number > = new Set< number >(),
+      descend?: ( localID: number ) => boolean,
+      leafSpans?: { address: number, length: number }[] ): Promise< Set< number > > {
 
     if ( !this.isSourceExternal ) {
       return seen
@@ -805,16 +899,48 @@ implements Iterable<BaseEntity>, Model {
 
       await Promise.all( wave.map( ( id ) => this.ensureResidentByLocalID( id ) ) )
 
+      const waveSpans: { address: number, length: number }[] = []
+
       for ( const id of wave ) {
+
+        if ( descend !== void 0 && !descend( id ) ) {
+          continue
+        }
+
+        const skipped: number[] = []
 
         for ( const expressID of this.scanRecordRefs_( id ) ) {
 
           const referenced = this.expressIDMap_.get( expressID )
 
-          if ( referenced !== void 0 && !seen.has( referenced ) ) {
-            frontier.push( referenced )
+          if ( referenced === void 0 || seen.has( referenced ) ) {
+            continue
+          }
+
+          // Leaf types are claimed so a later path does not walk them.
+          // Their bytes are pinned as one span (packed Faces[] run).
+          if ( descend !== void 0 && !descend( referenced ) ) {
+            skipped.push( referenced )
+            continue
+          }
+
+          frontier.push( referenced )
+        }
+
+        if ( skipped.length > 0 ) {
+          const span = this.spanOf_( skipped )
+
+          if ( span !== void 0 ) {
+            this.pinAddressRange( span.address, span.length )
+            waveSpans.push( span )
+            leafSpans?.push( span )
           }
         }
+      }
+
+      if ( waveSpans.length > 0 ) {
+        await Promise.all( waveSpans.map( ( span ) =>
+          this.ensureResidentRange( span.address, span.length ) ) )
       }
     }
 
@@ -934,7 +1060,119 @@ implements Iterable<BaseEntity>, Model {
       return seen ?? new Set< number >()
     }
 
-    return this.ensureResidentClosureByLocalID( localID, extraLocalIDs, seen )
+    return this.ensureResidentClosureByLocalID(
+        localID, extraLocalIDs, seen )
+  }
+
+
+  /**
+   * Tight source span covering the records referenced by `expressIDs`
+   * from `fromIndex` onward. A packed Faces[] run is consecutive in
+   * parse order — two express-ID lookups then cover the whole range.
+   * Non-dense sets fall back to resolving every id.
+   *
+   * @param expressIDs Referenced express IDs (e.g. a faceset's #refs).
+   * @param fromIndex First index to include (skip Coordinates at [0]).
+   * @return {{address: number, length: number} | undefined} The span.
+   */
+  public spanOfExpressIDExtremes(
+      expressIDs: readonly number[],
+      fromIndex: number = 0 ): { address: number, length: number } | undefined {
+
+    let minExpressID = Infinity
+    let maxExpressID = 0
+    let count = 0
+
+    for ( let i = fromIndex; i < expressIDs.length; ++i ) {
+
+      const expressID = expressIDs[ i ]
+
+      if ( expressID < minExpressID ) {
+        minExpressID = expressID
+      }
+
+      if ( expressID > maxExpressID ) {
+        maxExpressID = expressID
+      }
+
+      ++count
+    }
+
+    if ( count === 0 || !Number.isFinite( minExpressID ) ) {
+      return
+    }
+
+    const minLocal = this.expressIDMap_.get( minExpressID )
+    const maxLocal = this.expressIDMap_.get( maxExpressID )
+
+    if ( minLocal === void 0 || maxLocal === void 0 ) {
+      return
+    }
+
+    const lo = Math.min( minLocal, maxLocal )
+    const hi = Math.max( minLocal, maxLocal )
+
+    if ( hi - lo + 1 === count ) {
+      const address = this.address_[ lo ]
+      const end = this.address_[ hi ] + this.length_[ hi ]
+
+      if ( end <= address ) {
+        return
+      }
+
+      return { address, length: end - address }
+    }
+
+    const locals: number[] = []
+
+    for ( let i = fromIndex; i < expressIDs.length; ++i ) {
+
+      const localID = this.expressIDMap_.get( expressIDs[ i ] )
+
+      if ( localID !== void 0 ) {
+        locals.push( localID )
+      }
+    }
+
+    return this.spanOf_( locals )
+  }
+
+
+  /**
+   * Tight source span covering `localIDs` (file-order faces of one set).
+   *
+   * @param localIDs The records.
+   * @return {{address: number, length: number} | undefined} The span.
+   */
+  private spanOf_(
+      localIDs: number[] ): { address: number, length: number } | undefined {
+
+    let minAddress = Infinity
+    let maxEnd = 0
+
+    for ( const id of localIDs ) {
+
+      if ( id >= this.count_ ) {
+        continue
+      }
+
+      const address = this.address_[ id ]
+      const end = address + this.length_[ id ]
+
+      if ( address < minAddress ) {
+        minAddress = address
+      }
+
+      if ( end > maxEnd ) {
+        maxEnd = end
+      }
+    }
+
+    if ( !Number.isFinite( minAddress ) || maxEnd <= minAddress ) {
+      return
+    }
+
+    return { address: minAddress, length: maxEnd - minAddress }
   }
 
 


### PR DESCRIPTION
## What

Store-backed extract follow-up from the 1.513 PSB profile: Geometry was ~39s, of which ~15s / 78k pins was a BFS of `IfcPolygonalFaceSet.Faces[]`. Packed extract already reads `CoordIndex` as integers, so that walk was pure tax.

- Product extract treats facesets as leaves. Coordinates is one pin; `Faces[]` is one address span from two express-ID extremes on a dense parse-order run (`spanOfExpressIDExtremes`).
- Rel-aggregates no longer BFS related products into `Faces[]` before the per-product descend can skip them, and no longer seed `seen` with those product IDs (that skipped their closures).
- `releaseSourceViews` after each product; unpin local IDs + leaf spans in `finally`.
- `releaseScratchParsingBuffer()` after the 16 MiB parse window goes out of scope.
- After the index exists, walk Project → Site → Building → Storey → Space and emit AABB plates. Halfway down the tree, never Spaces, always storeys; collapse wrappers whose box matches their only child. Colour is black at 0.3 opacity with `solid: true` so Share can fill rather than wireframe.
- Store-backed open no longer emits parse-time point-list cubes (1959 unaligned AABBs on PSB). Spatial plates replace them.

## Why

Local PSB store extract vs 1.513:

| | 1.513 | this |
|---|---|---|
| `pinMax` | 77,934 | **742** (210–379 for most of the pump) |
| prefetch | ~14.9 s | **492 ms** |
| geometry | ~38.7 s | **23.4 s** |
| window | 61–64 MB | **60.7 MB** |

Spatial walk on PSB: **27 boxes**, ~1s after parse. Parse slide is not an over-read (`bytesRead === fileSize`); open’s 1.7 GB is parse + demand-prep.

Share still wireframes every `aabb` payload until it honours `solid`. That lands on the Share bump.

## Tests

- skip-descend does not follow `#refs`; `leafSpans` records the coalesced range
- `spanOfExpressIDExtremes` covers a dense run
- spatial depth cap / never-spaces / always-storeys
- `index.ifc` emits solid black 0.3 boxes, no Spaces

Does not close #446 / #392.