### PR TITLE
Read LOGICAL attributes as LOGICAL: pin bump, regen, and the fixture that holds it

### DIFF
--- a/scripts/code-gen.cjs
+++ b/scripts/code-gen.cjs
@@ -17,7 +17,7 @@ const ifcGenPath = path.resolve(__dirname, '../external/IFC-gen-internal');
 // warn you. Verified at this SHA: regenerating both schemas reproduces the
 // checked-in output byte for byte, 1111 AP214 files and 1180 IFC4 files, zero
 // differences.
-const IFC_GEN_REVISION = '94ff4cc19399fa1baad9bb687cd1e2cde778b18c';
+const IFC_GEN_REVISION = 'c001505abd849e8be826ce61b0f7db0e6b6d82f4';
 
 function runCommand(command, options = {}) {
   try {

--- a/src/AP214E3_2010/AP214E3_2010_gen/b_spline_curve.gen.ts
+++ b/src/AP214E3_2010/AP214E3_2010_gen/b_spline_curve.gen.ts
@@ -28,8 +28,8 @@ export  class b_spline_curve extends bounded_curve {
   private degree_? : number
   private control_points_list_? : Array<cartesian_point>
   private curve_form_? : b_spline_curve_form
-  private closed_curve_? : boolean
-  private self_intersect_? : boolean
+  private closed_curve_? : boolean | null
+  private self_intersect_? : boolean | null
 
   public get degree() : number {
     if ( this.degree_ === void 0 ) {
@@ -80,20 +80,20 @@ export  class b_spline_curve extends bounded_curve {
     return this.curve_form_ as b_spline_curve_form
   }
 
-  public get closed_curve() : boolean {
+  public get closed_curve() : boolean | null {
     if ( this.closed_curve_ === void 0 ) {
-      this.closed_curve_ = this.extractBoolean( 4, 1, 4, false )
+      this.closed_curve_ = this.extractLogical( 4, 1, 4, false )
     }
 
-    return this.closed_curve_ as boolean
+    return this.closed_curve_ as boolean | null
   }
 
-  public get self_intersect() : boolean {
+  public get self_intersect() : boolean | null {
     if ( this.self_intersect_ === void 0 ) {
-      this.self_intersect_ = this.extractBoolean( 5, 1, 4, false )
+      this.self_intersect_ = this.extractLogical( 5, 1, 4, false )
     }
 
-    return this.self_intersect_ as boolean
+    return this.self_intersect_ as boolean | null
   }
 
   public get upper_index_on_control_points() : number {

--- a/src/AP214E3_2010/AP214E3_2010_gen/b_spline_surface.gen.ts
+++ b/src/AP214E3_2010/AP214E3_2010_gen/b_spline_surface.gen.ts
@@ -29,9 +29,9 @@ export  class b_spline_surface extends bounded_surface {
   private v_degree_? : number
   private control_points_list_? : Array<Array<cartesian_point>>
   private surface_form_? : b_spline_surface_form
-  private u_closed_? : boolean
-  private v_closed_? : boolean
-  private self_intersect_? : boolean
+  private u_closed_? : boolean | null
+  private v_closed_? : boolean | null
+  private self_intersect_? : boolean | null
 
   public get u_degree() : number {
     if ( this.u_degree_ === void 0 ) {
@@ -100,28 +100,28 @@ export  class b_spline_surface extends bounded_surface {
     return this.surface_form_ as b_spline_surface_form
   }
 
-  public get u_closed() : boolean {
+  public get u_closed() : boolean | null {
     if ( this.u_closed_ === void 0 ) {
-      this.u_closed_ = this.extractBoolean( 5, 1, 4, false )
+      this.u_closed_ = this.extractLogical( 5, 1, 4, false )
     }
 
-    return this.u_closed_ as boolean
+    return this.u_closed_ as boolean | null
   }
 
-  public get v_closed() : boolean {
+  public get v_closed() : boolean | null {
     if ( this.v_closed_ === void 0 ) {
-      this.v_closed_ = this.extractBoolean( 6, 1, 4, false )
+      this.v_closed_ = this.extractLogical( 6, 1, 4, false )
     }
 
-    return this.v_closed_ as boolean
+    return this.v_closed_ as boolean | null
   }
 
-  public get self_intersect() : boolean {
+  public get self_intersect() : boolean | null {
     if ( this.self_intersect_ === void 0 ) {
-      this.self_intersect_ = this.extractBoolean( 7, 1, 4, false )
+      this.self_intersect_ = this.extractLogical( 7, 1, 4, false )
     }
 
-    return this.self_intersect_ as boolean
+    return this.self_intersect_ as boolean | null
   }
 
   public get u_upper() : number {

--- a/src/AP214E3_2010/AP214E3_2010_gen/composite_curve.gen.ts
+++ b/src/AP214E3_2010/AP214E3_2010_gen/composite_curve.gen.ts
@@ -22,7 +22,7 @@ export  class composite_curve extends bounded_curve {
     return EntityTypesAP214.COMPOSITE_CURVE
   }
   private segments_? : Array<composite_curve_segment>
-  private self_intersect_? : boolean
+  private self_intersect_? : boolean | null
 
   public get segments() : Array<composite_curve_segment> {
     if ( this.segments_ === void 0 ) {
@@ -57,12 +57,12 @@ export  class composite_curve extends bounded_curve {
     return this.segments_ as Array<composite_curve_segment>
   }
 
-  public get self_intersect() : boolean {
+  public get self_intersect() : boolean | null {
     if ( this.self_intersect_ === void 0 ) {
-      this.self_intersect_ = this.extractBoolean( 2, 1, 4, false )
+      this.self_intersect_ = this.extractLogical( 2, 1, 4, false )
     }
 
-    return this.self_intersect_ as boolean
+    return this.self_intersect_ as boolean | null
   }
 
   public get n_segments() : number {

--- a/src/AP214E3_2010/AP214E3_2010_gen/offset_curve_2d.gen.ts
+++ b/src/AP214E3_2010/AP214E3_2010_gen/offset_curve_2d.gen.ts
@@ -16,7 +16,7 @@ export  class offset_curve_2d extends curve {
   }
   private basis_curve_? : curve
   private distance_? : number
-  private self_intersect_? : boolean
+  private self_intersect_? : boolean | null
 
   public get basis_curve() : curve {
     if ( this.basis_curve_ === void 0 ) {
@@ -34,12 +34,12 @@ export  class offset_curve_2d extends curve {
     return this.distance_ as number
   }
 
-  public get self_intersect() : boolean {
+  public get self_intersect() : boolean | null {
     if ( this.self_intersect_ === void 0 ) {
-      this.self_intersect_ = this.extractBoolean( 3, 1, 3, false )
+      this.self_intersect_ = this.extractLogical( 3, 1, 3, false )
     }
 
-    return this.self_intersect_ as boolean
+    return this.self_intersect_ as boolean | null
   }
   constructor(
     localID: number,

--- a/src/AP214E3_2010/AP214E3_2010_gen/offset_curve_3d.gen.ts
+++ b/src/AP214E3_2010/AP214E3_2010_gen/offset_curve_3d.gen.ts
@@ -17,7 +17,7 @@ export  class offset_curve_3d extends curve {
   }
   private basis_curve_? : curve
   private distance_? : number
-  private self_intersect_? : boolean
+  private self_intersect_? : boolean | null
   private ref_direction_? : direction
 
   public get basis_curve() : curve {
@@ -36,12 +36,12 @@ export  class offset_curve_3d extends curve {
     return this.distance_ as number
   }
 
-  public get self_intersect() : boolean {
+  public get self_intersect() : boolean | null {
     if ( this.self_intersect_ === void 0 ) {
-      this.self_intersect_ = this.extractBoolean( 3, 1, 3, false )
+      this.self_intersect_ = this.extractLogical( 3, 1, 3, false )
     }
 
-    return this.self_intersect_ as boolean
+    return this.self_intersect_ as boolean | null
   }
 
   public get ref_direction() : direction {

--- a/src/AP214E3_2010/AP214E3_2010_gen/offset_surface.gen.ts
+++ b/src/AP214E3_2010/AP214E3_2010_gen/offset_surface.gen.ts
@@ -16,7 +16,7 @@ export  class offset_surface extends surface {
   }
   private basis_surface_? : surface
   private distance_? : number
-  private self_intersect_? : boolean
+  private self_intersect_? : boolean | null
 
   public get basis_surface() : surface {
     if ( this.basis_surface_ === void 0 ) {
@@ -34,12 +34,12 @@ export  class offset_surface extends surface {
     return this.distance_ as number
   }
 
-  public get self_intersect() : boolean {
+  public get self_intersect() : boolean | null {
     if ( this.self_intersect_ === void 0 ) {
-      this.self_intersect_ = this.extractBoolean( 3, 1, 3, false )
+      this.self_intersect_ = this.extractLogical( 3, 1, 3, false )
     }
 
-    return this.self_intersect_ as boolean
+    return this.self_intersect_ as boolean | null
   }
   constructor(
     localID: number,

--- a/src/AP214E3_2010/AP214E3_2010_gen/schema_ap214.gen.ts
+++ b/src/AP214E3_2010/AP214E3_2010_gen/schema_ap214.gen.ts
@@ -5421,7 +5421,7 @@ let descriptions : EntityDescription< EntityTypesAP214 >[] = [
       },
       product_definitional: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: false,
         offset: 3,
       },
@@ -10840,13 +10840,13 @@ let descriptions : EntityDescription< EntityTypesAP214 >[] = [
       },
       closed_curve: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: false,
         offset: 4,
       },
       self_intersect: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: false,
         offset: 5,
       },
@@ -10979,19 +10979,19 @@ let descriptions : EntityDescription< EntityTypesAP214 >[] = [
       },
       u_closed: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: false,
         offset: 5,
       },
       v_closed: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: false,
         offset: 6,
       },
       self_intersect: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: false,
         offset: 7,
       },
@@ -11831,7 +11831,7 @@ let descriptions : EntityDescription< EntityTypesAP214 >[] = [
       },
       self_intersect: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: false,
         offset: 2,
       },
@@ -11842,7 +11842,7 @@ let descriptions : EntityDescription< EntityTypesAP214 >[] = [
       },
       closed_curve: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: true,
       },
     },
@@ -14269,7 +14269,7 @@ let descriptions : EntityDescription< EntityTypesAP214 >[] = [
       },
       self_intersect: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: false,
         offset: 3,
       },
@@ -14296,7 +14296,7 @@ let descriptions : EntityDescription< EntityTypesAP214 >[] = [
       },
       self_intersect: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: false,
         offset: 3,
       },
@@ -20945,7 +20945,7 @@ let descriptions : EntityDescription< EntityTypesAP214 >[] = [
       },
       self_intersect: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: false,
         offset: 3,
       },

--- a/src/AP214E3_2010/AP214E3_2010_gen/shape_aspect.gen.ts
+++ b/src/AP214E3_2010/AP214E3_2010_gen/shape_aspect.gen.ts
@@ -22,7 +22,7 @@ export  class shape_aspect extends StepEntityBase< EntityTypesAP214 > {
   private name_? : string
   private description_? : string | null
   private of_shape_? : product_definition_shape
-  private product_definitional_? : boolean
+  private product_definitional_? : boolean | null
 
   public get name() : string {
     if ( this.name_ === void 0 ) {
@@ -48,12 +48,12 @@ export  class shape_aspect extends StepEntityBase< EntityTypesAP214 > {
     return this.of_shape_ as product_definition_shape
   }
 
-  public get product_definitional() : boolean {
+  public get product_definitional() : boolean | null {
     if ( this.product_definitional_ === void 0 ) {
-      this.product_definitional_ = this.extractBoolean( 3, 0, 0, false )
+      this.product_definitional_ = this.extractLogical( 3, 0, 0, false )
     }
 
-    return this.product_definitional_ as boolean
+    return this.product_definitional_ as boolean | null
   }
 
   public get id() : string {

--- a/src/AP214E3_2010/ap214_logical_attribute.test.ts
+++ b/src/AP214E3_2010/ap214_logical_attribute.test.ts
@@ -1,0 +1,147 @@
+// ISO 10303-42 declares `b_spline_surface.u_closed`, `v_closed` and
+// `self_intersect` (and the matching attributes on `b_spline_curve`,
+// `composite_curve`, `offset_curve_2d/3d`, `offset_surface` and
+// `shape_aspect`) as LOGICAL, which is three-valued - `.T.`, `.F.`, `.U.`.
+// The generator used to emit `extractBoolean` for them, so a `.U.` threw
+// 'Value in STEP was incorrectly typed' out of the getter and took the whole
+// face - and in the NIST AP242 exports, whole solids - with it.
+//
+// The generator now carries a distinct `logical` token, so a bare EXPRESS
+// LOGICAL selects `extractLogical` and reads `.U.` as null. This test pins
+// that against the regenerated tree: it fails on the pre-regen output, where
+// the `.U.` reads throw. BOOLEAN attributes are asserted alongside, because
+// the failure mode of an over-broad fix is every BOOLEAN quietly becoming a
+// LOGICAL. See bldrs-ai/conway#480 and IFC-gen-internal#2.
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import AP214StepParser from './ap214_step_parser'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ParseResult } from '../step/parsing/step_parser'
+import { b_spline_surface_with_knots, edge_curve } from './AP214E3_2010_gen'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+
+
+const conwayGeom = new ConwayGeometry()
+
+/**
+ * Initialize the wasm.
+ */
+async function initializeWasm() {
+
+  await conwayGeom.initialize()
+}
+
+const parser = AP214StepParser.Instance
+
+// A bilinear patch, so the fixture stays readable, carrying the same
+// attribute shape as the bicubic patches in `nist_ftc_07_asme1_ap242-e2.stp`
+// that this defect dropped: `.UNSPECIFIED.` surface form followed by
+// u_closed / v_closed / self_intersect all written `.U.`. That file has 20
+// such surfaces, and each one lost an ADVANCED_FACE.
+const UNKNOWN_SURFACE = `
+#1 = CARTESIAN_POINT('',(0.,0.,0.));
+#2 = CARTESIAN_POINT('',(1.,0.,0.));
+#3 = CARTESIAN_POINT('',(0.,1.,0.));
+#4 = CARTESIAN_POINT('',(1.,1.,0.));
+#10 = B_SPLINE_SURFACE_WITH_KNOTS('',1,1,((#1,#2),(#3,#4)),.UNSPECIFIED.,
+  .U.,.U.,.U.,(2,2),(2,2),(0.,1.),(0.,1.),.UNSPECIFIED.);
+`
+
+// The same surface with the three LOGICALs written as the two determinate
+// values. A fix that read every LOGICAL as null would pass the `.U.` case
+// and fail here.
+const DETERMINATE_SURFACE = `
+#1 = CARTESIAN_POINT('',(0.,0.,0.));
+#2 = CARTESIAN_POINT('',(1.,0.,0.));
+#3 = CARTESIAN_POINT('',(0.,1.,0.));
+#4 = CARTESIAN_POINT('',(1.,1.,0.));
+#10 = B_SPLINE_SURFACE_WITH_KNOTS('',1,1,((#1,#2),(#3,#4)),.UNSPECIFIED.,
+  .T.,.F.,.F.,(2,2),(2,2),(0.,1.),(0.,1.),.UNSPECIFIED.);
+`
+
+const SURFACE_EXPRESS_ID = 10
+
+// `edge_curve.same_sense` is a genuine BOOLEAN and must keep reading as one.
+// The edge's vertex and curve references are left dangling: only the trailing
+// BOOLEAN is read here, and resolving the rest would need a curve definition
+// that has nothing to do with what is being pinned.
+const BOOLEAN_EDGES = `
+#20 = EDGE_CURVE('',#21,#22,#23,.T.);
+#30 = EDGE_CURVE('',#21,#22,#23,.F.);
+`
+
+const TRUE_EDGE_EXPRESS_ID = 20
+const FALSE_EDGE_EXPRESS_ID = 30
+
+/**
+ * Parse a STEP fragment and return the model it produced.
+ *
+ * @param source The STEP text to parse.
+ * @return {ReturnType< typeof parser.parseDataToModel >[ 1 ]} The model.
+ */
+function modelOf( source: string ) {
+
+  const [ result, model ] =
+    parser.parseDataToModel( new ParsingBuffer( new TextEncoder().encode( source ) ) )
+
+  // INCOMPLETE is expected for the edge fixture, whose references dangle.
+  if ( model === void 0 ||
+    ( result !== ParseResult.COMPLETE && result !== ParseResult.INCOMPLETE ) ) {
+    throw new Error( `parse failed with result ${result}` )
+  }
+
+  return model
+}
+
+/**
+ * Parse a surface fixture and read back its three LOGICAL attributes.
+ *
+ * @param source The STEP text to parse.
+ * @return {Array< boolean | null >} u_closed, v_closed, self_intersect.
+ */
+function surfaceLogicalsOf( source: string ): Array< boolean | null > {
+
+  const surface = modelOf( source ).getElementByExpressID( SURFACE_EXPRESS_ID )
+
+  if ( !( surface instanceof b_spline_surface_with_knots ) ) {
+    throw new Error( 'expected a b_spline_surface_with_knots' )
+  }
+
+  return [ surface.u_closed, surface.v_closed, surface.self_intersect ]
+}
+
+
+beforeAll( async () => {
+  await initializeWasm()
+})
+
+describe( 'a LOGICAL attribute', () => {
+
+  test( '.U. reads as null instead of throwing', () => {
+
+    expect( surfaceLogicalsOf( UNKNOWN_SURFACE ) ).toEqual( [ null, null, null ] )
+  })
+
+  test( '.T. and .F. still read as true and false', () => {
+
+    expect( surfaceLogicalsOf( DETERMINATE_SURFACE ) ).toEqual( [ true, false, false ] )
+  })
+})
+
+describe( 'a BOOLEAN attribute', () => {
+
+  test( '.T. and .F. are unaffected', () => {
+
+    const model = modelOf( BOOLEAN_EDGES )
+
+    const trueEdge = model.getElementByExpressID( TRUE_EDGE_EXPRESS_ID )
+    const falseEdge = model.getElementByExpressID( FALSE_EDGE_EXPRESS_ID )
+
+    if ( !( trueEdge instanceof edge_curve ) || !( falseEdge instanceof edge_curve ) ) {
+      throw new Error( 'expected two edge_curves' )
+    }
+
+    expect( trueEdge.same_sense ).toBe( true )
+    expect( falseEdge.same_sense ).toBe( false )
+  })
+})

--- a/src/ifc/ifc4_gen/IfcLogical.gen.ts
+++ b/src/ifc/ifc4_gen/IfcLogical.gen.ts
@@ -14,14 +14,14 @@ export class IfcLogical extends StepEntityBase< EntityTypesIfc > {
     return EntityTypesIfc.IFCLOGICAL
   }
 
-  private Value_? : boolean;
+  private Value_? : boolean | null;
 
-  public get Value() : boolean {
+  public get Value() : boolean | null {
     if ( this.Value_ === void 0 ) {
-      this.Value_ = this.extractBoolean( 0, 0, 0, false )
+      this.Value_ = this.extractLogical( 0, 0, 0, false )
     }
 
-    return this.Value_ as boolean
+    return this.Value_ as boolean | null
   }
 
   constructor(

--- a/src/ifc/ifc4_gen/IfcRelInterferesElements.gen.ts
+++ b/src/ifc/ifc4_gen/IfcRelInterferesElements.gen.ts
@@ -20,7 +20,7 @@ export  class IfcRelInterferesElements extends IfcRelConnects {
   private RelatedElement_? : IfcElement
   private InterferenceGeometry_? : IfcConnectionGeometry | null
   private InterferenceType_? : string | null
-  private ImpliedOrder_? : boolean
+  private ImpliedOrder_? : boolean | null
 
   public get RelatingElement() : IfcElement {
     if ( this.RelatingElement_ === void 0 ) {
@@ -54,12 +54,12 @@ export  class IfcRelInterferesElements extends IfcRelConnects {
     return this.InterferenceType_ as string | null
   }
 
-  public get ImpliedOrder() : boolean {
+  public get ImpliedOrder() : boolean | null {
     if ( this.ImpliedOrder_ === void 0 ) {
-      this.ImpliedOrder_ = this.extractBoolean( 8, 4, 3, false )
+      this.ImpliedOrder_ = this.extractLogical( 8, 4, 3, false )
     }
 
-    return this.ImpliedOrder_ as boolean
+    return this.ImpliedOrder_ as boolean | null
   }
   constructor(
     localID: number,

--- a/src/ifc/ifc4_gen/schema_ifc.gen.ts
+++ b/src/ifc/ifc4_gen/schema_ifc.gen.ts
@@ -29376,7 +29376,7 @@ let descriptions : EntityDescription< EntityTypesIfc >[] = [
       },
       ImpliedOrder: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: false,
         offset: 8,
       },
@@ -34371,7 +34371,7 @@ let descriptions : EntityDescription< EntityTypesIfc >[] = [
     fields: {
       Value: {
         kind: f.BOOLEAN,
-        optional: false,
+        optional: true,
         derived: false,
         offset: 0,
       },

--- a/src/step/step_entity_base.ts
+++ b/src/step/step_entity_base.ts
@@ -346,22 +346,20 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
    * Used by other extraction methods with wrappers to perform
    * semantically correct extraction.
    *
+   * Unlike the other extractors this has a single signature rather than an
+   * optional/non-optional overload pair, because LOGICAL is three-valued:
+   * `.U.` is a legitimate value that reads as null, so a non-optional LOGICAL
+   * is null-valued too and `optional` only decides whether a *missing* value
+   * throws. The old `optional: false` overload promised a bare `boolean` and
+   * was a lie for exactly the `.U.` case this extractor exists to handle.
+   *
    * @param offset The offset in the vtable to extract from
    * @param baseOffset The base offset in the vtable to extract from
    * @param depth The depth of the vtable to extract from
    * @param optional Is this an optional field?
-   * @return {boolean | null} The extracted logical or null for optionals.
+   * @return {boolean | null} The extracted logical, or null for `.U.` and for
+   * an absent optional.
    */
-  public extractLogical(
-    offset: number,
-    baseOffset: number,
-    depth: number,
-    optional: true): boolean | null
-  public extractLogical(
-    offset: number,
-    baseOffset: number,
-    depth: number,
-    optional: false): boolean
   public extractLogical(
     offset: number,
     baseOffset: number,


### PR DESCRIPTION
Closes #480.

The downstream half of the LOGICAL/BOOLEAN fix. [IFC-gen-internal#2](https://github.com/bldrs-ai/IFC-gen-internal/pull/2) merged as `c001505abd849e8be826ce61b0f7db0e6b6d82f4`; nothing changes in conway until it regenerates, so this steps `IFC_GEN_REVISION` and commits what regenerating both schemas produces.

## What was wrong

ISO 10303-42 declares `b_spline_surface.u_closed` / `v_closed` / `self_intersect` — and the matching attributes on `b_spline_curve`, `composite_curve`, `offset_curve_2d/3d`, `offset_surface`, `shape_aspect` — as **LOGICAL**, which is three-valued (`.T.`, `.F.`, `.U.`). The generator emitted `extractBoolean` for them, so a `.U.` threw and took the enclosing `ADVANCED_FACE` with it. The path, straight out of the pre-change `errors.csv`:

```
Error extracting face ADVANCED_FACE - Value in STEP was incorrectly typed
Error: Value in STEP was incorrectly typed
    at b_spline_surface_with_knots.extractBoolean (step_entity_base.js:575:23)
    at get u_closed (AP214E3_2010_gen/b_spline_surface.gen.js:67:35)
    at AP214GeometryExtraction.extractBSplineSurface (ap214_geometry_extraction.js:2372:27)
    at ... extractAdvancedFace ... extractFaces ... extractManifoldSolidBrep
```

`extractLogical` already existed; the generator never selected it. Upstream, `ParseSimpleType` collapsed the EXPRESS `LOGICAL` arm onto the `"boolean"` token, and the logical path was reachable only through a name test on the literal string `"IfcLogical"`, which no ISO 10303 schema matches.

## The regenerated diff — exactly 11 files, 61 line-pairs

Every changed line is a LOGICAL slot. Nothing else in either tree differs.

**AP214 (8 files)** — `b_spline_curve`, `b_spline_surface`, `composite_curve`, `offset_curve_2d`, `offset_curve_3d`, `offset_surface`, `shape_aspect`, `schema_ap214`
**IFC4 (3 files)** — `IfcRelInterferesElements` (`ImpliedOrder`, a bare `LOGICAL`), `IfcLogical` (`Value` — the one type the old name test was written for, never reached because the wrapper generator passes the wrapped built-in and loses the name), `schema_ifc`

By change class:

| count | change |
|---:|---|
| 13 | `extractBoolean` → `extractLogical` at the call |
| 13 | getter return `boolean` → `boolean \| null` |
| 13 | backing field + cast `boolean` → `boolean \| null` |
| 13 | reflection `optional: false` → `true` |

Thirteen reflection flips for twelve emitted getters: the extra is `composite_curve.closed_curve`, which is derived and has no getter. Nothing typed `IfcLogical` or `IfcBoolean` moves.

## Reproducibility of the regeneration

.NET 6 is egress-blocked here, so this ran on apt SDK **8.0.129** with `DOTNET_ROLL_FORWARD=LatestMajor`. Before touching the pin, `yarn code-gen` was run at the **old** `94ff4cc`: **zero diff**, 1111 AP214 files and 1180 IFC4 files — byte-identical to what is checked in, exactly as `code-gen.cjs`'s comment claims. Toolchain drift is therefore excluded from everything below.

## Behavioural change, and the re-bless list

A `.U.` that previously threw now reads `null`. `ap214_geometry_extraction.ts:3355` already null-coalesces (`from.u_closed ?? false`) — a guard that was dead under the old typing and is now live — so the recovered faces extract with the determinate default.

Measured with the digest batch (`ifc_regression_batch_main`, parallel) over the 22-model NIST corpus plus `duplex.ifc` and `data/index.ifc`, before and after. **Two models change; the other 22 are byte-identical.**

| model | digest before → after | rows | `errors.csv` occurrences | `main.csv` error field |
|---|---|---|---|---|
| `nist_ftc_07_asme1_ap242-e2.stp` | `e1e96b854401…` → `a26c9d0d7c82…` | 6 → 6 | 20 → **0** | 12 → **0** |
| `nist_ftc_10_asme1_ap242-e2.stp` | `559bb4be0d6d…` → `d143588865d7…` | 32 → 32 | 1 → **0** | 12 → **0** |

In each the single changed digest row is the one `MANIFOLD_SOLID_BREP` (`#13272` and `#13886`) whose faces were being dropped — the row *count* is unchanged, the mesh hash is not. `errors.csv` loses exactly the two `Error extracting face ADVANCED_FACE - Value in STEP was incorrectly typed` rows, 21 occurrences (20 in `ftc_07`, 1 in `ftc_10`); every other error row is untouched.

Byte-identical, verified: `duplex.ifc` (`e3f035f1b9e5…`, 1340 rows), `data/index.ifc` (`6b5681730eca…`, 16 rows), all five AP203 controls, and the 15 other AP242 models — **including** `nist_ctc_02` (194 `.U.` tokens), `nist_ctc_04` (236) and `nist_stc_07` (243), whose `.U.` values sit in slots the extractor never reads. `zero_geometry.csv` is unchanged: `nist_ftc_08_asme1_ap242-e1-tg` still produces no geometry, which is #521's tessellated-geometry gap, not this.

Baselines live in bldrs-ai/test-models and are **not** touched here; the two rows above are the re-bless list.

**Side note settling an open question in the thread:** `nist_ftc_07_asme1_ap242-e2.stp` carries **439** `.U.` tokens, not 399. The generator commit message was right and [the earlier count](https://github.com/bldrs-ai/conway/issues/480#issuecomment-5284085973) was wrong.

## Pinning it

`src/AP214E3_2010/ap214_logical_attribute.test.ts` — a fixture, not a corpus model, since the files carrying a `.U.` are in the private test-models repo. It reproduces the attribute shape of the 20 bicubic patches in `ftc_07` that were dropped (`.UNSPECIFIED.` surface form, three `.U.` logicals) on a bilinear patch, and asserts three things so the plausible wrong fixes fail in different directions:

1. `.U.` reads `null` instead of throwing;
2. `.T.`/`.F.` on the same LOGICAL slots still read `true`/`false` — so reading every LOGICAL as null cannot pass;
3. `edge_curve.same_sense`, a genuine BOOLEAN, is unaffected — so widening `extractLogical` over BOOLEAN cannot either.

**Fails without the change:** stashing the 11 regenerated files and rebuilding gives `1 failed, 2 passed` — only assertion 1, throwing `Value in STEP was incorrectly typed` from `extractBoolean` at `get u_closed`. Both controls pass on either tree, as they should.

## Cleanup commit

`extractLogical`'s `optional: false` overload promised a bare `boolean` while `stepExtractLogical` maps `.U.` to `null`, which flows straight through the `value === void 0` guard — the typing lie the generator work flagged. The overload pair is collapsed to one honest `boolean | null` signature; both halves would now return the same type anyway. Every caller is generated code assigning into a `boolean | null` field, so nothing rippled: it compiles clean and lint warnings on the file are unchanged at 13.

## Verification

- Full gate green via the pre-commit hook on all three commits.
- Suite: **90 passed / 517 tests**, up from **89 / 514** on `f398a63` (+1 suite, +3 tests — this PR's).
- `yarn eslint src`: no new findings; `step_entity_base.ts` holds at 13 warnings, all pre-existing.
- No submodule pointer and no `package.json` version stamp in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013y57koArrUCwNYRYhn9483

---
_Generated by [Claude Code](https://claude.ai/code/session_013y57koArrUCwNYRYhn9483)_