### PR TITLE
Read only what this call paged: fix the concurrent prefetch crash

### DIFF
--- a/src/ifc/ifc_demand_extraction.test.ts
+++ b/src/ifc/ifc_demand_extraction.test.ts
@@ -15,6 +15,12 @@ import ParsingBuffer from '../parsing/parsing_buffer'
 import { ConwayGeometry } from '../../dependencies/conway-geom'
 import { ExtractResult } from '../core/shared_constants'
 import { IfcProduct, IfcStyledItem } from './ifc4_gen'
+import EntityTypesIfc from './ifc4_gen/entity_types_ifc.gen'
+import { openStreamedIfcModelFromStore } from './ifc_stream_open'
+import {
+  InMemoryStepByteStore,
+  WindowedStepBufferProvider,
+} from '../step/step_buffer_provider'
 
 let conwayGeometry: ConwayGeometry
 
@@ -169,4 +175,192 @@ describe( 'per-product demand extraction (Phase B2)', () => {
 
     expect( checked ).toBeGreaterThan( 0 )
   } )
+} )
+
+
+// conway#526. `extractGeometryBatchAsync` prefetches a batch of products
+// through one Promise.all over ONE shared `seen` set, so the closure walk
+// skips any record a sibling product already claimed — that sibling has
+// pinned the range, but a pin reserves a chunk against eviction, it does
+// not make it resident, and its read may still be in flight. The faceset
+// payload pass then scanned the shared set and synchronously acquired a
+// record nobody had finished reading:
+//
+//   StepBufferNotResidentError: STEP source range [164128495, 164187850)
+//   is not resident — call ensureResident before synchronous extraction
+//
+// which escaped the prefetch and aborted the whole load on a large model.
+describe( 'concurrent windowed product prefetch (conway#526)', () => {
+
+  const CHUNK = 4 * 1024
+
+  /**
+   * A store-backed model over a deliberately cramped window: 4 KiB
+   * chunks with 2 resident, so a sibling's chunks are gone by the time
+   * anyone else looks for them.
+   *
+   * @param store The backing store.
+   * @return {Promise<IfcStepModel>} The windowed model.
+   */
+  async function windowedModel( store: InMemoryStepByteStore ):
+      Promise< IfcStepModel > {
+
+    const open = await openStreamedIfcModelFromStore( store, { pool: CHUNK } )
+
+    expect( open.model ).toBeDefined()
+
+    return new IfcStepModel(
+        void 0,
+        open.columns as any,
+        new WindowedStepBufferProvider( store, CHUNK, 2 ) )
+  }
+
+  test( 'a shared seen set does not make one product read records it never paged',
+      async () => {
+
+        const store = new InMemoryStepByteStore(
+            new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ) )
+        const model = await windowedModel( store )
+        const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+
+        extraction.quietRecoverableLogging = true
+        extraction.deferDanglingPlacements = true
+
+        const prepPins = await extraction.ensureResidentForDemandPrep()
+
+        try {
+          extraction.prepareDemandExtraction( true )
+        } finally {
+          model.releaseSourceViews( prepPins )
+          model.unpinLocalIDs( prepPins )
+        }
+
+        const products = [ ...model.types( IfcProduct ) ].map( ( p ) => p.localID )
+
+        expect( products.length ).toBeGreaterThan( 1 )
+
+        // The pump's shape: one shared pin set across the batch.
+        const pins = new Set< number >()
+        const leafSpans: { address: number, length: number }[] = []
+
+        // Seed the shared set until it holds facesets — not every
+        // product carries tessellated geometry, and the payload pass is
+        // what this is about.
+        let seeded = 0
+        let claimedFacesets: number[] = []
+
+        while ( seeded < products.length && claimedFacesets.length === 0 ) {
+
+          await extraction.ensureResidentForProductExtract(
+              products[ seeded++ ], pins, leafSpans )
+
+          claimedFacesets = [ ...pins ].filter( ( id ) =>
+            model.typeIDOf( id ) === EntityTypesIfc.IFCPOLYGONALFACESET )
+        }
+
+        expect( claimedFacesets.length ).toBeGreaterThan( 0 )
+        expect( seeded ).toBeLessThan( products.length )
+
+        // Now force the state the production race produced by timing:
+        // records that are IN the shared set but NOT resident from the
+        // next caller's point of view. Dropping the pins and filling the
+        // 2-chunk window with an unrelated range evicts them, which is
+        // the same invariant violation as a sibling's read still being
+        // in flight — and unlike the race, it happens every run.
+        model.releaseSourceViews( pins )
+        model.unpinLocalIDs( pins )
+
+        for ( const span of leafSpans ) {
+          model.unpinAddressRange( span.address, span.length )
+        }
+
+        leafSpans.length = 0
+
+        const facesetAt = model.recordAddress( claimedFacesets[ 0 ] )!
+        const far = facesetAt >= CHUNK * 4 ? 0 : store.byteLength - CHUNK * 2
+
+        await model.ensureResidentRange( far, CHUNK * 2 )
+
+        // Pre-#526 the payload pass walked the shared set, synchronously
+        // acquired those evicted facesets and threw
+        // StepBufferNotResidentError out of the prefetch, killing the load.
+        await expect( Promise.all( products.slice( seeded ).map( ( localID ) =>
+          extraction.ensureResidentForProductExtract(
+              localID, pins, leafSpans ) ) ) ).resolves.toBeDefined()
+
+        expect( pins.size ).toBeGreaterThan( 0 )
+
+        model.releaseSourceViews( pins )
+        model.unpinLocalIDs( pins )
+
+        for ( const span of leafSpans ) {
+          model.unpinAddressRange( span.address, span.length )
+        }
+      }, 120000 )
+
+  test( 'the closure walk reports only what THIS call claimed', async () => {
+
+    const model = await windowedModel(
+        new InMemoryStepByteStore( new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ) ) )
+    const products = [ ...model.types( IfcProduct ) ].map( ( p ) => p.localID )
+
+    expect( products.length ).toBeGreaterThan( 1 )
+
+    // The invariant the payload pass now rests on: with a shared set,
+    // a second walk claims only what the first left unclaimed, so
+    // `claimed` is what this call has actually awaited residency for.
+    const shared = new Set< number >()
+    const firstClaimed = new Set< number >()
+    const secondClaimed = new Set< number >()
+
+    await model.ensureResidentClosureByLocalID(
+        products[ 0 ], void 0, shared, void 0, void 0, void 0, firstClaimed )
+    await model.ensureResidentClosureByLocalID(
+        products[ 0 ], void 0, shared, void 0, void 0, void 0, secondClaimed )
+
+    expect( firstClaimed.size ).toBeGreaterThan( 0 )
+    expect( secondClaimed.size ).toBe( 0 )
+
+    for ( const id of firstClaimed ) {
+      expect( shared.has( id ) ).toBe( true )
+    }
+
+    model.unpinLocalIDs( shared )
+  }, 120000 )
+
+  test( 'a product whose paging fails is skipped, not fatal to the batch', async () => {
+
+    const model = await windowedModel(
+        new InMemoryStepByteStore( new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ) ) )
+    const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+
+    const products = [ ...model.types( IfcProduct ) ].map( ( p ) => p.localID )
+    const failing = products[ 0 ]
+
+    // A store read that rejects for one product's closure must not take
+    // the batch — the pump's Promise.all would otherwise reject and the
+    // load dies where a missing product would do.
+    const realEnsure = model.ensureResidentClosureByLocalID.bind( model )
+
+    ;( model as any ).ensureResidentClosureByLocalID =
+      ( localID: number, ...rest: unknown[] ) => {
+
+        if ( localID === failing ) {
+          return Promise.reject( new Error( 'simulated store read failure' ) )
+        }
+
+        return ( realEnsure as any )( localID, ...rest )
+      }
+
+    const pins = new Set< number >()
+
+    await expect( Promise.all( products.slice( 0, 4 ).map( ( localID ) =>
+      extraction.ensureResidentForProductExtract(
+          localID, pins ) ) ) ).resolves.toBeDefined()
+
+    ;( model as any ).ensureResidentClosureByLocalID = realEnsure
+
+    model.releaseSourceViews( pins )
+    model.unpinLocalIDs( pins )
+  }, 120000 )
 } )

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -6973,6 +6973,50 @@ export class IfcGeometryExtraction {
       return seen ?? new Set< number >()
     }
 
