### PR TITLE
Rotation-aware spatial imposters, and store-path first pixels

### DIFF
--- a/src/compat/web-ifc/spatial_imposter.test.ts
+++ b/src/compat/web-ifc/spatial_imposter.test.ts
@@ -42,6 +42,69 @@ interface SpatialFixture {
    * only record of the height, which some exporters do.
    */
   storeyPlacementZ?: 'elevation' | 'datum'
+  /**
+   * Rotation baked into the SITE placement's IfcAxis2Placement3D, in
+   * degrees. `'z'` is the true-north rotation Revit routinely writes
+   * (plan rotation); `'x'` tips the model out of plumb, which no
+   * exporter really writes but which separates a correct composition
+   * from one that mixes up the Axis and RefDirection columns — a Z-only
+   * fixture leaves the third column at the identity and cannot see that.
+   */
+  siteRotation?: { axis: 'x' | 'z', degrees: number }
+}
+
+
+/**
+ * The axes an IfcAxis2Placement3D needs to state a rotation, as
+ * `[Axis (local +Z), RefDirection (local +X)]`.
+ *
+ * @param rotation The fixture's rotation knob.
+ * @return {[[number, number, number], [number, number, number]] | undefined}
+ * The two direction ratios, or undefined for no rotation.
+ */
+function rotationAxes( rotation: SpatialFixture['siteRotation'] ):
+  [[number, number, number], [number, number, number]] | undefined {
+
+  if ( rotation === void 0 ) {
+    return
+  }
+
+  const radians = rotation.degrees * Math.PI / 180
+  const cos = Math.cos( radians )
+  const sin = Math.sin( radians )
+
+  // Columns of the rotation matrix: Axis is its third (local +Z),
+  // RefDirection its first (local +X).
+  return rotation.axis === 'z' ?
+    [[0, 0, 1], [cos, sin, 0]] :
+    [[0, -sin, cos], [1, 0, 0]]
+}
+
+
+/**
+ * Transform a point by the fixture's site rotation — what the composed
+ * placement chain must reproduce.
+ *
+ * @param rotation The fixture's rotation knob.
+ * @param point A point in the site's local frame.
+ * @return {[number, number, number]} The rotated point.
+ */
+function rotatePoint(
+    rotation: SpatialFixture['siteRotation'],
+    point: [number, number, number] ): [number, number, number] {
+
+  if ( rotation === void 0 ) {
+    return point
+  }
+
+  const radians = rotation.degrees * Math.PI / 180
+  const cos = Math.cos( radians )
+  const sin = Math.sin( radians )
+  const [x, y, z] = point
+
+  return rotation.axis === 'z' ?
+    [x * cos - y * sin, x * sin + y * cos, z] :
+    [x, y * cos - z * sin, y * sin + z * cos]
 }
 
 
