### PR TITLE
Severe-bug burndown: stale wasm heap views, grid placement, pcurves, AP203 measurement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,67 @@ The same lifecycle and the same gate shape apply in
 [Share](https://github.com/bldrs-ai/Share) — see its `AGENTS.md` for
 which jobs are gated there.
 
+## Issue-queue burndowns: sub-agents and the rubric
+
+Sizeable issue queues (triage passes, bug burndowns) are worked by a
+coordinator session that plans, defines issues and manages the queue,
+dispatching one sub-agent per issue for the hands-on work — issue
+handling, PR authoring, review and release lifecycle. Use a
+Fable-class model for the coordinator and Opus-class for the
+sub-agents. This is the org direction, not a one-repo experiment;
+Share carries the same guidance
+([design/new/agent-workflow.md](https://github.com/bldrs-ai/Share/blob/main/design/new/agent-workflow.md)).
+Sequence agents that share a branch or files; parallelize only across
+disjoint trees.
+
+A dispatch brief must carry: the branch and its current state, the
+verification bar as numbers (the suite/test/lint counts the tree meets
+today), the issue's full context — and an instruction to read the live
+issue thread before coding, with explicit license to stop and report
+if the thread has retracted the premise. Premises rot; never assert an
+issue's triage state in a brief without having read its comments. (The
+Aug 2026 burndown lost one dispatch exactly this way, and the agent
+that refused to ship against the dead premise was right.)
+
+The rubric every sub-agent is held to — written after reviewing a PR
+that failed most of these (#508), then applied across
+#485/#504/#505/#503:
+
+1. **Read the thread first.** If comments retract the premise, stop
+   and report rather than ship.
+2. **Path evidence before claim.** A fix for a specific failure must
+   show the failing path reaches the changed code — entity chain,
+   stack, or captured diagnostic. "Consistent with" is not "caused
+   by".
+3. **Claim discipline.** State what the change establishes vs. what it
+   hopes. No closing keywords, and no `(#N)` in a title, for unproven
+   fixes of flaky or statistical bugs — auto-close has burned #485
+   twice.
+4. **Description ≡ diff.** PR and commit text describe the code as it
+   is, not an earlier draft's intent.
+5. **No speculative defenses.** Every guard corresponds to a state
+   something can actually produce; cite what can throw.
+6. **Tests pin the change, not the language.** Prove it: run the new
+   tests against a stash/revert of the source change and show them
+   fail.
+7. **Verify environment assumptions empirically.** Emscripten flags,
+   glue behaviour, schema revisions — read the built artifact or the
+   pinned source, never memory of a different configuration.
+8. **Diagnosis before defense** on silent-corruption and flaky bugs. A
+   change that makes a symptom vanish without establishing mechanism
+   closes an issue while keeping the bug.
+9. **Digest discipline.** Byte-identical output for every model the
+   change shouldn't touch, and a precise enumeration of the models it
+   legitimately changes — those baselines need re-blessing.
+10. **Report honestly.** Exact counts, verified vs. unverified,
+    confounders named (LFS stubs, wasm-prebuilt drift, upstream
+    fixes already landed).
+
+Reviewers hold the same bar, in this order: verify claims against the
+diff (not the description), against repo history, then against the
+actual failure path — and grade findings by evidence, not
+plausibility.
+
 ## Debugging a bad model
 
 When a model renders wrong — spikes, missing parts, exploded assemblies —

--- a/data/grid_placement.ifc
+++ b/data/grid_placement.ifc
@@ -71,6 +71,16 @@ DATA;
 #311=IFCSHAPEREPRESENTATION(#20,'Body','CSG',(#312));
 #312=IFCBLOCK(#313,1.,1.,1.);
 #313=IFCAXIS2PLACEMENT3D(#22,$,$);
+/* Product D: an ordinary local placement measured FROM the grid placement
+   of product A - 1m up from it, so at (8,17,10) in the world. */
+#600=IFCBUILDINGELEMENTPROXY('6kF0kSTOX3ovkcpuOhkPrX',$,'GridRelative',$,$,#601,#610,$,.NOTDEFINED.);
+#601=IFCLOCALPLACEMENT(#201,#602);
+#602=IFCAXIS2PLACEMENT3D(#603,$,$);
+#603=IFCCARTESIANPOINT((0.,0.,1.));
+#610=IFCPRODUCTDEFINITIONSHAPE($,$,(#611));
+#611=IFCSHAPEREPRESENTATION(#20,'Body','CSG',(#612));
+#612=IFCBLOCK(#613,1.,1.,1.);
+#613=IFCAXIS2PLACEMENT3D(#22,$,$);
 /* Grid #400, one of whose axes is a circle. */
 #400=IFCGRID('4kF0kSTOX3ovkcpuOhkPrX',$,'CurvedGrid',$,$,#401,$,(#410),(#420),$,.RECTANGULAR.);
 #401=IFCLOCALPLACEMENT($,#21);

--- a/data/grid_placement.ifc
+++ b/data/grid_placement.ifc
@@ -101,5 +101,21 @@ DATA;
 #511=IFCSHAPEREPRESENTATION(#20,'Body','CSG',(#512));
 #512=IFCBLOCK(#513,1.,1.,1.);
 #513=IFCAXIS2PLACEMENT3D(#22,$,$);
+/* Product E: axes A and 1 with no offsets, so the intersection is (0,0,0)
+   in the grid and (10,20,5) in the world — but with a reference direction
+   of +Z (#23, the same direction the grid's own placement uses as its
+   axis). A grid placement's z axis is forced to +Z, so a
+   PlacementRefDirection along it steers the x axis nowhere: normalising it
+   against that z yields NaN, which addTransform then bakes into this
+   placement and everything measured from it. Guarded, the schema default
+   stands in instead — the first axis' tangent, +X in the grid, which the
+   quarter turn takes to world +Y, the same x axis product A gets. */
+#700=IFCBUILDINGELEMENTPROXY('7kF0kSTOX3ovkcpuOhkPrX',$,'GridRefParallelZ',$,$,#701,#710,$,.NOTDEFINED.);
+#701=IFCGRIDPLACEMENT(#702,#23);
+#702=IFCVIRTUALGRIDINTERSECTION((#110,#130),(0.,0.));
+#710=IFCPRODUCTDEFINITIONSHAPE($,$,(#711));
+#711=IFCSHAPEREPRESENTATION(#20,'Body','CSG',(#712));
+#712=IFCBLOCK(#713,1.,1.,1.);
+#713=IFCAXIS2PLACEMENT3D(#22,$,$);
 ENDSEC;
 END-ISO-10303-21;

--- a/data/grid_placement.ifc
+++ b/data/grid_placement.ifc
@@ -1,0 +1,95 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('grid_placement.ifc','2026-08-17T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+/* Minimal synthetic model exercising IFCGRIDPLACEMENT (conway#504).
+
+   Grid #100 is placed at (10,20,5) and turned a quarter turn about +Z, so a
+   product placed against it can only land correctly if the grid placement
+   COMPOSES onto the grid's own object placement rather than adding to it.
+
+   Its U axes run along +X, its V axes along +Y, all in the grid's own
+   coordinate system:
+
+     A: y = 0    B: y = 5    1: x = 0    2: x = 7
+
+   Grid #400 exists to cover the unsupported-axis-curve path: one of its two
+   axes is an IFCCIRCLE, which this extractor does not reduce to a line. */
+#1=IFCPROJECT('0kF0kSTOX3ovkcpuOhkPrX',$,'GridPlacement',$,$,$,$,(#20),#10);
+#10=IFCUNITASSIGNMENT((#11));
+#11=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#20=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-05,#21,$);
+#21=IFCAXIS2PLACEMENT3D(#22,$,$);
+#22=IFCCARTESIANPOINT((0.,0.,0.));
+#23=IFCDIRECTION((0.,0.,1.));
+#25=IFCDIRECTION((0.,1.,0.));
+/* Grid #100, placed at (10,20,5) with its x axis along world +Y. */
+#100=IFCGRID('1kF0kSTOX3ovkcpuOhkPrX',$,'Grid',$,$,#101,$,(#110,#120),(#130,#140),$,.RECTANGULAR.);
+#101=IFCLOCALPLACEMENT($,#102);
+#102=IFCAXIS2PLACEMENT3D(#103,#23,#25);
+#103=IFCCARTESIANPOINT((10.,20.,5.));
+/* U axes: two-point polylines along +X. */
+#110=IFCGRIDAXIS('A',#111,.T.);
+#111=IFCPOLYLINE((#112,#113));
+#112=IFCCARTESIANPOINT((0.,0.));
+#113=IFCCARTESIANPOINT((1.,0.));
+#120=IFCGRIDAXIS('B',#121,.T.);
+#121=IFCPOLYLINE((#122,#123));
+#122=IFCCARTESIANPOINT((0.,5.));
+#123=IFCCARTESIANPOINT((1.,5.));
+/* V axes: two-point polylines along +Y. */
+#130=IFCGRIDAXIS('1',#131,.T.);
+#131=IFCPOLYLINE((#132,#133));
+#132=IFCCARTESIANPOINT((0.,0.));
+#133=IFCCARTESIANPOINT((0.,1.));
+#140=IFCGRIDAXIS('2',#141,.T.);
+#141=IFCPOLYLINE((#142,#143));
+#142=IFCCARTESIANPOINT((7.,0.));
+#143=IFCCARTESIANPOINT((7.,1.));
+/* Product A: axes A and 1, offsets (2.,3.,4.), no reference direction.
+   Offsetting A by 2 gives y = 2, offsetting 1 by 3 gives x = -3 (both
+   normal to the axis tangent, anti-clockwise), so the intersection sits at
+   (-3,2,4) in the grid and at (8,17,9) in the world. */
+#200=IFCBUILDINGELEMENTPROXY('2kF0kSTOX3ovkcpuOhkPrX',$,'GridPlacedA',$,$,#201,#210,$,.NOTDEFINED.);
+#201=IFCGRIDPLACEMENT(#202,$);
+#202=IFCVIRTUALGRIDINTERSECTION((#110,#130),(2.,3.,4.));
+#210=IFCPRODUCTDEFINITIONSHAPE($,$,(#211));
+#211=IFCSHAPEREPRESENTATION(#20,'Body','CSG',(#212));
+#212=IFCBLOCK(#213,1.,1.,1.);
+#213=IFCAXIS2PLACEMENT3D(#22,$,$);
+/* Product B: axes B and 2, two offsets only (1.,2.), reference direction
+   +Y in the grid. Offsetting B by 1 gives y = 6, offsetting 2 by 2 gives
+   x = 5, so the intersection sits at (5,6,0) in the grid and at (4,25,5)
+   in the world. */
+#300=IFCBUILDINGELEMENTPROXY('3kF0kSTOX3ovkcpuOhkPrX',$,'GridPlacedB',$,$,#301,#310,$,.NOTDEFINED.);
+#301=IFCGRIDPLACEMENT(#302,#25);
+#302=IFCVIRTUALGRIDINTERSECTION((#120,#140),(1.,2.));
+#310=IFCPRODUCTDEFINITIONSHAPE($,$,(#311));
+#311=IFCSHAPEREPRESENTATION(#20,'Body','CSG',(#312));
+#312=IFCBLOCK(#313,1.,1.,1.);
+#313=IFCAXIS2PLACEMENT3D(#22,$,$);
+/* Grid #400, one of whose axes is a circle. */
+#400=IFCGRID('4kF0kSTOX3ovkcpuOhkPrX',$,'CurvedGrid',$,$,#401,$,(#410),(#420),$,.RECTANGULAR.);
+#401=IFCLOCALPLACEMENT($,#21);
+#410=IFCGRIDAXIS('C',#411,.T.);
+#411=IFCCIRCLE(#412,4.);
+#412=IFCAXIS2PLACEMENT2D(#413,$);
+#413=IFCCARTESIANPOINT((0.,0.));
+#420=IFCGRIDAXIS('3',#421,.T.);
+#421=IFCPOLYLINE((#422,#423));
+#422=IFCCARTESIANPOINT((0.,0.));
+#423=IFCCARTESIANPOINT((0.,1.));
+/* Product C: placed against the circular axis, which cannot be reduced to
+   a line - no transform is registered and the warning says why. */
+#500=IFCBUILDINGELEMENTPROXY('5kF0kSTOX3ovkcpuOhkPrX',$,'GridPlacedC',$,$,#501,#510,$,.NOTDEFINED.);
+#501=IFCGRIDPLACEMENT(#502,$);
+#502=IFCVIRTUALGRIDINTERSECTION((#410,#420),(0.,0.));
+#510=IFCPRODUCTDEFINITIONSHAPE($,$,(#511));
+#511=IFCSHAPEREPRESENTATION(#20,'Body','CSG',(#512));
+#512=IFCBLOCK(#513,1.,1.,1.);
+#513=IFCAXIS2PLACEMENT3D(#22,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/data/pcurve-basis-surfaces.step
+++ b/data/pcurve-basis-surfaces.step
@@ -39,7 +39,16 @@ DATA;
 /* --- Cone: a generator line at u = 0, v from 0 to 20. The placement is
  *     offset and turned a quarter turn about z so the local frame has to be
  *     applied for the mapped points to land. Radius 10 at v = 0, opening at
- *     a 30 degree semi-angle. */
+ *     a 30 degree semi-angle.
+ *
+ *     ISO 10303-42's cone measures v along the AXIS, so the ring radius is
+ *     10 + v tan(30 deg) and the local point at (u, v) = (0, 20) is
+ *     (10 + 20*0.57735, 0, 20) = (21.547005, 0, 20). Under #22 local +x is
+ *     world +y and local +y is world -x, so the two ends land at
+ *     (5, -3 + 10, 50) = (5, 7, 50) and (5, -3 + 21.547005, 70) =
+ *     (5, 18.547005, 70). Reading v along the generator instead would give
+ *     a ring of 10 + 20 sin(30 deg) = 20 at an axial 20 cos(30 deg), putting
+ *     the far end at (5, 17, 67.320508) - see bldrs-ai/conway#520. */
 #20 = PCURVE('cone',#21,#26);
 #21 = CONICAL_SURFACE('',#22,10.,0.5235987755982988);
 #22 = AXIS2_PLACEMENT_3D('',#23,#24,#25);

--- a/data/pcurve-basis-surfaces.step
+++ b/data/pcurve-basis-surfaces.step
@@ -1,0 +1,120 @@
+ISO-10303-21;
+HEADER;
+/* Synthetic fixture for bldrs-ai/conway#505: PCURVEs whose basis surfaces
+ * span the elementary surface types conway parameterizes, plus the two
+ * residue cases (an unsupported basis surface, and a pcurve that is one
+ * variant of a complex instance which also carries an explicit curve_3d).
+ *
+ * Every parameter curve here is chosen so the mapped 3D points are
+ * analytically checkable - see ap214_pcurve_basis_surfaces.test.ts. The
+ * entities are deliberately NOT wired into a shape representation: the test
+ * drives extractCurve() on the PCURVEs directly, which is the arm the issue
+ * is about. */
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('pcurve-basis-surfaces.step','2026-08-17T00:00:00',(''),(''),
+'','','');
+FILE_SCHEMA(('AUTOMOTIVE_DESIGN { 1 0 10303 214 3 1 1 }'));
+ENDSEC;
+DATA;
+#1 = APPLICATION_PROTOCOL_DEFINITION('international standard',
+  'automotive_design',2010,#2);
+#2 = APPLICATION_CONTEXT('core data for automotive mechanical design processes');
+#3 = ( GEOMETRIC_REPRESENTATION_CONTEXT(2) PARAMETRIC_REPRESENTATION_CONTEXT()
+  REPRESENTATION_CONTEXT('2D SPACE','') );
+
+/* --- Cylinder: a straight run in (u, v) is a helix arc of radius 25,
+ *     sweeping u from 0 to pi while v climbs from 0 to 20. */
+#10 = PCURVE('cylinder',#11,#15);
+#11 = CYLINDRICAL_SURFACE('',#12,25.);
+#12 = AXIS2_PLACEMENT_3D('',#13,#14,#140);
+#13 = CARTESIAN_POINT('',(0.,0.,0.));
+#14 = DIRECTION('',(0.,0.,1.));
+#140 = DIRECTION('',(1.,0.,0.));
+#15 = DEFINITIONAL_REPRESENTATION('',(#16),#3);
+#16 = POLYLINE('',(#17,#18,#19));
+#17 = CARTESIAN_POINT('',(0.,0.));
+#18 = CARTESIAN_POINT('',(1.5707963267948966,10.));
+#19 = CARTESIAN_POINT('',(3.141592653589793,20.));
+
+/* --- Cone: a generator line at u = 0, v from 0 to 20. The placement is
+ *     offset and turned a quarter turn about z so the local frame has to be
+ *     applied for the mapped points to land. Radius 10 at v = 0, opening at
+ *     a 30 degree semi-angle. */
+#20 = PCURVE('cone',#21,#26);
+#21 = CONICAL_SURFACE('',#22,10.,0.5235987755982988);
+#22 = AXIS2_PLACEMENT_3D('',#23,#24,#25);
+#23 = CARTESIAN_POINT('',(5.,-3.,50.));
+#24 = DIRECTION('',(0.,0.,1.));
+#25 = DIRECTION('',(0.,1.,0.));
+#26 = DEFINITIONAL_REPRESENTATION('',(#27),#3);
+#27 = POLYLINE('',(#28,#29));
+#28 = CARTESIAN_POINT('',(0.,0.));
+#29 = CARTESIAN_POINT('',(0.,20.));
+
+/* --- Sphere: u sweeps a quarter turn at a constant latitude of 30 degrees,
+ *     so every mapped point sits on radius 10 at z = 5. */
+#30 = PCURVE('sphere',#31,#35);
+#31 = SPHERICAL_SURFACE('',#32,10.);
+#32 = AXIS2_PLACEMENT_3D('',#33,#34,#340);
+#33 = CARTESIAN_POINT('',(0.,0.,0.));
+#34 = DIRECTION('',(0.,0.,1.));
+#340 = DIRECTION('',(1.,0.,0.));
+#35 = DEFINITIONAL_REPRESENTATION('',(#36),#3);
+#36 = POLYLINE('',(#37,#38));
+#37 = CARTESIAN_POINT('',(0.,0.5235987755982988));
+#38 = CARTESIAN_POINT('',(1.5707963267948966,0.5235987755982988));
+
+/* --- Torus: half a turn around the tube (v) at a fixed u, walking the
+ *     outer equator across to the inner one. Major 20, minor 5. */
+#40 = PCURVE('torus',#41,#45);
+#41 = TOROIDAL_SURFACE('',#42,20.,5.);
+#42 = AXIS2_PLACEMENT_3D('',#43,#44,#440);
+#43 = CARTESIAN_POINT('',(0.,0.,0.));
+#44 = DIRECTION('',(0.,0.,1.));
+#440 = DIRECTION('',(1.,0.,0.));
+#45 = DEFINITIONAL_REPRESENTATION('',(#46),#3);
+#46 = POLYLINE('',(#47,#48));
+#47 = CARTESIAN_POINT('',(0.,0.));
+#48 = CARTESIAN_POINT('',(0.,3.141592653589793));
+
+/* --- Plane: (u, v) are distances along the placement's x and y axes. */
+#50 = PCURVE('plane',#51,#55);
+#51 = PLANE('',#52);
+#52 = AXIS2_PLACEMENT_3D('',#53,#54,#540);
+#53 = CARTESIAN_POINT('',(1.,2.,3.));
+#54 = DIRECTION('',(0.,0.,1.));
+#540 = DIRECTION('',(1.,0.,0.));
+#55 = DEFINITIONAL_REPRESENTATION('',(#56),#3);
+#56 = POLYLINE('',(#57,#58));
+#57 = CARTESIAN_POINT('',(0.,0.));
+#58 = CARTESIAN_POINT('',(4.,7.));
+
+/* --- Residue: a B-spline basis surface has no closed-form parameterization
+ *     here, so this one is warned about by name and dropped. */
+#60 = PCURVE('bspline',#61,#66);
+#61 = B_SPLINE_SURFACE_WITH_KNOTS('',1,1,((#62,#63),(#64,#65)),.UNSPECIFIED.,
+  .F.,.F.,.F.,(2,2),(2,2),(0.,1.),(0.,1.),.UNSPECIFIED.);
+#62 = CARTESIAN_POINT('',(0.,0.,0.));
+#63 = CARTESIAN_POINT('',(0.,1.,0.));
+#64 = CARTESIAN_POINT('',(1.,0.,0.));
+#65 = CARTESIAN_POINT('',(1.,1.,1.));
+#66 = DEFINITIONAL_REPRESENTATION('',(#67),#3);
+#67 = POLYLINE('',(#68,#69));
+#68 = CARTESIAN_POINT('',(0.,0.));
+#69 = CARTESIAN_POINT('',(1.,1.));
+
+/* --- A pcurve that is one variant of a complex instance also carrying a
+ *     SURFACE_CURVE: the explicit curve_3d wins over the parameter space
+ *     mapping. The 3D polyline runs along +y from (25,0,0), which the
+ *     pcurve's own parameter curve (a helix on the cylinder) never touches. */
+#70 = ( CURVE() GEOMETRIC_REPRESENTATION_ITEM() PCURVE(#11,#75)
+  REPRESENTATION_ITEM('complex') SURFACE_CURVE(#71,(#10),.CURVE_3D.) );
+#71 = POLYLINE('',(#72,#73));
+#72 = CARTESIAN_POINT('',(25.,0.,0.));
+#73 = CARTESIAN_POINT('',(25.,40.,0.));
+#75 = DEFINITIONAL_REPRESENTATION('',(#76),#3);
+#76 = POLYLINE('',(#77,#78));
+#77 = CARTESIAN_POINT('',(0.,0.));
+#78 = CARTESIAN_POINT('',(3.141592653589793,20.));
+ENDSEC;
+END-ISO-10303-21;

--- a/design/new/step-support.md
+++ b/design/new/step-support.md
@@ -56,7 +56,7 @@ work.
 |---|------|----------|-------|
 | 1 | Public API surface | High | `src/index.ts` exports IFC types only. AP214 model / extraction / parser need stable named exports. |
 | 2 | Regression coverage | High | No AP21x analog of `ifc_regression_main.ts` or `ifc_regression_batch_main.ts`. The 47-CSV golden corpus in `regression/test_models/` is IFC-only. |
-| 3 | AP203 fall-through correctness | Medium | The loader logs `"AP203 Step Detected, using AP214 loader"` and reuses the AP214 parser. Real AP203 entities may diverge — needs a sweep across known AP203 exports. Now tracked as #503. |
+| 3 | AP203 fall-through correctness | Low (measured) | The loader logs `"AP203 Step Detected, using AP214 loader"` and reuses the AP214 parser. Measured Aug 2026 over all 16 AP203 models in the corpus: 76 of 214,437 instances (0.035%) name a type the AP214 vtable has no slot for, none of them geometry-bearing, and zero errors attributable to the schema alias. See §"AP203 fall-through: measured" (#503). |
 | 4 | AP242 | Medium | Not implemented. ISO 10303-242 supersets AP214 and is the modern PMI-bearing target; no detection, no entities, no parser. |
 | 5 | Test models | Medium | `data/` now carries 9 STEP fixtures (incl. AP203/AP242 header minima, the AS1 assembly, and a CTC properties reduction). Still need broader *geometry* coverage: real-world AP203 CAD exports, AP242 PMI samples, the full NIST CAx-IF corpus (which lives in `test-models/step/nist/`, not `data/`). |
 | 6 | AP214 test depth | Low | The metadata track added `ap214_product_structure_extraction.test` + `ap214_property_extraction.test` (and occurrence-path geometry tests, PR #353) on top of `ap214_step_model.test.ts` / `ap214_geometry_extraction.test.ts`. Still missing equivalents for block extraction and full scene-builder coverage. |
@@ -104,8 +104,9 @@ work.
 
 ### Phase 4 — AP203 schema sweep
 
-- [ ] Enumerate AP203 entities that are not in the AP214 vtable (walk
-      via `step_vtable_builder.ts`)
+- [x] Enumerate AP203 entities that are not in the AP214 vtable —
+      done Aug 2026, both statically and against the corpus. Numbers and
+      method in §"AP203 fall-through: measured" below (#503).
 - [ ] If divergence is small: extend AP214 model with conditional
       handling keyed off detected schema
 - [ ] If divergence is large: generate a parallel `src/AP203_1994/` tree
@@ -113,6 +114,11 @@ work.
       that produced `AP214E3_2010_gen/`
 - [ ] Acceptance: parse + geometry-extract three independently-sourced
       AP203 CAD exports with no parser errors
+
+The measurement says **neither fork is currently earning its keep** —
+the AP214 parser already reads every geometry- and product-structure-
+bearing entity these files contain. The cheapest real improvement is
+the diagnostic gap the measurement exposed (below), not schema work.
 
 ### Phase 5 — AP242 (ISO 10303-242)
 
@@ -218,6 +224,125 @@ geometry" — an empty dump hashes to SHA-1's empty string
 (`da39a3ee…`), which is how a face can pass a triangle-count probe and
 still be invisible.
 
+### AP203 fall-through: measured
+
+The loader routes both AP203 schema names to the AP214 parser (#503,
+and the sibling AP242 alias in #480). Measured Aug 2026; the short
+answer is that the alias costs almost nothing, and the interesting
+finding is *why* — the two schemas share the same ISO 10303 integrated
+resources, so the geometry and product-structure entities a CAD
+exporter actually writes are the same entities with the same attribute
+order in both.
+
+Note first that "AP203" is two schemas, not one, and the detector
+matches both:
+
+- **`CONFIG_CONTROL_DESIGN`** — AP203 edition 1 (ISO 10303-203:1994
+  AIM long form). Small: 254 entities.
+- **`AP203_CONFIGURATION_CONTROLLED_3D_DESIGN_…_MIM_LF`** — AP203
+  edition 2 (ISO/TS 10303-403 MIM long form). Large: 1,006 entities,
+  because the MIM pulls in whole modules (procedural/parametric
+  representation, sheet metal, the rule/logic schema) that no CAD
+  exporter emits.
+
+Both appear in the corpus: of the 16 AP203 models under
+`test-models/step/nist/NIST-PMI-STEP-Files/`, 3 are edition 1 and 13
+are edition 2.
+
+**Static gap** (schema entity set vs. the 966 names in
+`EntityTypesAP214`, i.e. what `step_vtable_builder.ts` can dispatch):
+
+| schema | entities | absent from vtable | of those, geometry/topology-bearing |
+|---|---:|---:|---:|
+| CONFIG_CONTROL_DESIGN | 254 | 22 | 4 (`WIRE_SHELL`, `VERTEX_SHELL`, `SHELL_BASED_WIREFRAME_MODEL`/`_SHAPE_REPRESENTATION`) |
+| AP203e2 MIM_LF | 1,006 | 332 | 131 |
+
+The 332 looks alarming and is almost entirely a MIM-superset artifact —
+see the empirical number below before sizing any work off it.
+
+**Attribute-order divergence** — the dangerous class, because a
+same-named entity whose attributes are declared in a different order
+mis-parses *silently* under positional STEP encoding. Five cases exist
+across the two schemas, all outside geometry, and **none of them occurs
+in the corpus**:
+
+- `DATED_EFFECTIVITY` — edition 1 declares `(start_date, end_date)`,
+  AP214 declares `(end_date, start_date)`. A genuine silent swap; the
+  AP214 parser would read an edition-1 file's dates transposed.
+  Edition 2 uses the AP214 order, so this is an edition-1-only hazard.
+- `AREA_UNIT` / `VOLUME_UNIT` — edition 1 subtypes `named_unit`
+  (attribute `dimensions`, one reference); AP214 and edition 2 both
+  subtype `derived_unit` (attribute `elements`, an aggregate). Again
+  edition-1-only.
+- `APPLIED_NAME_ASSIGNMENT` (`item` scalar vs. `items` aggregate) and
+  `VECTOR_STYLE` (multiple-inheritance parents declared in the opposite
+  order) — edition 2 vs. AP214.
+
+Restricting the comparison to the entity names the corpus actually
+instantiates and checking *types* as well as order: 140 shared names
+for edition 2, **zero** divergent attribute slots; 63 shared names for
+edition 1, 8 slots that differ only by widening (`TEXT` vs `LABEL`,
+required vs `OPTIONAL`, an entity reference vs. a select that contains
+it) — all safe in the AP203→AP214 direction.
+
+**Empirical gap**, counting every instance in every AP203 model against
+the vtable, with the AP242 files as a same-build control:
+
+| corpus | files | instances | naming a type absent from the vtable | distinct such types |
+|---|---:|---:|---:|---:|
+| AP203 (both editions) | 16 | 214,437 | **76 (0.035%)** | 6 |
+| AP242 (control) | 17 | 220,215 | 19,610 (8.90%) | 47 |
+
+The six are `CC_DESIGN_PERSON_AND_ORGANIZATION_ASSIGNMENT` (24),
+`CC_DESIGN_APPROVAL` (18), `CC_DESIGN_DATE_AND_TIME_ASSIGNMENT` (12),
+`DESIGN_CONTEXT` (8), `MECHANICAL_CONTEXT` (8),
+`CC_DESIGN_SECURITY_CLASSIFICATION` (6) — configuration-management and
+product-context records. Nothing in `src/` reads any of them (nor the
+AP214 `product_context` / `product_definition_context` they specialize),
+so dropping them costs nothing conway currently consumes. Eight of the
+16 files use none of them at all, including all three edition-1 files:
+those write plain `PRODUCT_CONTEXT` / `PRODUCT_DEFINITION_CONTEXT`
+despite the `CONFIG_CONTROL_DESIGN` header.
+
+Every AP203 model produces geometry — **zero** zero-geometry loads,
+against one in the AP242 control (`nist_ftc_08…-e1-tg`, #480). Total
+error volume across all 16: 25 messages, none schema-attributable —
+`Unsupported type: GEOMETRIC_SET` ×3 (an unimplemented extraction for
+an entity that *is* in the vtable), spherical-pole triangulation
+failures ×10, and 16 informational whole-curve-trim recoveries.
+
+Two confounders were controlled explicitly, both of which distorted the
+first AP242 measurement in #480: all 16 models were materialized from
+Git LFS before measuring (a pointer stub parses as an empty document,
+#486), and the run post-dates the #493 select-deserialization fix. A
+third is worth naming because it is *not* AP203-specific: the
+LOGICAL-read-as-BOOLEAN generator bug (#480) reaches
+`B_SPLINE_CURVE`, `B_SPLINE_SURFACE` and `COMPOSITE_CURVE` alike, and
+three AP203 files carry 53 `.U.` tokens in those attributes. It does
+not fire here only because no AP203 file in the corpus pairs a
+`.U.` with an attribute the extractor reads.
+
+**The gap this leaves.** An entity name the vtable cannot resolve is
+indexed with an undefined type and dropped with **no diagnostic at
+all** — `this.index_.get(...)` in `step_parser.ts` returns `undefined`
+and nothing counts it. That is the failure mode #503 was filed about,
+and it is real; it is just cheap here (76 instances) and ruinous for
+AP242 (19,610). A parse-time tally of unresolved type names, logged
+once per name with a count, would turn "silently absent" into a
+readable signal for every schema at once. It is deliberately *not*
+bundled with this measurement: it adds rows to `errors.csv` for most
+of the corpus, IFC included, so it needs its own PR and a baseline
+re-bless.
+
+Reproducing: the entity list for each schema comes from the EXPRESS
+long forms (edition 1 and edition 2 from the STEPcode `data/` tree,
+both carrying their ISO TC184/SC4/WG3 provenance in the file header;
+AP214 from `schemas/AP214E3_2010.exp` in the pinned `IFC-gen-internal`
+revision, which is the exact input the checked-in `*.gen.ts` were
+generated from). The per-model run is
+`node --experimental-specifier-resolution=node
+compiled/src/AP214E3_2010/ap214_regression_main.js -d <file> <out>`.
+
 ### Error accounting
 
 `Logger` dedups on the exact message string, and `errors.csv` carries a
@@ -234,13 +359,24 @@ family attributable to specific entities.
 ## Open questions
 
 - AP203 strategy: indefinite AP214 fall-through, or its own gen tree
-  once divergence is measured? Decision needed before Phase 4 work
-  starts (#503 tracks the measurement).
+  once divergence is measured? Measured under #503 — see §"AP203
+  fall-through: measured". The data supports staying on the
+  fall-through: 0.035% of instances unresolvable, none geometry-bearing,
+  no geometry loss. Still open as a *policy* question, since the
+  measurement covers one exporter family (the NIST corpus is CATIA- and
+  Creo-sourced) and edition-1 CCD files carry a real
+  `DATED_EFFECTIVITY` attribute-order hazard that this corpus never
+  exercises.
 - Test model storage: checked into `data/`, into a
   `regression/test_models_step/` corpus, or in a separate `test-models`
   repo similar to IFC's? Affects PR-time test budget and licensing.
 - AP242 in scope for the first production cut, or follow-up release?
   Drives whether Phase 5 is gating.
-- CONFIG_CONTROL_DESIGN routing: currently aliases to AP214, but it's
-  a profile of AP203, not AP214 — verify this isn't producing silent
-  parse errors on real CCD files. Filed as #503.
+- ~~CONFIG_CONTROL_DESIGN routing: verify the AP214 alias isn't
+  producing silent parse errors on real CCD files.~~ Answered under
+  #503: it isn't. The three CCD files in the corpus resolve every
+  entity they contain against the AP214 vtable and load clean. The
+  residual risk is the `DATED_EFFECTIVITY` / `AREA_UNIT` /
+  `VOLUME_UNIT` attribute-order divergences, which are edition-1-only
+  and unexercised here — a CCD file that *does* use them mis-parses
+  silently, with no diagnostic.

--- a/src/AP214E3_2010/ap214_command_line_main.ts
+++ b/src/AP214E3_2010/ap214_command_line_main.ts
@@ -11,6 +11,7 @@ import { AP214SceneBuilder } from './ap214_scene_builder'
 import { ConwayGeometry } from '../../dependencies/conway-geom'
 import GeometryAggregator from '../core/geometry_aggregator'
 import GeometryConvertor from '../core/geometry_convertor'
+import { wasmHeapByteLength } from '../core/wasm_heap'
 import { AP214GeometryExtraction } from './ap214_geometry_extraction'
 import { ExtractResult } from '../core/shared_constants'
 import Environment from '../utilities/environment'
@@ -554,11 +555,15 @@ function geometryExtraction(
   const ONE_KB = 1024
   const ONE_MB = ONE_KB * ONE_KB
 
-  const wasmHeap = conwaywasm.wasmModule?.HEAPU8
+  // Measured through wasmHeapByteLength rather than HEAPU8.length: the
+  // module's cached view can be a growth step behind the real heap (#485), and
+  // a high-water figure that under-reports is worse than none.
+  const wasmModule = conwaywasm.wasmModule
 
-  if (wasmHeap !== void 0) {
+  if (wasmModule !== void 0) {
     Logger.info(
-        `WASM heap high-water: ${(wasmHeap.length / ONE_MB).toFixed(1)} MB`)
+        `WASM heap high-water: ${
+          (wasmHeapByteLength(wasmModule) / ONE_MB).toFixed(1)} MB`)
   }
 
   statistics?.setGeometryMemory(conwayModel.model.geometry.calculateGeometrySize() / (ONE_MB))

--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -57,7 +57,7 @@ import {
 import { MemoizationCapture, RegressionCaptureState } from '../core/regression_capture_state'
 import { ExtractResult } from '../core/shared_constants'
 import Logger from '../logging/logger'
-import { arrayToWasmHeap } from '../core/wasm_heap'
+import { arrayToWasmHeap, wasmHeapView } from '../core/wasm_heap'
 import {
   advanced_brep_shape_representation,
   advanced_face,
@@ -3870,13 +3870,14 @@ export class AP214GeometryExtraction {
       capacity = maxPossibleFloats
     }
 
-    // 2) Create a Float64Array view into WASM memory
-    // We only need to create a subarray up to the capacity
-    const wasmFloat64View = this.wasmModule.HEAPF64.subarray(
-        pointer / bytesPerElement,
-         
-        pointer / bytesPerElement + capacity,
-    )
+    // 2) Create a Float64Array view into WASM memory, over the heap as it is
+    // after the _malloc above rather than over whatever view the module had
+    // cached before it - see wasm_heap.ts for why those can differ. Built
+    // rather than subarray'd off HEAPF64 for the same reason: subarray clamps
+    // an out-of-range window into a short one, and the set() loop below would
+    // then quietly write somewhere other than the allocation (#485).
+    const wasmFloat64View =
+      wasmHeapView(this.wasmModule, Float64Array, pointer, capacity)
 
     // 3) Single pass to skip consecutive duplicates, fill up the wasm array
     let offset = 0

--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -125,7 +125,6 @@ import {
   rational_b_spline_surface,
   representation_item,
   representation_relationship_with_transformation,
-  seam_curve,
   shape_definition_representation,
   shape_representation,
   shape_representation_relationship,
@@ -161,6 +160,29 @@ type Mutable<T> = { -readonly [P in keyof T]: T[P] }
 // Fewest points a bound can have and still span a plane, which is what
 // GetBasisFromCoplanarPoints needs downstream.
 const MINIMUM_BOUND_POINTS = 3
+
+// Ceiling on how finely one span of a pcurve's parameter curve is sampled
+// when it is pushed through an angular surface parameterization. Nothing in
+// STEP bounds how far a parameter curve may run in u or v - a helix wound a
+// thousand times is a legal (if unusual) parameter-space line - and without a
+// cap the sample count is a function of file content rather than of the
+// extractor. At circleSegments density this is over twenty full turns of a
+// single span - well past the point where the polyline is the limiting
+// factor on any face it bounds.
+const MAXIMUM_PCURVE_SPAN_SAMPLES = 256
+
+/**
+ * How a basis surface turns a point in its own parameter space into a point
+ * in its placement's local frame, plus which of (u, v) are angles - the
+ * latter is what decides how finely a mapped span has to be sampled, since a
+ * straight run in an angular parameter is an arc in space.
+ */
+interface SurfaceParameterization {
+  position: axis2_placement_3d
+  evaluate: ( u: number, v: number ) => Vector3
+  angularU: boolean
+  angularV: boolean
+}
 
 /**
  * Whether an edge's vertices are the basis curve's own endpoints, making its
@@ -960,7 +982,7 @@ export class AP214GeometryExtraction {
    * @param array
    * @return {number} Pointer/memory address
    */
-  arrayToWasmHeap(array:Float32Array | Uint32Array): any {
+  arrayToWasmHeap(array:Float32Array | Float64Array | Uint32Array): any {
     return arrayToWasmHeap(this.wasmModule, array)
   }
 
@@ -1777,11 +1799,18 @@ export class AP214GeometryExtraction {
 
     } else if ( from instanceof pcurve ) {
 
-      const seamCurve = from.findVariant( seam_curve )
+      // An explicit 3D representation beats the parameter-space mapping where
+      // one is carried, as it already does for surface_curve and seam_curve
+      // reached in their own right. surface_curve rather than seam_curve:
+      // seam_curve and intersection_curve are both its subtypes and all three
+      // carry curve_3d, so this is the same preference over the whole family
+      // (bldrs-ai/conway#505).
+      const surfaceCurve = from.findVariant( surface_curve )
 
-      if ( seamCurve !== void 0 ) {
+      if ( surfaceCurve !== void 0 ) {
 
-        stepCurve = this.extractCurve( seamCurve.curve_3d, parentSense, isEdge, trimmingArguments )
+        stepCurve =
+          this.extractCurve( surfaceCurve.curve_3d, parentSense, isEdge, trimmingArguments )
 
       } else {
 
@@ -1859,54 +1888,279 @@ export class AP214GeometryExtraction {
   }  
 
   /**
+   * The ISO 10303-42 parameterization of an elementary basis surface,
+   * expressed in that surface's placement-local frame.
    *
-   * @param from
-   * @return {CurveObject | undefined}
+   * The formulae are the ones conway-geom tessellates these surfaces with:
+   * TriangulateCylindricalSurface, TriangulateSphericalSurface,
+   * TriangulateConicalSurface and TriangulateToroidalSurface (conway-geom
+   * `conway_geometry/operations/mesh_utils.h`) recover (theta, height) or
+   * (theta, latitude) from world points by inverting exactly these, so a
+   * pcurve mapped here lands on the same surface the face it bounds is
+   * triangulated on.
+   *
+   * Angular parameters are radians taken straight from the file. Conway
+   * applies no plane-angle unit conversion anywhere on the STEP path -
+   * conical_surface.semi_angle reaches conway-geom raw in
+   * extractConicalSurface - so a degree-unit export is wrong here in exactly
+   * the same way, and consistently so.
+   *
+   * @param from The basis surface.
+   * @return {SurfaceParameterization | undefined} The parameterization, or
+   * undefined for a surface that has none here (b-spline and swept surfaces).
+   */
+  private surfaceParameterization(
+      from: surface ): SurfaceParameterization | undefined {
+
+    if ( from instanceof plane ) {
+
+      // The one non-angular case: (u, v) are distances along the placement's
+      // x and y axes.
+      return {
+        position: from.position,
+        evaluate: ( u: number, v: number ) => ( { x: u, y: v, z: 0 } ),
+        angularU: false,
+        angularV: false,
+      }
+    }
+
+    if ( from instanceof cylindrical_surface ) {
+
+      const radius = from.radius
+
+      return {
+        position: from.position,
+        evaluate: ( u: number, v: number ) =>
+          ( { x: radius * Math.cos( u ), y: radius * Math.sin( u ), z: v } ),
+        angularU: true,
+        angularV: false,
+      }
+    }
+
+    if ( from instanceof conical_surface ) {
+
+      const radius = from.radius
+
+      // Signed, unlike the native tesselator's tan(fabs(semi_angle)): that
+      // one fits its generator line from boundary samples and only needs the
+      // taper's magnitude, whereas the 2D curve here was authored against the
+      // spec's parameterization, where the radius grows with v by the SIGNED
+      // taper and a narrowing cone runs the other way.
+      const taper = Math.tan( from.semi_angle )
+
+      return {
+        position: from.position,
+        evaluate: ( u: number, v: number ) => {
+
+          const ring = radius + ( v * taper )
+
+          return { x: ring * Math.cos( u ), y: ring * Math.sin( u ), z: v }
+        },
+        angularU: true,
+        angularV: false,
+      }
+    }
+
+    if ( from instanceof spherical_surface ) {
+
+      const radius = from.radius
+
+      return {
+        position: from.position,
+        evaluate: ( u: number, v: number ) => {
+
+          const ring = radius * Math.cos( v )
+
+          return {
+            x: ring * Math.cos( u ),
+            y: ring * Math.sin( u ),
+            z: radius * Math.sin( v ),
+          }
+        },
+        angularU: true,
+        angularV: true,
+      }
+    }
+
+    // Covers degenerate_toroidal_surface, which is a subtype and shares the
+    // parameterization (it only restricts the range v is meaningful over).
+    if ( from instanceof toroidal_surface ) {
+
+      const majorRadius = from.major_radius
+      const minorRadius = from.minor_radius
+
+      return {
+        position: from.position,
+        evaluate: ( u: number, v: number ) => {
+
+          const ring = majorRadius + ( minorRadius * Math.cos( v ) )
+
+          return {
+            x: ring * Math.cos( u ),
+            y: ring * Math.sin( u ),
+            z: minorRadius * Math.sin( v ),
+          }
+        },
+        angularU: true,
+        angularV: true,
+      }
+    }
+
+    return void 0
+  }
+
+  /**
+   * Extract a pcurve: a curve given in the parameter space of a basis surface
+   * (ISO 10303-42). The parameter curve is extracted through the ordinary
+   * curve path and its (u, v) samples are pushed through the basis surface's
+   * parameterization, giving the 3D polyline every other arm of extractCurve
+   * hands back.
+   *
+   * Extent comes from the parameter curve itself: a bounded one (polyline,
+   * b-spline, trimmed or composite curve) carries its own, and an unbounded
+   * 2D LINE or CIRCLE gets whatever the ordinary line/circle extraction gives
+   * it. An EDGE_CURVE's vertex trims are 3D and are deliberately NOT inverted
+   * back into parameter space here, so an edge whose parameter curve is an
+   * unbounded LINE comes out at that line's own extent rather than the edge's
+   * - see https://github.com/bldrs-ai/conway/issues/505.
+   *
+   * @param from The pcurve to extract.
+   * @return {CurveObject | undefined} The mapped 3D curve, or undefined where
+   * the basis surface has no parameterization here or the parameter curve
+   * yields no points. Both are warned about naming the type responsible, so
+   * the residue is measurable per surface family rather than as one row.
    */
   extractPScurve1( from: pcurve ): CurveObject | undefined {
 
-    const surface = from.basis_surface
+    const basisSurface = from.basis_surface
 
-    if ( !( surface instanceof plane ) ) {
-      Logger.error( 'PSCurve not a plane, other curves unsupported')
+    const parameterization = this.surfaceParameterization( basisSurface )
+
+    if ( parameterization === void 0 ) {
+
+      Logger.warning(
+          'Unsupported PCURVE basis surface, type: ' +
+          `${EntityTypesAP214[ basisSurface.type ]}`,
+          from.expressID )
       return
     }
 
-    const point = surface.position.location.coordinates
+    // ISO 10303-42 constrains reference_to_curve to a single curve item in a
+    // 2D parametric context, but the field is a general representation, so
+    // the curve is searched for rather than indexed blindly.
+    const parameterCurveItem =
+      from.reference_to_curve.items.find(
+          ( item ): item is curve => item instanceof curve )
 
-    const dim   = point.length
+    if ( parameterCurveItem === void 0 ) {
 
-    const pointsFlattened = new Float32Array( dim * 1 )
-
-    pointsFlattened[ 0 ] = point[ 0 ]
-    pointsFlattened[ 1 ] = point[ 1 ]
-
-     
-    if ( dim > 2 ) {
-
-      pointsFlattened[ 2 ] = point[ 2 ]
-
-      // pointsFlattened[ 3 ] = point[ 0 ] + ( dir[ 0 ] * mag )
-      // pointsFlattened[ 4 ] = point[ 1 ] + ( dir[ 1 ] * mag )
-      // pointsFlattened[ 5 ] = point[ 2 ] + ( dir[ 2 ] * mag )
-    } else {
-      // pointsFlattened[ 2 ] = point[ 0 ] + ( dir[ 0 ] * mag )
-      // pointsFlattened[ 3 ] = point[ 1 ] + ( dir[ 1 ] * mag )
+      Logger.warning(
+          'PCURVE reference_to_curve carries no curve item', from.expressID )
+      return
     }
 
-    const pointsPtr = this.arrayToWasmHeap(pointsFlattened)
+    const parameterCurve = this.extractCurve( parameterCurveItem )
+    const parameterCount = parameterCurve?.getPointsSize() ?? 0
+
+    if ( parameterCurve === void 0 || parameterCount === 0 ) {
+
+      // extractCurve has already warned under the parameter curve's own type.
+      return
+    }
+
+    // The frame is built by the same native call the surface side uses
+    // (extractCylindricalSurface and friends), so the pcurve is orthonormalised
+    // identically to the surface it lies on rather than by a second, subtly
+    // different implementation here.
+    const placement = this.conwayModel.getAxis2Placement3D(
+        this.extractAxis2Placement3D(
+            parameterization.position, basisSurface.localID, true ) )
+
+    const transform = placement.getValues()
+
+    // Sample density for angular parameters: the same knob the ellipse path
+    // uses, so a mapped arc is tessellated like every other arc conway emits.
+    const angularStep = ( 2 * Math.PI ) / this.circleSegments
+
+    const localPoints: Vector3[] = []
+
+    let previous = parameterCurve.get2d( 0 )
+
+    localPoints.push( parameterization.evaluate( previous.x, previous.y ) )
+
+    for ( let index = 1; index < parameterCount; ++index ) {
+
+      const current = parameterCurve.get2d( index )
+
+      const deltaU = current.x - previous.x
+      const deltaV = current.y - previous.y
+
+      // A straight run in an angular parameter is an arc in space, so a span
+      // that covers real angle is subdivided rather than chorded across.
+      let samples = 1
+
+      if ( parameterization.angularU ) {
+
+        samples = Math.max( samples, Math.ceil( Math.abs( deltaU ) / angularStep ) )
+      }
+
+      if ( parameterization.angularV ) {
+
+        samples = Math.max( samples, Math.ceil( Math.abs( deltaV ) / angularStep ) )
+      }
+
+      samples = Math.min( samples, MAXIMUM_PCURVE_SPAN_SAMPLES )
+
+      for ( let sample = 1; sample <= samples; ++sample ) {
+
+        const ratio = sample / samples
+
+        localPoints.push( parameterization.evaluate(
+            previous.x + ( deltaU * ratio ),
+            previous.y + ( deltaV * ratio ) ) )
+      }
+
+      previous = current
+    }
+
+    // Column-major Glmdmat4: basis columns at 0, 4, 8, translation at 12.
+    const pointsFlattened =
+      new Float64Array( localPoints.length * this.THREE_DIMENSIONS )
+
+    let offset = 0
+
+    for ( const localPoint of localPoints ) {
+
+      pointsFlattened[ offset ] =
+        ( transform[ 0 ] * localPoint.x ) + ( transform[ 4 ] * localPoint.y ) +
+        ( transform[ 8 ] * localPoint.z ) + transform[ 12 ]
+      pointsFlattened[ offset + 1 ] =
+        ( transform[ 1 ] * localPoint.x ) + ( transform[ 5 ] * localPoint.y ) +
+        ( transform[ 9 ] * localPoint.z ) + transform[ 13 ]
+      pointsFlattened[ offset + 2 ] =
+        ( transform[ 2 ] * localPoint.x ) + ( transform[ 6 ] * localPoint.y ) +
+        ( transform[ 10 ] * localPoint.z ) + transform[ 14 ]
+
+      offset += this.THREE_DIMENSIONS
+    }
+
+    placement.delete()
+
+    const pointsPtr = this.arrayToWasmHeap( pointsFlattened )
 
     const parameters = this.paramsGetPolyCurvePool!.acquire()
 
     parameters.points = pointsPtr
-    parameters.pointsLength = 1
-    parameters.dimensions = dim
+    parameters.pointsLength = localPoints.length
+    parameters.dimensions = this.THREE_DIMENSIONS
+    parameters.senseAgreement = true
+    parameters.isEdge = false
 
-    const curve_ = this.conwayModel.getPolyCurve(parameters)
+    const curve_ = this.conwayModel.getPolyCurve( parameters )
 
-    this.paramsGetPolyCurvePool!.release(parameters)
+    this.paramsGetPolyCurvePool!.release( parameters )
 
-    this.wasmModule._free(pointsPtr)
+    this.wasmModule._free( pointsPtr )
 
     return curve_
   }
@@ -2413,16 +2667,21 @@ export class AP214GeometryExtraction {
   }
 
   /**
-   * Efficiently flatten the points into a Float32Array
+   * Efficiently flatten the points into a Float64Array.
+   *
+   * Float64 because getPolyCurve, the only consumer, reinterprets the buffer
+   * as `const double *`: Float32 elements decode there as unrelated numbers
+   * (and read twice as many bytes as were written). Matches the IFC side's
+   * helper of the same name.
    *
    * @param points - Array of AP214CartesianPoint
    * @param dimensions - dimensions of points
-   * @return {Float32Array}
+   * @return {Float64Array}
    */
-  flattenPointsToFloat32Array( points: cartesian_point[], dimensions:number ): Float32Array {
+  flattenPointsToFloat64Array( points: cartesian_point[], dimensions:number ): Float64Array {
 
     const totalCoordinates = points.length * dimensions
-    const flatCoordinates = new Float32Array(totalCoordinates)
+    const flatCoordinates = new Float64Array(totalCoordinates)
 
     let offset = 0
 
@@ -2453,7 +2712,7 @@ export class AP214GeometryExtraction {
 
     if (pointsLength > 0) {
 
-      const pointsFlattened = this.flattenPointsToFloat32Array(points, dim)
+      const pointsFlattened = this.flattenPointsToFloat64Array(points, dim)
 
       const pointsPtr = this.arrayToWasmHeap(pointsFlattened)
 

--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -1907,10 +1907,10 @@ export class AP214GeometryExtraction {
    * carrying its equation under "Definition according to ISO/CD 10303-42" plus
    * "Entity adapted from <name> defined in ISO 10303-42".
    *
-   * The cone is the one worth stating explicitly, because it is the arm two
-   * reviews have queried (bldrs-ai/conway#520): its v is distance along the
-   * AXIS, so the radius grows by tan a per unit v - not distance along the
-   * generator, which would grow it by sin a. Two independent STEP readers
+   * The cone is the one worth stating explicitly, because it is the arm a
+   * review of this code read the other way (bldrs-ai/conway#520): its v is
+   * distance along the AXIS, so the radius grows by tan a per unit v - not
+   * distance along the generator, which would grow it by sin a. Two STEP readers
    * settle it the same way. Open CASCADE parameterizes its own
    * Geom_ConicalSurface along the generator, P(u,v) = O + (R + v sin a)(...)
    * + v cos a z, and therefore rescales v by 1/cos(a) coming in from STEP and

--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -1889,15 +1889,44 @@ export class AP214GeometryExtraction {
 
   /**
    * The ISO 10303-42 parameterization of an elementary basis surface,
-   * expressed in that surface's placement-local frame.
+   * expressed in that surface's placement-local frame. Writing C for the
+   * placement's origin, x/y/z for its axes, R (and r) for the radii and a for
+   * conical_surface.semi_angle, the standard's forms are
    *
-   * The formulae are the ones conway-geom tessellates these surfaces with:
+   *   plane        s(u,v) = C + u x + v y
+   *   cylindrical  s(u,v) = C + R((cos u) x + (sin u) y) + v z
+   *   conical      s(u,v) = C + (R + v tan a)((cos u) x + (sin u) y) + v z
+   *   spherical    s(u,v) = C + R cos v ((cos u) x + (sin u) y) + R sin v z
+   *   toroidal     s(u,v) = C + (R + r cos v)((cos u) x + (sin u) y)
+   *                           + r sin v z
+   *
+   * Note v on a sphere is a LATITUDE in [-90, 90] degrees, not a polar angle,
+   * and v on a torus runs around the tube. Those four are quoted here from the
+   * entities IFC adopted verbatim from this part - IfcPlane,
+   * IfcCylindricalSurface, IfcSphericalSurface and IfcToroidalSurface, each
+   * carrying its equation under "Definition according to ISO/CD 10303-42" plus
+   * "Entity adapted from <name> defined in ISO 10303-42".
+   *
+   * The cone is the one worth stating explicitly, because it is the arm two
+   * reviews have queried (bldrs-ai/conway#520): its v is distance along the
+   * AXIS, so the radius grows by tan a per unit v - not distance along the
+   * generator, which would grow it by sin a. Two independent STEP readers
+   * settle it the same way. Open CASCADE parameterizes its own
+   * Geom_ConicalSurface along the generator, P(u,v) = O + (R + v sin a)(...)
+   * + v cos a z, and therefore rescales v by 1/cos(a) coming in from STEP and
+   * by cos(a) going back out - GeomConvert_Units::DegreeToRadian and
+   * ::RadianToDegree, which is exactly the path its STEP reader pushes pcurves
+   * through (StepToTopoDS_TranslateEdge::MakePCurve). truck's STEP reader
+   * builds the cone by revolving the line (R,0,0) + t (tan a, 0, 1), which is
+   * the form above with t = v.
+   *
+   * conway-geom tessellates the same surfaces by inverting these formulae:
    * TriangulateCylindricalSurface, TriangulateSphericalSurface,
    * TriangulateConicalSurface and TriangulateToroidalSurface (conway-geom
    * `conway_geometry/operations/mesh_utils.h`) recover (theta, height) or
-   * (theta, latitude) from world points by inverting exactly these, so a
-   * pcurve mapped here lands on the same surface the face it bounds is
-   * triangulated on.
+   * (theta, latitude) from world points, so a pcurve mapped here lands on the
+   * same surface the face it bounds is triangulated on. It differs in one
+   * deliberate way, on the cone's sign - see that arm.
    *
    * Angular parameters are radians taken straight from the file. Conway
    * applies no plane-angle unit conversion anywhere on the STEP path -
@@ -1941,6 +1970,9 @@ export class AP214GeometryExtraction {
 
       const radius = from.radius
 
+      // tan, not sin, because v is axial distance rather than distance along
+      // the generator - see the equations in this method's doc comment.
+      //
       // Signed, unlike the native tesselator's tan(fabs(semi_angle)): that
       // one fits its generator line from boundary samples and only needs the
       // taper's magnitude, whereas the 2D curve here was authored against the

--- a/src/AP214E3_2010/ap214_pcurve_basis_surfaces.test.ts
+++ b/src/AP214E3_2010/ap214_pcurve_basis_surfaces.test.ts
@@ -188,6 +188,14 @@ describe('AP214 pcurve basis surfaces (bldrs-ai/conway#505)', () => {
   // A generator line at u = 0 on a cone whose placement is offset and turned a
   // quarter turn about z, so the local frame has to be applied for the mapped
   // points to land: local +x is world +y here.
+  //
+  // This also pins the cone's v convention, which is the arm reviews keep
+  // querying (bldrs-ai/conway#520): ISO 10303-42 measures v along the axis, so
+  // the far end is a ring of 10 + 20 tan(30 deg) = 21.547005 at an axial 20,
+  // landing at (5, 18.547005, 70). Were v distance along the generator, the
+  // same (0, 20) would give a ring of 10 + 20 sin(30 deg) = 20 at an axial
+  // 20 cos(30 deg), i.e. (5, 17, 67.320508), and both of the assertions on
+  // `last` below would fail.
   test('a conical basis surface applies the taper and the placement frame', () => {
 
     const points = extractedPoints('cone')

--- a/src/AP214E3_2010/ap214_pcurve_basis_surfaces.test.ts
+++ b/src/AP214E3_2010/ap214_pcurve_basis_surfaces.test.ts
@@ -189,8 +189,8 @@ describe('AP214 pcurve basis surfaces (bldrs-ai/conway#505)', () => {
   // quarter turn about z, so the local frame has to be applied for the mapped
   // points to land: local +x is world +y here.
   //
-  // This also pins the cone's v convention, which is the arm reviews keep
-  // querying (bldrs-ai/conway#520): ISO 10303-42 measures v along the axis, so
+  // This also pins the cone's v convention, the point a review of this code
+  // queried (bldrs-ai/conway#520): ISO 10303-42 measures v along the axis, so
   // the far end is a ring of 10 + 20 tan(30 deg) = 21.547005 at an axial 20,
   // landing at (5, 18.547005, 70). Were v distance along the generator, the
   // same (0, 20) would give a ring of 10 + 20 sin(30 deg) = 20 at an axial

--- a/src/AP214E3_2010/ap214_pcurve_basis_surfaces.test.ts
+++ b/src/AP214E3_2010/ap214_pcurve_basis_surfaces.test.ts
@@ -1,0 +1,313 @@
+import fs from 'fs'
+import { describe, expect, test, beforeAll } from '@jest/globals'
+import { Vector3 } from '../../dependencies/conway-geom'
+import { CurveObject } from '../../dependencies/conway-geom/interface/curve_object'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import Logger, { LogEntry, LogLevel } from '../logging/logger'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ParseResult } from '../step/parsing/step_parser'
+import { AP214GeometryExtraction } from './ap214_geometry_extraction'
+import { pcurve } from './AP214E3_2010_gen'
+import AP214StepParser from './ap214_step_parser'
+import AP214StepModel from './ap214_step_model'
+
+
+let extraction: AP214GeometryExtraction
+let model: AP214StepModel
+
+// Coordinates round-trip through the native curve at float precision (a
+// CurveObject's get3d hands back ~1e-7 relative of what went in), so the
+// checks here are geometric and to four decimal places rather than bit-exact.
+const PRECISION_DIGITS = 4
+const MONOTONIC_EPSILON = 1e-4
+
+const CYLINDER_RADIUS = 25
+const CYLINDER_TOP = 20
+const CONE_ORIGIN_X = 5
+const CONE_ORIGIN_Y = -3
+const CONE_ORIGIN_Z = 50
+const CONE_BASE_RADIUS = 10
+const CONE_HEIGHT = 20
+const CONE_SEMI_ANGLE = Math.PI / 6
+const CONE_TOP_RADIUS = CONE_BASE_RADIUS + (CONE_HEIGHT * Math.tan(CONE_SEMI_ANGLE))
+const SPHERE_RADIUS = 10
+const SPHERE_HEIGHT = 5
+const SPHERE_LATITUDE = Math.PI / 6
+const SPHERE_RING_RADIUS = SPHERE_RADIUS * Math.cos(SPHERE_LATITUDE)
+const TORUS_MAJOR_RADIUS = 20
+const TORUS_MINOR_RADIUS = 5
+const TORUS_OUTER = 25
+const TORUS_INNER = 15
+const PLANE_ORIGIN: Vector3 = { x: 1, y: 2, z: 3 }
+const PLANE_END: Vector3 = { x: 5, y: 9, z: 3 }
+const CURVE_3D_END_Y = 40
+const PARAMETER_SAMPLES = 3
+
+/**
+ * Parse the fixture and set up geometry extraction.
+ *
+ * @return {Promise<boolean>} True if initialization succeeded.
+ */
+async function initialize(): Promise<boolean> {
+  const parser = AP214StepParser.Instance
+  const buffer: Buffer = fs.readFileSync('data/pcurve-basis-surfaces.step')
+  const bufferInput = new ParsingBuffer(buffer)
+
+  if (parser.parseHeader(bufferInput)[1] !== ParseResult.COMPLETE) {
+    return false
+  }
+
+  const conwayGeometry = new ConwayGeometry()
+
+  if (!(await conwayGeometry.initialize())) {
+    return false
+  }
+
+  const [, parsedModel] = parser.parseDataToModel(bufferInput)
+
+  if (parsedModel === void 0) {
+    return false
+  }
+
+  model = parsedModel
+  extraction = new AP214GeometryExtraction(conwayGeometry, model)
+
+  return extraction.isInitialized()
+}
+
+/**
+ * Find the fixture's pcurve carrying a given name.
+ *
+ * @param name The PCURVE's name attribute.
+ * @return {pcurve} The matching pcurve.
+ */
+function pcurveNamed(name: string): pcurve {
+
+  const found = Array.from(model.types(pcurve)).find((item) => item.name === name)
+
+  expect(found).toBeDefined()
+
+  return found!
+}
+
+/**
+ * Extract a pcurve through extractCurve - the arm that dispatches to
+ * extractPScurve1 - and read its points out.
+ *
+ * @param name The PCURVE's name attribute.
+ * @return {Vector3[]} The extracted curve's points, empty if it was dropped.
+ */
+function extractedPoints(name: string): Vector3[] {
+
+  const curve: CurveObject | undefined = extraction.extractCurve(pcurveNamed(name))
+
+  if (curve === void 0) {
+    return []
+  }
+
+  const points: Vector3[] = []
+
+  for (let index = 0; index < curve.getPointsSize(); ++index) {
+    points.push(curve.get3d(index))
+  }
+
+  return points
+}
+
+/**
+ * Find a buffered warning containing a given fragment.
+ *
+ * @param fragment Text the message must contain.
+ * @return {LogEntry | undefined} The matching entry.
+ */
+function warningContaining(fragment: string): LogEntry | undefined {
+
+  return Logger.getLogs().find(
+      (entry) => entry.level === 'warning' && entry.message.includes(fragment))
+}
+
+describe('AP214 pcurve basis surfaces (bldrs-ai/conway#505)', () => {
+
+  beforeAll(async () => {
+
+    Logger.clearLogs()
+
+    // The b-spline basis surface warns by design below, and the echo would be
+    // noise in the test console. The buffer these tests read is filled
+    // regardless of the console threshold.
+    const threshold = Logger.getLogLevel()
+
+    Logger.setLogLevel(LogLevel.OFF)
+
+    try {
+
+      expect(await initialize()).toBe(true)
+
+    } finally {
+
+      Logger.setLogLevel(threshold)
+    }
+  })
+
+  // (u, v) walks a straight line from (0, 0) to (pi, 20): a half turn of the
+  // cylinder while climbing its full height, which is a helix arc and not the
+  // chord across it.
+  test('a cylindrical basis surface maps (u, v) onto the cylinder', () => {
+
+    const points = extractedPoints('cylinder')
+
+    // More points than the parameter curve has: the angular span is
+    // subdivided rather than chorded across.
+    expect(points.length).toBeGreaterThan(PARAMETER_SAMPLES)
+
+    let previousZ = -Infinity
+
+    for (const point of points) {
+
+      expect(Math.sqrt((point.x * point.x) + (point.y * point.y)))
+          .toBeCloseTo(CYLINDER_RADIUS, PRECISION_DIGITS)
+
+      // v maps to height along the axis, so it climbs with the parameter.
+      expect(point.z).toBeGreaterThanOrEqual(previousZ - MONOTONIC_EPSILON)
+
+      previousZ = point.z
+    }
+
+    const first = points[0]
+    const last = points[points.length - 1]
+
+    expect(first.x).toBeCloseTo(CYLINDER_RADIUS, PRECISION_DIGITS)
+    expect(first.y).toBeCloseTo(0, PRECISION_DIGITS)
+    expect(first.z).toBeCloseTo(0, PRECISION_DIGITS)
+
+    expect(last.x).toBeCloseTo(-CYLINDER_RADIUS, PRECISION_DIGITS)
+    expect(last.y).toBeCloseTo(0, PRECISION_DIGITS)
+    expect(last.z).toBeCloseTo(CYLINDER_TOP, PRECISION_DIGITS)
+  })
+
+  // A generator line at u = 0 on a cone whose placement is offset and turned a
+  // quarter turn about z, so the local frame has to be applied for the mapped
+  // points to land: local +x is world +y here.
+  test('a conical basis surface applies the taper and the placement frame', () => {
+
+    const points = extractedPoints('cone')
+
+    expect(points.length).toBeGreaterThan(1)
+
+    const first = points[0]
+    const last = points[points.length - 1]
+
+    expect(first.x).toBeCloseTo(CONE_ORIGIN_X, PRECISION_DIGITS)
+    expect(first.y).toBeCloseTo(CONE_ORIGIN_Y + CONE_BASE_RADIUS, PRECISION_DIGITS)
+    expect(first.z).toBeCloseTo(CONE_ORIGIN_Z, PRECISION_DIGITS)
+
+    // Radius at the far end is base + height * tan(30 degrees).
+    expect(last.x).toBeCloseTo(CONE_ORIGIN_X, PRECISION_DIGITS)
+    expect(last.y).toBeCloseTo(CONE_ORIGIN_Y + CONE_TOP_RADIUS, PRECISION_DIGITS)
+    expect(last.z).toBeCloseTo(CONE_ORIGIN_Z + CONE_HEIGHT, PRECISION_DIGITS)
+  })
+
+  // u sweeps a quarter turn at a fixed latitude of 30 degrees.
+  test('a spherical basis surface maps latitude to height', () => {
+
+    const points = extractedPoints('sphere')
+
+    expect(points.length).toBeGreaterThan(2)
+
+    for (const point of points) {
+
+      expect(Math.sqrt(
+          (point.x * point.x) + (point.y * point.y) + (point.z * point.z)))
+          .toBeCloseTo(SPHERE_RADIUS, PRECISION_DIGITS)
+
+      expect(point.z).toBeCloseTo(SPHERE_HEIGHT, PRECISION_DIGITS)
+    }
+
+    const first = points[0]
+    const last = points[points.length - 1]
+
+    expect(first.x).toBeCloseTo(SPHERE_RING_RADIUS, PRECISION_DIGITS)
+    expect(first.y).toBeCloseTo(0, PRECISION_DIGITS)
+
+    expect(last.x).toBeCloseTo(0, PRECISION_DIGITS)
+    expect(last.y).toBeCloseTo(SPHERE_RING_RADIUS, PRECISION_DIGITS)
+  })
+
+  // v walks half way around the tube at a fixed u, from the outer equator to
+  // the inner one.
+  test('a toroidal basis surface maps the tube angle', () => {
+
+    const points = extractedPoints('torus')
+
+    expect(points.length).toBeGreaterThan(2)
+
+    for (const point of points) {
+
+      const planar = Math.sqrt((point.x * point.x) + (point.y * point.y))
+      const fromTubeCentre = Math.sqrt(
+          ((planar - TORUS_MAJOR_RADIUS) * (planar - TORUS_MAJOR_RADIUS)) +
+          (point.z * point.z))
+
+      expect(fromTubeCentre).toBeCloseTo(TORUS_MINOR_RADIUS, PRECISION_DIGITS)
+    }
+
+    const first = points[0]
+    const last = points[points.length - 1]
+
+    expect(first.x).toBeCloseTo(TORUS_OUTER, PRECISION_DIGITS)
+    expect(first.z).toBeCloseTo(0, PRECISION_DIGITS)
+
+    expect(last.x).toBeCloseTo(TORUS_INNER, PRECISION_DIGITS)
+    expect(last.z).toBeCloseTo(0, PRECISION_DIGITS)
+  })
+
+  // The planar case the extractor already claimed to support: (u, v) are
+  // distances along the placement's x and y axes, so the parameter curve's
+  // (4, 7) lands 4 and 7 from an origin at (1, 2, 3).
+  test('a planar basis surface maps (u, v) along the placement axes', () => {
+
+    const points = extractedPoints('plane')
+
+    expect(points.length).toBe(2)
+
+    expect(points[0].x).toBeCloseTo(PLANE_ORIGIN.x, PRECISION_DIGITS)
+    expect(points[0].y).toBeCloseTo(PLANE_ORIGIN.y, PRECISION_DIGITS)
+    expect(points[0].z).toBeCloseTo(PLANE_ORIGIN.z, PRECISION_DIGITS)
+
+    expect(points[1].x).toBeCloseTo(PLANE_END.x, PRECISION_DIGITS)
+    expect(points[1].y).toBeCloseTo(PLANE_END.y, PRECISION_DIGITS)
+    expect(points[1].z).toBeCloseTo(PLANE_END.z, PRECISION_DIGITS)
+  })
+
+  // The residue: dropped, but under a message that names the basis surface so
+  // the family can be sized per type rather than as one undifferentiated row.
+  test('an unsupported basis surface is dropped with its type named', () => {
+
+    expect(extractedPoints('bspline').length).toBe(0)
+
+    const warning = warningContaining('Unsupported PCURVE basis surface')
+
+    expect(warning).toBeDefined()
+    expect(warning!.message).toContain('B_SPLINE_SURFACE_WITH_KNOTS')
+    expect(warning!.expressIDs.has(
+        String(pcurveNamed('bspline').expressID))).toBe(true)
+  })
+
+  // The pcurve here is one variant of a complex instance that also carries a
+  // SURFACE_CURVE; its curve_3d runs +y from (25, 0, 0), which the pcurve's
+  // own parameter curve (a helix on the cylinder) never touches.
+  test('an explicit curve_3d on the same instance beats the mapping', () => {
+
+    const points = extractedPoints('complex')
+
+    expect(points.length).toBe(2)
+
+    expect(points[0].x).toBeCloseTo(CYLINDER_RADIUS, PRECISION_DIGITS)
+    expect(points[0].y).toBeCloseTo(0, PRECISION_DIGITS)
+    expect(points[0].z).toBeCloseTo(0, PRECISION_DIGITS)
+
+    expect(points[1].x).toBeCloseTo(CYLINDER_RADIUS, PRECISION_DIGITS)
+    expect(points[1].y).toBeCloseTo(CURVE_3D_END_Y, PRECISION_DIGITS)
+    expect(points[1].z).toBeCloseTo(0, PRECISION_DIGITS)
+  })
+})

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -5,6 +5,9 @@ import {versionString} from '../../version/version'
 import Logger, { LogLevel as ConwayLogLevel } from '../../logging/logger'
 import { ProgressCallback } from '../../core/progress'
 import { ModelInfo } from '../../core/progress_log'
+import {
+  WasmHeapArrayConstructor, wasmHeapView,
+} from '../../core/wasm_heap'
 import Environment from '../../utilities/environment'
 import * as glmatrix from 'gl-matrix'
 import { StepExternalByteStore } from '../../step/step_buffer_provider'
@@ -841,8 +844,18 @@ export class IfcAPI {
    */
   getSubArray(heap: Float32Array | Uint32Array, startPtr: number, sizeBytes: number):
     Float32Array | Uint32Array {
-    // eslint-disable-next-line no-magic-numbers, no-mixed-operators
-    return heap.subarray(startPtr / 4, startPtr / 4 + sizeBytes).slice(0)
+
+    // `heap` stays in the signature because web-ifc's API puts it there, but
+    // it is now read only for its element type. The view itself is rebuilt
+    // over the module's CURRENT heap buffer: a caller-held HEAPF32/HEAPU32 can
+    // be bound to a pre-growth buffer on the MT build, and subarray() on such
+    // a view clamps the window silently and returns short data rather than
+    // failing (#485, and see core/wasm_heap.ts).
+    const arrayType =
+      heap.constructor as WasmHeapArrayConstructor<Float32Array | Uint32Array>
+
+    // slice(0) as before, so the result outlives the next call into wasm.
+    return wasmHeapView(this.wasmModule, arrayType, startPtr, sizeBytes).slice(0)
   }
 
   /**

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -32,6 +32,9 @@ import { AP214Properties } from './ap214_properties'
 import { EntityTypesAP214Count } from '../../AP214E3_2010/AP214E3_2010_gen/entity_types_ap214.gen'
 import { ProgressTracker } from '../../core/progress'
 import { formatModelLine } from '../../core/progress_log'
+import {
+  WasmHeapArrayConstructor, wasmHeapView,
+} from '../../core/wasm_heap'
 import { extractModelInfo } from '../../loaders/loading_utilities'
 import { StepHeader } from '../../step/parsing/step_parser'
 import { BufferByteSource } from '../../step/parsing/byte_source'
@@ -1229,8 +1232,18 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
    */
   getSubArray(heap: Float32Array | Uint32Array, startPtr: number, sizeBytes: number):
     Float32Array | Uint32Array {
-    // eslint-disable-next-line no-magic-numbers, no-mixed-operators
-    return heap.subarray(startPtr / 4, startPtr / 4 + sizeBytes).slice(0)
+
+    // `heap` stays in the signature because web-ifc's API puts it there, but
+    // it is now read only for its element type. The view itself is rebuilt
+    // over the module's CURRENT heap buffer: a caller-held HEAPF32/HEAPU32 can
+    // be bound to a pre-growth buffer on the MT build, and subarray() on such
+    // a view clamps the window silently and returns short data rather than
+    // failing (#485, and see core/wasm_heap.ts).
+    const arrayType =
+      heap.constructor as WasmHeapArrayConstructor<Float32Array | Uint32Array>
+
+    // slice(0) as before, so the result outlives the next call into wasm.
+    return wasmHeapView(this.wasmModule, arrayType, startPtr, sizeBytes).slice(0)
   }
 
   /**

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -25,6 +25,9 @@ import { IfcProperties } from './ifc_properties'
 import Logger from '../../logging/logger'
 import { ProgressTracker } from '../../core/progress'
 import { formatModelLine } from '../../core/progress_log'
+import {
+  WasmHeapArrayConstructor, wasmHeapView,
+} from '../../core/wasm_heap'
 import { extractModelInfo } from '../../loaders/loading_utilities'
 import IfcStepParser from '../../ifc/ifc_step_parser'
 import ParsingBuffer from '../../parsing/parsing_buffer'
@@ -1785,8 +1788,18 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    */
   getSubArray(heap: Float32Array | Uint32Array, startPtr: number, sizeBytes: number):
     Float32Array | Uint32Array {
-    // eslint-disable-next-line no-magic-numbers, no-mixed-operators
-    return heap.subarray(startPtr / 4, startPtr / 4 + sizeBytes).slice(0)
+
+    // `heap` stays in the signature because web-ifc's API puts it there, but
+    // it is now read only for its element type. The view itself is rebuilt
+    // over the module's CURRENT heap buffer: a caller-held HEAPF32/HEAPU32 can
+    // be bound to a pre-growth buffer on the MT build, and subarray() on such
+    // a view clamps the window silently and returns short data rather than
+    // failing (#485, and see core/wasm_heap.ts).
+    const arrayType =
+      heap.constructor as WasmHeapArrayConstructor<Float32Array | Uint32Array>
+
+    // slice(0) as before, so the result outlives the next call into wasm.
+    return wasmHeapView(this.wasmModule, arrayType, startPtr, sizeBytes).slice(0)
   }
 
   /**

--- a/src/core/wasm_heap.test.ts
+++ b/src/core/wasm_heap.test.ts
@@ -42,6 +42,24 @@ function fakeModule(
 }
 
 
+// Distinctive enough that a test can assert an error is NOT one of these. The
+// point of the assertions using them is that neither ever reaches a caller.
+const SCRATCH_PUSH_FAILURE = 'embind push_back could not allocate'
+const SCRATCH_DELETE_FAILURE = 'embind delete re-entered a dead runtime'
+
+/**
+ * Which halves of the embind scratch round trip should fail.
+ *
+ * Both are reachable, and for different reasons - see refreshHeapViews. This
+ * is how the tests put the module into each of them.
+ */
+interface ScratchFaults {
+  /** push_back throws: embind marshalling allocates, and the heap is short. */
+  push?: boolean
+  /** delete() throws: teardown re-enters a runtime that may have failed. */
+  delete?: boolean
+}
+
 /** What growingFakeModule hands back, so a test can look at both buffers. */
 interface GrowingFake {
   wasmModule: WasmHeapModule
@@ -77,13 +95,16 @@ interface GrowingFake {
  * @param refresh How the fake models emscripten's refresh route. 'embind'
  * mimics the std::string round trip that is the only route conway's builds
  * have; 'none' models a module with no route at all.
+ * @param scratchFaults Which halves of the embind round trip should throw.
+ * Only meaningful for the 'embind' route.
  * @return {GrowingFake} The fake and the two buffers to assert against.
  */
 function growingFakeModule(
     staleBytes: number,
     grownBytes: number,
     address: number,
-    refresh: 'embind' | 'exported' | 'none' = 'embind' ): GrowingFake {
+    refresh: 'embind' | 'exported' | 'none' = 'embind',
+    scratchFaults: ScratchFaults = {} ): GrowingFake {
 
   const staleBuffer = new ArrayBuffer( staleBytes )
   const grownBuffer = new ArrayBuffer( grownBytes )
@@ -119,12 +140,26 @@ function growingFakeModule(
       /** @param value Ignored; the marshalling is the point, not the string. */
       public push_back( value: string ): void {
         void value
+
+        // Before the rebind, because a marshalling failure is a refresh that
+        // did NOT happen - which is the state the caller then has to report.
+        if ( scratchFaults.push === true ) {
+          throw new Error( SCRATCH_PUSH_FAILURE )
+        }
+
         rebind()
       }
 
       /** Returns the scratch vector to wasm. */
       public delete(): void {
+        // Counted out first even when the fault is armed: what `balanced`
+        // pins is that the delete was ATTEMPTED for every vector taken, and a
+        // delete that throws has still been attempted.
         --outstanding
+
+        if ( scratchFaults.delete === true ) {
+          throw new Error( SCRATCH_DELETE_FAILURE )
+        }
       }
 
       /** Counts itself out so the test can prove it was given back. */
@@ -301,6 +336,52 @@ describe( 'arrayToWasmHeap', () => {
             .toContain( `ptr ${past} + ${PAYLOAD.byteLength} bytes` )
         }
       } )
+
+  // The refresh is a repair ATTEMPT, and it runs under exactly the memory
+  // pressure that makes embind's own marshalling allocation fail. If that
+  // failure escapes, it reaches the caller INSTEAD of the heap diagnostic -
+  // and #485 is the issue about how expensive it is to debug this path
+  // without that diagnostic, so destroying it here would undo the fix.
+  test( 'reports the heap state when the refresh itself cannot allocate', () => {
+
+    const fake = growingFakeModule(
+      STALE_HEAP_BYTES, GROWN_HEAP_BYTES, GROWN_ADDRESS, 'embind',
+      { push: true } )
+
+    let raised: unknown
+
+    try {
+      arrayToWasmHeap( fake.wasmModule, PAYLOAD )
+    } catch ( error ) {
+      raised = error
+    }
+
+    expect( ( raised as Error ).message ).toMatch( /outside the heap/ )
+    expect( ( raised as Error ).message ).not.toContain( SCRATCH_PUSH_FAILURE )
+
+    // The constructor is what registers the embind handle, so a vector whose
+    // push threw is still owed a delete.
+    expect( fake.balanced() ).toBe( true )
+  } )
+
+  // The mirror case, and the one where quieting actually changes the ANSWER
+  // rather than the error text: by the time delete() runs the push has already
+  // made emscripten rebuild the views, so the refresh succeeded and the copy
+  // has somewhere correct to land. Failing it over the teardown of a scratch
+  // object would break an operation that had just been repaired.
+  test( 'completes the copy when only the refresh teardown fails', () => {
+
+    const address = GROWN_ADDRESS
+
+    const fake = growingFakeModule(
+      STALE_HEAP_BYTES, GROWN_HEAP_BYTES, address, 'embind', { delete: true } )
+
+    expect( arrayToWasmHeap( fake.wasmModule, PAYLOAD ) ).toBe( address )
+
+    const written = new Float64Array( fake.grownBuffer, address, PAYLOAD.length )
+
+    expect( Array.from( written ) ).toEqual( Array.from( PAYLOAD ) )
+  } )
 
   // A module with no refresh route at all - which is what every fake here was
   // before this change, and what a non-emscripten module would be.
@@ -520,6 +601,19 @@ describe( 'wasmHeapByteLength', () => {
 
     const fake = growingFakeModule(
       STALE_HEAP_BYTES, GROWN_HEAP_BYTES, GROWN_ADDRESS, 'none' )
+
+    expect( wasmHeapByteLength( fake.wasmModule ) ).toBe( STALE_HEAP_BYTES )
+  } )
+
+  // Same reasoning as the no-route case above, but for a route that is present
+  // and fails. This one's only consumer is the AP214 CLI's high-water log
+  // line, so letting an embind failure out would abort an otherwise complete
+  // extraction from a log statement.
+  test( 'falls back to the cached view when the refresh route throws', () => {
+
+    const fake = growingFakeModule(
+      STALE_HEAP_BYTES, GROWN_HEAP_BYTES, GROWN_ADDRESS, 'embind',
+      { push: true } )
 
     expect( wasmHeapByteLength( fake.wasmModule ) ).toBe( STALE_HEAP_BYTES )
   } )

--- a/src/core/wasm_heap.test.ts
+++ b/src/core/wasm_heap.test.ts
@@ -5,12 +5,20 @@
 import { describe, expect, test } from '@jest/globals'
 
 import {
-  arraysToWasmHeap, arrayToWasmHeap, freeAll, releaseQuietly, WasmHeapModule,
+  arraysToWasmHeap, arrayToWasmHeap, freeAll, releaseQuietly,
+  WasmHeapArrayConstructor, wasmHeapByteLength, WasmHeapModule, wasmHeapView,
   withRelease,
 } from './wasm_heap'
 
 
 const HEAP_BYTES = 1024
+
+// #485's captured state in miniature: a heap that has grown, a module view
+// still describing the size before it, and an address that is valid in the
+// first and past the end of the second.
+const STALE_HEAP_BYTES = 256
+const GROWN_HEAP_BYTES = 1024
+const GROWN_ADDRESS = 512
 
 // Named rather than inlined, and non-zero, since what every assertion here
 // actually checks is that the right bytes landed somewhere that starts out
@@ -31,6 +39,108 @@ function fakeModule(
   const heap = new Uint8Array( new ArrayBuffer( heapBytes ) )
 
   return { _malloc: malloc, _free: () => { /* recorded by callers that care */ }, HEAPU8: heap }
+}
+
+
+/** What growingFakeModule hands back, so a test can look at both buffers. */
+interface GrowingFake {
+  wasmModule: WasmHeapModule
+  /** The buffer the module's views were bound to before the growth. */
+  staleBuffer: ArrayBuffer
+  /** The buffer the heap actually lives in after the growth. */
+  grownBuffer: ArrayBuffer
+  /** How many times a refresh route was taken. */
+  refreshes: () => number
+  /** Whether every scratch object the refresh took was given back. */
+  balanced: () => boolean
+}
+
+
+/**
+ * A module in exactly the state #485 was captured in.
+ *
+ * The heap has grown - a pthread did it, so this thread's glue never ran - and
+ * growth on a NON-extensible SharedArrayBuffer produces a different buffer
+ * object rather than lengthening the one in hand. So `_malloc` hands back an
+ * address that is perfectly valid in the real heap and past the end of the
+ * view the module is still caching, and stays that way until something makes
+ * emscripten rebuild its views.
+ *
+ * `HEAPU8` is a getter for the same reason it is re-read rather than cached in
+ * the code under test: the refresh REPLACES the property, and a fake that
+ * handed out one fixed view could not tell a helper that re-reads from one
+ * that does not.
+ *
+ * @param staleBytes Size of the heap the module's views still describe.
+ * @param grownBytes Size of the heap that actually exists.
+ * @param address What _malloc returns, an address in the grown region.
+ * @param refresh How the fake models emscripten's refresh route. 'embind'
+ * mimics the std::string round trip that is the only route conway's builds
+ * have; 'none' models a module with no route at all.
+ * @return {GrowingFake} The fake and the two buffers to assert against.
+ */
+function growingFakeModule(
+    staleBytes: number,
+    grownBytes: number,
+    address: number,
+    refresh: 'embind' | 'exported' | 'none' = 'embind' ): GrowingFake {
+
+  const staleBuffer = new ArrayBuffer( staleBytes )
+  const grownBuffer = new ArrayBuffer( grownBytes )
+
+  let viewsAreCurrent = false
+  let refreshes = 0
+  let outstanding = 0
+
+  /** Model emscripten's updateMemoryViews: rebind everything to the real heap. */
+  function rebind(): void {
+    ++refreshes
+    viewsAreCurrent = true
+  }
+
+  const wasmModule: WasmHeapModule = {
+    _malloc: () => address,
+    _free: () => { /* recorded by callers that care */ },
+
+    get HEAPU8(): Uint8Array {
+      return new Uint8Array( viewsAreCurrent ? grownBuffer : staleBuffer )
+    },
+  }
+
+  if ( refresh === 'exported' ) {
+
+    wasmModule.updateMemoryViews = rebind
+  } else if ( refresh === 'embind' ) {
+
+    // The refresh conway's builds actually have: emscripten's own glue calls
+    // growMemViews() before touching the heap to marshal a std::string, so a
+    // push_back is what rebuilds the module's views for us.
+    wasmModule.stringVector = class {
+      /** @param value Ignored; the marshalling is the point, not the string. */
+      public push_back( value: string ): void {
+        void value
+        rebind()
+      }
+
+      /** Returns the scratch vector to wasm. */
+      public delete(): void {
+        --outstanding
+      }
+
+      /** Counts itself out so the test can prove it was given back. */
+      public constructor() {
+        ++outstanding
+      }
+    }
+  }
+
+  return {
+    wasmModule,
+    staleBuffer,
+    grownBuffer,
+    refreshes: () => refreshes,
+    balanced: () => outstanding === 0,
+  }
 }
 
 
@@ -103,6 +213,108 @@ describe( 'arrayToWasmHeap', () => {
       .not.toThrow( /_malloc returned an unusable address/ )
   } )
 
+  // #485's confirmed shape end to end: the heap grew on another thread, so
+  // _malloc's address is real and the module's cached view ends before it.
+  // Getting this wrong is not a crash but a WRONG ANSWER - the bytes have to
+  // land in the heap that exists, not in the one the view remembers.
+  test( 'copies into the grown heap when a pointer lands past the stale view',
+      () => {
+
+        const address = GROWN_ADDRESS
+
+        const fake = growingFakeModule(
+          STALE_HEAP_BYTES, GROWN_HEAP_BYTES, address )
+
+        expect( arrayToWasmHeap( fake.wasmModule, PAYLOAD ) ).toBe( address )
+
+        expect( fake.refreshes() ).toBe( 1 )
+
+        const written = new Float64Array(
+          fake.grownBuffer, address, PAYLOAD.length )
+
+        expect( Array.from( written ) ).toEqual( Array.from( PAYLOAD ) )
+
+        // Nothing may have been written to the buffer that is on its way out;
+        // a write there is the silent-wrong-digest failure, not a loud one.
+        expect( Array.from( new Uint8Array( fake.staleBuffer ) )
+          .some( ( byte ) => byte !== 0 ) ).toBe( false )
+      } )
+
+  test( 'gives back the scratch object the refresh borrowed', () => {
+
+    const fake = growingFakeModule(
+      STALE_HEAP_BYTES, GROWN_HEAP_BYTES, GROWN_ADDRESS )
+
+    arrayToWasmHeap( fake.wasmModule, PAYLOAD )
+
+    expect( fake.balanced() ).toBe( true )
+  } )
+
+  // The refresh is not free, so it must not run on the ordinary path - which
+  // is every copy but the handful that follow a growth.
+  test( 'does not refresh when the pointer is already inside the view', () => {
+
+    const insideAddress = 64
+
+    const fake = growingFakeModule(
+      GROWN_HEAP_BYTES, GROWN_HEAP_BYTES * 4, insideAddress )
+
+    arrayToWasmHeap( fake.wasmModule, PAYLOAD )
+
+    expect( fake.refreshes() ).toBe( 0 )
+  } )
+
+  // Same situation, but on a build that exports emscripten's own rebuilder.
+  // Nothing conway ships does today; the point is that the preferred route is
+  // taken without the embind detour when it is there.
+  test( 'prefers an exported updateMemoryViews when the build has one', () => {
+
+    const address = GROWN_ADDRESS
+    const fake = growingFakeModule(
+      STALE_HEAP_BYTES, GROWN_HEAP_BYTES, address, 'exported' )
+
+    expect( arrayToWasmHeap( fake.wasmModule, PAYLOAD ) ).toBe( address )
+    expect( fake.refreshes() ).toBe( 1 )
+  } )
+
+  // The genuinely-impossible case #498 added the diagnostic for. A refresh
+  // that reconciles nothing means the address really is outside the heap, and
+  // that has to keep reporting the state rather than being retried away.
+  test( 'still reports the heap state when a refresh cannot reconcile it',
+      () => {
+
+        const past = GROWN_ADDRESS
+
+        // Grown, but not far enough to contain the address either.
+        const fake = growingFakeModule(
+          STALE_HEAP_BYTES, STALE_HEAP_BYTES + PAYLOAD.byteLength, past )
+
+        expect( () => arrayToWasmHeap( fake.wasmModule, PAYLOAD ) )
+          .toThrow( /outside the heap/ )
+
+        expect( fake.refreshes() ).toBe( 1 )
+
+        try {
+          arrayToWasmHeap( fake.wasmModule, PAYLOAD )
+        } catch ( error ) {
+          expect( ( error as Error ).message )
+            .toContain( `ptr ${past} + ${PAYLOAD.byteLength} bytes` )
+        }
+      } )
+
+  // A module with no refresh route at all - which is what every fake here was
+  // before this change, and what a non-emscripten module would be.
+  test( 'reports the heap state when the module offers no refresh route', () => {
+
+    const fake = growingFakeModule(
+      STALE_HEAP_BYTES, GROWN_HEAP_BYTES, GROWN_ADDRESS, 'none' )
+
+    expect( () => arrayToWasmHeap( fake.wasmModule, PAYLOAD ) )
+      .toThrow( /outside the heap/ )
+
+    expect( fake.refreshes() ).toBe( 0 )
+  } )
+
   test( 'a zero-length copy is not mistaken for a failed malloc', () => {
 
     const wasmModule = fakeModule( HEAP_BYTES, () => 0 )
@@ -120,7 +332,7 @@ describe( 'arrayToWasmHeap', () => {
     const source = PAYLOAD
 
     expect( () => arrayToWasmHeap( wasmModule, source ) )
-      .toThrow( /outside the heap view/ )
+      .toThrow( /outside the heap/ )
 
     try {
       arrayToWasmHeap( wasmModule, source )
@@ -159,9 +371,171 @@ describe( 'arrayToWasmHeap', () => {
     }
 
     expect( () => arrayToWasmHeap( wasmModule, PAYLOAD ) )
-      .toThrow( /outside the heap view/ )
+      .toThrow( /outside the heap/ )
 
     expect( freed ).toEqual( [ past ] )
+  } )
+} )
+
+
+describe( 'wasmHeapView', () => {
+
+  test( 'views the live heap at the pointer', () => {
+
+    const address = 64
+    const count = 3
+    const wasmModule = fakeModule( HEAP_BYTES, () => address )
+
+    const view = wasmHeapView( wasmModule, Float64Array, address, count )
+
+    view.set( PAYLOAD )
+
+    expect( Array.from(
+      new Float64Array( wasmModule.HEAPU8.buffer, address, count ) ) )
+      .toEqual( Array.from( PAYLOAD ) )
+  } )
+
+  // The reason views are CONSTRUCTED here rather than subarray'd off the
+  // module's view: subarray clamps an out-of-range window down to whatever
+  // fits and returns it, so a caller writing through it lands somewhere other
+  // than its allocation and no one hears about it. This asserts the difference
+  // rather than the mechanism - the clamped subarray is shown to be wrong, and
+  // the helper is shown not to produce it.
+  test( 'refuses a window subarray would have silently shortened', () => {
+
+    const count = 4
+    const address = STALE_HEAP_BYTES - count
+
+    const fake = growingFakeModule(
+      STALE_HEAP_BYTES, STALE_HEAP_BYTES, address, 'none' )
+
+    expect( fake.wasmModule.HEAPU8
+      .subarray( address, address + count * Float64Array.BYTES_PER_ELEMENT )
+      .length ).toBeLessThan( count * Float64Array.BYTES_PER_ELEMENT )
+
+    expect( () => wasmHeapView( fake.wasmModule, Float64Array, address, count ) )
+      .toThrow( /outside the heap/ )
+  } )
+
+  test( 'refreshes a stale view before building over it', () => {
+
+    const address = GROWN_ADDRESS
+    const count = 3
+    const fake = growingFakeModule(
+      STALE_HEAP_BYTES, GROWN_HEAP_BYTES, address )
+
+    const view = wasmHeapView( fake.wasmModule, Float64Array, address, count )
+
+    expect( view.buffer ).toBe( fake.grownBuffer )
+    expect( view.byteOffset ).toBe( address )
+    expect( view.length ).toBe( count )
+  } )
+
+  // A >2GB heap is reachable - every target builds with 4GB of maximum memory
+  // - and a pointer from a raw i32 export arrives negative up there. What
+  // matters is not that `>>> 0` works, it is that the view this helper hands
+  // back is positioned at the UNSIGNED address; a signed one would put it
+  // before the start of the heap. Asserted through a recording element type,
+  // because a real 2GB buffer cannot be allocated in a unit test.
+  test( 'positions the view at the unsigned address for a >2GB pointer', () => {
+
+    const signedAddress = -2147483648
+    const unsignedAddress = 2147483648
+    const headroom = 4096
+    const count = 2
+
+    /** Stands in for a typed array, recording how it was constructed. */
+    class RecordingArray {
+      public static readonly BYTES_PER_ELEMENT = 8
+
+      /**
+       * @param buffer The buffer the helper chose.
+       * @param byteOffset The address the helper passed.
+       * @param length The element count the helper passed.
+       */
+      public constructor(
+        public readonly buffer: ArrayBufferLike,
+        public readonly byteOffset: number,
+        public readonly length: number ) {
+      }
+    }
+
+    const wasmModule: WasmHeapModule = {
+      _malloc: () => signedAddress,
+      _free: () => { /* unused here */ },
+      HEAPU8: { length: 0, buffer: { byteLength: unsignedAddress + headroom } } as
+        unknown as Uint8Array,
+    }
+
+    const view = wasmHeapView(
+      wasmModule,
+      RecordingArray as WasmHeapArrayConstructor< RecordingArray >,
+      signedAddress,
+      count )
+
+    expect( view.byteOffset ).toBe( unsignedAddress )
+    expect( view.length ).toBe( count )
+  } )
+
+  // Left signed, the bounds test passes for free: a negative address plus a
+  // length is never greater than a byteLength. So this is the case where
+  // normalising is what makes the check able to reject anything at all.
+  test( 'a >2GB pointer past the end of the heap is still caught', () => {
+
+    const signedAddress = -2147483648
+    const wasmModule: WasmHeapModule = {
+      _malloc: () => signedAddress,
+      _free: () => { /* unused here */ },
+      HEAPU8: new Uint8Array( new ArrayBuffer( HEAP_BYTES ) ),
+    }
+
+    expect( () => wasmHeapView( wasmModule, Float64Array, signedAddress, 1 ) )
+      .toThrow( /outside the heap/ )
+  } )
+} )
+
+
+describe( 'wasmHeapByteLength', () => {
+
+  // HEAPU8.length is what this used to read, and it is a growth step short
+  // whenever the module's views are behind - so a high-water figure taken from
+  // it under-reports exactly when the number is interesting.
+  test( 'reports the heap that exists, not the view that is cached', () => {
+
+    const grownBytes = GROWN_HEAP_BYTES
+    const fake = growingFakeModule(
+      STALE_HEAP_BYTES, grownBytes, GROWN_ADDRESS )
+
+    // Nothing has touched the heap yet, so the module's view is still the
+    // pre-growth one - which is exactly the state this must not report from.
+    expect( fake.wasmModule.HEAPU8.length ).toBe( STALE_HEAP_BYTES )
+
+    expect( wasmHeapByteLength( fake.wasmModule ) ).toBe( grownBytes )
+    expect( fake.refreshes() ).toBe( 1 )
+  } )
+
+  // No route to refresh through means the cached view is all there is. Better
+  // a lagging number than a thrown one from a line that only exists to log.
+  test( 'falls back to the cached view when there is no refresh route', () => {
+
+    const fake = growingFakeModule(
+      STALE_HEAP_BYTES, GROWN_HEAP_BYTES, GROWN_ADDRESS, 'none' )
+
+    expect( wasmHeapByteLength( fake.wasmModule ) ).toBe( STALE_HEAP_BYTES )
+  } )
+
+  test( 'reads wasmMemory live when the build exposes it', () => {
+
+    const grownBytes = 4096
+
+    const wasmModule: WasmHeapModule = {
+      _malloc: () => 0,
+      _free: () => { /* unused here */ },
+      HEAPU8: new Uint8Array( new ArrayBuffer( HEAP_BYTES ) ),
+      wasmMemory: { buffer: new ArrayBuffer( grownBytes ) },
+    }
+
+    expect( wasmHeapByteLength( wasmModule ) ).toBe( grownBytes )
   } )
 } )
 

--- a/src/core/wasm_heap.ts
+++ b/src/core/wasm_heap.ts
@@ -77,6 +77,10 @@ export interface WasmHeapModule {
 
 export type CopyableArray = Float32Array | Float64Array | Uint32Array
 
+/** The scratch object refreshHeapViews borrows from the embind route. */
+type WasmScratchVector =
+  InstanceType< NonNullable< WasmHeapModule[ 'stringVector' ] > >
+
 /**
  * The part of a typed-array constructor wasmHeapView needs: build over a
  * buffer at a byte offset, and say how wide an element is.
@@ -204,13 +208,47 @@ function refreshHeapViews( wasmModule: WasmHeapModule ): void {
     return
   }
 
-  const scratch = new StringVector()
+  // Every step of the embind round trip is best-effort, INDIVIDUALLY, because
+  // this whole function is best-effort: it only ever runs once something has
+  // already gone wrong with the heap, and both of its callers have a
+  // well-defined answer for "the refresh achieved nothing" - reconcile reports
+  // the heap state (#485's actual diagnostic), and the byte-length reporter
+  // returns a possibly-lagging number. Letting an embind failure out of here
+  // would replace either of those with a bare marshalling error from a
+  // function that exists only to try.
+  //
+  // Both halves can throw, for different reasons:
+  //
+  // - construct-and-push allocates, and this path runs precisely under the
+  //   heap pressure that makes allocation fail. A throw here means the views
+  //   were NOT refreshed, so the caller carries on with its stale-view state
+  //   and reports it - which is the outcome that matters, since losing the
+  //   diagnostic to the failure of the repair attempt is what #485 cost two
+  //   sightings to locate.
+  // - delete() re-enters the same runtime that may just have failed. By then
+  //   the push has already made emscripten rebuild the views, so the refresh
+  //   SUCCEEDED; failing the caller's copy over the teardown of a scratch
+  //   object would break an operation that had just been repaired.
+  //
+  // Split rather than nested so a push that throws still gets its vector
+  // deleted: the constructor is what registers the embind handle, so anything
+  // constructed is owed a delete regardless of what the push did.
+  let scratch: WasmScratchVector | undefined
 
-  // delete() re-enters the wasm runtime that may just have failed, and losing
-  // the heap diagnostic to a teardown error would defeat the point.
-  withRelease(
-      () => scratch.push_back( '' ),
-      () => scratch.delete() )
+  releaseQuietly( () => {
+
+    const created = new StringVector()
+
+    scratch = created
+
+    created.push_back( '' )
+  } )
+
+  const created: WasmScratchVector | undefined = scratch
+
+  if ( created !== void 0 ) {
+    releaseQuietly( () => created.delete() )
+  }
 }
 
 
@@ -312,6 +350,12 @@ export function wasmHeapView< TArray >(
  * thing a high-water figure must not do. This is a reporting call - a line at
  * the end of a run - so paying microseconds for a true answer is the right
  * trade. Do not put it in a loop.
+ *
+ * That the refresh cannot throw (see refreshHeapViews) matters more here than
+ * at the other call site: this figure's only consumer is the AP214 CLI's
+ * high-water log line, so an embind failure escaping would abort an otherwise
+ * complete extraction from a log statement. A lagging number is the right
+ * answer there.
  *
  * @param wasmModule The module to measure.
  * @return {number} The heap's size in bytes, or 0 if it has no heap yet.

--- a/src/core/wasm_heap.ts
+++ b/src/core/wasm_heap.ts
@@ -1,5 +1,6 @@
 /**
- * Copying JS-side arrays into the wasm heap.
+ * Reading and writing the wasm heap from JS, through views that are known to
+ * belong to the heap as it is RIGHT NOW.
  *
  * This lives in one place because the two geometry extractors had a copy each,
  * and the copies had drifted: one honoured the source view's window and the
@@ -9,36 +10,104 @@
  * See bldrs-ai/conway#485 for what an uninstrumented failure on this path
  * costs: `Invalid typed array length: 80`, no context, and two sightings
  * across two models before it could even be located.
+ *
+ * The confirmed mechanism behind #485
+ * -----------------------------------
+ * conway's MT builds create their memory as
+ * `new WebAssembly.Memory({ initial, maximum: 65536, shared: true })` with no
+ * `maxByteLength`, so `wasmMemory.buffer` is a **non-extensible**
+ * SharedArrayBuffer - `growable === false`, `maxByteLength === byteLength`
+ * (verified against Dist/ConwayGeomWasmNodeMT.js and by inspecting a live
+ * module). A non-extensible buffer cannot grow in place, so
+ * `WebAssembly.Memory.grow()` materialises a NEW SharedArrayBuffer, which the
+ * `.buffer` getter hands out from then on.
+ *
+ * emscripten rebuilds `Module.HEAPU8` and friends over that new buffer in
+ * `updateMemoryViews()` - but only on the thread that did the growing, and
+ * only when its own glue passes through `growMemViews()`. Growth driven by a
+ * pthread runs `updateMemoryViews()` in the WORKER's JS scope; the main
+ * thread's `Module.HEAPU8` stays bound to the pre-growth buffer until some
+ * main-thread glue call happens to run `growMemViews()`. `_malloc` is a raw
+ * wasm export, so it is not one of those calls: it can hand back an address in
+ * the newly added region while the JS-side view still ends before it. That is
+ * exactly the state #498's diagnostic captured in CI - view length equal to
+ * its own buffer's byteLength (so not stale relative to that buffer),
+ * `extensible false` (so that buffer never grew), and the pointer past the end
+ * of both.
+ *
+ * Which is why every view here is built through wasmHeapView(): it re-reads
+ * the module's view, reconciles it against the pointer, and only then
+ * constructs.
  */
 
 import Logger from '../logging/logger'
 
 
-/** What the wasm module exposes that this needs. Deliberately narrow. */
+/**
+ * What the wasm module exposes that this needs. Deliberately narrow.
+ *
+ * Everything past `HEAPU8` is a refresh route that MAY be present; see
+ * refreshHeapViews for what each one is worth and which of them conway's
+ * current builds actually have.
+ */
 export interface WasmHeapModule {
   _malloc( bytes: number ): number
   _free( pointer: number ): void
   HEAPU8: Uint8Array
+
+  /**
+   * emscripten's own view rebuilder, if the build exports it. Not exported by
+   * any conway build today.
+   */
+  updateMemoryViews?: () => void
+
+  /**
+   * The live `WebAssembly.Memory`, if the build exposes it. Its `.buffer`
+   * getter always yields the current buffer, which makes staleness
+   * unrepresentable. Not exposed by any conway build today.
+   */
+  wasmMemory?: { readonly buffer: ArrayBufferLike }
+
+  /**
+   * embind's `std::vector<std::string>`. Present on every conway-geom build;
+   * used as a refresh route of last resort (see refreshHeapViews).
+   */
+  stringVector?: new () => { push_back( value: string ): void, delete(): void }
 }
 
 export type CopyableArray = Float32Array | Float64Array | Uint32Array
+
+/**
+ * The part of a typed-array constructor wasmHeapView needs: build over a
+ * buffer at a byte offset, and say how wide an element is.
+ */
+export interface WasmHeapArrayConstructor< TArray > {
+  new ( buffer: ArrayBufferLike, byteOffset: number, length: number ): TArray
+  readonly BYTES_PER_ELEMENT: number
+}
 
 
 /**
  * Describe the heap and the request, for an error message that is actually
  * actionable.
  *
- * The buffer's kind matters, and there are two kinds to tell apart, not one.
- * conway's MT build creates its memory with `shared: true`, so its heap is a
- * growable SharedArrayBuffer; single-threaded builds on emscripten 6 get a
- * resizable ArrayBuffer (see decode_utf8.ts). Both cases have length-tracking
- * views that extend by themselves, which is why emscripten's
- * updateMemoryViews() early-returns on growth rather than rebuilding them.
+ * Three of these fields exist to tell #485's two candidate mechanisms apart,
+ * and the CI capture that settled it read them in this order:
  *
- * So both flags are reported. They have different names on the two buffer
- * types, and printing only one makes every single-threaded failure look like
- * the assumption has broken when it has not - which would be a false alarm
- * pointing away from whatever the real cause was.
+ * - `heap view length` BELOW `byteLength` means the view is stale relative to
+ *   its own buffer - a buffer that grew in place while the view kept its
+ *   original length.
+ * - `heap view length` EQUAL to `byteLength`, with the pointer past both,
+ *   means the view is fine for the buffer it has and the buffer itself is the
+ *   old one - the heap grew into a different buffer object entirely.
+ * - `extensible` settles whether the first was even possible: a non-extensible
+ *   buffer can never have grown in place.
+ *
+ * The flag has different names on the two buffer kinds (`growable` on
+ * SharedArrayBuffer, `resizable` on ArrayBuffer), so it is reported as one
+ * field alongside the kind rather than making a reader know which goes with
+ * which. Printing only one name would make every single-threaded failure look
+ * like the shared-memory case, pointing away from whatever the real cause was.
  *
  * @param wasmModule The module whose heap is being written to.
  * @param arrayPtr The pointer _malloc returned.
@@ -50,7 +119,7 @@ function describeHeap(
 
   const heap = wasmModule.HEAPU8
   const buffer =
-    heap?.buffer as ( ArrayBuffer | SharedArrayBuffer | undefined ) &
+    currentHeapBuffer( wasmModule ) as ( ArrayBufferLike | undefined ) &
       { growable?: boolean, resizable?: boolean }
 
   const shared = typeof SharedArrayBuffer !== 'undefined' &&
@@ -71,6 +140,191 @@ function describeHeap(
 
 
 /**
+ * The buffer the heap lives in as of this instant.
+ *
+ * `wasmMemory` is authoritative when a build exposes it - its `.buffer` getter
+ * cannot be stale - and reading it is a property access, so it is worth
+ * preferring even though nothing exposes it yet. Otherwise this is the
+ * module's cached view's buffer, which is what everything downstream then has
+ * to reconcile.
+ *
+ * @param wasmModule The module whose heap is wanted.
+ * @return {ArrayBufferLike} The heap's backing buffer.
+ */
+function currentHeapBuffer( wasmModule: WasmHeapModule ): ArrayBufferLike {
+
+  const memory = wasmModule.wasmMemory
+
+  // Re-read HEAPU8 off the module every time rather than caching it: an
+  // emscripten refresh REPLACES the property, so a cached reference is exactly
+  // the stale view this module exists to avoid.
+  return memory !== void 0 ? memory.buffer : wasmModule.HEAPU8?.buffer
+}
+
+
+/**
+ * Bring the module's cached heap views back in line with the real memory.
+ *
+ * Only ever called once a pointer has been seen to fall outside the cached
+ * view, so cost here is paid about once per growth event, not per copy.
+ *
+ * The routes are tried best-first, and the last one is the only one conway's
+ * current builds actually have. That is a finding, not an oversight: the
+ * emscripten output exposes `HEAP8/HEAPU8/HEAP32/HEAPU32/HEAPF32/HEAPF64`,
+ * `_malloc` and `_free` and nothing else memory-related - no `wasmMemory`, no
+ * `updateMemoryViews`, no `growMemViews`, no `GROWABLE_HEAP_*` helpers. What
+ * it does have is `growMemViews()` guarding every heap access inside its own
+ * JS library, and embind's `std::string` marshalling is one of those accesses
+ * (`stringToUTF8` reads `(growMemViews(), HEAPU8)`). So pushing an empty
+ * string into an embind vector makes emscripten notice the growth and rebuild
+ * `Module.HEAPU8` for us, which is what the reconcile below then re-reads.
+ * Measured at ~9us per round trip, on a path that runs after a heap growth.
+ *
+ * @param wasmModule The module whose views may be stale.
+ */
+function refreshHeapViews( wasmModule: WasmHeapModule ): void {
+
+  if ( typeof wasmModule.updateMemoryViews === 'function' ) {
+
+    wasmModule.updateMemoryViews()
+
+    return
+  }
+
+  // Nothing to refresh - currentHeapBuffer already reads this live.
+  if ( wasmModule.wasmMemory !== void 0 ) {
+    return
+  }
+
+  const StringVector = wasmModule.stringVector
+
+  // Absent on a module that is not conway-geom (the fakes in the tests, say),
+  // in which case there is no route and the caller reports the state instead.
+  if ( StringVector === void 0 ) {
+    return
+  }
+
+  const scratch = new StringVector()
+
+  // delete() re-enters the wasm runtime that may just have failed, and losing
+  // the heap diagnostic to a teardown error would defeat the point.
+  withRelease(
+      () => scratch.push_back( '' ),
+      () => scratch.delete() )
+}
+
+
+/**
+ * Reconcile a pointer against the heap, refreshing stale views if that is what
+ * is wrong, and hand back the buffer the view should be built over.
+ *
+ * The hot path is one property read, one add and one compare - the same test
+ * that was already here - so the refresh machinery costs nothing until a
+ * pointer actually lands outside.
+ *
+ * @param wasmModule The module the pointer belongs to.
+ * @param address The pointer, already normalised to unsigned.
+ * @param numBytes How many bytes past it will be touched.
+ * @return {ArrayBufferLike} A buffer that contains [address, address+numBytes).
+ */
+function reconcileHeapBuffer(
+    wasmModule: WasmHeapModule, address: number, numBytes: number ):
+    ArrayBufferLike {
+
+  const buffer = currentHeapBuffer( wasmModule )
+
+  if ( buffer !== void 0 && address + numBytes <= buffer.byteLength ) {
+    return buffer
+  }
+
+  refreshHeapViews( wasmModule )
+
+  const refreshed = currentHeapBuffer( wasmModule )
+
+  if ( refreshed !== void 0 && address + numBytes <= refreshed.byteLength ) {
+    return refreshed
+  }
+
+  // Past here the heap really does not contain the address, so this is the
+  // genuinely-impossible case #498 added the diagnostic for rather than the
+  // growth race it was chasing.
+  throw new Error(
+      'wasm heap allocation lies outside the heap, and refreshing the module ' +
+      'views did not reconcile it. ' +
+      describeHeap( wasmModule, address, numBytes ) )
+}
+
+
+/**
+ * Build a typed-array view over a region of the wasm heap.
+ *
+ * Every view onto the heap in this repo goes through here, because the
+ * property that makes a view safe - that its buffer is the heap's CURRENT
+ * buffer - is not something a caller can check by looking at its own code. It
+ * depends on whether some other thread grew the heap between the call that
+ * produced `pointer` and this line.
+ *
+ * Two things beyond the reconcile are worth knowing:
+ *
+ * - The pointer is normalised to unsigned. Pointers reaching JS from raw i32
+ *   wasm exports arrive NEGATIVE once the heap passes 2GB, and every target
+ *   builds with `maximum: 65536` pages (4GB), so that is a reachable state and
+ *   not a theoretical one. (This build's `applySignatureConversions` already
+ *   wraps `_malloc` as `a0 => f(a0) >>> 0`; pointers from other exports and
+ *   from other builds are not covered by that, so it is done here too.)
+ * - A view is CONSTRUCTED rather than `subarray`d off the module's view.
+ *   `subarray` silently clamps an out-of-range window, which turns "the heap
+ *   moved" into a short view and then into a copy that lands somewhere else
+ *   entirely; the constructor throws instead, and by then the reconcile has
+ *   already made throwing the right answer.
+ *
+ * @param wasmModule The module owning the heap.
+ * @param arrayType The typed-array constructor for the element type wanted.
+ * @param pointer Byte address in the heap, signed or unsigned.
+ * @param elementCount How many elements the view spans.
+ * @return {TArray} A view over the live heap. Do not retain it across any
+ * further call into wasm.
+ */
+export function wasmHeapView< TArray >(
+    wasmModule: WasmHeapModule,
+    arrayType: WasmHeapArrayConstructor< TArray >,
+    pointer: number,
+    elementCount: number ): TArray {
+
+  const address = pointer >>> 0
+  const numBytes = elementCount * arrayType.BYTES_PER_ELEMENT
+
+  return new arrayType(
+      reconcileHeapBuffer( wasmModule, address, numBytes ),
+      address,
+      elementCount )
+}
+
+
+/**
+ * How many bytes of wasm heap there currently are.
+ *
+ * Refreshes first, unconditionally - which is the opposite of what
+ * wasmHeapView does, and deliberate. There is nothing to compare a size
+ * against, so lag here cannot be detected the way an out-of-range pointer can;
+ * and `HEAPU8.length` on its own under-reports by a whole growth step whenever
+ * the module's views are behind (see this file's header), which is the one
+ * thing a high-water figure must not do. This is a reporting call - a line at
+ * the end of a run - so paying microseconds for a true answer is the right
+ * trade. Do not put it in a loop.
+ *
+ * @param wasmModule The module to measure.
+ * @return {number} The heap's size in bytes, or 0 if it has no heap yet.
+ */
+export function wasmHeapByteLength( wasmModule: WasmHeapModule ): number {
+
+  refreshHeapViews( wasmModule )
+
+  return currentHeapBuffer( wasmModule )?.byteLength ?? 0
+}
+
+
+/**
  * Copy an array into a fresh wasm heap allocation.
  *
  * @param wasmModule The module to allocate in.
@@ -82,15 +336,12 @@ export function arrayToWasmHeap(
 
   const numBytes = array.length * array.BYTES_PER_ELEMENT
 
-  // Normalised, not rejected. _malloc is bound raw from wasmExports and
-  // returns i32, and every target builds with MAXIMUM_MEMORY=4GB, so a
-  // perfectly good address at or above 2^31 arrives here NEGATIVE. Treating
-  // that as a failure would hard-fail every copy once the heap passes 2GB -
-  // which is the memory-pressure scenario #485 is about - so it is converted
-  // the way emscripten's own glue does (`HEAPU32[ptr >>> 2 >>> 0]`) and used
-  // in that form for the bounds test, the view, the free and the message.
-  // Left signed it would also pass the bounds test below, since a negative
-  // plus numBytes is not greater than byteLength.
+  // Normalised, not rejected. Pointers arriving from raw i32 wasm exports are
+  // NEGATIVE at or above 2^31, and every target builds with 4GB of maximum
+  // memory, so that is reachable - and it is reachable precisely under the
+  // memory pressure #485 is about. wasmHeapView normalises too; doing it here
+  // as well keeps the zero test, the free and the message all talking about
+  // the same address.
   const arrayPtr = wasmModule._malloc( numBytes ) >>> 0
 
   // 0 is _malloc's failure return and also a valid byteOffset, so the view
@@ -104,14 +355,12 @@ export function arrayToWasmHeap(
       describeHeap( wasmModule, arrayPtr, numBytes ) )
   }
 
-  const heapBuffer = wasmModule.HEAPU8.buffer
+  let destination: Uint8Array
 
-  // Checked rather than left to the TypedArray constructor, whose RangeError
-  // is just "Invalid typed array length: N" - true, unactionable, and
-  // indistinguishable from a dozen other causes.
-  if ( arrayPtr + numBytes > heapBuffer.byteLength ) {
+  try {
 
-    const description = describeHeap( wasmModule, arrayPtr, numBytes )
+    destination = wasmHeapView( wasmModule, Uint8Array, arrayPtr, numBytes )
+  } catch ( error ) {
 
     // The allocation SUCCEEDED and only the view is refused, so this owns a
     // pointer nobody else can reach - arraysToWasmHeap's cleanup cannot see it
@@ -120,12 +369,8 @@ export function arrayToWasmHeap(
     // trouble.
     releaseQuietly( () => wasmModule._free( arrayPtr ) )
 
-    throw new Error(
-      'wasm heap allocation lies outside the heap view - ' +
-      `the view is stale or the heap grew without it. ${description}` )
+    throw error
   }
-
-  const destination = new Uint8Array( heapBuffer, arrayPtr, numBytes )
 
   // Honour the source view's own window: subarray() results share their
   // parent's backing buffer, so copying `array.buffer` wholesale reads the

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -51,6 +51,7 @@ import {
   FlattenedPointsResult,
 } from '../../dependencies/conway-geom'
 import { Uint32Sink } from '../step/parsing/uint32_sink'
+import { StepBufferNotResidentError } from '../step/step_buffer_provider'
 import { CanonicalMaterial, ColorRGBA, exponentToRoughness } from '../core/canonical_material'
 import { CanonicalMesh, CanonicalMeshType } from '../core/canonical_mesh'
 import { CanonicalProfile } from '../core/canonical_profile'
@@ -5924,25 +5925,49 @@ export class IfcGeometryExtraction {
       }
     }
 
-    const grid = this.gridByAxis(placementLocation.IntersectingAxes[0])
+    // The gridByAxis scan reads IfcGrid records, which are outside the
+    // forward-reference closure a windowed source pages for a product
+    // (the grid references the axes, not vice versa - see
+    // ensureResidentForProductExtract). A residency miss here must not
+    // fail the whole product: fall back to placing the intersection in
+    // the current frame, the same degraded state the no-grid arm gives,
+    // and strictly better than the pre-implementation
+    // rendered-at-origin. gridByAxis memoises only a COMPLETE scan, so a
+    // later product on a fully resident model rebuilds rather than
+    // trusting a partial index.
+    try {
 
-    if (grid === void 0) {
+      const grid = this.gridByAxis(placementLocation.IntersectingAxes[0])
 
-      // Axes belonging to no grid: the intersection is still a point, but
-      // there is no grid placement to measure it from, so it lands in
-      // whatever frame is current.
-      Logger.warning(
-          'IfcGridPlacement: no IfcGrid lists the axes of this placement.',
-          from.expressID)
+      if (grid === void 0) {
 
-    } else {
+        // Axes belonging to no grid: the intersection is still a point, but
+        // there is no grid placement to measure it from, so it lands in
+        // whatever frame is current.
+        Logger.warning(
+            'IfcGridPlacement: no IfcGrid lists the axes of this placement.',
+            from.expressID)
 
-      const gridPlacement = grid.ObjectPlacement
+      } else {
 
-      if (gridPlacement !== null) {
+        const gridPlacement = grid.ObjectPlacement
 
-        this.extractPlacement(gridPlacement, isRelVoid)
+        if (gridPlacement !== null) {
+
+          this.extractPlacement(gridPlacement, isRelVoid)
+        }
       }
+    } catch (error) {
+
+      if (!(error instanceof StepBufferNotResidentError)) {
+        throw error
+      }
+
+      Logger.warning(
+          'IfcGridPlacement: grid records are not resident on this ' +
+          'windowed source - placing at the grid intersection in the ' +
+          'current frame, without the grid\'s own placement.',
+          from.expressID)
     }
 
     const placementTransform = this.conwayModel.getAxis2Placement3D({

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -5925,38 +5925,27 @@ export class IfcGeometryExtraction {
       }
     }
 
-    // The gridByAxis scan reads IfcGrid records, which are outside the
-    // forward-reference closure a windowed source pages for a product
-    // (the grid references the axes, not vice versa - see
-    // ensureResidentForProductExtract). A residency miss here must not
-    // fail the whole product: fall back to placing the intersection in
-    // the current frame, the same degraded state the no-grid arm gives,
-    // and strictly better than the pre-implementation
-    // rendered-at-origin. gridByAxis memoises only a COMPLETE scan, so a
-    // later product on a fully resident model rebuilds rather than
-    // trusting a partial index.
+    // Two guarded regions rather than one, because the two reads degrade to
+    // DIFFERENT states and a single catch could only describe one of them
+    // truthfully. Neither may fail the product: dropping it entirely is
+    // strictly worse than the pre-implementation rendered-at-origin.
+    //
+    // Region 1 - the gridByAxis scan. It reads IfcGrid records, which are
+    // outside the forward-reference closure a windowed source pages for a
+    // product (the grid references the axes, not vice versa - see
+    // ensureResidentForProductExtract), so this is the read most likely to
+    // miss. Nothing has been applied when it throws, so the intersection
+    // lands in the current frame - the same degraded state the no-grid arm
+    // gives. gridByAxis memoises only a COMPLETE scan, so a later product on
+    // a fully resident model rebuilds rather than trusting a partial index.
+    let grid: IfcGrid | undefined
+    let gridScanned = false
+
     try {
 
-      const grid = this.gridByAxis(placementLocation.IntersectingAxes[0])
+      grid = this.gridByAxis(placementLocation.IntersectingAxes[0])
+      gridScanned = true
 
-      if (grid === void 0) {
-
-        // Axes belonging to no grid: the intersection is still a point, but
-        // there is no grid placement to measure it from, so it lands in
-        // whatever frame is current.
-        Logger.warning(
-            'IfcGridPlacement: no IfcGrid lists the axes of this placement.',
-            from.expressID)
-
-      } else {
-
-        const gridPlacement = grid.ObjectPlacement
-
-        if (gridPlacement !== null) {
-
-          this.extractPlacement(gridPlacement, isRelVoid)
-        }
-      }
     } catch (error) {
 
       if (!(error instanceof StepBufferNotResidentError)) {
@@ -5968,6 +5957,45 @@ export class IfcGeometryExtraction {
           'windowed source - placing at the grid intersection in the ' +
           'current frame, without the grid\'s own placement.',
           from.expressID)
+    }
+
+    if (gridScanned && grid === void 0) {
+
+      // Axes belonging to no grid: the intersection is still a point, but
+      // there is no grid placement to measure it from, so it lands in
+      // whatever frame is current.
+      Logger.warning(
+          'IfcGridPlacement: no IfcGrid lists the axes of this placement.',
+          from.expressID)
+
+    } else if (grid !== void 0) {
+
+      // Region 2 - the grid's own placement chain. extractPlacement walks
+      // PlacementRelTo upwards and pushes a transform per level as it
+      // returns, so a residency miss PART WAY UP leaves some ancestors
+      // already applied. Region 1's message would be a lie about this state
+      // (it says the grid's placement was not applied at all), and the frame
+      // this placement then composes onto is partial rather than current.
+      try {
+
+        const gridPlacement = grid.ObjectPlacement
+
+        if (gridPlacement !== null) {
+
+          this.extractPlacement(gridPlacement, isRelVoid)
+        }
+      } catch (error) {
+
+        if (!(error instanceof StepBufferNotResidentError)) {
+          throw error
+        }
+
+        Logger.warning(
+            'IfcGridPlacement: the grid\'s own placement chain is not fully ' +
+            'resident on this windowed source - it was applied as far as it ' +
+            'reads, so this placement composes onto a partial frame.',
+            from.expressID)
+      }
     }
 
     const placementTransform = this.conwayModel.getAxis2Placement3D({

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -84,6 +84,8 @@ import {
   IfcCompositeProfileDef,
   IfcDirection,
   IfcExtrudedAreaSolid,
+  IfcGrid,
+  IfcGridAxis,
   IfcGridPlacement,
   IfcIndexedPolyCurve,
   IfcIndexedPolygonalFaceWithVoids,
@@ -191,6 +193,7 @@ import {
   IfcCompositeCurveSegment,
   IfcRevolvedAreaSolid,
   IfcFaceSurface,
+  IfcVirtualGridIntersection,
 } from './ifc4_gen'
 import EntityTypesIfc from './ifc4_gen/entity_types_ifc.gen'
 import { IfcMaterialCache } from './ifc_material_cache'
@@ -215,6 +218,18 @@ type Mutable<T> = { -readonly [P in keyof T]: T[P] }
 // Await cadence for extractIFCGeometryDataAsync: long enough that yielding
 // doesn't dominate, short enough that browser paint + watchdogs stay live.
 const DEFAULT_GEOMETRY_YIELD_INTERVAL_MS = 50
+
+// IfcVirtualGridIntersection.IntersectingAxes is LIST [2:2] and
+// OffsetDistances LIST [2:3], the third entry displacing the intersection
+// along the grid placement's z axis.
+const GRID_INTERSECTION_AXIS_COUNT = 2
+const GRID_INTERSECTION_Z_OFFSET = 2
+
+// Sine of the smallest angle two grid axes may cross at and still be treated
+// as intersecting. Grid axes cross at architectural angles, so this only has
+// to separate "crossing" from "drawn along each other" (or from an axis with
+// no length at all).
+const GRID_AXIS_PARALLEL_EPSILON = 1e-9
 
 
 /**
@@ -421,6 +436,12 @@ export class IfcGeometryExtraction {
   public readonly geometryTypeCounts = new Map<string, number>()
 
   private csgDepth: number = 0
+
+  /**
+   * IfcGridAxis local ID -> the IfcGrid that lists it, built on the first
+   * IfcGridPlacement a model contains (see `gridByAxis`).
+   */
+  private gridByAxis_?: Map<number, IfcGrid>
 
   /**
    * Construct a geometry extraction from an IFC step model and conway model
@@ -5641,6 +5662,308 @@ export class IfcGeometryExtraction {
   }
 
   /**
+   * Reduce a grid axis to an unbounded line in the plane of the grid's
+   * placement: a point on it, and its tangent there.
+   *
+   * Only the straight axis curves are handled — an IfcLine, or the single
+   * segment of a two-point IfcPolyline — which is what grid axes are in
+   * practice. Anything else returns undefined after warning, so the
+   * placement lands in errors.csv rather than being dropped in silence.
+   *
+   * `SameSense` is folded into the tangent because everything downstream is
+   * measured from it: the offset in IfcVirtualGridIntersection is normal to
+   * the tangent, and the tangent is also an IfcGridPlacement's default
+   * x-axis, so a reversed axis offsets to the other side and points the
+   * other way.
+   *
+   * @param axis The grid axis to reduce.
+   * @return {{x, y, dx, dy} | undefined} A point and (unnormalised) tangent
+   * in the grid's coordinate system, or undefined for an axis curve this
+   * does not handle.
+   */
+  private static gridAxisLine(axis: IfcGridAxis):
+    { x: number, y: number, dx: number, dy: number } | undefined {
+
+    const curve = axis.AxisCurve
+
+    let x: number
+    let y: number
+    let dx: number
+    let dy: number
+
+    if (curve instanceof IfcPolyline) {
+
+      const points = curve.Points
+
+      if (points.length !== 2) {
+
+        // A multi-segment axis needs the segment nearest the intersection
+        // picked per axis pair, which this does not do.
+        Logger.warning(
+            'IfcGridPlacement: grid axis IfcPolyline is not a single segment.',
+            axis.expressID)
+
+        return void 0
+      }
+
+      const start = points[0].Coordinates
+      const end = points[1].Coordinates
+
+      x = start[0]
+      y = start[1]
+      dx = end[0] - start[0]
+      dy = end[1] - start[1]
+
+    } else if (curve instanceof IfcLine) {
+
+      const origin = curve.Pnt.Coordinates
+      const direction = curve.Dir.Orientation.DirectionRatios
+
+      // IfcVector.Magnitude scales the direction; the axis is unbounded
+      // here, so it changes neither the line nor the normalised tangent.
+      x = origin[0]
+      y = origin[1]
+      dx = direction[0]
+      dy = direction[1]
+
+    } else {
+
+      Logger.warning(
+          `IfcGridPlacement: unsupported grid axis curve, type: ${
+            EntityTypesIfc[curve.type]}`,
+          axis.expressID)
+
+      return void 0
+    }
+
+    if (!axis.SameSense) {
+
+      dx = -dx
+      dy = -dy
+    }
+
+    return { x: x, y: y, dx: dx, dy: dy }
+  }
+
+  /**
+   * Resolve an IfcVirtualGridIntersection to a point in the coordinate system
+   * of the IfcGrid that owns its axes, along with the tangent of its first
+   * axis — which is the default x-axis of an IfcGridPlacement located here.
+   *
+   * Per IFC4 each axis is replaced by its offset curve before intersecting:
+   * OffsetDistances[n] is measured from axis n normal to its tangent,
+   * positive towards the tangent turned a quarter turn anti-clockwise. Both
+   * axes here are straight, so their offset curves are parallel to them and
+   * the tangents are unchanged. A third offset, when the file gives one,
+   * displaces the result along the grid placement's z axis.
+   *
+   * @param from The intersection to resolve.
+   * @return {{position, tangent} | undefined} The intersection point and the
+   * first axis' unit tangent, or undefined when the axes cannot be reduced to
+   * two lines that meet (warned at the point of failure).
+   */
+  private resolveVirtualGridIntersection(from: IfcVirtualGridIntersection):
+    { position: Vector3, tangent: Vector2 } | undefined {
+
+    const axes = from.IntersectingAxes
+
+    if (axes.length < GRID_INTERSECTION_AXIS_COUNT) {
+
+      // LIST [2:2] in the schema, so this is a malformed or absent list.
+      Logger.warning(
+          'IfcGridPlacement: virtual grid intersection has fewer than two axes.',
+          from.expressID)
+
+      return void 0
+    }
+
+    const line0 = IfcGeometryExtraction.gridAxisLine(axes[0])
+    const line1 = IfcGeometryExtraction.gridAxisLine(axes[1])
+
+    if (line0 === void 0 || line1 === void 0) {
+
+      return void 0
+    }
+
+    const length0 = Math.sqrt(line0.dx * line0.dx + line0.dy * line0.dy)
+    const length1 = Math.sqrt(line1.dx * line1.dx + line1.dy * line1.dy)
+    const cross = line0.dx * line1.dy - line0.dy * line1.dx
+
+    // |cross| / (length0 * length1) is the sine of the angle between the
+    // axes, so the test is independent of the model's units. A zero-length
+    // tangent (a polyline whose two points coincide) also lands here,
+    // before it can divide its way into a NaN below.
+    if (Math.abs(cross) <= GRID_AXIS_PARALLEL_EPSILON * length0 * length1) {
+
+      Logger.warning(
+          'IfcGridPlacement: intersecting grid axes are parallel or degenerate.',
+          from.expressID)
+
+      return void 0
+    }
+
+    const offsets = from.OffsetDistances
+
+    const offset0 = offsets[0] ?? 0
+    const offset1 = offsets[1] ?? 0
+
+    // Offset curve origins: the axis point pushed along the tangent's
+    // anti-clockwise normal, (-dy, dx) normalised.
+    const x0 = line0.x - (offset0 * line0.dy) / length0
+    const y0 = line0.y + (offset0 * line0.dx) / length0
+    const x1 = line1.x - (offset1 * line1.dy) / length1
+    const y1 = line1.y + (offset1 * line1.dx) / length1
+
+    // Parameter along the first offset curve where the two meet, from
+    // crossing (p1 - p0) + t * d0 = s * d1 with d1.
+    const t = ((x1 - x0) * line1.dy - (y1 - y0) * line1.dx) / cross
+
+    return {
+      position: {
+        x: x0 + t * line0.dx,
+        y: y0 + t * line0.dy,
+        z: offsets[GRID_INTERSECTION_Z_OFFSET] ?? 0,
+      },
+      tangent: { x: line0.dx / length0, y: line0.dy / length0 },
+    }
+  }
+
+  /**
+   * The IfcGrid that lists a given axis, or undefined if no grid does.
+   *
+   * IfcGridAxis's route back to its grid is the PartOfU/PartOfV/PartOfW
+   * inverse attributes, and the generated schema layer carries no inverses,
+   * so this is a scan of every IfcGrid's axis lists, memoised. It is built on
+   * the first grid placement extracted and never at all for a model without
+   * one.
+   *
+   * @param axis The axis to look up.
+   * @return {IfcGrid | undefined} The grid listing the axis.
+   */
+  private gridByAxis(axis: IfcGridAxis): IfcGrid | undefined {
+
+    let gridByAxis = this.gridByAxis_
+
+    if (gridByAxis === void 0) {
+
+      gridByAxis = new Map<number, IfcGrid>()
+
+      for (const grid of this.model.types(IfcGrid)) {
+
+        for (const gridAxis of grid.UAxes) {
+          gridByAxis.set(gridAxis.localID, grid)
+        }
+
+        for (const gridAxis of grid.VAxes) {
+          gridByAxis.set(gridAxis.localID, grid)
+        }
+
+        for (const gridAxis of grid.WAxes ?? []) {
+          gridByAxis.set(gridAxis.localID, grid)
+        }
+      }
+
+      this.gridByAxis_ = gridByAxis
+    }
+
+    return gridByAxis.get(axis.localID)
+  }
+
+  /**
+   * Extract an IfcGridPlacement, registering a transform against its local ID
+   * the same way the IfcLocalPlacement arm does — same scene, same
+   * memoisation, same composition onto the current parent.
+   *
+   * The origin is the virtual intersection of two grid axes and the x-axis
+   * comes from PlacementRefDirection (defaulting to the first axis' tangent),
+   * both expressed in the coordinate system of the IfcGrid that owns the
+   * axes. IfcGridPlacement has no PlacementRelTo of its own in IFC4, so that
+   * grid's object placement IS the parent: extracting it first leaves it as
+   * the scene's current transform, which `addTransform` then composes onto.
+   *
+   * @param from The grid placement to extract.
+   * @param isRelVoid Whether this placement is being resolved into the void
+   * scene rather than the main one.
+   */
+  private extractGridPlacement(from: IfcGridPlacement, isRelVoid: boolean): void {
+
+    const placementLocation = from.PlacementLocation
+    const location = this.resolveVirtualGridIntersection(placementLocation)
+
+    if (location === void 0) {
+
+      // Warned where it failed, with the axis or curve responsible.
+      return
+    }
+
+    let xAxisRef: Vector3 = { x: location.tangent.x, y: location.tangent.y, z: 0 }
+
+    const refDirection = from.PlacementRefDirection
+
+    if (refDirection instanceof IfcDirection) {
+
+      const ratios = refDirection.DirectionRatios
+
+      xAxisRef = { x: ratios[0], y: ratios[1], z: ratios[2] ?? 0 }
+
+    } else if (refDirection instanceof IfcVirtualGridIntersection) {
+
+      // The x-axis runs from this placement's intersection to the reference
+      // one. If the reference cannot be resolved the resolver has already
+      // said why, and the schema's own default — the first axis' tangent —
+      // stands in.
+      const reference = this.resolveVirtualGridIntersection(refDirection)
+
+      if (reference !== void 0) {
+
+        xAxisRef = {
+          x: reference.position.x - location.position.x,
+          y: reference.position.y - location.position.y,
+          z: reference.position.z - location.position.z,
+        }
+      }
+    }
+
+    const grid = this.gridByAxis(placementLocation.IntersectingAxes[0])
+
+    if (grid === void 0) {
+
+      // Axes belonging to no grid: the intersection is still a point, but
+      // there is no grid placement to measure it from, so it lands in
+      // whatever frame is current.
+      Logger.warning(
+          'IfcGridPlacement: no IfcGrid lists the axes of this placement.',
+          from.expressID)
+
+    } else {
+
+      const gridPlacement = grid.ObjectPlacement
+
+      if (gridPlacement !== null) {
+
+        this.extractPlacement(gridPlacement, isRelVoid)
+      }
+    }
+
+    const placementTransform = this.conwayModel.getAxis2Placement3D({
+      position: location.position,
+      // A grid is planar in its own placement, so this placement's z axis is
+      // the grid's z axis; only the x axis is steered here.
+      zAxisRef: { x: 0, y: 0, z: 1 },
+      xAxisRef: xAxisRef,
+      normalizeZ: false,
+      normalizeX: true,
+    })
+
+    const scene = isRelVoid ? this.voidScene : this.scene
+
+    scene.addTransform(
+        from.localID,
+        placementTransform.getValues(),
+        placementTransform)
+  }
+
+  /**
    *
    * @param from
    * @param isRelVoid
@@ -5686,13 +6009,8 @@ export class IfcGeometryExtraction {
       }
 
     } else if (from instanceof IfcGridPlacement) {
-      // Nothing is registered for this placement's local ID, so the product
-      // hanging off it keeps whatever frame the walk left current - at the
-      // root of the scene, i.e. the model origin. The warning is what makes
-      // that measurable: the express ID rides the logger's parameter rather
-      // than the message text, so every grid-placed product in a model
-      // collapses into one errors.csv row with a count (see conway#495).
-      Logger.warning('IfcGridPlacement: unimplemented.', from.expressID)
+
+      this.extractGridPlacement(from, isRelVoid)
     }
   }
 

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -198,7 +198,7 @@ import { IfcSceneBuilder, IfcSceneTransform } from './ifc_scene_builder'
 import IfcStepModel from './ifc_step_model'
 import Logger from '../logging/logger'
 import {
-  arraysToWasmHeap, arrayToWasmHeap, freeAll, withRelease,
+  arraysToWasmHeap, arrayToWasmHeap, freeAll, wasmHeapView, withRelease,
 } from '../core/wasm_heap'
 // import fs from 'fs'
 import Environment, { EnvironmentType } from '../utilities/environment'
@@ -3811,13 +3811,14 @@ export class IfcGeometryExtraction {
       capacity = maxPossibleFloats
     }
 
-    // 2) Create a Float64Array view into WASM memory
-    // We only need to create a subarray up to the capacity
-    const wasmFloat64View = this.wasmModule.HEAPF64.subarray(
-        pointer / bytesPerElement,
-         
-        pointer / bytesPerElement + capacity,
-    )
+    // 2) Create a Float64Array view into WASM memory, over the heap as it is
+    // after the _malloc above rather than over whatever view the module had
+    // cached before it - see wasm_heap.ts for why those can differ. Built
+    // rather than subarray'd off HEAPF64 for the same reason: subarray clamps
+    // an out-of-range window into a short one, and the set() loop below would
+    // then quietly write somewhere other than the allocation (#485).
+    const wasmFloat64View =
+      wasmHeapView(this.wasmModule, Float64Array, pointer, capacity)
 
     // 3) Single pass to skip consecutive duplicates, fill up the wasm array
     let offset = 0

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -5686,8 +5686,13 @@ export class IfcGeometryExtraction {
       }
 
     } else if (from instanceof IfcGridPlacement) {
-      // TODO(nickcastel50) Implement IfcGridPlacement
-      // Logger.warning('IfcGridPlacement: unimplemented.')
+      // Nothing is registered for this placement's local ID, so the product
+      // hanging off it keeps whatever frame the walk left current - at the
+      // root of the scene, i.e. the model origin. The warning is what makes
+      // that measurable: the express ID rides the logger's parameter rather
+      // than the message text, so every grid-placed product in a model
+      // collapses into one errors.csv row with a count (see conway#495).
+      Logger.warning('IfcGridPlacement: unimplemented.', from.expressID)
     }
   }
 

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -5925,6 +5925,45 @@ export class IfcGeometryExtraction {
       }
     }
 
+    // getAxis2Placement3D below is called with a forced z of (0,0,1) and
+    // normalizeX, and the native side (ConwayGeometryProcessor's
+    // getAxis2Placement3D) has no degeneracy guard of its own: an xAxisRef
+    // with nothing off that z has no component left after the projection,
+    // normalises to NaN, and addTransform then bakes the NaN into this
+    // placement and every descendant of it. Measured on data/grid_placement.ifc
+    // product E, whose x axis came out (NaN,NaN,NaN) before this guard.
+    //
+    // Two schema-reachable states produce it, and because z is exactly +Z both
+    // reduce to one test - the xy magnitude vanishing relative to the vector's
+    // own, in the same units-independent form as the axis-parallel check in
+    // resolveVirtualGridIntersection (a zero vector fails it too, 0 <= 0):
+    //
+    // - PlacementRefDirection is an IfcVirtualGridIntersection resolving to
+    //   the same point as PlacementLocation, so the difference above is the
+    //   zero vector;
+    // - PlacementRefDirection is IFCDIRECTION((0.,0.,1.)), parallel to the
+    //   forced z.
+    //
+    // The fallback is the schema's own default for an absent
+    // PlacementRefDirection, and it is already in hand and already known
+    // non-degenerate: resolveVirtualGridIntersection returns the first axis'
+    // tangent normalised, and only after rejecting a zero-length one.
+    const xAxisRefPlanar =
+      Math.sqrt(xAxisRef.x * xAxisRef.x + xAxisRef.y * xAxisRef.y)
+    const xAxisRefLength =
+      Math.sqrt(xAxisRefPlanar * xAxisRefPlanar + xAxisRef.z * xAxisRef.z)
+
+    if (xAxisRefPlanar <= GRID_AXIS_PARALLEL_EPSILON * xAxisRefLength) {
+
+      Logger.warning(
+          'IfcGridPlacement: the placement reference direction is parallel ' +
+          'to the grid placement\'s z axis, or has no length - falling back ' +
+          'to the schema default, the first axis\' tangent.',
+          from.expressID)
+
+      xAxisRef = { x: location.tangent.x, y: location.tangent.y, z: 0 }
+    }
+
     // Two guarded regions rather than one, because the two reads degrade to
     // DIFFERENT states and a single catch could only describe one of them
     // truthfully. Neither may fail the product: dropping it entirely is

--- a/src/ifc/ifc_grid_placement.test.ts
+++ b/src/ifc/ifc_grid_placement.test.ts
@@ -1,0 +1,184 @@
+import fs from 'fs'
+import { beforeAll, describe, expect, test } from '@jest/globals'
+import { IfcGeometryExtraction } from './ifc_geometry_extraction'
+import { IfcSceneTransform } from './ifc_scene_builder'
+import { ParseResult } from '../step/parsing/step_parser'
+import IfcStepParser from './ifc_step_parser'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import { ExtractResult } from '../core/shared_constants'
+import Logger, { LogEntry, LogLevel } from '../logging/logger'
+
+
+/* Express IDs in data/grid_placement.ifc — see that file for the geometry
+ * each of them describes and where the expectations below come from. */
+const PLACEMENT_A = 201
+const PLACEMENT_B = 301
+const PLACEMENT_C = 501
+const CIRCULAR_AXIS = 410
+
+/* Where the two supported placements land in world space, derived in the
+ * comments beside each product in the fixture. */
+const A_WORLD_X = 8
+const A_WORLD_Y = 17
+const A_WORLD_Z = 9
+const B_WORLD_X = 4
+const B_WORLD_Y = 25
+const B_WORLD_Z = 5
+
+/* Column-major offsets into a 4x4 transform's values. */
+const X_AXIS = 0
+const TRANSLATION = 12
+
+let extraction: IfcGeometryExtraction
+let extractResult: ExtractResult
+
+
+/**
+ * Parse data/grid_placement.ifc and extract its geometry.
+ *
+ * @return {Promise<ExtractResult>} The result of the extraction.
+ */
+async function extractGridModel(): Promise<ExtractResult> {
+
+  const parser = IfcStepParser.Instance
+  const input = new ParsingBuffer(fs.readFileSync('data/grid_placement.ifc'))
+
+  if (parser.parseHeader(input)[1] !== ParseResult.COMPLETE) {
+    return ExtractResult.INCOMPLETE
+  }
+
+  const conwayGeometry = new ConwayGeometry()
+
+  if (!await conwayGeometry.initialize()) {
+    return ExtractResult.INCOMPLETE
+  }
+
+  const [, model] = parser.parseDataToModel(input)
+
+  if (model === void 0) {
+    return ExtractResult.INCOMPLETE
+  }
+
+  extraction = new IfcGeometryExtraction(conwayGeometry, model)
+
+  return extraction.extractIFCGeometryData()[0]
+}
+
+/**
+ * The scene transform registered for an object placement.
+ *
+ * @param expressID The express ID of the placement.
+ * @return {IfcSceneTransform | undefined} Its transform, or undefined when
+ * the extraction registered none for it.
+ */
+function placementTransform(expressID: number): IfcSceneTransform | undefined {
+
+  const placement = extraction.model.getElementByExpressID(expressID)
+
+  expect(placement).toBeDefined()
+
+  return extraction.scene.getTransform(placement!.localID)
+}
+
+/**
+ * Find a buffered warning by the start of its message.
+ *
+ * @param prefix The leading text of the message to look for.
+ * @return {LogEntry | undefined} The matching entry.
+ */
+function warningStartingWith(prefix: string): LogEntry | undefined {
+
+  return Logger.getLogs().find(
+      (entry) => entry.level === 'warning' && entry.message.startsWith(prefix))
+}
+
+beforeAll(async () => {
+
+  Logger.clearLogs()
+
+  // The unsupported-axis product warns by design here, and the echo would be
+  // noise in the test console. The buffer these tests read is filled
+  // regardless of the console threshold.
+  const threshold = Logger.getLogLevel()
+
+  Logger.setLogLevel(LogLevel.OFF)
+
+  try {
+
+    extractResult = await extractGridModel()
+
+  } finally {
+
+    Logger.setLogLevel(threshold)
+  }
+})
+
+describe('IfcGridPlacement extraction', () => {
+
+  test('the model extracts', () => {
+
+    expect(extractResult).toBe(ExtractResult.COMPLETE)
+  })
+
+  test('a grid placement composes onto the grid\'s own placement', () => {
+
+    const transform = placementTransform(PLACEMENT_A)
+
+    expect(transform).toBeDefined()
+
+    const values = transform!.absoluteTransform
+
+    // Grid intersection (-3,2,4) carried through the grid's placement — a
+    // quarter turn about +Z, then (10,20,5). Landing at the origin is the
+    // defect this covers, and landing at (7,22,9) would mean the grid's
+    // rotation had been added rather than composed.
+    expect(values[TRANSLATION]).toBeCloseTo(A_WORLD_X)
+    expect(values[TRANSLATION + 1]).toBeCloseTo(A_WORLD_Y)
+    expect(values[TRANSLATION + 2]).toBeCloseTo(A_WORLD_Z)
+
+    // No PlacementRefDirection, so the x axis is the first axis' tangent
+    // (+X in the grid), which the grid's quarter turn takes to world +Y.
+    expect(values[X_AXIS]).toBeCloseTo(0)
+    expect(values[X_AXIS + 1]).toBeCloseTo(1)
+    expect(values[X_AXIS + 2]).toBeCloseTo(0)
+  })
+
+  test('two offsets and an explicit reference direction', () => {
+
+    const transform = placementTransform(PLACEMENT_B)
+
+    expect(transform).toBeDefined()
+
+    const values = transform!.absoluteTransform
+
+    // Grid intersection (5,6), with no third offset, so z stays on the grid.
+    expect(values[TRANSLATION]).toBeCloseTo(B_WORLD_X)
+    expect(values[TRANSLATION + 1]).toBeCloseTo(B_WORLD_Y)
+    expect(values[TRANSLATION + 2]).toBeCloseTo(B_WORLD_Z)
+
+    // PlacementRefDirection is +Y in the grid, which the quarter turn takes
+    // to world -X.
+    expect(values[X_AXIS]).toBeCloseTo(-1)
+    expect(values[X_AXIS + 1]).toBeCloseTo(0)
+    expect(values[X_AXIS + 2]).toBeCloseTo(0)
+  })
+
+  test('an axis curve that is not a line warns rather than dropping silently', () => {
+
+    expect(placementTransform(PLACEMENT_C)).toBeUndefined()
+
+    const warning = warningStartingWith('IfcGridPlacement: unsupported grid axis curve')
+
+    expect(warning).toBeDefined()
+    expect(warning!.message).toContain('IFCCIRCLE')
+    expect(warning!.expressIDs.has(String(CIRCULAR_AXIS))).toBe(true)
+  })
+
+  test('nothing in this model is left unimplemented', () => {
+
+    // The arm this covers used to be a no-op; a supported placement that
+    // still warns would mean the implementation had not been reached.
+    expect(warningStartingWith('IfcGridPlacement: unimplemented')).toBeUndefined()
+  })
+})

--- a/src/ifc/ifc_grid_placement.test.ts
+++ b/src/ifc/ifc_grid_placement.test.ts
@@ -19,6 +19,7 @@ const PLACEMENT_A = 201
 const PLACEMENT_B = 301
 const PLACEMENT_C = 501
 const PLACEMENT_D = 601
+const PLACEMENT_E = 701
 const CIRCULAR_AXIS = 410
 
 /* Where the two supported placements land in world space, derived in the
@@ -32,6 +33,9 @@ const B_WORLD_Z = 5
 const D_WORLD_X = 8
 const D_WORLD_Y = 17
 const D_WORLD_Z = 10
+const E_WORLD_X = 10
+const E_WORLD_Y = 20
+const E_WORLD_Z = 5
 
 /* Column-major offsets into a 4x4 transform's values. */
 const X_AXIS = 0
@@ -202,6 +206,41 @@ describe('IfcGridPlacement extraction', () => {
     expect(warning).toBeDefined()
     expect(warning!.message).toContain('IFCCIRCLE')
     expect(warning!.expressIDs.has(String(CIRCULAR_AXIS))).toBe(true)
+  })
+
+  test('a reference direction along the placement z falls back to the tangent', () => {
+
+    const transform = placementTransform(PLACEMENT_E)
+
+    expect(transform).toBeDefined()
+
+    const values = transform!.absoluteTransform
+
+    // The failure this covers is not a wrong number but a poisoned one:
+    // unguarded, normalising a reference direction that lies along the forced
+    // z gives NaN, and addTransform carries it into every descendant. Asserted
+    // over the whole matrix rather than the x axis alone, since that is how it
+    // spreads.
+    expect(Array.from(values).every((value) => Number.isFinite(value)))
+      .toBe(true)
+
+    // Axes A and 1 with no offsets meet at the grid origin.
+    expect(values[TRANSLATION]).toBeCloseTo(E_WORLD_X)
+    expect(values[TRANSLATION + 1]).toBeCloseTo(E_WORLD_Y)
+    expect(values[TRANSLATION + 2]).toBeCloseTo(E_WORLD_Z)
+
+    // The schema default the guard falls back to: the first axis' tangent,
+    // +X in the grid, taken to world +Y by the grid's quarter turn - so the
+    // same x axis product A gets from having no reference direction at all.
+    expect(values[X_AXIS]).toBeCloseTo(0)
+    expect(values[X_AXIS + 1]).toBeCloseTo(1)
+    expect(values[X_AXIS + 2]).toBeCloseTo(0)
+
+    const warning = warningStartingWith(
+        'IfcGridPlacement: the placement reference direction is parallel')
+
+    expect(warning).toBeDefined()
+    expect(warning!.expressIDs.has(String(PLACEMENT_E))).toBe(true)
   })
 
   test('nothing in this model is left unimplemented', () => {

--- a/src/ifc/ifc_grid_placement.test.ts
+++ b/src/ifc/ifc_grid_placement.test.ts
@@ -44,6 +44,8 @@ let extractResult: ExtractResult
 /**
  * Parse data/grid_placement.ifc and extract its geometry.
  *
+ * @param mutateModel Optional hook run on the parsed model before extraction,
+ * for the windowed-source tests that need a specific read to throw.
  * @return {Promise<ExtractResult>} The result of the extraction.
  */
 async function extractGridModel(
@@ -267,5 +269,63 @@ describe('IfcGridPlacement on a windowed source', () => {
 
         expect(warning).toBeDefined()
         expect(warning!.expressIDs.has(String(PLACEMENT_A))).toBe(true)
+      })
+
+  test('a partially resident grid placement chain warns about the partial frame',
+      async () => {
+
+        // The other residency miss on this path, and the reason the guard is
+        // two regions rather than one: the grid IS found, and the read that
+        // fails is its own placement chain. extractPlacement pushes a
+        // transform per level as it unwinds, so a miss part way up leaves
+        // ancestors applied - which the scan-failure message would describe
+        // wrongly. Patched on the prototype because the failing read is a
+        // generated accessor, not a model call the mutator hook can reach.
+        const placementProperty = 'ObjectPlacement'
+        const threshold = Logger.getLogLevel()
+
+        // The buffer is file-wide, and the preceding test deliberately fires
+        // the scan-failure warning this one asserts the ABSENCE of.
+        Logger.clearLogs()
+        Logger.setLogLevel(LogLevel.OFF)
+
+        Object.defineProperty(IfcGrid.prototype, placementProperty, {
+          configurable: true,
+          /** @return {never} Always throws, as a non-resident read would. */
+          get(): never {
+            throw new StepBufferNotResidentError(0, 0)
+          },
+        })
+
+        let result: ExtractResult
+
+        try {
+
+          result = await extractGridModel()
+
+        } finally {
+
+          delete (IfcGrid.prototype as unknown as Record<string, unknown>)[
+            placementProperty]
+
+          Logger.setLogLevel(threshold)
+        }
+
+        expect(result).toBe(ExtractResult.COMPLETE)
+
+        // Still placed, and still not dropped.
+        expect(placementTransform(PLACEMENT_A)).toBeDefined()
+
+        const warning = warningStartingWith(
+            'IfcGridPlacement: the grid\'s own placement chain is not fully ' +
+            'resident')
+
+        expect(warning).toBeDefined()
+        expect(warning!.expressIDs.has(String(PLACEMENT_A))).toBe(true)
+
+        // The scan succeeded, so the message that says the grid records were
+        // never reached must NOT be the one reported.
+        expect(warningStartingWith(
+            'IfcGridPlacement: grid records are not resident')).toBeUndefined()
       })
 })

--- a/src/ifc/ifc_grid_placement.test.ts
+++ b/src/ifc/ifc_grid_placement.test.ts
@@ -15,6 +15,7 @@ import Logger, { LogEntry, LogLevel } from '../logging/logger'
 const PLACEMENT_A = 201
 const PLACEMENT_B = 301
 const PLACEMENT_C = 501
+const PLACEMENT_D = 601
 const CIRCULAR_AXIS = 410
 
 /* Where the two supported placements land in world space, derived in the
@@ -25,6 +26,9 @@ const A_WORLD_Z = 9
 const B_WORLD_X = 4
 const B_WORLD_Y = 25
 const B_WORLD_Z = 5
+const D_WORLD_X = 8
+const D_WORLD_Y = 17
+const D_WORLD_Z = 10
 
 /* Column-major offsets into a 4x4 transform's values. */
 const X_AXIS = 0
@@ -162,6 +166,22 @@ describe('IfcGridPlacement extraction', () => {
     expect(values[X_AXIS]).toBeCloseTo(-1)
     expect(values[X_AXIS + 1]).toBeCloseTo(0)
     expect(values[X_AXIS + 2]).toBeCloseTo(0)
+  })
+
+  test('a local placement measured from a grid placement composes onto it', () => {
+
+    const transform = placementTransform(PLACEMENT_D)
+
+    expect(transform).toBeDefined()
+
+    const values = transform!.absoluteTransform
+
+    // 1m up from product A's grid placement, which is where an
+    // IfcLocalPlacement whose PlacementRelTo is an IfcGridPlacement lands
+    // once that placement registers a transform to be relative to.
+    expect(values[TRANSLATION]).toBeCloseTo(D_WORLD_X)
+    expect(values[TRANSLATION + 1]).toBeCloseTo(D_WORLD_Y)
+    expect(values[TRANSLATION + 2]).toBeCloseTo(D_WORLD_Z)
   })
 
   test('an axis curve that is not a line warns rather than dropping silently', () => {

--- a/src/ifc/ifc_grid_placement.test.ts
+++ b/src/ifc/ifc_grid_placement.test.ts
@@ -7,6 +7,9 @@ import IfcStepParser from './ifc_step_parser'
 import ParsingBuffer from '../parsing/parsing_buffer'
 import { ConwayGeometry } from '../../dependencies/conway-geom'
 import { ExtractResult } from '../core/shared_constants'
+import { StepBufferNotResidentError } from '../step/step_buffer_provider'
+import { IfcGrid } from './ifc4_gen'
+import IfcStepModel from './ifc_step_model'
 import Logger, { LogEntry, LogLevel } from '../logging/logger'
 
 
@@ -43,7 +46,9 @@ let extractResult: ExtractResult
  *
  * @return {Promise<ExtractResult>} The result of the extraction.
  */
-async function extractGridModel(): Promise<ExtractResult> {
+async function extractGridModel(
+    mutateModel?: (model: IfcStepModel) => void):
+    Promise<ExtractResult> {
 
   const parser = IfcStepParser.Instance
   const input = new ParsingBuffer(fs.readFileSync('data/grid_placement.ifc'))
@@ -63,6 +68,8 @@ async function extractGridModel(): Promise<ExtractResult> {
   if (model === void 0) {
     return ExtractResult.INCOMPLETE
   }
+
+  mutateModel?.(model)
 
   extraction = new IfcGeometryExtraction(conwayGeometry, model)
 
@@ -201,4 +208,64 @@ describe('IfcGridPlacement extraction', () => {
     // still warns would mean the implementation had not been reached.
     expect(warningStartingWith('IfcGridPlacement: unimplemented')).toBeUndefined()
   })
+})
+
+describe('IfcGridPlacement on a windowed source', () => {
+
+  test('non-resident grid records degrade to the intersection, not a dropped product',
+      async () => {
+
+        // A store-backed model pages a product's forward-reference closure,
+        // which reaches the axes but never the IfcGrid that back-references
+        // them — so the gridByAxis scan is the one read here that can throw
+        // StepBufferNotResidentError. Simulate exactly that read failing.
+        const threshold = Logger.getLogLevel()
+
+        Logger.setLogLevel(LogLevel.OFF)
+
+        let result: ExtractResult
+
+        try {
+
+          result = await extractGridModel((model) => {
+
+            const originalTypes = model.types.bind(model)
+
+            model.types = ((...requested: Parameters<typeof originalTypes>) => {
+
+              if (requested.length === 1 && requested[0] === IfcGrid) {
+                throw new StepBufferNotResidentError(0, 0)
+              }
+
+              return originalTypes(...requested)
+            }) as typeof model.types
+          })
+
+        } finally {
+
+          Logger.setLogLevel(threshold)
+        }
+
+        // The product survives - dropping it entirely would be strictly worse
+        // than the pre-implementation rendered-at-origin state.
+        expect(result).toBe(ExtractResult.COMPLETE)
+
+        const transform = placementTransform(PLACEMENT_A)
+
+        expect(transform).toBeDefined()
+
+        const values = transform!.absoluteTransform
+
+        // The grid-frame intersection with its offsets, WITHOUT the grid's
+        // own placement composed on: the degraded-but-warned state.
+        expect(values[TRANSLATION]).toBeCloseTo(-3)
+        expect(values[TRANSLATION + 1]).toBeCloseTo(2)
+        expect(values[TRANSLATION + 2]).toBeCloseTo(4)
+
+        const warning =
+          warningStartingWith('IfcGridPlacement: grid records are not resident')
+
+        expect(warning).toBeDefined()
+        expect(warning!.expressIDs.has(String(PLACEMENT_A))).toBe(true)
+      })
 })

--- a/src/ifc/ifc_stream_open.test.ts
+++ b/src/ifc/ifc_stream_open.test.ts
@@ -137,16 +137,30 @@ describe( 'openStreamedIfcModel (Phase B3)', () => {
     // Populate vtable + buffer the way a first extract does.
     expect( first.extractLineArguments().length ).toBeGreaterThan( 0 )
 
-    const copied: number[] = []
-    const fakeResult = { resize: ( n: number ) => n }
-    const fakeModule = { HEAPU8: { set: ( src: Uint8Array ) => {
+    // A real heap rather than a stubbed HEAPU8.set. extractParseBuffer builds
+    // its destination through wasmHeapView now, which reconciles the pointer
+    // against the heap's actual buffer before writing (#485) - so the fake has
+    // to have one. It also makes the assertions stronger: the bytes are
+    // checked where they landed, not just counted on the way past.
+    const wasmHeap = new Uint8Array( 4 * 1024 )
+    const fakeModule = { HEAPU8: wasmHeap }
 
-      copied.push( src.length )
-    } } }
+    const copied: number[] = []
+    const fakeResult = { resize: ( n: number ) => {
+
+      copied.push( n )
+
+      return 0
+    } }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     first.extractParseBuffer( 0, 0, 0, fakeResult as any, fakeModule as any, true )
     expect( copied[ 0 ] ).toBeGreaterThan( 0 )
+
+    // Landed in the heap, at the pointer resize handed back.
+    const written = Array.from( wasmHeap.subarray( 0, copied[ 0 ] ) )
+
+    expect( written.some( ( byte ) => byte !== 0 ) ).toBe( true )
 
     model.releaseSourceViews( [ localID ] )
     await model.ensureResidentByLocalID( localID )

--- a/src/step/step_entity_base.ts
+++ b/src/step/step_entity_base.ts
@@ -3,6 +3,7 @@ import { Entity } from '../core/entity'
 import { EntityDescription, EntityFieldsDescription } from '../core/entity_description'
 import { EntityFieldDescription } from '../core/entity_field_description'
 import { WasmModule } from '../core/native_types'
+import { wasmHeapView } from '../core/wasm_heap'
 import {
   skipValue,
   stepExtractArray,
@@ -925,9 +926,16 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
       return false
     }
 
-    const dataPtr = result.resize( endCursor - cursor )
+    const length = endCursor - cursor
 
-    module.HEAPU8.set( buffer.subarray( cursor, endCursor ), dataPtr )
+    // resize() can grow the wasm heap, which on the MT build can leave the
+    // module's cached HEAPU8 bound to the pre-growth buffer - so the
+    // destination view is taken through wasmHeapView, after the resize, rather
+    // than off module.HEAPU8 (#485).
+    const dataPtr = result.resize( length )
+
+    wasmHeapView( module, Uint8Array, dataPtr, length )
+        .set( buffer.subarray( cursor, endCursor ) )
 
     return true
   }


### PR DESCRIPTION
One PR for the Aug 2026 severe-bug burndown — five orthogonal pieces of work sharing one CI pass. Each was developed and verified independently; commits are cleanly separable per issue.

Closes #504. Closes #505. Closes #503. References #485 and #480 **without** closing them: #485 stays open until CI statistics confirm the flake is gone, and #480 retains the LOGICAL/BOOLEAN generator defect (fix in review as IFC-gen-internal#2).

## 1. Stale wasm heap views (#485) — `6e5059a`, `7abb824`, `cc32ac9`

The first in-CI capture of #498's diagnostic (on PR #516's regression run) confirmed the mechanism behind the duplex.ifc digest flake: the MT build's heap is a **non-extensible** SharedArrayBuffer — growth materialises a new, larger buffer while the module's cached views (`HEAPU8` etc.) stay bound to the pre-growth SAB. The growable-SAB / length-tracking-views assumption previously documented in `wasm_heap.ts` is empirically false for this build (measured live: `growable === false`, `maxByteLength === byteLength`).

The fix is the shape #485 proposed: refresh the module heap views before constructing a view over a pointer, at **every** site, uniformly — `arrayToWasmHeap` (the captured path: #4396 → #4395 → polyline #4389 → `extractIfcPolyline`), both extractors' point-flatten helpers, `step_entity_base`'s `ParseBuffer` copy, and the three `getSubArray` implementations in `compat/web-ifc`. The refresh route was found by experiment against the real glue (this build exports no `wasmMemory`/`updateMemoryViews`/`GROWABLE_HEAP_*`; an embind string round-trip is the reliable ~9 µs fallback, with the cleaner routes feature-detected for future builds). #498's `describeHeap` diagnostic is kept for states that remain impossible. Per the review, the refresh is fully best-effort (`cc32ac9`): a failing scratch allocation can neither mask the heap diagnostic nor fail a copy the refresh already repaired — both pinned by tests.

Verified: the real module driven into the exact captured state reproduces the literal `Invalid typed array length` signature unguarded and round-trips correctly through the new helper; review independently confirmed the non-obvious safety property (a pre-growth SAB stays a live window onto the same memory, so the stale-buffer fast path is sound); duplex.ifc digest byte-identical before/after.

**Not claiming the flake fixed** — it is only statistically observable (~1 in 5 CI runs). The claim is: the confirmed mechanism is closed at every site it can express itself through.

## 2. IfcGridPlacement (#504) — `ee4e6ee`, `b484eeb`, `497e549`, `416740c`, `15ac05c`, `5d751d3`

The `IfcGridPlacement` arm was a silent no-op with its warning commented out — grid-placed products rendered at the model origin with no diagnostic. In issue order: (1) the diagnostic is re-enabled first as its own commit, family-stable per #495, so the next full-corpus run measures the real-world population; (2) the placement is implemented — `IfcVirtualGridIntersection` over two `IfcGridAxis` curves with the spec's offset rule (offsets act along the axis normal, a quarter turn anti-clockwise from the tangent; `SameSense` folded in), all three `PlacementRefDirection` cases, composed against the owning `IfcGrid`'s placement (IFC4 grid placements have no `PlacementRelTo`; the grid is resolved via a lazy reverse index that costs nothing on grid-free models); (3) a fixture with a rotated, offset grid — so composition and naive translation-adding disagree — covering placement cases plus the failure families.

Review hardening: windowed/store-backed sources degrade gracefully in two separately-guarded, accurately-worded regions instead of dropping the product (`416740c`, `15ac05c`), and a degenerate `PlacementRefDirection` (zero vector or parallel to the grid normal — both producible from legal files) falls back to the axis tangent instead of sending NaN through the native `normalize` into the whole subtree (`5d751d3`, probe-measured before/after). Line and two-point-polyline axes are implemented; exotic axis curves, multi-segment polylines, parallel and orphan axes each warn with their own named family instead of dropping silently.

The issue's open transform-stack question is answered (not a defect — the missing pop is by contract; every product extraction starts with `clearParentStack()`); details on the issue thread.

## 3. pcurves on non-planar basis surfaces (#505) — `7505f3a`

`extractPScurve1` rejected every basis surface that isn't a plane — and the plane arm itself was broken, emitting a single point at the plane's origin while ignoring the parameter curve entirely. Now: the 2D parameter curve is evaluated through the real surface parameterization for cylindrical, conical, spherical and toroidal surfaces (conventions read out of conway-geom's own tessellators in `mesh_utils.h`, including the signed cone semi-angle), with a `curve_3d` sibling fallback generalised from the existing `seam_curve` handling to `surface_curve` complex instances (strictly widening — `seam_curve` subtypes `surface_curve`, revert-verified), and a per-surface-type warning family for the residue (b-spline basis surfaces are deliberately not attempted).

Also fixed on the way, because it sat directly on the new path: AP214's `flattenPointsToFloat32Array` fed a Float32 buffer to a native function that reinterprets it as `double*`, so every AP214 `POLYLINE` decoded to garbage (proved with a literal round-trip). Now Float64, matching the IFC side.

**Digest neutrality of the POLYLINE fix — measured, not asserted.** The materialized corpus contains exactly six POLYLINE-bearing STEP models (`nist_ctc_01..05_asme1_ap203.stp`, `nist_ctc_05_asme1_ap242-e1.stp`; 346–1114 POLYLINEs each). All six produce **byte-identical digests** (cmp + sha256) between this branch and a minimal Float32 reversion of the flatten, because every one of their POLYLINEs is referenced only by `GEOMETRIC_CURVE_SET` under `ANNOTATION_OCCURRENCE`, which `extractRepresentationItem` skips — instrumented counters confirm `extractPolyline` runs zero times on all six, and a positive-control mutant (an `EDGE_CURVE` repointed at a POLYLINE) both fires the counters and *does* diff between the builds, proving the reversion was behaviour-changing where reached. Command: `node compiled/src/AP214E3_2010/ap214_regression_main.js <model> <out> -d` per build. Corpus models never materialized here (LFS stubs) remain outside the scan; the RC pass is the final authority.

## 4. AP203 alias measurement (#503) — `4d0ecaa`

The issue asked for measurement before building, and the measurement says: **don't build either Phase-4 fork.** Genuine `CONFIG_CONTROL_DESIGN` is missing only 22 entities from the AP214 vtable (4 geometry-bearing, all wireframe types); across all 16 NIST AP203 models, **0.035%** of entity instances name an unresolvable type (76 instances, 6 metadata-only types nothing in conway reads), against **8.9%** for the AP242 control. All 16 models produce geometry with zero schema-attributable error families. One genuine edition-1 landmine found and documented: `DATED_EFFECTIVITY`'s attributes are transposed vs AP214 — silent wrong dates, corpus-unused today (#524).

Recorded in `design/new/step-support.md` with sources, confounder accounting (LFS stubs per #486, the #493 generator fix, wasm-prebuilt drift per #523) and repro commands; the doc's own open questions on AP203 are answered in place.

## 5. Docs: sub-agent burndown workflow — `212a119`

`AGENTS.md` gains the burndown workflow and the 10-point rubric these fixes were dispatched and reviewed under. Share carries the same guidance in its `design/new/agent-workflow.md` (Share#1754, which merges after this PR for its cross-link).

## Review & verification (whole branch)

- Reviewed per the draft lifecycle: an independent full-diff review (correct `origin/main...HEAD` range) confirmed the load-bearing properties (SAB non-detachment, grid math recomputed by hand, parameterizations vs ISO 10303-42 and the native tessellator, revert-proofs on all major tests) and produced findings M1/L3/L4/L5 + the M2 claim-discipline gap — all fixed in `cc32ac9`/`15ac05c`/`5d751d3` with fails-without-change proofs, M2 settled empirically above. Out-of-scope findings against the pre-existing store-backed path are tracked in #525.
- Full gate green at every commit (pre-commit hook): final bar **89 suites / 505 tests**, eslint **0 errors / 663 warnings** (two below the pre-branch baseline).
- The #504 warning may legitimately add errors.csv rows for grid-placed corpus models; that discovery is the point of re-enabling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013y57koArrUCwNYRYhn9483