+    // Paging failures are contained to their product (conway#526).
+    // `extractGeometryBatchAsync` prefetches a batch through one
+    // Promise.all, so a rejection here used to escape the pump and
+    // abort the entire load — a whole model lost to one unreadable
+    // product. The extract that follows already tolerates a product it
+    // cannot read (its own per-product catch logs and moves on), so
+    // degrading to "this product is missing" is both the smaller
+    // failure and the one the pipeline is already built for.
+    //
+    // Deliberately no retry: a second attempt sharing `seen` would
+    // re-claim nothing and re-ensure nothing, and giving it a fresh set
+    // would double-pin every record it re-walked — pins are refcounted
+    // but the caller unpins once per unique ID, so the surplus would
+    // hold those chunks resident for the model's life and grow the
+    // window without bound.
+    try {
+      return await this.ensureResidentForProductExtractUnguarded_(
+          localID, seen, leafSpans )
+    } catch ( error ) {
+
+      Logger.error(
+          `Error paging product localID ${localID} for extract: ` +
+          `${error instanceof Error ? error.message : String( error )}` )
+
+      return seen ?? new Set< number >()
+    }
+  }
+
+  /**
+   * {@link ensureResidentForProductExtract} without the per-product
+   * fault containment — split out so the guard cannot accidentally
+   * swallow a failure raised by its own bookkeeping.
+   *
+   * @param localID The product's local ID.
+   * @param seen Optional set to extend.
+   * @param leafSpans Coalesced Faces[] pin ranges — caller unpins.
+   * @return {Promise<Set<number>>} Pinned local IDs.
+   */
+  private async ensureResidentForProductExtractUnguarded_(
+      localID: number,
+      seen?: Set< number >,
+      leafSpans?: { address: number, length: number }[] ):
+      Promise< Set< number > > {
+
     const extra: number[] = []
     const voids = this.productToVoidGeometryMap.get( localID )
 
@@ -7005,9 +7049,14 @@ export class IfcGeometryExtraction {
         typeID !== EntityTypesIfc.IFCTRIANGULATEDFACESET
     }
 
+    // IDs THIS call claimed and awaited, as opposed to `visited`, which
+    // is the caller's shared set when a batch prefetches concurrently.
+    // Only the former may be read synchronously afterwards (conway#526).
+    const claimed = new Set< number >()
+
     const visited =
       await this.model.ensureResidentClosureByLocalID(
-          localID, extra, seen, descend, leafSpans, isFace )
+          localID, extra, seen, descend, leafSpans, isFace, claimed )
     const styleExtra: number[] = []
 
     for ( const visitedID of visited ) {
@@ -7027,10 +7076,10 @@ export class IfcGeometryExtraction {
 
     if ( styleExtra.length > 0 ) {
       await this.model.ensureResidentClosureByLocalID(
-          localID, styleExtra, visited, descend, leafSpans, isFace )
+          localID, styleExtra, visited, descend, leafSpans, isFace, claimed )
     }
 
-    await this.ensureResidentVisitedFacesetPayloads_( visited, leafSpans )
+    await this.ensureResidentVisitedFacesetPayloads_( claimed, visited, leafSpans )
 
     return visited
   }