@@ -69,20 +132,33 @@ function syntheticSpatialIfc( fixture: SpatialFixture ): Uint8Array {
   const num = ( value: number ): string => value.toFixed( 4 )
   const guid = ( seed: number ): string => `3vB2${String( seed ).padStart( 18, '0' )}`
 
+  // Direction ratios get more decimals than `num`'s four: they are
+  // trigonometric, and rounding cos(30 deg) at four places moves a
+  // sampled origin by ~1e-4 source units — enough to break assertions
+  // that compare a composed plate against the same rotation applied in
+  // double precision.
+  const direction = ( ratios: [number, number, number] ): number =>
+    push( `IFCDIRECTION((${ratios.map( ( r ) => r.toFixed( 12 ) ).join( ',' )}))` )
+
   const placement = (
       relTo: number | undefined,
       x: number,
       y: number,
-      z: number ): number => {
+      z: number,
+      axes?: [[number, number, number], [number, number, number]] ): number => {
 
     const point = push( `IFCCARTESIANPOINT((${num( x )},${num( y )},${num( z )}))` )
-    const axis = push( `IFCAXIS2PLACEMENT3D(#${point},$,$)` )
+    const axisRef = axes !== void 0 ? `#${direction( axes[ 0 ] )}` : '$'
+    const refDirection = axes !== void 0 ? `#${direction( axes[ 1 ] )}` : '$'
+    const axis =
+      push( `IFCAXIS2PLACEMENT3D(#${point},${axisRef},${refDirection})` )
 
     return push(
         `IFCLOCALPLACEMENT(${relTo === void 0 ? '$' : `#${relTo}`},#${axis})` )
   }
 
-  const sitePlacement = placement( void 0, ...fixture.siteOrigin )
+  const sitePlacement = placement(
+      void 0, ...fixture.siteOrigin, rotationAxes( fixture.siteRotation ) )
   const buildingPlacement = placement( sitePlacement, 0, 0, fixture.buildingZ )
 
   const project = push( `IFCPROJECT('${guid( 1 )}',$,'P',$,$,$,$,$,$)` )
@@ -447,6 +523,96 @@ describe( 'emitSpatialStructureImposters coordination frame', () => {
         expect( plates[ 0 ].aabb!.min[ 2 ] ).toBeCloseTo( 100, 6 )
         expect( plates[ 1 ].aabb!.min[ 2 ] ).toBeCloseTo( 103.5, 6 )
       } )
+
+  // conway#517: the placement chain used to SUM Location translations
+  // and ignore rotation outright, so on a Revit export rotated to true
+  // north every sampled origin landed unrotated in raw model space while
+  // the durable meshes did not — the plate cloud read as a rotated ghost
+  // of the building. Both fixtures below fail against that composition.
+  describe( 'rotation-aware placement composition', () => {
+
+    /** Site rotated 30 deg about Z — Revit's true-north plan rotation. */
+    const ROTATED_SITE: SpatialFixture = {
+      siteOrigin: [0, 0, 0],
+      buildingZ: 0,
+      storeyElevations: [0, 3.5],
+      wallOffset: [8, 6],
+      siteRotation: { axis: 'z', degrees: 30 },
+    }
+
+    /** Site tipped 30 deg about X, with the building datum 100 up. */
+    const TILTED_SITE: SpatialFixture = {
+      siteOrigin: [0, 0, 0],
+      buildingZ: 100,
+      storeyElevations: [0, 3.5],
+      wallOffset: [8, 6],
+      siteRotation: { axis: 'x', degrees: 30 },
+    }
+
+    test( 'plan rotation: plate XY is the AABB of the ROTATED samples',
+        async () => {
+
+          const [payloads, model] = await emitForFixture( ROTATED_SITE, 1 )
+          const plates = storeyPlates( payloads, model )
+
+          expect( plates ).toHaveLength( 2 )
+
+          // The two walls each storey contains, composed through the
+          // rotated site placement.
+          const cornerA = rotatePoint( ROTATED_SITE.siteRotation, [0, 0, 0] )
+          const cornerB = rotatePoint(
+              ROTATED_SITE.siteRotation, [...ROTATED_SITE.wallOffset, 0] )
+
+          for ( const plate of plates ) {
+
+            expect( plate.aabb!.min[ 0 ] )
+                .toBeCloseTo( Math.min( cornerA[ 0 ], cornerB[ 0 ] ), 6 )
+            expect( plate.aabb!.max[ 0 ] )
+                .toBeCloseTo( Math.max( cornerA[ 0 ], cornerB[ 0 ] ), 6 )
+            expect( plate.aabb!.min[ 1 ] )
+                .toBeCloseTo( Math.min( cornerA[ 1 ], cornerB[ 1 ] ), 6 )
+            expect( plate.aabb!.max[ 1 ] )
+                .toBeCloseTo( Math.max( cornerA[ 1 ], cornerB[ 1 ] ), 6 )
+          }
+
+          // And specifically NOT the unrotated offset the translation-sum
+          // implementation produced: 6 m north instead of 9.2 m.
+          expect( plates[ 0 ].aabb!.max[ 1 ] )
+              .not.toBeCloseTo( ROTATED_SITE.wallOffset[ 1 ], 3 )
+        } )
+
+    test( 'tilt about X: storey floors band on the DATUM\'s world Z',
+        async () => {
+
+          const [payloads, model] = await emitForFixture( TILTED_SITE, 1 )
+          const plates = storeyPlates( payloads, model )
+
+          expect( plates ).toHaveLength( 2 )
+
+          const rotation = TILTED_SITE.siteRotation
+          const floorA = rotatePoint( rotation, [0, 0, 100] )
+          const floorB = rotatePoint( rotation, [...TILTED_SITE.wallOffset, 100] )
+
+          // Elevation is a length along the datum's own +Z, so a tilted
+          // datum puts the floor at cos(30) * the elevation, not at it.
+          expect( plates[ 0 ].aabb!.min[ 2 ] ).toBeCloseTo( floorA[ 2 ], 6 )
+          expect( plates[ 1 ].aabb!.min[ 2 ] )
+              .toBeCloseTo( rotatePoint( rotation, [0, 0, 103.5] )[ 2 ], 6 )
+
+          // A Z-only fixture leaves the third matrix column at the
+          // identity; this one does not, so an Axis/RefDirection mixup
+          // shows up as Y bounds that never left zero.
+          expect( plates[ 0 ].aabb!.min[ 1 ] )
+              .toBeCloseTo( Math.min( floorA[ 1 ], floorB[ 1 ] ), 6 )
+          expect( plates[ 0 ].aabb!.max[ 1 ] )
+              .toBeCloseTo( Math.max( floorA[ 1 ], floorB[ 1 ] ), 6 )
+
+          // The translation-sum implementation put both floors at the
+          // bare elevations, 100 and 103.5.
+          expect( plates[ 0 ].aabb!.min[ 2 ] ).not.toBeCloseTo( 100, 3 )
+          expect( plates[ 1 ].aabb!.min[ 2 ] ).not.toBeCloseTo( 103.5, 3 )
+        } )
+  } )
 
   test( 'nothing emits `solid`', async () => {
 

--- a/src/compat/web-ifc/spatial_imposter.test.ts
+++ b/src/compat/web-ifc/spatial_imposter.test.ts
@@ -51,7 +51,26 @@ interface SpatialFixture {
    * fixture leaves the third column at the identity and cannot see that.
    */
   siteRotation?: { axis: 'x' | 'z', degrees: number }
+  /**
+   * Raw `[Axis, RefDirection]` on the site placement, overriding
+   * `siteRotation`; either slot may be omitted to write `$`. Lets a
+   * fixture state an Axis with no RefDirection, which is how a
+   * lie-down placement is commonly authored.
+   */
+  siteAxes?: PlacementAxes
+  /**
+   * Write the site's RelativePlacement as an IfcAxis2Placement**2D**.
+   * `IfcLocalPlacement.RelativePlacement` admits both forms and the two
+   * disagree on every field past Location, so a walk that reads the 3D
+   * direction fields unconditionally throws on this file.
+   */
+  sitePlacement2D?: boolean
 }
+
+
+/** `[Axis (local +Z), RefDirection (local +X)]`, either one omittable. */
+type PlacementAxes =
+  [[number, number, number] | undefined, [number, number, number] | undefined]
 
 
 /**
@@ -59,11 +78,11 @@ interface SpatialFixture {
  * `[Axis (local +Z), RefDirection (local +X)]`.
  *
  * @param rotation The fixture's rotation knob.
- * @return {[[number, number, number], [number, number, number]] | undefined}
- * The two direction ratios, or undefined for no rotation.
+ * @return {PlacementAxes | undefined} The two direction ratios, or
+ * undefined for no rotation.
  */
-function rotationAxes( rotation: SpatialFixture['siteRotation'] ):
-  [[number, number, number], [number, number, number]] | undefined {
+function rotationAxes(
+    rotation: SpatialFixture['siteRotation'] ): PlacementAxes | undefined {
 
   if ( rotation === void 0 ) {
     return
@@ -140,25 +159,37 @@ function syntheticSpatialIfc( fixture: SpatialFixture ): Uint8Array {
   const direction = ( ratios: [number, number, number] ): number =>
     push( `IFCDIRECTION((${ratios.map( ( r ) => r.toFixed( 12 ) ).join( ',' )}))` )
 
+  const ref = ( ratios: [number, number, number] | undefined ): string =>
+    ratios !== void 0 ? `#${direction( ratios )}` : '$'
+
   const placement = (
       relTo: number | undefined,
       x: number,
       y: number,
       z: number,
-      axes?: [[number, number, number], [number, number, number]] ): number => {
+      axes?: PlacementAxes,
+      twoDimensional: boolean = false ): number => {
 
-    const point = push( `IFCCARTESIANPOINT((${num( x )},${num( y )},${num( z )}))` )
-    const axisRef = axes !== void 0 ? `#${direction( axes[ 0 ] )}` : '$'
-    const refDirection = axes !== void 0 ? `#${direction( axes[ 1 ] )}` : '$'
-    const axis =
-      push( `IFCAXIS2PLACEMENT3D(#${point},${axisRef},${refDirection})` )
+    // A 2D placement's Location is a 2D point, and its only direction
+    // field is RefDirection — there is no Axis to state.
+    const point = twoDimensional ?
+      push( `IFCCARTESIANPOINT((${num( x )},${num( y )}))` ) :
+      push( `IFCCARTESIANPOINT((${num( x )},${num( y )},${num( z )}))` )
+
+    const axis = twoDimensional ?
+      push( `IFCAXIS2PLACEMENT2D(#${point},$)` ) :
+      push( `IFCAXIS2PLACEMENT3D(#${point},` +
+        `${ref( axes?.[ 0 ] )},${ref( axes?.[ 1 ] )})` )
 
     return push(
         `IFCLOCALPLACEMENT(${relTo === void 0 ? '$' : `#${relTo}`},#${axis})` )
   }
 
   const sitePlacement = placement(
-      void 0, ...fixture.siteOrigin, rotationAxes( fixture.siteRotation ) )
+      void 0,
+      ...fixture.siteOrigin,
+      fixture.siteAxes ?? rotationAxes( fixture.siteRotation ),
+      fixture.sitePlacement2D === true )
   const buildingPlacement = placement( sitePlacement, 0, 0, fixture.buildingZ )
 
   const project = push( `IFCPROJECT('${guid( 1 )}',$,'P',$,$,$,$,$,$)` )
@@ -612,6 +643,68 @@ describe( 'emitSpatialStructureImposters coordination frame', () => {
           expect( plates[ 0 ].aabb!.min[ 2 ] ).not.toBeCloseTo( 100, 3 )
           expect( plates[ 1 ].aabb!.min[ 2 ] ).not.toBeCloseTo( 103.5, 3 )
         } )
+
+    test( 'an Axis with no RefDirection still yields a frame', async () => {
+
+      // Axis = world +X with RefDirection omitted: the IFC default
+      // RefDirection (1,0,0) is parallel to it, so a naive build finds a
+      // zero cross product. Falling all the way back to world axes there
+      // discards a perfectly good rotation; IFC's IfcFirstProjAxis
+      // substitutes a perpendicular reference instead, which sends local
+      // (a,b,c) to world (c,a,b).
+      const [payloads, model] = await emitForFixture( {
+        siteOrigin: [0, 0, 0],
+        buildingZ: 0,
+        storeyElevations: [0, 3.5],
+        wallOffset: [8, 6],
+        siteAxes: [[1, 0, 0], void 0],
+      }, 1 )
+
+      const plates = storeyPlates( payloads, model )
+
+      expect( plates ).toHaveLength( 2 )
+
+      // Lower storey's walls: local (0,0,0) and (8,6,0) -> (0,0,0) and
+      // (0,8,6). X collapses, so the plate is MIN_EDGE thick about
+      // zero there; the identity fallback would have spanned 0..8.
+      const plate = plates[ 0 ].aabb!
+
+      expect( ( plate.min[ 0 ] + plate.max[ 0 ] ) * 0.5 ).toBeCloseTo( 0, 6 )
+      expect( plate.max[ 0 ] - plate.min[ 0 ] ).toBeCloseTo( 1, 6 )
+      expect( plate.max[ 1 ] ).toBeCloseTo( 8, 6 )
+      expect( plate.max[ 2 ] ).toBeCloseTo( 6, 6 )
+    } )
+
+    test( 'a 2D relative placement does not break the chain', async () => {
+
+      // IfcLocalPlacement.RelativePlacement admits IfcAxis2Placement2D,
+      // whose field 1 is RefDirection (not Axis) and which has no field
+      // 2 at all. Reading the 3D direction fields unconditionally throws
+      // "too few fields in record"; that throw memoizes an undefined
+      // placement, and every DESCENDANT then composes in local
+      // coordinates — the site translation below silently disappears.
+      const [payloads, model] = await emitForFixture( {
+        siteOrigin: [10, 20, 0],
+        buildingZ: 100,
+        storeyElevations: [0, 3.5],
+        wallOffset: [8, 6],
+        sitePlacement2D: true,
+      }, 1 )
+
+      const plates = storeyPlates( payloads, model )
+
+      expect( plates ).toHaveLength( 2 )
+
+      // The site's XY still reaches the storeys...
+      expect( plates[ 0 ].aabb!.min[ 0 ] ).toBeCloseTo( 10, 6 )
+      expect( plates[ 0 ].aabb!.max[ 0 ] ).toBeCloseTo( 18, 6 )
+      expect( plates[ 0 ].aabb!.min[ 1 ] ).toBeCloseTo( 20, 6 )
+      expect( plates[ 0 ].aabb!.max[ 1 ] ).toBeCloseTo( 26, 6 )
+
+      // ...and so does the building datum the elevations band on.
+      expect( plates[ 0 ].aabb!.min[ 2 ] ).toBeCloseTo( 100, 6 )
+      expect( plates[ 1 ].aabb!.min[ 2 ] ).toBeCloseTo( 103.5, 6 )
+    } )
   } )
 
   test( 'nothing emits `solid`', async () => {

--- a/src/compat/web-ifc/spatial_imposter.ts
+++ b/src/compat/web-ifc/spatial_imposter.ts
@@ -130,6 +130,9 @@ const TRANSLATION = [12, 13, 14] as const
 /** Column-major index of the local +Z axis' world Z component. */
 const LOCAL_Z_WORLD_Z = 10
 
+/** Cross-product magnitude below which two unit axes are parallel. */
+const MIN_AXIS_CROSS = 1e-9
+
 
 const SPACE_TYPES = new Set< number >( [
   EntityTypesIfc.IFCSPACE,
@@ -370,9 +373,52 @@ async function directionRatios_(
 
 
 /**
- * The 4x4 an IfcAxis2Placement3D denotes: Location as the translation,
- * Axis as local +Z and RefDirection as local +X, both defaulting to the
- * world axes when absent per the IFC defaults.
+ * The local +X reference to use when a placement states an `Axis` but no
+ * `RefDirection`: world +X, unless that is (nearly) parallel to the
+ * stated axis, in which case world +Y.
+ *
+ * IFC's own `IfcFirstProjAxis` makes exactly this substitution, and
+ * without it a lie-down placement — `Axis = (1,0,0)`, RefDirection
+ * omitted, which is how a wall-mounted or rotated-into-plan element is
+ * commonly written — has its Axis cross the defaulted (1,0,0) to zero
+ * and falls all the way back to the world frame, discarding a perfectly
+ * well-formed rotation. conway-geom divides by that zero cross product
+ * and returns NaN, so matching the C++ settles nothing here; keeping the
+ * stated Axis is strictly better than dropping it.
+ *
+ * @param zAxis The normalized local +Z.
+ * @return {[number, number, number]} A reference not parallel to it.
+ */
+function defaultRefDirection_(
+    zAxis: [number, number, number] ): [number, number, number] {
+
+  // |cross(zAxis, worldX)| — world +X stays the default (which is what
+  // the IFC default says, and what the overwhelmingly common
+  // zAxis = (0,0,1) needs) until it degenerates.
+  return Math.hypot( zAxis[ 1 ], zAxis[ 2 ] ) > MIN_AXIS_CROSS ?
+    [1, 0, 0] : [0, 1, 0]
+}
+
+
+/**
+ * The 4x4 an IfcAxis2Placement denotes: Location as the translation,
+ * and — on the 3D form only — Axis as local +Z and RefDirection as local
+ * +X, both defaulting to the world axes when absent per the IFC
+ * defaults.
+ *
+ * The 2D form has to be handled, not assumed away.
+ * `IfcLocalPlacement.RelativePlacement` is
+ * `IfcAxis2Placement2D | IfcAxis2Placement3D`, and the two disagree on
+ * every field past Location: offset 1 is `Axis` on the 3D entity but
+ * `RefDirection` on the 2D one, and offset 2 does not exist there at
+ * all, so reading it throws "too few fields in record". That throw would
+ * escape to {@link placementTransform_}'s catch, which memoizes
+ * `undefined` for the placement — and a memoized undefined is not merely
+ * a lost sample: every descendant placement then takes the
+ * no-parent branch and is composed in LOCAL coordinates, silently
+ * reparenting a whole subtree to the origin. So the direction fields are
+ * read only once the type is confirmed 3D, which also restores the
+ * pre-#517 behaviour for 2D links (translation only).
  *
  * Deliberately the same construction as conway-geom's
  * `GetAxis2Placement3D` (ConwayGeometryProcessor.cpp) — normalize the
@@ -424,21 +470,28 @@ async function axisPlacementMatrix_(
     }
   }
 
-  const axisRatios =
-    await directionRatios_( model, placement, PLACEMENT_AXIS )
-  const refRatios =
-    await directionRatios_( model, placement, PLACEMENT_REF_DIRECTION )
+  const is3D =
+    model.typeIDOf( axisLocalID ) === EntityTypesIfc.IFCAXIS2PLACEMENT3D
+
+  const axisRatios = is3D ?
+    await directionRatios_( model, placement, PLACEMENT_AXIS ) : void 0
+  const refRatios = is3D ?
+    await directionRatios_( model, placement, PLACEMENT_REF_DIRECTION ) : void 0
 
   let zAxis: [number, number, number] =
     ( axisRatios !== void 0 ? normalize3_( axisRatios ) : void 0 ) ?? [0, 0, 1]
   let refAxis: [number, number, number] =
-    ( refRatios !== void 0 ? normalize3_( refRatios ) : void 0 ) ?? [1, 0, 0]
+    ( refRatios !== void 0 ? normalize3_( refRatios ) : void 0 ) ??
+      defaultRefDirection_( zAxis )
 
   let yAxis = normalize3_( cross3_( zAxis, refAxis ) )
 
   if ( yAxis === void 0 ) {
-    // Axis and RefDirection parallel (or garbage): no frame is derivable
-    // from them, so keep the translation and drop back to world axes.
+    // Axis and RefDirection are parallel (or garbage): nothing here
+    // determines a frame, so keep the translation and drop back to world
+    // axes. Only reachable with an explicit RefDirection now — an Axis
+    // on its own gets a perpendicular default instead of being thrown
+    // away with it (see defaultRefDirection_).
     zAxis = [0, 0, 1]
     refAxis = [1, 0, 0]
     yAxis = [0, 1, 0]

--- a/src/compat/web-ifc/spatial_imposter.ts
+++ b/src/compat/web-ifc/spatial_imposter.ts
@@ -110,7 +110,25 @@ const PRODUCT_PLACEMENT = [5, 5, 3] as const
 const LOCAL_PLACEMENT_REL_TO = [0, 0, 1] as const
 const LOCAL_PLACEMENT_RELATIVE = [1, 0, 1] as const
 const PLACEMENT_LOCATION = [0, 0, 2] as const
+const PLACEMENT_AXIS = [1, 1, 3] as const
+const PLACEMENT_REF_DIRECTION = [2, 1, 3] as const
 const STOREY_ELEVATION = [9, 9, 6] as const
+
+/** Column-major 4x4, the convention {@link mat4MultiplyF64} multiplies in. */
+type Mat4 = number[]
+
+const IDENTITY_PLACEMENT: Mat4 = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+]
+
+/** Column-major indices of a 4x4's translation component. */
+const TRANSLATION = [12, 13, 14] as const
+
+/** Column-major index of the local +Z axis' world Z component. */
+const LOCAL_Z_WORLD_Z = 10
 
 
 const SPACE_TYPES = new Set< number >( [
@@ -130,6 +148,9 @@ interface SpatialNode {
   typeID: number
   depth: number
   children: number[]
+  /** Composed world placement, or undefined when the chain gave none. */
+  placement?: Mat4
+  /** `placement`'s translation column, cached for the box arithmetic. */
   origin?: [number, number, number]
   elevation?: number
   aabb?: Aabb3
@@ -281,19 +302,183 @@ async function ensure_( model: IfcStepModel, localID: number ): Promise< void > 
 
 
 /**
- * World translation of an IfcLocalPlacement chain (rotation ignored —
- * enough for the axis-aligned storey plates this first pass draws).
+ * @param v A vector.
+ * @return {[number, number, number] | undefined} `v` scaled to unit
+ * length, or undefined when it has none (zero / non-finite input).
+ */
+function normalize3_(
+    v: [number, number, number] ): [number, number, number] | undefined {
+
+  const length = Math.hypot( v[ 0 ], v[ 1 ], v[ 2 ] )
+
+  return Number.isFinite( length ) && length > 0 ?
+    [v[ 0 ] / length, v[ 1 ] / length, v[ 2 ] / length] : void 0
+}
+
+
+/**
+ * @param a Left vector.
+ * @param b Right vector.
+ * @return {[number, number, number]} `a` x `b`.
+ */
+function cross3_(
+    a: [number, number, number],
+    b: [number, number, number] ): [number, number, number] {
+
+  return [
+    a[ 1 ] * b[ 2 ] - a[ 2 ] * b[ 1 ],
+    a[ 2 ] * b[ 0 ] - a[ 0 ] * b[ 2 ],
+    a[ 0 ] * b[ 1 ] - a[ 1 ] * b[ 0 ],
+  ]
+}
+
+
+/**
+ * The `DirectionRatios` of an IfcDirection referenced from `field` of
+ * `entity`, or undefined when the field is absent.
+ *
+ * @param model The model.
+ * @param entity The referring entity.
+ * @param field The (index, min, max) field triple.
+ * @return {Promise<[number, number, number] | undefined>} The ratios.
+ */
+async function directionRatios_(
+    model: IfcStepModel,
+    entity: { extractReferenceLocalID(
+      a: number, b: number, c: number, optional: boolean ): number | null },
+    field: readonly [number, number, number] ):
+    Promise< [number, number, number] | undefined > {
+
+  const directionID =
+    entity.extractReferenceLocalID( field[ 0 ], field[ 1 ], field[ 2 ], true )
+
+  if ( directionID === null ) {
+    return
+  }
+
+  await ensure_( model, directionID )
+  const direction = model.getElementByLocalID( directionID ) as
+    { DirectionRatios?: number[] } | undefined
+  const ratios = direction?.DirectionRatios
+
+  if ( ratios === void 0 || ratios.length < 2 ) {
+    return
+  }
+
+  return [ratios[ 0 ], ratios[ 1 ], ratios[ 2 ] ?? 0]
+}
+
+
+/**
+ * The 4x4 an IfcAxis2Placement3D denotes: Location as the translation,
+ * Axis as local +Z and RefDirection as local +X, both defaulting to the
+ * world axes when absent per the IFC defaults.
+ *
+ * Deliberately the same construction as conway-geom's
+ * `GetAxis2Placement3D` (ConwayGeometryProcessor.cpp) — normalize the
+ * two references, `y = normalize(z x x)`, then re-derive
+ * `x = normalize(y x z)` so a non-perpendicular RefDirection is
+ * projected rather than skewing the frame. It has to match: the plates
+ * are previewing meshes the durable pipeline places with that function,
+ * and a second convention here (Gram-Schmidt on x, say) would rotate
+ * them apart on any file whose RefDirection is off-perpendicular.
+ *
+ * One deviation, on degenerate input: where the C++ divides by a zero
+ * cross product and yields NaN, this falls back to the identity axes. A
+ * NaN transform reaching Share is an invisible or scene-destroying box,
+ * and the imposter path's standing rule is that a preview must never
+ * break open.
+ *
+ * @param model The model.
+ * @param axisLocalID The IfcAxis2Placement3D's local ID.
+ * @return {Promise<Mat4>} The placement, identity if unreadable.
+ */
+async function axisPlacementMatrix_(
+    model: IfcStepModel,
+    axisLocalID: number ): Promise< Mat4 > {
+
+  await ensure_( model, axisLocalID )
+  const placement = model.getElementByLocalID( axisLocalID )
+
+  if ( placement === void 0 ) {
+    return IDENTITY_PLACEMENT.slice()
+  }
+
+  let translation: [number, number, number] = [0, 0, 0]
+
+  const locationID = placement.extractReferenceLocalID(
+      PLACEMENT_LOCATION[ 0 ],
+      PLACEMENT_LOCATION[ 1 ],
+      PLACEMENT_LOCATION[ 2 ],
+      false )
+
+  if ( locationID !== null ) {
+
+    await ensure_( model, locationID )
+    const point = model.getElementByLocalID( locationID ) as
+      { Coordinates?: number[] } | undefined
+    const coords = point?.Coordinates
+
+    if ( coords !== void 0 && coords.length >= 2 ) {
+      translation = [coords[ 0 ], coords[ 1 ], coords[ 2 ] ?? 0]
+    }
+  }
+
+  const axisRatios =
+    await directionRatios_( model, placement, PLACEMENT_AXIS )
+  const refRatios =
+    await directionRatios_( model, placement, PLACEMENT_REF_DIRECTION )
+
+  let zAxis: [number, number, number] =
+    ( axisRatios !== void 0 ? normalize3_( axisRatios ) : void 0 ) ?? [0, 0, 1]
+  let refAxis: [number, number, number] =
+    ( refRatios !== void 0 ? normalize3_( refRatios ) : void 0 ) ?? [1, 0, 0]
+
+  let yAxis = normalize3_( cross3_( zAxis, refAxis ) )
+
+  if ( yAxis === void 0 ) {
+    // Axis and RefDirection parallel (or garbage): no frame is derivable
+    // from them, so keep the translation and drop back to world axes.
+    zAxis = [0, 0, 1]
+    refAxis = [1, 0, 0]
+    yAxis = [0, 1, 0]
+  }
+
+  const xAxis = normalize3_( cross3_( yAxis, zAxis ) ) ?? refAxis
+
+  return [
+    xAxis[ 0 ], xAxis[ 1 ], xAxis[ 2 ], 0,
+    yAxis[ 0 ], yAxis[ 1 ], yAxis[ 2 ], 0,
+    zAxis[ 0 ], zAxis[ 1 ], zAxis[ 2 ], 0,
+    translation[ 0 ], translation[ 1 ], translation[ 2 ], 1,
+  ]
+}
+
+
+/**
+ * The composed world transform of an IfcLocalPlacement chain: every
+ * link's IfcAxis2Placement3D built out in full and multiplied
+ * `parent * local`, which is exactly conway-geom's `GetLocalPlacement`.
+ *
+ * Rotation used to be dropped here — the chain summed Location
+ * translations and nothing else (conway#514's shortcut). That is correct
+ * only while every ancestor placement is axis-aligned, and Revit
+ * routinely rotates the site or building placement to true north, so on
+ * a real export every sampled origin landed unrotated in raw model space
+ * while the durable meshes beside it did not: the plate cloud read as a
+ * rotated ghost of the building (conway#517).
  *
  * @param model The model.
  * @param placementLocalID IfcObjectPlacement local ID.
- * @param cache Memo.
- * @return {Promise<[number, number, number] | undefined>} World origin.
+ * @param cache Memo of composed transforms, keyed by placement local ID.
+ * A placement re-entered while it is being composed (a cyclic RelativeTo)
+ * reads back undefined and stops the recursion.
+ * @return {Promise<Mat4 | undefined>} The world transform.
  */
-async function placementOrigin_(
+async function placementTransform_(
     model: IfcStepModel,
     placementLocalID: number,
-    cache: Map< number, [number, number, number] | undefined > ):
-    Promise< [number, number, number] | undefined > {
+    cache: Map< number, Mat4 | undefined > ): Promise< Mat4 | undefined > {
 
   if ( cache.has( placementLocalID ) ) {
     return cache.get( placementLocalID )
@@ -322,34 +507,9 @@ async function placementOrigin_(
         LOCAL_PLACEMENT_RELATIVE[ 2 ],
         false )
 
-    let local: [number, number, number] = [0, 0, 0]
-
-    if ( relativeID !== null ) {
-
-      await ensure_( model, relativeID )
-      const relative = model.getElementByLocalID( relativeID )
-
-      if ( relative !== void 0 ) {
-
-        const locationID = relative.extractReferenceLocalID(
-            PLACEMENT_LOCATION[ 0 ],
-            PLACEMENT_LOCATION[ 1 ],
-            PLACEMENT_LOCATION[ 2 ],
-            false )
-
-        if ( locationID !== null ) {
-
-          await ensure_( model, locationID )
-          const point = model.getElementByLocalID( locationID ) as
-            { Coordinates?: number[] } | undefined
-          const coords = point?.Coordinates
-
-          if ( coords !== void 0 && coords.length >= 2 ) {
-            local = [coords[ 0 ], coords[ 1 ], coords[ 2 ] ?? 0]
-          }
-        }
-      }
-    }
+    const local = relativeID !== null ?
+      await axisPlacementMatrix_( model, relativeID ) :
+      IDENTITY_PLACEMENT.slice()
 
     const parentID = entity.extractReferenceLocalID(
         LOCAL_PLACEMENT_REL_TO[ 0 ],
@@ -362,18 +522,8 @@ async function placementOrigin_(
       return local
     }
 
-    const parent = await placementOrigin_( model, parentID, cache )
-
-    if ( parent === void 0 ) {
-      cache.set( placementLocalID, local )
-      return local
-    }
-
-    const world: [number, number, number] = [
-      parent[ 0 ] + local[ 0 ],
-      parent[ 1 ] + local[ 1 ],
-      parent[ 2 ] + local[ 2 ],
-    ]
+    const parent = await placementTransform_( model, parentID, cache )
+    const world = parent === void 0 ? local : mat4MultiplyF64( parent, local )
 
     cache.set( placementLocalID, world )
     return world
@@ -383,11 +533,25 @@ async function placementOrigin_(
 }
 
 
-async function productOrigin_(
+/**
+ * @param transform A composed world transform.
+ * @return {[number, number, number]} Its translation column, i.e. where
+ * the placement's own origin lands in world space.
+ */
+function originOf_( transform: Mat4 ): [number, number, number] {
+
+  return [
+    transform[ TRANSLATION[ 0 ] ],
+    transform[ TRANSLATION[ 1 ] ],
+    transform[ TRANSLATION[ 2 ] ],
+  ]
+}
+
+
+async function productTransform_(
     model: IfcStepModel,
     localID: number,
-    cache: Map< number, [number, number, number] | undefined > ):
-    Promise< [number, number, number] | undefined > {
+    cache: Map< number, Mat4 | undefined > ): Promise< Mat4 | undefined > {
 
   await ensure_( model, localID )
   const entity = model.getElementByLocalID( localID )
@@ -406,7 +570,7 @@ async function productOrigin_(
     return
   }
 
-  return placementOrigin_( model, placementID, cache )
+  return placementTransform_( model, placementID, cache )
 }
 
 
@@ -676,7 +840,7 @@ export async function emitSpatialStructureImposters(
     }
   }
 
-  const originCache = new Map< number, [number, number, number] | undefined >()
+  const placementCache = new Map< number, Mat4 | undefined >()
 
   for ( const node of nodes.values() ) {
 
@@ -685,7 +849,11 @@ export async function emitSpatialStructureImposters(
       // IfcProject is an IfcContext, not an IfcProduct — field 5 is
       // not ObjectPlacement.
       if ( node.typeID !== EntityTypesIfc.IFCPROJECT ) {
-        node.origin = await productOrigin_( model, node.localID, originCache )
+
+        node.placement =
+          await productTransform_( model, node.localID, placementCache )
+        node.origin = node.placement !== void 0 ?
+          originOf_( node.placement ) : void 0
       }
 
       if ( STOREY_TYPES.has( node.typeID ) ) {
@@ -720,10 +888,11 @@ export async function emitSpatialStructureImposters(
     for ( let i = 0; i < products.length && origins.length < PRODUCT_SAMPLE; i += stride ) {
 
       try {
-        const origin = await productOrigin_( model, products[ i ], originCache )
+        const transform =
+          await productTransform_( model, products[ i ], placementCache )
 
-        if ( origin !== void 0 ) {
-          origins.push( origin )
+        if ( transform !== void 0 ) {
+          origins.push( originOf_( transform ) )
         }
       } catch {
         // Skip one product.
@@ -818,7 +987,7 @@ export async function emitSpatialStructureImposters(
       // storey placement on the datum.
       const storeyZ0 =
         STOREY_TYPES.has( node.typeID ) && node.elevation !== void 0 ?
-          storeyDatumZ_( localID, nodes, parentOf ) + node.elevation : void 0
+          storeyFloorZ_( localID, node.elevation, nodes, parentOf ) : void 0
 
       if ( node.origin !== void 0 ) {
 
@@ -865,7 +1034,12 @@ export async function emitSpatialStructureImposters(
         // elevation), but a file that parks every storey placement on
         // the building datum and carries the height only in Elevation
         // would then collapse all of its plates onto one Z. Storey
-        // HEIGHTS stay on elevation deltas — datum-invariant either way.
+        // HEIGHTS stay on elevation deltas — datum-invariant either way,
+        // though on a datum tilted out of plumb they over-thicken the
+        // plate by 1/cos(tilt) (the floor Z is tilt-correct; see
+        // storeyFloorZ_). Left alone: the sample-derived height fallback
+        // is already a world-Z span, so one scale cannot serve both, and
+        // a tilted building has no horizontal storeys to plate anyway.
         const z0 = storeyZ0 ?? node.origin?.[ 2 ] ?? box.min[ 2 ]
         const z1 = height !== void 0 ? z0 + height : box.max[ 2 ]
         box = {
@@ -946,22 +1120,33 @@ export async function emitSpatialStructureImposters(
 
 
 /**
- * World Z of the datum an IfcBuildingStorey's `Elevation` is measured
- * from — the nearest ancestor with a resolved placement, i.e. the
- * IfcBuilding in a well-formed file.
+ * World Z of an IfcBuildingStorey's floor: `Elevation` measured up the
+ * datum's own +Z from the datum's world origin, where the datum is the
+ * nearest ancestor with a resolved placement (the IfcBuilding in a
+ * well-formed file).
  *
- * Zero when nothing up the chain resolved one, which reads Elevation as
- * world-relative. That is the pre-fix behaviour and the only remaining
- * fallback: a storey whose ancestors have no usable placement gives us
- * nothing better to anchor on.
+ * Elevation is a length along the datum's Z, not along world Z, so the
+ * datum's whole transform is needed and not just its height — on a
+ * building tilted out of plumb the two differ by `cos(tilt)`. Only the
+ * Z component is taken, because that is all the banding uses: the plate
+ * keeps the XY footprint its placement and contained samples give it.
+ * A tilted building's storeys are not horizontal anyway, so the
+ * axis-aligned plate is an approximation there by construction — this
+ * just stops it being an approximation on the *height* as well.
+ *
+ * Falls back to a world-relative Elevation (datum at zero, +Z up) when
+ * nothing up the chain resolved a placement: the pre-fix behaviour, and
+ * the only thing left to anchor on.
  *
  * @param localID The storey.
+ * @param elevation The storey's `Elevation`, in source units.
  * @param nodes All walked nodes.
  * @param parentOf Child -> parent.
- * @return {number} The datum's world Z.
+ * @return {number} The floor's world Z.
  */
-function storeyDatumZ_(
+function storeyFloorZ_(
     localID: number,
+    elevation: number,
     nodes: Map< number, SpatialNode >,
     parentOf: Map< number, number > ): number {
 
@@ -972,16 +1157,17 @@ function storeyDatumZ_(
   // untrusted everywhere else too (see `computing` in aabbOf).
   for ( let hops = 0; id !== void 0 && hops <= nodes.size; ++hops ) {
 
-    const originZ = nodes.get( id )?.origin?.[ 2 ]
+    const placement = nodes.get( id )?.placement
 
-    if ( originZ !== void 0 ) {
-      return originZ
+    if ( placement !== void 0 ) {
+      return placement[ TRANSLATION[ 2 ] ] +
+        elevation * placement[ LOCAL_Z_WORLD_Z ]
     }
 
     id = parentOf.get( id )
   }
 
-  return 0
+  return elevation
 }
 
 
@@ -997,9 +1183,9 @@ function storeyDatumZ_(
  * Best-effort by construction, and the failure has two shapes. Beyond
  * LARGE_COORDINATE_BUDGET_M both sides snap to COORDINATION_SNAP_M and
  * agree as long as the spatial root and the first geometry share a grid
- * cell. Worse: the anchor comes from `placementOrigin_`, which sums
- * IfcLocalPlacement translations and never looks at geometry — so a file
- * that keeps identity placements and bakes absolute coordinates into the
+ * cell. Worse: the anchor comes from `placementTransform_`, which reads
+ * IfcLocalPlacement chains and never looks at geometry — so a file that
+ * keeps identity placements and bakes absolute coordinates into the
  * vertices (civil/GIS exports do this) has a root box near zero and gets
  * no recentre at all, while the durable walk anchors tens of km out and
  * does. That is a full site-offset, not a one-cell disagreement. Whenever

--- a/src/compat/web-ifc/store_preview_channel.test.ts
+++ b/src/compat/web-ifc/store_preview_channel.test.ts
@@ -255,6 +255,82 @@ describe( 'StorePreviewChannel', () => {
     channel.stop()
   } )
 
+  // Codex review on #519: IfcProject alone does not prove the scaling
+  // factor is resolvable — a valid file may forward-reference its
+  // IfcUnitAssignment, and a prefix holding the project but not the
+  // units record would emit (and latch) plates scaled by a silent 1.
+  test( 'early plates defer until the unit assignment is indexed', async () => {
+
+    /**
+     * Minimal spatial IFC: Project/Site/Building/Storey + aggregates +
+     * a placed wall, with the unit assignment optionally omitted.
+     *
+     * @param withUnits Include the IfcSiUnit/IfcUnitAssignment records.
+     * @return {Uint8Array} File bytes.
+     */
+    const syntheticIfc = ( withUnits: boolean ): Uint8Array => {
+
+      const units = withUnits ?
+        '#90=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);\n' +
+        '#91=IFCUNITASSIGNMENT((#90));\n' : ''
+
+      const text =
+        'ISO-10303-21;\nHEADER;\n' +
+        'FILE_DESCRIPTION((\'\'),\'2;1\');\n' +
+        'FILE_NAME(\'u.ifc\',\'2026-01-01T00:00:00\',(\'\'),(\'\'),\'\',\'\',\'\');\n' +
+        'FILE_SCHEMA((\'IFC4\'));\nENDSEC;\nDATA;\n' +
+        '#1=IFCCARTESIANPOINT((0.,0.,0.));\n' +
+        '#2=IFCAXIS2PLACEMENT3D(#1,$,$);\n' +
+        '#3=IFCLOCALPLACEMENT($,#2);\n' +
+        `#10=IFCPROJECT('3vP000000000000000001',$,'P',$,$,$,$,$,${
+          withUnits ? '#91' : '$'});\n` +
+        '#11=IFCSITE(\'3vP000000000000000002\',$,\'S\',$,$,#3,$,$,.ELEMENT.,$,$,$,$,$);\n' +
+        '#12=IFCBUILDING(\'3vP000000000000000003\',$,\'B\',$,$,#3,$,$,.ELEMENT.,$,$,$);\n' +
+        '#13=IFCBUILDINGSTOREY(\'3vP000000000000000004\',$,\'L0\',$,$,#3,$,$,.ELEMENT.,0.);\n' +
+        '#20=IFCRELAGGREGATES(\'3vP000000000000000005\',$,$,$,#10,(#11));\n' +
+        '#21=IFCRELAGGREGATES(\'3vP000000000000000006\',$,$,$,#11,(#12));\n' +
+        '#22=IFCRELAGGREGATES(\'3vP000000000000000007\',$,$,$,#12,(#13));\n' +
+        '#30=IFCWALL(\'3vP000000000000000008\',$,$,$,$,#3,$,$,$);\n' +
+        '#31=IFCRELCONTAINEDINSPATIALSTRUCTURE' +
+        '(\'3vP000000000000000009\',$,$,$,(#30),#13);\n' +
+        units +
+        'ENDSEC;\nEND-ISO-10303-21;\n'
+
+      return new TextEncoder().encode( text )
+    }
+
+    const runChannel = async ( fileBytes: Uint8Array ): Promise< number > => {
+
+      const sink = new ColumnarIndexSink< number >()
+
+      buildIndexStreaming(
+          new BufferByteSource( fileBytes ),
+          IfcStepParser.Instance,
+          4 * 1024,
+          void 0,
+          sink )
+
+      const channel = new StorePreviewChannel(
+          new InMemoryStepByteStore( fileBytes ), sink, conwayGeometry, true,
+          () => { /* plates counted via earlyPlateCount */ },
+          64, 48 * 1024 * 1024, 1 )
+
+      await channel.maybeTickAsync()
+
+      const count = channel.earlyPlateCount
+
+      channel.stop()
+      return count
+    }
+
+    // Without a unit assignment anywhere in the index, the guard defers
+    // — the end-of-parse walk covers such a file instead.
+    expect( await runChannel( syntheticIfc( false ) ) ).toBe( 0 )
+
+    // The same structure with units indexed emits immediately.
+    expect( await runChannel( syntheticIfc( true ) ) ).toBeGreaterThan( 0 )
+  } )
+
   test( 'open from store still leaves the source windowed', async () => {
 
     const store = new InMemoryStepByteStore( bytes )

--- a/src/compat/web-ifc/store_preview_channel.test.ts
+++ b/src/compat/web-ifc/store_preview_channel.test.ts
@@ -80,6 +80,71 @@ describe( 'StorePreviewChannel', () => {
     expect( channel.coordinationMatrix ).toBeDefined()
   } )
 
+  // conway#518: the store path used to extract exactly ONE product per
+  // tick, on a 150ms->600ms decaying cadence.
+  test( 'a tick extracts under a time budget, not one product', async () => {
+
+    const store = new InMemoryStepByteStore( bytes )
+    const sink = new ColumnarIndexSink< number >()
+    const { result } = buildIndexStreaming(
+        new BufferByteSource( bytes ),
+        IfcStepParser.Instance,
+        4 * 1024,
+        void 0,
+        sink )
+
+    expect( result ).toBe( ParseResult.COMPLETE )
+
+    const channel = new StorePreviewChannel(
+        store, sink, conwayGeometry, true, () => { /* counted below */ },
+        64, 48 * 1024 * 1024, 1 )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = channel as any
+
+    // Lift the wall clock the way the streamed channel's test does: the
+    // assertion is about how many products ONE tick consumes, and a real
+    // 20ms budget makes that a coin flip on a loaded runner.
+    internals.tickBudgetMs_ = Number.MAX_SAFE_INTEGER
+
+    await channel.maybeTickAsync()
+
+    const attempted = internals.unitOrdinal_ as number
+
+    // Capped by TICK_MAX_ATTEMPTS, and emphatically more than the one
+    // product the pre-#518 tick managed.
+    expect( attempted ).toBeGreaterThan( 1 )
+    expect( attempted ).toBeLessThanOrEqual(
+        internals.tickMaxAttempts_ as number )
+
+    channel.stop()
+  } )
+
+  test( 'an unproductive tick does not decay the cadence', async () => {
+
+    const sink = new ColumnarIndexSink< number >()
+
+    // Nothing parsed into the sink, so no generation can build. Every
+    // such tick used to pay the interval decay anyway, cooling the
+    // cadence toward its 600ms ceiling before there was ever anything
+    // to extract.
+    const channel = new StorePreviewChannel(
+        new InMemoryStepByteStore( bytes ),
+        sink, conwayGeometry, true, () => { /* nothing emits */ } )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = channel as any
+
+    for ( let tick = 0; tick < 5; ++tick ) {
+      internals.lastInlineTick_ = 0
+      await channel.maybeTickAsync()
+    }
+
+    expect( internals.tickIntervalMs_ ).toBe( 150 )
+
+    channel.stop()
+  } )
+
   test( 'open from store still leaves the source windowed', async () => {
 
     const store = new InMemoryStepByteStore( bytes )

--- a/src/compat/web-ifc/store_preview_channel.test.ts
+++ b/src/compat/web-ifc/store_preview_channel.test.ts
@@ -180,15 +180,80 @@ describe( 'StorePreviewChannel', () => {
         expect( plates[ 0 ].geometryExpressID ).toBe( -1 )
         expect( plates[ 0 ].flatTransformation ).toHaveLength( 16 )
 
-        // A successful walk is not repeated on later generations.
+        // The walk necessarily ran before any product could latch a
+        // coordination frame, so it used the imposter walk's own
+        // fallback derivation.
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        expect( ( channel as any ).earlyPlatesUsedFallbackFrame_ ).toBe( true )
+
         const first = channel.earlyPlateCount
 
         await channel.drainForTest()
 
-        expect( channel.earlyPlateCount ).toBe( first )
+        // Draining latches a real frame off the first captured product.
+        expect( channel.coordinationMatrix ).toBeDefined()
 
         channel.stop()
+
+        expect( channel.earlyPlateCount ).toBeGreaterThanOrEqual( first )
       } )
+
+  test( 'early plates are re-emitted once a real frame latches', async () => {
+
+    const store = new InMemoryStepByteStore( bytes )
+    const sink = new ColumnarIndexSink< number >()
+
+    buildIndexStreaming(
+        new BufferByteSource( bytes ),
+        IfcStepParser.Instance,
+        4 * 1024,
+        void 0,
+        sink )
+
+    const payloads: PreviewMeshPayload[] = []
+    const channel = new StorePreviewChannel(
+        store, sink, conwayGeometry, true,
+        ( mesh ) => payloads.push( mesh ),
+        64, 48 * 1024 * 1024, 1 )
+
+    await channel.drainForTest()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = channel as any
+
+    expect( internals.earlyPlatesUsedFallbackFrame_ ).toBe( true )
+    expect( channel.coordinationMatrix ).toBeDefined()
+
+    const before = payloads.filter( ( p ) => p.aabb !== void 0 ).length
+
+    // Let a fresh generation build now that a frame exists — normally
+    // an index doubling does this mid-parse. Retiring the active
+    // generation is what makes ensureGeneration_ take the build path;
+    // rewinding the ordinal alone would just keep the current one.
+    internals.disposeGeneration_()
+    internals.lastSnapshotRecords_ = 0
+    internals.unitOrdinal_ = 0
+
+    await channel.drainForTest()
+
+    const after = payloads.filter( ( p ) => p.aabb !== void 0 ).length
+
+    // The plates came again, this time under the latched frame. Under
+    // the replace-by-expressID contract that is a correction, not a
+    // duplicate — and it does not happen a third time.
+    expect( after ).toBeGreaterThan( before )
+    expect( internals.earlyPlatesUsedFallbackFrame_ ).toBe( false )
+
+    internals.disposeGeneration_()
+    internals.lastSnapshotRecords_ = 0
+    internals.unitOrdinal_ = 0
+
+    await channel.drainForTest()
+
+    expect( payloads.filter( ( p ) => p.aabb !== void 0 ).length ).toBe( after )
+
+    channel.stop()
+  } )
 
   test( 'open from store still leaves the source windowed', async () => {
 

--- a/src/compat/web-ifc/store_preview_channel.test.ts
+++ b/src/compat/web-ifc/store_preview_channel.test.ts
@@ -61,27 +61,29 @@ describe( 'StorePreviewChannel', () => {
 
     channel.stop()
 
-    const withGeom = payloads.filter( ( p ) => p.vertexData !== void 0 )
+    // The channel now emits spatial plates off its prefix generations
+    // too (conway#518), so the placed meshes are the aabb-less half of
+    // the stream rather than all of it.
+    const meshes = payloads.filter( ( p ) => p.aabb === void 0 )
+    const withGeom = meshes.filter( ( p ) => p.vertexData !== void 0 )
 
     // index.ifc is polygonal-faceset; some local Dist builds OOB on the
     // packed extract (same as ifc_api_preview_channel). The channel
-    // still found products. When extract works, payloads are placed
-    // meshes — not AABB imposters.
-    if ( payloads.length === 0 ) {
+    // still found products.
+    if ( meshes.length === 0 ) {
       return
     }
 
     expect( withGeom.length ).toBeGreaterThan( 0 )
-    expect( payloads[ 0 ].flatTransformation ).toHaveLength( 16 )
-    expect( payloads[ 0 ].aabb ).toBeUndefined()
-    expect( payloads[ 0 ].solid ).toBeUndefined()
+    expect( meshes[ 0 ].flatTransformation ).toHaveLength( 16 )
+    expect( meshes[ 0 ].solid ).toBeUndefined()
     expect( withGeom[ 0 ].vertexData!.length % 6 ).toBe( 0 )
     expect( withGeom[ 0 ].indexData!.length % 3 ).toBe( 0 )
     expect( channel.coordinationMatrix ).toBeDefined()
   } )
 
   // conway#518: the store path used to extract exactly ONE product per
-  // tick, on a 150ms->600ms decaying cadence.
+  // tick, and to run the spatial walk only after the whole parse.
   test( 'a tick extracts under a time budget, not one product', async () => {
 
     const store = new InMemoryStepByteStore( bytes )
@@ -141,9 +143,52 @@ describe( 'StorePreviewChannel', () => {
     }
 
     expect( internals.tickIntervalMs_ ).toBe( 150 )
+    expect( channel.earlyPlateCount ).toBe( 0 )
 
     channel.stop()
   } )
+
+  test( 'spatial plates come off a prefix generation, before parse end',
+      async () => {
+
+        const store = new InMemoryStepByteStore( bytes )
+        const sink = new ColumnarIndexSink< number >()
+
+        buildIndexStreaming(
+            new BufferByteSource( bytes ),
+            IfcStepParser.Instance,
+            4 * 1024,
+            void 0,
+            sink )
+
+        const payloads: PreviewMeshPayload[] = []
+        const channel = new StorePreviewChannel(
+            store, sink, conwayGeometry, true,
+            ( mesh ) => payloads.push( mesh ),
+            64, 48 * 1024 * 1024, 1 )
+
+        // One tick is enough: the walk runs as the generation is built,
+        // ahead of any product extraction.
+        await channel.maybeTickAsync()
+
+        expect( channel.earlyPlateCount ).toBeGreaterThan( 0 )
+
+        const plates = payloads.filter( ( p ) => p.aabb !== void 0 )
+
+        expect( plates.length ).toBe( channel.earlyPlateCount )
+        expect( plates[ 0 ].color ).toEqual( { x: 0, y: 0, z: 0, w: 0.3 } )
+        expect( plates[ 0 ].geometryExpressID ).toBe( -1 )
+        expect( plates[ 0 ].flatTransformation ).toHaveLength( 16 )
+
+        // A successful walk is not repeated on later generations.
+        const first = channel.earlyPlateCount
+
+        await channel.drainForTest()
+
+        expect( channel.earlyPlateCount ).toBe( first )
+
+        channel.stop()
+      } )
 
   test( 'open from store still leaves the source windowed', async () => {
 

--- a/src/compat/web-ifc/store_preview_channel.ts
+++ b/src/compat/web-ifc/store_preview_channel.ts
@@ -26,6 +26,28 @@ import {
 const TICK_INTERVAL_MS = 150
 const TICK_INTERVAL_MAX_MS = 600
 const TICK_INTERVAL_GROWTH = 1.1
+
+/**
+ * Extraction + capture budget per tick, mirroring
+ * {@link StreamedPreviewChannel}'s. The store path used to extract
+ * exactly ONE product per tick on the interval below, i.e. 2-7
+ * products/second — which is why PSB's preview arrived girder by girder
+ * where the resident path delivered batches (conway#518).
+ */
+const TICK_BUDGET_MS = 20
+
+/**
+ * Products a single tick may attempt, whatever the clock says.
+ *
+ * `deferDanglingPlacements` (Share#1744) defers any product whose
+ * placement records the prefix does not hold yet, and Revit writes
+ * per-product placements toward the file tail — so early ticks meet long
+ * runs of products that cannot extract. Each such attempt still pages
+ * source through the windowed provider, so a run of them is not free;
+ * this caps the run rather than letting the deadline be the only bound.
+ */
+const TICK_MAX_ATTEMPTS = 32
+
 const FIRST_GENERATION_MIN_RECORDS = 1024
 const GENERATION_GROWTH_FACTOR = 2.0
 const DEFAULT_MAX_PREVIEW_UNITS = 512
@@ -39,10 +61,10 @@ const FLUSH_BUDGET_MS = 100
  * Parse-time placed-mesh preview for a windowed (store-backed) open.
  *
  * Twin of {@link StreamedPreviewChannel}: same capture math and
- * COORDINATE_TO_ORIGIN frame, but the prefix model pages product
- * closures from `store` instead of a resident buffer. After each
- * product the pins drop, so peak source residency stays the windowed
- * LRU — not the file.
+ * COORDINATE_TO_ORIGIN frame, same time-budgeted tick, but the prefix
+ * model pages product closures from `store` instead of a resident
+ * buffer. After each product the pins drop, so peak source residency
+ * stays the windowed LRU — not the file.
  */
 export class StorePreviewChannel {
 
@@ -57,6 +79,13 @@ export class StorePreviewChannel {
   private lastSnapshotRecords_ = 0
   private lastFailedSnapshotRecords_ = 0
   lastFailReason?: string
+
+  // Fields rather than the constants directly, so a test can lift the
+  // wall-clock bounds the way ifc_api_preview_channel.test.ts already
+  // lifts the streamed channel's: asserting "this tick ran N products"
+  // against a real 20ms budget is a coin flip on a loaded runner.
+  private tickBudgetMs_ = TICK_BUDGET_MS
+  private tickMaxAttempts_ = TICK_MAX_ATTEMPTS
 
   private readonly emittedGeometry_ = new Set< number >()
 
@@ -104,11 +133,28 @@ export class StorePreviewChannel {
   }
 
   /**
-   * One cadence-gated tick. No-op until the interval elapses or the
-   * index can support a generation. Safe to call from parse progress.
+   * One cadence-gated, time-budgeted tick. No-op until the interval
+   * elapses or the index can support a generation. Safe to call from
+   * parse progress.
    *
-   * @return {Promise<void>} Settles when this tick's product (if any)
-   * is captured.
+   * **Cadence and budget interact once, not twice.** The interval is
+   * measured tick-start to tick-start (`lastInlineTick_` is stamped
+   * before the work, as on the streamed channel), so a tick that spends
+   * its whole budget shortens the gap to the next one by that budget
+   * rather than adding to it. And the decay is charged only to ticks
+   * that actually attempted a product: a tick that found no generation —
+   * which is every tick through the opening seconds of a big parse, when
+   * the index has not yet reached FIRST_GENERATION_MIN_RECORDS — used to
+   * decay the interval anyway, so by the time there was anything to
+   * extract the cadence had already cooled toward
+   * TICK_INTERVAL_MAX_MS. Deliberately divergent from
+   * {@link StreamedPreviewChannel}, which decays unconditionally; the
+   * cost is that a channel which never finds a generation keeps probing
+   * at TICK_INTERVAL_MS, and a probe that finds nothing is a record
+   * count compared against two thresholds.
+   *
+   * @return {Promise<void>} Settles when this tick's products (if any)
+   * are captured.
    */
   public async maybeTickAsync(): Promise< void > {
 
@@ -123,14 +169,41 @@ export class StorePreviewChannel {
     }
 
     this.lastInlineTick_ = now
-    this.tickIntervalMs_ =
-      Math.min( this.tickIntervalMs_ * TICK_INTERVAL_GROWTH, TICK_INTERVAL_MAX_MS )
 
     try {
-      await this.tickOnce_()
+
+      if ( ( await this.tickBudgeted_() ) > 0 ) {
+        this.tickIntervalMs_ = Math.min(
+            this.tickIntervalMs_ * TICK_INTERVAL_GROWTH, TICK_INTERVAL_MAX_MS )
+      }
     } catch {
       this.stopped_ = true
     }
+  }
+
+  /**
+   * Attempt products until the time budget or the attempt cap runs out,
+   * whichever comes first.
+   *
+   * @return {Promise<number>} Products attempted this tick.
+   */
+  private async tickBudgeted_(): Promise< number > {
+
+    const deadline = Date.now() + this.tickBudgetMs_
+    let attempts = 0
+
+    while ( !this.capped &&
+        attempts < this.tickMaxAttempts_ &&
+        Date.now() < deadline ) {
+
+      if ( !( await this.tickOnce_() ) ) {
+        break
+      }
+
+      ++attempts
+    }
+
+    return attempts
   }
 
   /**

--- a/src/compat/web-ifc/store_preview_channel.ts
+++ b/src/compat/web-ifc/store_preview_channel.ts
@@ -6,6 +6,7 @@ import { IfcGeometryExtraction } from '../../ifc/ifc_geometry_extraction'
 import {
   IfcBuildingStorey,
   IfcProduct,
+  IfcProject,
   IfcRelAggregates,
 } from '../../ifc/ifc4_gen'
 import { ColumnarIndexSink } from '../../step/parsing/columnar_index'
@@ -100,6 +101,14 @@ export class StorePreviewChannel {
 
   /** Set once a prefix-generation spatial walk has emitted a plate. */
   private earlyPlatesEmitted_ = 0
+
+  /**
+   * Whether those plates were composed under the walk's own fallback
+   * frame because no preview instance had latched one yet. They get one
+   * re-emission on a later generation once a real frame exists — see
+   * {@link maybeEmitEarlySpatialPlates_}.
+   */
+  private earlyPlatesUsedFallbackFrame_ = false
 
   private readonly emittedGeometry_ = new Set< number >()
 
@@ -446,9 +455,23 @@ export class StorePreviewChannel {
    * **The end-of-parse walk in the proxy is the refresh, not a
    * duplicate.** It re-emits the same expressIDs with contained-product
    * samples the prefix did not hold and under the frame the channel
-   * latched (which may not yet exist here — see below), and the consumer
-   * contract is that an `aabb` payload REPLACES the prior plate for its
-   * expressID. Double emission is the design; see PreviewMeshPayload.
+   * latched, and the consumer contract is that an `aabb` payload
+   * REPLACES the prior plate for its expressID. Double emission is the
+   * design; see PreviewMeshPayload.
+   *
+   * **Known gap in that contract, and it is a gap, not a subtlety.**
+   * Replacement only reaches nodes the final walk still emits, and the
+   * emit set is not stable between the two: `aabbMostlyEqual` collapses
+   * a single-child wrapper (Project over Site over Building) once its
+   * box matches its child's, which a prefix generation's degenerate
+   * boxes may not yet do. A wrapper emitted here and collapsed there is
+   * never replaced and never removed — the payload contract has no
+   * delete — so its early box lingers as one small plate until Share
+   * tears the preview scenery down at load end. Bounded (the wrapper
+   * chain is a handful of nodes, and the collapse needs exactly one
+   * child), but real. Closing it properly needs either a delete/
+   * generation channel in the payload contract or an emit set the two
+   * walks agree on, and both are consumer-side changes.
    *
    * @param model The prefix model.
    * @param extraction Its prepared extraction.
@@ -458,34 +481,57 @@ export class StorePreviewChannel {
       model: IfcStepModel,
       extraction: IfcGeometryExtraction ): Promise< void > {
 
-    if ( this.earlyPlatesEmitted_ > 0 ) {
+    // Same choice the proxy's imposterCoordination() makes: the latched
+    // preview frame when the open asked to coordinate, else identity.
+    const coordination = this.coordinateToOrigin_ ?
+      this.coordinationMatrix : IDENTITY_MAT4
+
+    // This runs as a generation is BUILT, before that tick captures its
+    // first product — and capture is the only thing that latches a
+    // frame. So the first walk on a coordinating open always finds
+    // `undefined` here and takes the walk's fallback derivation, which
+    // its own docs describe as capable of a full site-offset on a file
+    // that bakes absolute coordinates into vertices behind identity
+    // placements. Waiting for a latched frame instead would put the
+    // skeleton back behind the deferred-placement gate this whole change
+    // exists to get in front of, so: emit now, and re-emit ONCE on a
+    // later generation as soon as a real frame exists. That second
+    // emission is exactly what the replace-by-expressID contract is for.
+    const usingFallbackFrame = coordination === void 0
+    const canImproveFrame =
+      this.earlyPlatesUsedFallbackFrame_ && !usingFallbackFrame
+
+    if ( this.earlyPlatesEmitted_ > 0 && !canImproveFrame ) {
       return
     }
 
     try {
 
-      // Cheap prefix-sum reads, so this is affordable per generation:
-      // no storeys or no aggregate chain means the walk would emit
-      // nothing but still pay for the type scans.
-      if ( model.typeCount( IfcBuildingStorey ) < 1 ||
+      // Cheap prefix-sum reads, so this is affordable per generation.
+      // No storeys or no aggregate chain means the walk would emit
+      // nothing but still pay for the type scans. IfcProject is in the
+      // guard for a different reason: `extractLinearScalingFactor`
+      // returns with the factor still at 1 when the model holds no
+      // project (it only logs), and a silent 1 on a millimetre model
+      // scales the whole skeleton 1000x — the conway#515 symptom. A
+      // prefix that reached the storeys but not the project is unusual,
+      // not impossible, and the read costs one prefix sum.
+      if ( model.typeCount( IfcProject ) < 1 ||
+          model.typeCount( IfcBuildingStorey ) < 1 ||
           model.typeCount( IfcRelAggregates ) < 1 ) {
         return
       }
 
-      // Same choice the proxy's imposterCoordination() makes: the
-      // latched preview frame when the open asked to coordinate, else
-      // identity. Undefined here (no product has been captured yet, so
-      // nothing has latched) sends the walk to its own fallback
-      // derivation — and if the channel later latches a different frame,
-      // the end-of-parse refresh re-emits these plates under it.
-      const coordination = this.coordinateToOrigin_ ?
-        this.coordinationMatrix : IDENTITY_MAT4
-
-      this.earlyPlatesEmitted_ = await emitSpatialStructureImposters(
+      const emitted = await emitSpatialStructureImposters(
           model,
           this.onMesh_,
           coordination,
           extraction.getLinearScalingFactor() )
+
+      if ( emitted > 0 ) {
+        this.earlyPlatesEmitted_ = emitted
+        this.earlyPlatesUsedFallbackFrame_ = usingFallbackFrame
+      }
     } catch {
       // A failed early walk retries on the next generation; the
       // end-of-parse walk covers it regardless.

--- a/src/compat/web-ifc/store_preview_channel.ts
+++ b/src/compat/web-ifc/store_preview_channel.ts
@@ -8,6 +8,7 @@ import {
   IfcProduct,
   IfcProject,
   IfcRelAggregates,
+  IfcUnitAssignment,
 } from '../../ifc/ifc4_gen'
 import { ColumnarIndexSink } from '../../step/parsing/columnar_index'
 import { cursorIterator } from '../../indexing/cursor_utilities'
@@ -509,14 +510,23 @@ export class StorePreviewChannel {
 
       // Cheap prefix-sum reads, so this is affordable per generation.
       // No storeys or no aggregate chain means the walk would emit
-      // nothing but still pay for the type scans. IfcProject is in the
-      // guard for a different reason: `extractLinearScalingFactor`
-      // returns with the factor still at 1 when the model holds no
-      // project (it only logs), and a silent 1 on a millimetre model
-      // scales the whole skeleton 1000x — the conway#515 symptom. A
-      // prefix that reached the storeys but not the project is unusual,
-      // not impossible, and the read costs one prefix sum.
+      // nothing but still pay for the type scans. IfcProject and
+      // IfcUnitAssignment are in the guard for a different reason:
+      // `extractLinearScalingFactor` returns with the factor still at 1
+      // when it cannot resolve the project's UnitsInContext (it only
+      // logs), and a silent 1 on a millimetre model scales the whole
+      // skeleton 1000x — the conway#515 symptom. The project alone is
+      // not enough: a valid file may forward-reference its
+      // IfcUnitAssignment, so a prefix can hold the project while the
+      // units record is still ahead of the parse cursor, and because a
+      // successful walk latches `earlyPlatesEmitted_`, mis-scaled early
+      // plates would stand until the frame-improvement re-emit or the
+      // post-parse refresh (Codex review on #519). The guard therefore
+      // defers plates until the units record is indexed; a file with
+      // genuinely no unit assignment never emits EARLY plates and is
+      // covered by the end-of-parse walk instead.
       if ( model.typeCount( IfcProject ) < 1 ||
+          model.typeCount( IfcUnitAssignment ) < 1 ||
           model.typeCount( IfcBuildingStorey ) < 1 ||
           model.typeCount( IfcRelAggregates ) < 1 ) {
         return

--- a/src/compat/web-ifc/store_preview_channel.ts
+++ b/src/compat/web-ifc/store_preview_channel.ts
@@ -3,7 +3,11 @@ import { CanonicalMaterial } from '../../index'
 import { CanonicalMeshType } from '../../index'
 import IfcStepModel from '../../ifc/ifc_step_model'
 import { IfcGeometryExtraction } from '../../ifc/ifc_geometry_extraction'
-import { IfcProduct } from '../../ifc/ifc4_gen'
+import {
+  IfcBuildingStorey,
+  IfcProduct,
+  IfcRelAggregates,
+} from '../../ifc/ifc4_gen'
 import { ColumnarIndexSink } from '../../step/parsing/columnar_index'
 import { cursorIterator } from '../../indexing/cursor_utilities'
 import { WindowedStepBufferProvider } from '../../step/step_buffer_provider'
@@ -13,8 +17,10 @@ import * as glmatrix from 'gl-matrix'
 import {
   composeTransformF64,
   deriveCoordinationF64,
+  IDENTITY_MAT4,
   NORMALIZE_MAT_F64,
 } from './coordination_f64'
+import { emitSpatialStructureImposters } from './spatial_imposter'
 import {
   PreviewMeshPayload,
   releaseModelGeometry,
@@ -65,6 +71,11 @@ const FLUSH_BUDGET_MS = 100
  * model pages product closures from `store` instead of a resident
  * buffer. After each product the pins drop, so peak source residency
  * stays the windowed LRU — not the file.
+ *
+ * It also runs the spatial-structure walk off its own prefix
+ * generations, so the building's skeleton goes up in the first seconds
+ * of a long parse rather than after it — see
+ * {@link maybeEmitEarlySpatialPlates_}.
  */
 export class StorePreviewChannel {
 
@@ -86,6 +97,9 @@ export class StorePreviewChannel {
   // against a real 20ms budget is a coin flip on a loaded runner.
   private tickBudgetMs_ = TICK_BUDGET_MS
   private tickMaxAttempts_ = TICK_MAX_ATTEMPTS
+
+  /** Set once a prefix-generation spatial walk has emitted a plate. */
+  private earlyPlatesEmitted_ = 0
 
   private readonly emittedGeometry_ = new Set< number >()
 
@@ -130,6 +144,14 @@ export class StorePreviewChannel {
   /** Products the current generation would run (test seam). */
   public get productCount(): number {
     return this.generation_?.products.length ?? 0
+  }
+
+  /**
+   * Plates the prefix-generation spatial walk emitted, 0 while it has
+   * not succeeded (see {@link maybeEmitEarlySpatialPlates_}).
+   */
+  public get earlyPlateCount(): number {
+    return this.earlyPlatesEmitted_
   }
 
   /**
@@ -383,11 +405,90 @@ export class StorePreviewChannel {
       this.lastSnapshotRecords_ = records
       this.lastFailedSnapshotRecords_ = 0
       this.lastFailReason = void 0
+
+      await this.maybeEmitEarlySpatialPlates_( model, extraction )
+
       return true
     } catch ( error ) {
       this.lastFailedSnapshotRecords_ = records
       this.lastFailReason = error instanceof Error ? error.message : String( error )
       return false
+    }
+  }
+
+  /**
+   * Put the spatial skeleton up from a PREFIX generation, seconds into
+   * the parse instead of after it (conway#518).
+   *
+   * The spatial records sit at the file head on Revit exports — on PSB
+   * `IFCSITE` is record #211 — and a prefix generation is already
+   * everything the walk needs: a columns snapshot over a windowed
+   * provider, with `prepareDemandExtraction(true)` done, which is what
+   * makes `getLinearScalingFactor()` report real units rather than 1.
+   * So the plates can lead the first extracted product rather than
+   * trailing the whole parse, which is what the store path's three
+   * stacked latency gates (one product per tick, early products
+   * deferring on late placements, the walk waiting for the full index)
+   * added up to: a blank screen through the first ~60% of a 16.7 s
+   * parse.
+   *
+   * **Runs at most once successfully, on the parse's cooperative path.**
+   * The walk is reused as-is, with no internal budget: it awaits a
+   * residency ensure per spatial node and per sampled product placement
+   * (PRODUCT_SAMPLE per node), so its cost tracks the prefix's spatial
+   * tree, not the file. On the first qualifying generation that tree is
+   * small by construction — the storeys exist but few
+   * `IfcRelContainedInSpatialStructure` do — which is the same property
+   * that makes these early plates coarse. Retries are bounded without a
+   * counter: generations only rebuild on a GENERATION_GROWTH_FACTOR
+   * doubling of the index, so there are O(log records) of them.
+   *
+   * **The end-of-parse walk in the proxy is the refresh, not a
+   * duplicate.** It re-emits the same expressIDs with contained-product
+   * samples the prefix did not hold and under the frame the channel
+   * latched (which may not yet exist here — see below), and the consumer
+   * contract is that an `aabb` payload REPLACES the prior plate for its
+   * expressID. Double emission is the design; see PreviewMeshPayload.
+   *
+   * @param model The prefix model.
+   * @param extraction Its prepared extraction.
+   * @return {Promise<void>} Settles when the walk has run or been skipped.
+   */
+  private async maybeEmitEarlySpatialPlates_(
+      model: IfcStepModel,
+      extraction: IfcGeometryExtraction ): Promise< void > {
+
+    if ( this.earlyPlatesEmitted_ > 0 ) {
+      return
+    }
+
+    try {
+
+      // Cheap prefix-sum reads, so this is affordable per generation:
+      // no storeys or no aggregate chain means the walk would emit
+      // nothing but still pay for the type scans.
+      if ( model.typeCount( IfcBuildingStorey ) < 1 ||
+          model.typeCount( IfcRelAggregates ) < 1 ) {
+        return
+      }
+
+      // Same choice the proxy's imposterCoordination() makes: the
+      // latched preview frame when the open asked to coordinate, else
+      // identity. Undefined here (no product has been captured yet, so
+      // nothing has latched) sends the walk to its own fallback
+      // derivation — and if the channel later latches a different frame,
+      // the end-of-parse refresh re-emits these plates under it.
+      const coordination = this.coordinateToOrigin_ ?
+        this.coordinationMatrix : IDENTITY_MAT4
+
+      this.earlyPlatesEmitted_ = await emitSpatialStructureImposters(
+          model,
+          this.onMesh_,
+          coordination,
+          extraction.getLinearScalingFactor() )
+    } catch {
+      // A failed early walk retries on the next generation; the
+      // end-of-parse walk covers it regardless.
     }
   }
 

--- a/src/compat/web-ifc/streamed_preview_channel.ts
+++ b/src/compat/web-ifc/streamed_preview_channel.ts
@@ -75,6 +75,18 @@ export interface PreviewMeshPayload {
    * Reported in RAW IFC source-unit space as a consumer reference — the
    * `flatTransformation` beside it is in the durable coordination frame
    * like every other payload's, so that is what places the cube.
+   *
+   * **Re-emission replaces, it does not add.** An `aabb` payload
+   * carrying an `expressID` the consumer has already drawn a plate for
+   * REPLACES that plate; consumers key imposters by expressID rather
+   * than by arrival order. The store path emits each spatial node twice
+   * by design (conway#518): once early, off a prefix generation that
+   * holds the storeys but few of their contained products, and again
+   * after the parse with the full sample set and the finally-latched
+   * coordination frame. The early plate can be coarse — a Z band from
+   * elevations with a degenerate XY footprint — and the second emission
+   * is what corrects it. Vertex-carrying payloads are unaffected: those
+   * are keyed by `geometryExpressID` and never re-sent.
    */
   aabb?: { min: [number, number, number], max: [number, number, number] }
   /**


### PR DESCRIPTION
Follow-ups to #516, both observed on the [1.516.1463 PSB smoke](https://github.com/bldrs-ai/Share/pull/1753). Adds five commits on top of `claude/psb-30-review-juca6l` (already merged to main via #516), so the diff here is only what is new.

Closes #517
Closes #518
Part of #390
References #515, #516. Consumer: Share#1753.

---

## #517 — the plates were in the right frame but the wrong orientation

`placementOrigin_` walked the `IfcLocalPlacement` chain **summing `Location` translations and ignoring rotation outright** — #514's shortcut, and correct only while every ancestor placement is axis-aligned. Revit rotates the site/building placement to true north as a matter of course, so on PSB every sampled origin landed unrotated in raw model space while the durable meshes did not: the plate cloud read as a rotated ghost of the building.

**What changed.** Each link's `IfcAxis2Placement3D` is now built out in full — `Location` as the translation, `Axis` as local +Z, `RefDirection` as local +X, world axes by IFC default when absent — and composed `parent * local` down the chain. The construction deliberately mirrors conway-geom's `GetAxis2Placement3D` / `GetLocalPlacement` (normalize both references, `y = normalize(z × x)`, then re-derive `x = normalize(y × z)`), because a second convention here would rotate the plates away from the meshes they preview on any file whose `RefDirection` is off-perpendicular. One deliberate deviation: degenerate axes fall back to the identity frame where the C++ divides by a zero cross product and yields NaN — a NaN transform reaching Share is a scene-destroying box, and a preview must never break the open.

The memo caches composed matrices rather than origins; a sample point is its matrix's translation column. Storey banding follows from that: the datum's whole transform is kept, so `Elevation` is measured up **the datum's own +Z** from the datum's world origin rather than added to a bare world Z.

Everything stays in raw IFC source units — the coordination frame `C` still applies on top exactly as in #516.

Two cases the translation-summing predecessor tolerated by never looking past `Location`, both found in review and fixed in `97df255d`:

- **2D relative placements.** `IfcLocalPlacement.RelativePlacement` admits `IfcAxis2Placement2D`, whose field 1 is `RefDirection` (not `Axis`) and which has no field 2 at all, so reading the 3D direction fields throws. That throw memoized an `undefined` placement, and every *descendant* then composed in local coordinates — silently reparenting a subtree to the origin. The direction fields are now read only once the type is confirmed 3D.
- **`Axis` with no `RefDirection`.** The IFC default `RefDirection` is parallel to `Axis = (1,0,0)` — the ordinary lie-down placement — so the cross product degenerated and the whole rotation was thrown away with it. `defaultRefDirection_` now substitutes a perpendicular reference the way IFC's own `IfcFirstProjAxis` does.

**Known residual, documented in place:** storey *heights* still come from elevation deltas, so a datum tilted out of plumb over-thickens the plate by `1/cos(tilt)`. The floor Z is tilt-correct; the height is not, because the sample-derived height fallback is already a world-Z span and one scale cannot serve both. A tilted building has no horizontal storeys to plate anyway.

## #518a — one product per tick

`tickOnce_` extracted exactly one product per tick on a 150 ms→600 ms decaying cadence: 2–7 products/second, which is why the smoke showed a single girder arriving segment by segment where the resident path delivers batches. Now it loops under a ~20 ms deadline capped at 32 attempts, whichever comes first — the shape `StreamedPreviewChannel` has always had. `tickOnce_` stays the primitive, so per-product pin/release hygiene is untouched and `flushAsync`/`drainForTest` keep their own bounds.

**Cadence interaction, settled rather than left implicit.** Two decisions, both documented on `maybeTickAsync`:

- The interval is measured **tick-start to tick-start** (`lastInlineTick_` stamped before the work, as on the streamed channel), so a tick that spends its whole budget shortens the gap to the next one by that budget rather than adding to it. The budget is paid once, not twice.
- The decay is **charged only to ticks that attempted a product**. Every tick through the opening seconds of a big parse finds no generation (the index has not reached `FIRST_GENERATION_MIN_RECORDS`) and used to decay the interval anyway, so the cadence had already cooled toward 600 ms by the time there was anything to extract. This diverges from `StreamedPreviewChannel`, which decays unconditionally; the cost is that a channel which never finds a generation keeps probing at 150 ms, and a probe that finds nothing is a record count compared against two thresholds.

The attempt cap exists because `deferDanglingPlacements` (Share#1744) defers products whose placement records the prefix does not hold, and Revit writes those toward the file tail — so early ticks meet long runs of products that cannot extract, each still paging source through the windowed provider.

## #518b — the skeleton now leads the parse instead of trailing it

The spatial walk ran only after the parse *and* the demand prep, so the one thing that could cover for the other latency gates appeared last. PSB: blank screen through the first ~10 s of a 16.7 s parse.

The spatial records sit at the file head on Revit exports (`IFCSITE` is record #211 on PSB), and a prefix generation is already everything the walk needs — a columns snapshot over a windowed provider with `prepareDemandExtraction(true)` done, which is what makes `getLinearScalingFactor()` report real units rather than 1. So `StorePreviewChannel` runs the walk itself as each generation is built, gated on the prefix type-index holding an `IfcProject`, ≥1 `IfcBuildingStorey` and ≥1 `IfcRelAggregates`, and stops retrying once a walk emits a plate.

`IfcProject` is in that guard for a different reason than the other two: `extractLinearScalingFactor` returns with the factor still at 1 when the model holds no project (it only logs), and afterwards that is indistinguishable from a genuine metre model — so a prefix that reached the storeys first would emit the whole skeleton 1000x oversized on a millimetre file, the #515 symptom.

**The proxy is untouched** — it already constructs the channel and runs the final walk, so no `ifc_api_proxy_ifc.ts` edit was needed for this.

**Frame.** The walk runs as a generation is built, before that tick captures its first product — and capture is the only thing that latches a coordination frame — so the first walk on a coordinating open necessarily takes the imposter walk's own fallback derivation, which can be a full site-offset out on a file that bakes absolute coordinates into vertices behind identity placements. Waiting for a latched frame would put the skeleton back behind the deferred-placement gate this change exists to get in front of, so instead the walk emits immediately and **re-emits once** on a later generation as soon as a real frame exists (`528f4d79`). The replace-by-expressID contract is what makes that correction free.

**Cost, stated rather than hidden.** The walk is reused as-is with no internal budget: it awaits a residency ensure per spatial node and per sampled product placement, so its cost tracks the prefix's spatial tree, not the file. On the first qualifying generation that tree is small by construction — the storeys exist but few `IfcRelContainedInSpatialStructure` do — which is the same property that makes these early plates coarse. Retries need no counter: generations only rebuild on a `GENERATION_GROWTH_FACTOR` doubling of the index, so there are O(log records) of them.

### Consumer contract for Share (the load-bearing part of this PR)

Now written on `PreviewMeshPayload.aabb`:

> **An `aabb` payload re-emitted with an `expressID` the consumer has already drawn a plate for REPLACES that plate — it does not add a second one.** Consumers key spatial imposters by `expressID` rather than by arrival order. The store path emits each spatial node twice by design: once early, off a prefix generation that holds the storeys but few of their contained products, and again after the parse with the full sample set and the finally-latched coordination frame. Double emission is the designed behaviour, not a bug. The early plate may be coarse — a Z band from elevations with a degenerate XY footprint — and the second emission is what corrects it. Vertex-carrying payloads are unaffected: those are keyed by `geometryExpressID` and are never re-sent.

The end-of-parse walk in the proxy is therefore the **refresh**, not a duplicate.

**One known gap in that contract, documented on `maybeEmitEarlySpatialPlates_`.** Replacement only reaches nodes the *final* walk still emits, and the emit set is not stable between the two: `aabbMostlyEqual` collapses a single-child wrapper (Project over Site over Building) once its box matches its child's, which a prefix generation's degenerate boxes may not yet do. A wrapper emitted early and collapsed late is never replaced and never removed, because the payload contract has no delete — so its early box lingers as one small plate until Share tears the preview scenery down at load end. Bounded (the wrapper chain is a handful of nodes, and the collapse needs exactly one child) but real. Closing it properly needs either a delete/generation channel in the contract or an emit set both walks agree on, and both are consumer-side changes rather than something this channel can do unilaterally.

## Test coverage

`src/compat/web-ifc/`: **16 suites, 97 tests**; full suite **87 suites / 480 tests**, all passing. `yarn lint` clean (0 errors).

- **#517** — the #516 synthetic-fixture harness gains a site-rotation knob, a raw `[Axis, RefDirection]` override with omittable slots, and a flag to write the site's RelativePlacement as an `IfcAxis2Placement2D`. `'z'` is Revit's true-north plan rotation; `'x'` tips the model out of plumb, which no exporter really writes but which is the only way to catch an `Axis`/`RefDirection` mixup — a Z-only fixture leaves the third matrix column at the identity and cannot see one. Assertions compare plate AABBs against the same rotation applied independently in double precision. **Verified against the pre-change module**: the two rotation tests fail on the translation-sum implementation (`max[1]` 6 not 9.2; floors at 100/103.5 not 86.60/89.63) and pass after. The 2D-placement and axis-only tests likewise fail against the composition as first written. Fixture direction ratios are written at 12 decimals rather than the fixture's usual four, because rounding `cos(30°)` at four places moves a sampled origin ~1e-4, above the assertions' tolerance.
- **#518a** — one tick attempts >1 product and ≤ the attempt cap (wall clock lifted via the same private-field seam `ifc_api_preview_channel.test.ts` already uses); five unproductive ticks leave the interval at 150 ms.
- **#518b** — a single `maybeTickAsync()` produces plates with the imposter colour/`geometryExpressID`/transform shape; the first walk is confirmed to use the fallback frame, the re-emission happens once a real frame latches, and there is no third emission. The pre-existing "emits placed vertex payloads" test now filters to the aabb-less half of the stream, since plates and meshes share the channel.

## Still open from the #516 review

Deliberately **not** done here, and the reason is mechanical rather than technical: this session can only write to GitHub through `push_files`, which takes whole-file contents. `ifc_api_proxy_ifc.ts` is ~3000 lines / ~100 KB and `ifc_api_proxy_ap214.ts` ~2000 lines; reproducing either byte-exactly to change a comment is a poor risk trade against corrupting the file, so both were left alone.

- **(a)** The two `emitSpatialStructureImposters` call-site comments in `ifc_api_proxy_ifc.ts` still say *"Both calls run in the same synchronous stretch after the parse, so nothing reaches the screen any later."* That is not true and the function's own JSDoc says so — it costs first-feedback latency, deliberately. The store-path call site should also now be labelled as the **refresh** per the contract above.
- **(b)** The three private `NormalizeMat` literals (`IfcAPI`, `IfcApiProxyIfc`, `IfcApiProxyAP214`) are still not folded into `NORMALIZE_MAT_F64`. `new Float32Array( NORMALIZE_MAT_F64 )` typechecks against the `glmatrix.mat4` field type and is lossless (every component is 0 or ±1) — the change is one line per file plus an import, and was verified locally to build and pass the full suite before being reverted for the reason above. `coordination_f64.ts`'s note about the remaining copies is therefore left as-is and still accurate.

Both are small, mechanical, and better done by an editor with direct write access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkzKiqMWweJHR7QFMAC8aq