@@ -7040,15 +7089,34 @@ export class IfcGeometryExtraction {
    * or more tight address spans. The generic closure visits the
    * faceset but does not scan Faces[].
    *
-   * @param visited Faceset local IDs already pinned (and the set to
-   * extend with Coordinates).
+   * **Iterates `claimed`, not `visited`, and re-ensures before the
+   * scan** — both halves of conway#526. `referencedExpressIDs` is a
+   * SYNCHRONOUS acquire of the faceset's own bytes, and when a batch
+   * prefetches products concurrently through one shared `visited` set
+   * (`extractGeometryBatchAsync`'s Promise.all over 8 products), the
+   * closure walk skips any ID a sibling product already claimed. That
+   * sibling has pinned the range but its read may still be in flight,
+   * so scanning the shared set threw
+   * `StepBufferNotResidentError: STEP source range [...] is not
+   * resident` out of the prefetch and killed the whole load — a pin
+   * reserves a chunk against eviction, it does not make it resident.
+   * Iterating this call's own claims fixes that (and drops the
+   * quadratic re-scan of every sibling's facesets); the `await` below
+   * makes the guarantee local rather than inherited, since a resident
+   * chunk costs only a microtask there.
+   *
+   * @param claimed Faceset local IDs this call claimed and awaited.
+   * @param visited The (possibly shared) visited set — read for
+   * Coordinates de-duplication and extended with the ones pinned here,
+   * so the caller's unpin covers them.
    * @param leafSpans Coalesced Faces[] pin ranges — caller unpins.
    */
   private async ensureResidentVisitedFacesetPayloads_(
+      claimed: Set< number >,
       visited: Set< number >,
       leafSpans?: { address: number, length: number }[] ): Promise< void > {
 
-    for ( const localID of visited ) {
+    for ( const localID of claimed ) {
 
       const typeID = this.model.typeIDOf( localID )
 
@@ -7056,6 +7124,11 @@ export class IfcGeometryExtraction {
           typeID !== EntityTypesIfc.IFCTRIANGULATEDFACESET ) {
         continue
       }
+
+      // Cheap when already resident (a Map hit and a microtask), and
+      // the difference between a guarantee and an assumption when the
+      // window has churned since this record was claimed.
+      await this.model.ensureResidentByLocalID( localID )
 
       const refs = this.model.referencedExpressIDs( localID )
 

--- a/src/step/step_model_base.ts
+++ b/src/step/step_model_base.ts
@@ -850,6 +850,14 @@ implements Iterable<BaseEntity>, Model {
    * extract reads `IfcIndexedPolygonalFace.CoordIndex` as integers —
    * following those faces pinned ~78k records per PSB product. If
    * omitted, `!descend` children use this span path (test helper).
+   * @param claimed Optional out-set of the IDs *this call* claimed and
+   * awaited residency for — a strict subset of `seen`. When `seen` is
+   * shared across concurrent walks (a batch of products sharing mapped
+   * geometry), an ID another walk claimed is skipped here and is NOT
+   * resident yet from this call's point of view: that walk's pin holds
+   * the chunk once it lands, but its read is still in flight. Anything
+   * that must synchronously read a record's bytes after this returns
+   * has to iterate `claimed`, never `seen` (conway#526).
    * @return {Promise<Set<number>>} The local IDs that were visited.
    */
   public async ensureResidentClosureByLocalID(
@@ -858,7 +866,8 @@ implements Iterable<BaseEntity>, Model {
       seen: Set< number > = new Set< number >(),
       descend?: ( localID: number ) => boolean,
       leafSpans?: { address: number, length: number }[],
-      spanLeaf?: ( localID: number ) => boolean ): Promise< Set< number > > {
+      spanLeaf?: ( localID: number ) => boolean,
+      claimed?: Set< number > ): Promise< Set< number > > {
 
     if ( !this.isSourceExternal ) {
       return seen
@@ -901,6 +910,7 @@ implements Iterable<BaseEntity>, Model {
         seen.add( id )
         this.pinByLocalID( id )
         wave.push( id )
+        claimed?.add( id )
       }
 
       frontier.length = 0


### PR DESCRIPTION
Closes #526. Part of #390. References #515 / #519. Consumer report: bldrs-ai/Share#1753.

## The mechanism

`extractGeometryBatchAsync` prefetches a batch of products through one `Promise.all` over **one shared `seen` set**, and `ensureResidentClosureByLocalID` skips any record a sibling walk already claimed. The sibling has pinned that range — but **a pin reserves a chunk against eviction, it does not make it resident**, and the sibling's read may still be in flight.

`ensureResidentVisitedFacesetPayloads_` then iterated that shared set and did a **synchronous** `referencedExpressIDs()` acquire on a record nobody had finished reading:

```
StepBufferNotResidentError: STEP source range [164128495, 164187850)
is not resident - call ensureResident before synchronous extraction
```

That rejection escaped the `Promise.all`, escaped the pump, and aborted the whole load on a large model.

## The fix, in two parts

**1. Read only what this call paged.** `ensureResidentClosureByLocalID` takes a new optional `claimed` out-set — the IDs *this* call claimed and awaited residency for, a strict subset of `seen`. The faceset payload pass iterates `claimed` instead of the shared set (which also drops a quadratic re-scan of every sibling's facesets), and re-`ensureResidentByLocalID`s each record immediately before the synchronous scan, so residency is a local guarantee rather than an assumption inherited from a sibling. That await is a Map hit and a microtask when the record is already resident. `visited` is still read for Coordinates de-duplication and extended with what gets pinned there, so the caller's unpin still covers it.

**2. Per-product fault containment.** `ensureResidentForProductExtract` is split into a thin guarded wrapper plus `ensureResidentForProductExtractUnguarded_`, so one product that cannot be paged degrades to "this product is missing" instead of taking the batch down — the extract that follows already tolerates a product it cannot read, via its own per-product catch. Split rather than wrapped in place so the guard cannot swallow a failure raised by its own bookkeeping.

**Deliberately no retry.** A second attempt sharing `seen` would re-claim nothing and re-ensure nothing; giving it a fresh set would double-pin every record it re-walked. Pins are refcounted but the caller unpins once per unique ID, so the surplus would hold those chunks resident for the model's life and grow the window without bound.

## Tests

Three new cases in `src/ifc/ifc_demand_extraction.test.ts`, all over a deliberately cramped window (4 KiB chunks, 2 resident):

- **The shared-set repro.** Rather than racing for the failure, it *forces* the pending-record state by eviction — drop the pins, fill the two-chunk window with an unrelated range — so it fires **every run** instead of on a scheduling win. It reproduces the same `StepBufferNotResidentError` against the pre-fix code.
- **The claimed-subset invariant**: a second walk over a shared set claims nothing, and everything the first claimed is in the shared set. This one does not even compile pre-fix — the parameter it rests on does not exist.
- **Per-product containment**: a closure walk that rejects for one product does not reject the batch's `Promise.all`.

## Verification

- `yarn build-incremental` — no `error TS`.
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage=false` — **89 suites / 517 tests passing**.
- `yarn lint` — 0 errors (662 pre-existing warnings, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkzKiqMWweJHR7QFMAC8aq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWaAdRZmvYbHrdYuei8rS9)_