### PR TITLE
M3 (#394): spike — what the durable pump holds, and whether extraction parallelises

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -564,10 +564,17 @@ Deliberately small first step; each has a measurable exit.
   **Release did not break delivery anywhere in the smoke corpus.** With
   every instance's product, geometry, transform, colour and
   `occurrencePath` hashed, `bounded` is identical to `classic` on 11 of
-  12 models — same instances, same payloads, same placement. So the
-  corpus provides **no evidence that per-batch release changes what a
-  consumer receives**, which is the M3 invariant, and the 342 MB / 100 MB
-  rows are a real result rather than one bought by dropping geometry.
+  12 models — same instances, same payloads, same placement — and
+  identical to **`copyout` on all 12**. That second comparison is the
+  one the release policy rests on: `copyout` and `bounded` run the same
+  deferred extraction and differ *only* in that `bounded` releases, so
+  agreement means release changed nothing, while checking each against
+  `classic` alone cannot tell — on the one model where the deferred path
+  itself diverges, a release regression would hide inside a difference
+  that is already expected. So the corpus provides **no evidence that
+  per-batch release changes what a consumer receives**, which is the M3
+  invariant, and the 342 MB / 100 MB rows are a real result rather than
+  one bought by dropping geometry.
 
   An earlier version of this section claimed the opposite — that
   retain-nothing delivered 169 instances against 101 on `supercap.step`,

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -620,22 +620,42 @@ Deliberately small first step; each has a measurable exit.
   1.34×. Per-worker wasm peak drops too (83 → 33 MB), because a shard
   that doesn't re-extract shared geometry doesn't hold it either.
 
-  `claim` is the cheaper rule to implement and the one to build: it
-  needs no global plan, only "first worker to touch an asset owns it,
-  and a product whose assets are owned follows them" — a worker rips
-  through a run and hands off when it meets something new. `affinity`
-  hashing is marginally better on CPU and marginally worse on balance,
-  which is what you would expect from a static partition against an
-  adaptive one.
+  **What this validates, precisely: a precomputed partition.** Both
+  strategies are scored and emitted *offline*, from a captured graph
+  that already knows every product's created/reused assets and its
+  measured cost before anything is dispatched. That is an oracle. It
+  establishes the ceiling — the duplication is entirely addressable by
+  placement, and asset-aware placement reaches the serial CPU floor —
+  but it is not yet a scheduler.
 
-  Three caveats the numbers carry. The partition table above was itself
-  produced twice: the first run reported that neither asset-aware
-  partition changed anything, because the harness's assignment path had
-  been dropped in an unrelated edit and every "partition" was silently
-  running round-robin. The lesson is the one this whole file keeps
-  relearning — a measurement that cannot fail is not a measurement, and
-  the tell was that two different partitions produced *byte-identical*
-  asset counts. Each shard also pays its own parse here, so
+  **What it does not validate: an online first-touch rule.** A live
+  worker cannot know that a pending product follows an existing owner
+  until it has discovered that product's assets, and discovering them by
+  extracting is exactly the duplication the rule exists to avoid. So
+  "first worker to touch an asset owns it" needs a **dispatch-time key**
+  — something derivable from the index without extracting, i.e. the
+  product's representation / mapped-source ID read straight from the
+  columns. That key is cheap and it is the natural candidate; whether it
+  partitions as well as the oracle is the next measurement, not a
+  settled result. Until it is taken, the honest statement is: asset
+  affinity is worth ~27 % of CPU and ~1.5× of wall-clock on a
+  representation-heavy model, and an online scheduler that approximates
+  it is the thing to design.
+
+  Three caveats the numbers carry. The partition table above was
+  produced twice, and the first version was wrong in two ways worth
+  recording rather than quietly fixing. It reported that neither
+  asset-aware partition changed anything — because the harness's
+  assignment path had been dropped in an unrelated edit, so every
+  "partition" was silently running round-robin; the tell was two
+  different partitions producing *byte-identical* asset counts. And the
+  sweep's own N=1 row, when an assignment was active, handed the
+  baseline child one shard's products while treating it as the whole
+  model, so the ratios those runs printed were nonsense (the published
+  figures came from a separate unassigned baseline, which is the only
+  reason the conclusion survived). Both are fixed; the lesson is the one
+  this file keeps relearning, that a measurement which cannot fail is
+  not a measurement. Each shard also pays its own parse here, so
   only the geometry phase is comparable; the shipping design parses once
   and hands workers transferable index columns, which is exactly what
   M2/M7's columns-from-birth index made possible (before it, sharding

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -561,17 +561,47 @@ Deliberately small first step; each has a measurable exit.
   accumulated with the number of geometries rather than with the batch
   and so masked the batch's effect entirely.)
 
-  **Retention is a correctness prerequisite, not an optimisation.**
-  Retain-nothing release breaks a real model: on `supercap.step` it
-  delivers **169 instances against 101**, because a later product
-  sharing a released geometry misses the cache, re-extracts, and appends
-  duplicate scene nodes — while `streamNewMeshes_`'s *positional*
-  per-entity watermarks desynchronise on top of it (a positional cursor
-  cannot survive an entry vanishing from the sequence it indexes). So
-  the shippable policy is refcount-on-asset (`SharedAssetPool`, already
-  written) plus an **asset-keyed delta capture**, which also deletes the
-  pump's O(batches × scene) re-walk. The 840 MB row is the measured
-  upper bound of the win, not a shippable configuration.
+  **Release did not break delivery anywhere in the smoke corpus.** With
+  every instance's product, geometry, transform, colour and
+  `occurrencePath` hashed, `bounded` is identical to `classic` on 11 of
+  12 models — same instances, same payloads, same placement. So the
+  corpus provides **no evidence that per-batch release changes what a
+  consumer receives**, which is the M3 invariant, and the 342 MB / 100 MB
+  rows are a real result rather than one bought by dropping geometry.
+
+  An earlier version of this section claimed the opposite — that
+  retain-nothing delivered 169 instances against 101 on `supercap.step`,
+  making retention a *measured* correctness prerequisite. That figure
+  came from a stale harness state and does not reproduce. Retracted.
+
+  **Retention is still required, but as a design argument, not a
+  measured one.** The mechanism is unchanged and real: the scene walk
+  resolves geometry through `model.geometry.getByLocalID` and skips what
+  it cannot find, so releasing an asset a later product shares makes
+  that product miss the cache and re-extract, appending duplicate scene
+  nodes — and `streamNewMeshes_`'s *positional* per-entity watermarks
+  cannot survive an entry vanishing from the sequence they index. This
+  corpus simply never triggers it at batch 64: shared geometry is copied
+  and released within the same batch that emits all of its instances.
+  A model that instances one definition across widely separated products
+  would, and finding or building that fixture is the next thing this
+  harness needs. The shippable policy is unchanged —
+  refcount-on-asset (`SharedAssetPool`, already written) plus an
+  **asset-keyed delta capture**, which also deletes the pump's
+  O(batches × scene) re-walk — but it is now justified by the code path
+  rather than by a number.
+
+  **The 12th model exposes something else, and it is a production bug.**
+  On `supercap.step` (AP214) the *deferred pump itself* diverges from
+  the classic walk before any release is involved: `ExtractGeometryBatch`
+  delivers **21 instances over 2 geometries** where `StreamAllMeshes`
+  delivers **101 over 6**. `copyout` — which releases nothing — diverges
+  exactly as `bounded` does, so release is not implicated. It is
+  deterministic across runs, reproduces before this branch merged M2,
+  and reproduces with the harness's native-clone handling removed. Since
+  the deferred pump is the path Share's demand/tiled rendering runs, an
+  AP214 assembly losing four fifths of its placed instances there is a
+  correctness bug in the production path, tracked separately from M3.
 
   **The worker pool is a live lever, and the MT result never tested it
   (measured 2026-08-18).** Two different parallelism axes were being

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -487,16 +487,20 @@ Deliberately small first step; each has a measurable exit.
 
   | phase | open | geometry | total | wasm peak | RSS | JS retained |
   | --- | --- | --- | --- | --- | --- | --- |
-  | `classic` — `OpenModel` + `StreamAllMeshes` | 53 s | 8 s | 61 s | **1956 MB** | 4202 MB | 1576 MB |
-  | `pump` — deferred, batched, no copy-out | 14 s | 33 s | 47 s | 1284 MB | 2829 MB | 1255 MB |
-  | `copyout` — + per-batch payload copy-out | 14 s | 39 s | 53 s | 1956 MB | 3640 MB | 1597 MB |
-  | `bounded` — + per-batch native release | 13 s | 27 s | **40 s** | **840 MB** | 2494 MB | 1589 MB |
+  | `classic` — `OpenModel` + `StreamAllMeshes` | 44 s | 8 s | 52 s | **1956 MB** | 4182 MB | 1566 MB |
+  | `pump` — deferred, batched, no copy-out | 13 s | 31 s | 44 s | 1284 MB | 2828 MB | 1255 MB |
+  | `copyout` — + per-batch payload copy-out | 13 s | 30 s | 43 s | 1956 MB | 3632 MB | 1597 MB |
+  | `bounded` — + per-batch native release | 13 s | 24 s | **37 s** | **840 MB** | 2486 MB | 1589 MB |
 
   Every payload-carrying phase **holds** its copied vertex and index
   buffers until it reports (40 356 typed arrays, 334 MB on PSB), because
   a consumer building a navigable scene keeps them — hashing and
   dropping them would report a JS working set nobody actually has, and
-  would hide the GC pressure of holding it. Compare rows within this
+  would hide the GC pressure of holding it. They are retained exactly as
+  `GetVertexArray`/`GetIndexArray` return them: those already hand back
+  owning copies (`getSubArray` ends with `slice(0)`), so a defensive
+  `.slice()` on top would double every payload and leave the first
+  generation as garbage — inflating the very columns this table reports. Compare rows within this
   table only: absolute wall-clock on this box moves ±25 % between runs,
   so the cross-run deltas that matter are the memory columns, which are
   stable and reproduce.
@@ -519,9 +523,14 @@ Deliberately small first step; each has a measurable exit.
      heap that is never dropped (`pump` 1284 MB vs `copyout` 1956 MB on
      identical extraction). Every consumer that reads its own vertices
      pays it, and it is invisible to any probe that doesn't.
-  4. **Bounding it is free** — `bounded` is the *fastest* row, not a
-     trade. Releasing costs nothing measurable and removes allocator
-     pressure about as fast as it adds calls.
+  4. **Releasing costs nothing measurable.** `bounded` is the fastest
+     row here, but the spread between rows (~24 %) sits inside this
+     box's run-to-run wall-clock variance (~25 %), so the honest claim is
+     the negative one: **no release overhead is distinguishable from
+     noise**, across every run taken. Establishing that release is
+     genuinely *faster* would need repeated timings with the variance
+     separated out, which nothing here depends on — the memory columns
+     are the result, and they are stable.
 
   **Batch size is not the remaining lever.** `bounded` at batch = 32
   reaches 727 MB (36.6 s, identical digests) against 840 MB at batch =
@@ -584,32 +593,49 @@ Deliberately small first step; each has a measurable exit.
   sharding, which preserves file-order locality, duplicates less and
   scales better (1.52× vs 1.39×).
 
-  **Partition ownership is an open question, not a settled one.** The
-  obvious answer — affinity by shared asset, the same
-  definition/occurrence boundary `SharedAssetPool` draws for retention —
-  was tested and **did not work**. `scripts/m3_affinity_spike.mjs`
-  captures the real product↔asset graph (one instrumented extraction
-  pass recording, per product, which assets it created, which it reused,
-  and how long it took) and replays partitions against it. Simulated, it
-  is decisive: on MB-Khaya at N=4, round-robin costs +46 % duplicated CPU
-  (against +40 % measured, so the cost model calibrates) while
-  asset-affinity and an adaptive claim-the-asset partition both reach
-  +0 %. Run against the real extractor, neither moves anything —
-  round-robin and claim both create **8678 assets** against a
-  single-shard **6851**, so the +27 % duplication is real and completely
-  independent of where products are placed.
+  **The partition wants affinity by shared asset**, not by product — the
+  same definition/occurrence boundary `SharedAssetPool` draws for
+  retention. One boundary, two payoffs. Measured rather than assumed:
+  `scripts/m3_affinity_spike.mjs` captures the real product↔asset graph
+  (one instrumented extraction pass recording, per product, which assets
+  it created, which it reused, and how long it took), replays candidate
+  partitions against it, and can emit any of them as per-shard product
+  lists so the **real extractor** runs the partition the simulation
+  scored.
 
-  Two known defects in that model, either of which could explain it: the
-  capture drives only the per-product seam, so it never sees the
-  **rel-aggregates pass** (5363 assets recorded against the 6851 really
-  created), and that pass is sharded positionally — re-running shared
-  master-void work per shard no matter what the product partition does.
-  If the duplication turns out to live there, the answer is "give
-  aggregates an owner", not "partition products by definition". Until
-  aggregates are captured and replayed, this doc records the mechanism
-  and declines to name the key.
+  **MB-Khaya, N=4, single-threaded shards, against a one-shard baseline
+  of 4.3 s / 7.5 s CPU / 6851 assets:**
 
-  Two caveats the numbers carry. Each shard pays its own parse here, so
+  | partition | geometry | total CPU | assets created |
+  | --- | --- | --- | --- |
+  | round-robin | 3.2 s | 11.2 s | 8678 (**+27 %**) |
+  | affinity — hash the product's primary asset | 2.3 s | **7.5 s** | **6851** (+0 %) |
+  | claim — first worker to touch an asset owns it | **2.2 s** | 7.8 s | **6851** (+0 %) |
+
+  Both asset-aware partitions eliminate the duplication **completely**:
+  four shards create exactly the assets one shard does, and total CPU
+  returns to the serial baseline, so nothing is wasted. The wall-clock
+  follows — 2.2 s against round-robin's 3.2 s at the same shard count,
+  which is 1.95× against the serial baseline where round-robin manages
+  1.34×. Per-worker wasm peak drops too (83 → 33 MB), because a shard
+  that doesn't re-extract shared geometry doesn't hold it either.
+
+  `claim` is the cheaper rule to implement and the one to build: it
+  needs no global plan, only "first worker to touch an asset owns it,
+  and a product whose assets are owned follows them" — a worker rips
+  through a run and hands off when it meets something new. `affinity`
+  hashing is marginally better on CPU and marginally worse on balance,
+  which is what you would expect from a static partition against an
+  adaptive one.
+
+  Three caveats the numbers carry. The partition table above was itself
+  produced twice: the first run reported that neither asset-aware
+  partition changed anything, because the harness's assignment path had
+  been dropped in an unrelated edit and every "partition" was silently
+  running round-robin. The lesson is the one this whole file keeps
+  relearning — a measurement that cannot fail is not a measurement, and
+  the tell was that two different partitions produced *byte-identical*
+  asset counts. Each shard also pays its own parse here, so
   only the geometry phase is comparable; the shipping design parses once
   and hands workers transferable index columns, which is exactly what
   M2/M7's columns-from-birth index made possible (before it, sharding

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -68,7 +68,7 @@ The remaining structural residencies — the things this doc exists to kill:
    harness's own leaked native clones). Geometry is extracted eagerly for
    the whole model and stays resident in the wasm heap even after the
    GLB/scene is built — see the M3 status below, where per-batch release
-   takes this to 342 MB at batch 256 and 100 MB at batch 32.
+   takes this to 342 MB at batch 256 and 84 MB at batch 32.
 3. **Eager whole-model geometry extraction.** Even with a bounded heap,
    extracting *everything up front* is O(model) time before first pixel
    and O(model) scene memory after.
@@ -544,10 +544,22 @@ Deliberately small first step; each has a measurable exit.
      are the result, and they are stable.
 
   **The high-water becomes O(batch), which is the whole point.**
-  `bounded` at batch = 32 reaches **100 MB** (37.5 s, identical digests)
-  against 342 MB at batch = 256. The residency now tracks the in-flight
+  `bounded` at batch = 32 reaches **84 MB** (identical digests) against
+  342 MB at batch = 256. The residency now tracks the in-flight
   working set the way the design says it should, rather than the model:
-  1283 MB → 342 MB → 100 MB as the batch shrinks, at no wall-clock cost.
+  1283 MB → 342 MB → 84 MB as the batch shrinks, at no wall-clock cost.
+
+  Release is keyed on what the extractor **creates**, not on what it
+  delivers. The two differ: natives are built that never reach a
+  consumer as a payload — void and opening geometry consumed by a
+  boolean — and a release keyed on delivered payloads leaves those
+  resident for the life of the model. On PSB that is 403 of 20 581
+  assets, and on MB-Khaya 3 347 of 8 947 (37 %). Correcting it is what
+  moves the batch-32 row from 100 MB to 84 MB; the batch-256 row is
+  unchanged at 342 MB, because at that size the in-flight set dominates
+  the residue. (An earlier version of this section reported 100 MB and
+  checked only that every *copied* geometry was freed — a check that
+  cannot see this class of leak at all.)
 
   **This clears M3's memory gate on PSB** — "steady-state wasm heap
   under a configured budget (e.g. 512 MB) with the full model
@@ -586,7 +598,7 @@ Deliberately small first step; each has a measurable exit.
   itself diverges, a release regression would hide inside a difference
   that is already expected. So the corpus provides **no evidence that
   per-batch release changes what a consumer receives**, which is the M3
-  invariant, and the 342 MB / 100 MB rows are a real result rather than
+  invariant, and the 342 MB / 84 MB rows are a real result rather than
   one bought by dropping geometry.
 
   An earlier version of this section claimed the opposite — that

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -470,6 +470,81 @@ Deliberately small first step; each has a measurable exit.
   (viewport-ordered). Exit: PSB time-to-first-pixel < 25 % of full-load
   time; steady-state wasm heap under a configured budget (e.g. 512 MB)
   with the full model *navigable* (tiles fill/evict on demand).
+
+  **Status 2026-08-18 — machinery shipped, discipline not in the
+  production path; re-scoped to bounded high-water.** Every part exists
+  and is tested (`DemandGeometryQueue`, `ChunkedPool` →
+  `SharedAssetPool` → `GeometryTilePool`, the C++ `TilePool` twin +
+  `createWasmTileBackend`, `IfcTileAssetExtractor`, the per-product
+  `extractProductGeometryByLocalID` seam), and outside tests nothing
+  consumes any of it: Share runs the shim's durable batch pump, which
+  extracts every product into `model.geometry` and holds it for the life
+  of the tab. Measured with `scripts/m3_pump_spike.mjs` (child process
+  per phase; placements and payloads hashed per phase so "M3 changes
+  *when*, not *what*" is a check, not a claim).
+
+  **PSB.ifc — 902 MB, node, 4-core sandbox, batch = 256:**
+
+  | phase | open | geometry | total | wasm peak | RSS |
+  | --- | --- | --- | --- | --- | --- |
+  | `classic` — `OpenModel` + `StreamAllMeshes` | 37.0 s | 2.0 s | 39.0 s | **1956 MB** | 3906 MB |
+  | `pump` — deferred, batched, no copy-out | 14.1 s | 22.6 s | 36.7 s | 1284 MB | 2831 MB |
+  | `copyout` — + per-batch payload copy-out | 12.9 s | 24.8 s | 37.7 s | 1956 MB | 3440 MB |
+  | `bounded` — + per-batch native release | 13.1 s | 23.9 s | **37.0 s** | **840 MB** | 2289 MB |
+
+  Identical placement and payload digests across `classic`, `copyout`
+  and `bounded`. Four readings:
+
+  1. **The geometry residency is the entire wasm heap.** The deferred
+     open reaches end-of-parse at **16 MB** of wasm; classic is already
+     at 1283 MB when `OpenModel` returns. Parsing costs no meaningful
+     wasm — so a parse-phase memory regression is never wasm-side, which
+     also redirects the Share-side "+1.7 GB parsing" hunt away from wasm
+     ArrayBuffers.
+  2. **The tab holds ~6× the geometry it delivers.** 23 454 instances
+     over 20 178 distinct geometries are **334 MB** of vertex+index
+     payload against a 1956 MB high-water. The gap is never releasing,
+     not the model.
+  3. **`GetGeometry` is itself a memory event: +672 MB.** Reading a
+     geometry's floats materialises a per-geometry mirror in the wasm
+     heap that is never dropped (`pump` 1284 MB vs `copyout` 1956 MB on
+     identical extraction). Every consumer that reads its own vertices
+     pays it, and it is invisible to any probe that doesn't.
+  4. **Bounding it is free** — `bounded` is 5.1 % *faster* end-to-end.
+
+  **Batch size is not the remaining lever.** `bounded` at batch = 32
+  reaches 727 MB (36.6 s, identical digests) against 840 MB at batch =
+  256 — an 8× smaller working set buys 113 MB. So the residual is not
+  the in-flight batch: it is the natives this policy never releases
+  (the rel-aggregates pass, materials, temporaries) plus the extraction
+  scratch's own high-water. Getting under the 512 MB gate and *staying*
+  there under evict/refill churn is what the dedicated chunk region is
+  for — which is the two-regime argument above, arrived at from
+  measurement rather than from first principles.
+
+  **Retention is a correctness prerequisite, not an optimisation.**
+  Retain-nothing release breaks a real model: on `supercap.step` it
+  delivers **169 instances against 101**, because a later product
+  sharing a released geometry misses the cache, re-extracts, and appends
+  duplicate scene nodes — while `streamNewMeshes_`'s *positional*
+  per-entity watermarks desynchronise on top of it (a positional cursor
+  cannot survive an entry vanishing from the sequence it indexes). So
+  the shippable policy is refcount-on-asset (`SharedAssetPool`, already
+  written) plus an **asset-keyed delta capture**, which also deletes the
+  pump's O(batches × scene) re-walk. The 840 MB row is the measured
+  upper bound of the win, not a shippable configuration.
+
+  Scope moved out by measurement rather than by preference: the
+  **geometry worker pool** (browser MT nets zero-to-negative —
+  Share#1610, conway-geom#148; "extraction off the main thread" survives
+  as a separate UI-responsiveness item), **demand ordering** (Share-side
+  priority into a queue that exists; does not gate the memory result),
+  and the **per-product native free blocker** (`IfcModelGeometry.delete`
+  already frees the native, and freeing into the general heap returns ~0
+  RSS — the missing piece was policy and retention, never a C++
+  surface). The time-to-first-pixel exit criterion predates the
+  streaming preview channel and is re-aimed at the preview→durable
+  handover, tracked Share-side.
 - **M4 — Range ByteSource + index sidecar.** S2. Exit: second visit to a
   remote PSB with sidecar reaches first pixel without fetching > 10 % of
   the file; property panel opens with < 1 MB fetched.

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -563,9 +563,10 @@ Deliberately small first step; each has a measurable exit.
 
   **Release did not break delivery anywhere in the smoke corpus.** With
   every instance's product, geometry, transform, colour and
-  `occurrencePath` hashed, and **every delivered vertex and index byte**
-  hashed exactly (at report time, so exactness costs the timings
-  nothing), `bounded` is identical to `classic` on 11 of
+  `occurrencePath` hashed, and **every delivered vertex and index hashed
+  by raw bit pattern** (at report time, so exactness costs the timings
+  nothing — and unquantised, so two payloads that differ in any bit
+  cannot compare equal), `bounded` is identical to `classic` on 11 of
   12 models — same instances, same payloads, same placement — and
   identical to **`copyout` on all 12**, with each run also asserting
   that release actually happened (every copied geometry freed — a

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -563,9 +563,14 @@ Deliberately small first step; each has a measurable exit.
 
   **Release did not break delivery anywhere in the smoke corpus.** With
   every instance's product, geometry, transform, colour and
-  `occurrencePath` hashed, `bounded` is identical to `classic` on 11 of
+  `occurrencePath` hashed, and **every delivered vertex and index byte**
+  hashed exactly (at report time, so exactness costs the timings
+  nothing), `bounded` is identical to `classic` on 11 of
   12 models — same instances, same payloads, same placement — and
-  identical to **`copyout` on all 12**. That second comparison is the
+  identical to **`copyout` on all 12**, with each run also asserting
+  that release actually happened (every copied geometry freed — a
+  release path that threw would otherwise produce the same agreement
+  while releasing nothing). That second comparison is the
   one the release policy rests on: `copyout` and `bounded` run the same
   deferred extraction and differ *only* in that `bounded` releases, so
   agreement means release changed nothing, while checking each against

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -534,10 +534,59 @@ Deliberately small first step; each has a measurable exit.
   pump's O(batches × scene) re-walk. The 840 MB row is the measured
   upper bound of the win, not a shippable configuration.
 
-  Scope moved out by measurement rather than by preference: the
-  **geometry worker pool** (browser MT nets zero-to-negative —
-  Share#1610, conway-geom#148; "extraction off the main thread" survives
-  as a separate UI-responsiveness item), **demand ordering** (Share-side
+  **The worker pool is a live lever, and the MT result never tested it
+  (measured 2026-08-18).** Two different parallelism axes were being
+  conflated. What conway-geom#148 measured is *pthreads inside one wasm
+  instance*: the C++ pool splits work **within** a product's
+  tessellation, on a **shared** heap, fed by **one serial JS driver** —
+  and its three suspects (main-thread `Atomics.wait` busy-spin,
+  `memory.grow` stalling every thread, pool oversubscription) are all
+  properties of that shape. What this doc's "Parallelism / multi-core"
+  section actually specifies is the other axis: N workers, each with its
+  **own** instance and heap and driver, pulling **disjoint products**.
+  Every one of those suspects is structurally absent there — separate
+  linear memories, and a worker may legally block — and #148's own
+  listed fix is "run extraction in a dedicated worker".
+
+  Measured by sharding the product worklist round-robin across N
+  independent processes (own instance, own heap, own driver — a worker
+  minus the postMessage plumbing), single-threaded wasm so one worker
+  means one core, on a 4-core box:
+
+  | model | N=1 | N=2 | N=3 | N=4 | total CPU N=1 → N=4 |
+  | --- | --- | --- | --- | --- | --- |
+  | **PSB.ifc** geometry | 23.1 s | 12.6 s (1.84×) | 9.8 s (2.37×) | **8.9 s (2.59×)** | 30.5 s → 35.2 s (+15 %) |
+  | **MB-Khaya.ifc** geometry | 4.0 s | 2.9 s (1.37×) | 2.8 s (1.41×) | 2.9 s (1.39×) | 7.2 s → 10.1 s (+40 %) |
+
+  **PSB scales.** 2.59× on 4 cores is 86 % of what this box can give:
+  one extraction process already burns 1.32 cores (main thread plus V8
+  GC/JIT — the allocation-heavy JS driver's own tax), which caps the
+  achievable speedup at 4 / 1.32 ≈ 3.0×. Per-worker wasm peak also falls
+  with N (1283 → 364 MB), so sharding is a **memory** lever as well as a
+  time one, and it composes with the bounded pump rather than competing.
+
+  **MB-Khaya does not**, and the reason is visible in the CPU column
+  rather than the wall-clock: sharding it costs +40 % total CPU against
+  PSB's +15 %. A small model that reuses representations heavily has
+  products that are *not* independent — round-robin scatters shared
+  geometry across every shard and each one re-extracts it. Contiguous
+  sharding, which preserves file-order locality, duplicates less and
+  scales better (1.52× vs 1.39×). So the partition wants **affinity by
+  shared asset**, not by product — the same definition/occurrence
+  boundary `SharedAssetPool` draws for retention. One boundary, two
+  payoffs.
+
+  Two caveats the numbers carry. Each shard pays its own parse here, so
+  only the geometry phase is comparable; the shipping design parses once
+  and hands workers transferable index columns, which is exactly what
+  M2/M7's columns-from-birth index made possible (before it, sharding
+  meant shipping an object-form index or letting the event stream
+  schedule). Even so, end-to-end wall with four redundant parses still
+  falls 39.4 s → 26.9 s. And a 4-core box cannot answer how this scales
+  at 8–16 cores; it can only show the axis is real.
+
+  Scope moved out by measurement rather than by preference:
+  **demand ordering** (Share-side
   priority into a queue that exists; does not gate the memory result),
   and the **per-product native free blocker** (`IfcModelGeometry.delete`
   already frees the native, and freeing into the general heap returns ~0

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -509,7 +509,10 @@ Deliberately small first step; each has a measurable exit.
   stable and reproduce.
 
   Identical placement and payload digests across `classic`, `copyout`
-  and `bounded`. Four readings:
+  and `bounded` **on PSB, the model this table measures** — corpus-wide
+  the deferred phases match `classic` on 11 of 12 models and each other
+  on all 12; see the smoke-corpus paragraph below for the
+  `supercap.step` exception. Four readings:
 
   1. **The geometry residency is the entire wasm heap.** The deferred
      open reaches end-of-parse at **16 MB** of wasm; classic is already

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -63,9 +63,12 @@ The remaining structural residencies — the things this doc exists to kill:
 1. **Parse-time source residency.** `parseDataToModel` needs the entire
    source as one contiguous buffer. The spill only happens *post*-parse.
    Peak = source + index. This is the "constant-memory parse" gap.
-2. **Grow-only wasm geometry heap.** ~2 GB on PSB at steady state.
-   Geometry is extracted eagerly for the whole model and stays resident in
-   the wasm heap even after the GLB/scene is built.
+2. **Grow-only wasm geometry heap.** 1283 MB on PSB at steady state
+   (measured 2026-08-18; earlier ~2 GB figures included a measurement
+   harness's own leaked native clones). Geometry is extracted eagerly for
+   the whole model and stays resident in the wasm heap even after the
+   GLB/scene is built — see the M3 status below, where per-batch release
+   takes this to 342 MB at batch 256 and 100 MB at batch 32.
 3. **Eager whole-model geometry extraction.** Even with a bounded heap,
    extracting *everything up front* is O(model) time before first pixel
    and O(model) scene memory after.
@@ -487,10 +490,10 @@ Deliberately small first step; each has a measurable exit.
 
   | phase | open | geometry | total | wasm peak | RSS | JS retained |
   | --- | --- | --- | --- | --- | --- | --- |
-  | `classic` — `OpenModel` + `StreamAllMeshes` | 44 s | 8 s | 52 s | **1956 MB** | 4182 MB | 1566 MB |
-  | `pump` — deferred, batched, no copy-out | 13 s | 31 s | 44 s | 1284 MB | 2828 MB | 1255 MB |
-  | `copyout` — + per-batch payload copy-out | 13 s | 30 s | 43 s | 1956 MB | 3632 MB | 1597 MB |
-  | `bounded` — + per-batch native release | 13 s | 24 s | **37 s** | **840 MB** | 2486 MB | 1589 MB |
+  | `classic` — `OpenModel` + `StreamAllMeshes` | 48 s | 8 s | 56 s | **1283 MB** | 3577 MB | 1566 MB |
+  | `pump` — deferred, batched, no copy-out | 13 s | 35 s | 48 s | 1283 MB | 2827 MB | 1255 MB |
+  | `copyout` — + per-batch payload copy-out | 13 s | 33 s | 46 s | 1283 MB | 3025 MB | 1597 MB |
+  | `bounded` — + per-batch native release | 13 s | 25 s | **38 s** | **342 MB** | 2048 MB | 1589 MB |
 
   Every payload-carrying phase **holds** its copied vertex and index
   buffers until it reports (40 356 typed arrays, 334 MB on PSB), because
@@ -514,15 +517,20 @@ Deliberately small first step; each has a measurable exit.
      wasm — so a parse-phase memory regression is never wasm-side, which
      also redirects the Share-side "+1.7 GB parsing" hunt away from wasm
      ArrayBuffers.
-  2. **The tab holds ~6× the geometry it delivers.** 23 454 instances
+  2. **The tab holds ~4× the geometry it delivers.** 23 454 instances
      over 20 178 distinct geometries are **334 MB** of vertex+index
-     payload against a 1956 MB high-water. The gap is never releasing,
+     payload against a 1283 MB high-water. The gap is never releasing,
      not the model.
-  3. **`GetGeometry` is itself a memory event: +672 MB.** Reading a
-     geometry's floats materialises a per-geometry mirror in the wasm
-     heap that is never dropped (`pump` 1284 MB vs `copyout` 1956 MB on
-     identical extraction). Every consumer that reads its own vertices
-     pays it, and it is invisible to any probe that doesn't.
+  3. **Reading vertices costs no extra wasm.** `pump` (no copy-out) and
+     `copyout` peak identically at 1283 MB, so serving a consumer its
+     own geometry is free on the wasm side — the payload is copied out
+     to JS and the native is untouched. An earlier version of this
+     section claimed `GetGeometry` cost +672 MB; that was the spike
+     harness leaking, not the engine. `GetGeometry` returns
+     `geometryObject.clone()` — an *owning* native copy — and the
+     harness never deleted it, so it accumulated one clone per geometry
+     inside the heap it was measuring. Consumers of this API must delete
+     what it hands them; conway's own paths already do.
   4. **Releasing costs nothing measurable.** `bounded` is the fastest
      row here, but the spread between rows (~24 %) sits inside this
      box's run-to-run wall-clock variance (~25 %), so the honest claim is
@@ -532,15 +540,26 @@ Deliberately small first step; each has a measurable exit.
      separated out, which nothing here depends on — the memory columns
      are the result, and they are stable.
 
-  **Batch size is not the remaining lever.** `bounded` at batch = 32
-  reaches 727 MB (36.6 s, identical digests) against 840 MB at batch =
-  256 — an 8× smaller working set buys 113 MB. So the residual is not
-  the in-flight batch: it is the natives this policy never releases
-  (the rel-aggregates pass, materials, temporaries) plus the extraction
-  scratch's own high-water. Getting under the 512 MB gate and *staying*
-  there under evict/refill churn is what the dedicated chunk region is
-  for — which is the two-regime argument above, arrived at from
-  measurement rather than from first principles.
+  **The high-water becomes O(batch), which is the whole point.**
+  `bounded` at batch = 32 reaches **100 MB** (37.5 s, identical digests)
+  against 342 MB at batch = 256. The residency now tracks the in-flight
+  working set the way the design says it should, rather than the model:
+  1283 MB → 342 MB → 100 MB as the batch shrinks, at no wall-clock cost.
+
+  **This clears M3's memory gate on PSB** — "steady-state wasm heap
+  under a configured budget (e.g. 512 MB) with the full model
+  navigable" — with room to spare, and *without* the dedicated chunk
+  region. That does not retire the chunk region: this measures a single
+  drain-once pass, and the region exists for what happens under
+  evict/refill *churn*, where a general allocator fragments and never
+  gives the pages back. But the ordering changes — the pump discipline
+  alone reaches the gate, and the region is what keeps it there.
+
+  (An earlier version of this section reported 840 MB and 727 MB for
+  these two rows and concluded batch size was not a lever. Both figures
+  were inflated by the harness's leaked `GetGeometry` clones, which
+  accumulated with the number of geometries rather than with the batch
+  and so masked the batch's effect entirely.)
 
   **Retention is a correctness prerequisite, not an optimisation.**
   Retain-nothing release breaks a real model: on `supercap.step` it

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -563,10 +563,14 @@ Deliberately small first step; each has a measurable exit.
 
   **Release did not break delivery anywhere in the smoke corpus.** With
   every instance's product, geometry, transform, colour and
-  `occurrencePath` hashed, and **every delivered vertex and index hashed
-  by raw bit pattern** (at report time, so exactness costs the timings
-  nothing — and unquantised, so two payloads that differ in any bit
-  cannot compare equal), `bounded` is identical to `classic` on 11 of
+  `occurrencePath` hashed, and **every delivered vertex and index byte
+  fed to SHA-256** (at report time, so it costs the timings nothing —
+  and over raw bytes rather than quantised values, so a small
+  tessellation change cannot land in the same bucket; two runs that
+  deliver different geometry agreeing would require a SHA-256
+  collision, which is the honest bound — an earlier 32-bit rolling hash
+  could not support the "cannot compare equal" wording this paragraph
+  used to carry), `bounded` is identical to `classic` on 11 of
   12 models — same instances, same payloads, same placement — and
   identical to **`copyout` on all 12**, with each run also asserting
   that release actually happened (every copied geometry freed — a

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -485,12 +485,21 @@ Deliberately small first step; each has a measurable exit.
 
   **PSB.ifc — 902 MB, node, 4-core sandbox, batch = 256:**
 
-  | phase | open | geometry | total | wasm peak | RSS |
-  | --- | --- | --- | --- | --- | --- |
-  | `classic` — `OpenModel` + `StreamAllMeshes` | 37.0 s | 2.0 s | 39.0 s | **1956 MB** | 3906 MB |
-  | `pump` — deferred, batched, no copy-out | 14.1 s | 22.6 s | 36.7 s | 1284 MB | 2831 MB |
-  | `copyout` — + per-batch payload copy-out | 12.9 s | 24.8 s | 37.7 s | 1956 MB | 3440 MB |
-  | `bounded` — + per-batch native release | 13.1 s | 23.9 s | **37.0 s** | **840 MB** | 2289 MB |
+  | phase | open | geometry | total | wasm peak | RSS | JS retained |
+  | --- | --- | --- | --- | --- | --- | --- |
+  | `classic` — `OpenModel` + `StreamAllMeshes` | 53 s | 8 s | 61 s | **1956 MB** | 4202 MB | 1576 MB |
+  | `pump` — deferred, batched, no copy-out | 14 s | 33 s | 47 s | 1284 MB | 2829 MB | 1255 MB |
+  | `copyout` — + per-batch payload copy-out | 14 s | 39 s | 53 s | 1956 MB | 3640 MB | 1597 MB |
+  | `bounded` — + per-batch native release | 13 s | 27 s | **40 s** | **840 MB** | 2494 MB | 1589 MB |
+
+  Every payload-carrying phase **holds** its copied vertex and index
+  buffers until it reports (40 356 typed arrays, 334 MB on PSB), because
+  a consumer building a navigable scene keeps them — hashing and
+  dropping them would report a JS working set nobody actually has, and
+  would hide the GC pressure of holding it. Compare rows within this
+  table only: absolute wall-clock on this box moves ±25 % between runs,
+  so the cross-run deltas that matter are the memory columns, which are
+  stable and reproduce.
 
   Identical placement and payload digests across `classic`, `copyout`
   and `bounded`. Four readings:
@@ -510,7 +519,9 @@ Deliberately small first step; each has a measurable exit.
      heap that is never dropped (`pump` 1284 MB vs `copyout` 1956 MB on
      identical extraction). Every consumer that reads its own vertices
      pays it, and it is invisible to any probe that doesn't.
-  4. **Bounding it is free** — `bounded` is 5.1 % *faster* end-to-end.
+  4. **Bounding it is free** — `bounded` is the *fastest* row, not a
+     trade. Releasing costs nothing measurable and removes allocator
+     pressure about as fast as it adds calls.
 
   **Batch size is not the remaining lever.** `bounded` at batch = 32
   reaches 727 MB (36.6 s, identical digests) against 840 MB at batch =
@@ -571,10 +582,32 @@ Deliberately small first step; each has a measurable exit.
   products that are *not* independent — round-robin scatters shared
   geometry across every shard and each one re-extracts it. Contiguous
   sharding, which preserves file-order locality, duplicates less and
-  scales better (1.52× vs 1.39×). So the partition wants **affinity by
-  shared asset**, not by product — the same definition/occurrence
-  boundary `SharedAssetPool` draws for retention. One boundary, two
-  payoffs.
+  scales better (1.52× vs 1.39×).
+
+  **Partition ownership is an open question, not a settled one.** The
+  obvious answer — affinity by shared asset, the same
+  definition/occurrence boundary `SharedAssetPool` draws for retention —
+  was tested and **did not work**. `scripts/m3_affinity_spike.mjs`
+  captures the real product↔asset graph (one instrumented extraction
+  pass recording, per product, which assets it created, which it reused,
+  and how long it took) and replays partitions against it. Simulated, it
+  is decisive: on MB-Khaya at N=4, round-robin costs +46 % duplicated CPU
+  (against +40 % measured, so the cost model calibrates) while
+  asset-affinity and an adaptive claim-the-asset partition both reach
+  +0 %. Run against the real extractor, neither moves anything —
+  round-robin and claim both create **8678 assets** against a
+  single-shard **6851**, so the +27 % duplication is real and completely
+  independent of where products are placed.
+
+  Two known defects in that model, either of which could explain it: the
+  capture drives only the per-product seam, so it never sees the
+  **rel-aggregates pass** (5363 assets recorded against the 6851 really
+  created), and that pass is sharded positionally — re-running shared
+  master-void work per shard no matter what the product partition does.
+  If the duplication turns out to live there, the answer is "give
+  aggregates an owner", not "partition products by definition". Until
+  aggregates are captured and replayed, this doc records the mechanism
+  and declines to name the key.
 
   Two caveats the numbers carry. Each shard pays its own parse here, so
   only the geometry phase is comparable; the shipping design parses once

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -261,6 +261,15 @@ function costModel( rows ) {
  */
 function assign( strategy, rows, count, cost ) {
 
+  // `claim` is the fall-through below, so an unrecognised value would emit a
+  // claim partition while the emitted assignment and every printed line
+  // attributed it to the name the caller typed — `--strategy cliam` producing
+  // real numbers for an algorithm that never ran. Refuse instead.
+  if ( !STRATEGIES.includes( strategy ) ) {
+    throw new Error(
+        `unknown strategy '${strategy}' — expected one of ${STRATEGIES.join( ', ' )}` )
+  }
+
   if ( strategy === 'roundrobin' ) {
     return rows.map( ( _, index ) => index % count )
   }

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -212,6 +212,21 @@ function rejectIfIncomplete( graph ) {
         'products; re-capture before simulating or emitting from it' )
     process.exit( 1 )
   }
+
+  // "No failed rows" is not "this capture saw anything". A header-only model
+  // captures zero products and zero assets, and every downstream number is then
+  // computed from an empty set: duplication `NaN%`, `max users -Infinity`,
+  // `NaNx` speedups for all four strategies, and an empty assignment from
+  // --emit — all at exit 0. A partition probe that never fired cannot be
+  // evidence for a partition.
+  const assets = graph.assets ?? 0
+
+  if ( graph.rows.length === 0 || assets === 0 ) {
+    console.error(
+        `capture has ${graph.rows.length} product(s) and ${assets} asset(s) — ` +
+        'nothing was extracted, so there is no partition to simulate or emit' )
+    process.exit( 1 )
+  }
 }
 
 /**

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -198,8 +198,12 @@ async function capture( filePath, outPath ) {
     }
   }
 
+  // Absolute, resolved against the CAPTURE's cwd — the sweep's shard children
+  // run from the repo root, so a relative path recorded here would later
+  // resolve against a different directory and the guard would reject the model
+  // for not being itself (or, worse, accept a different file of the same name).
   fs.writeFileSync( outPath, `${JSON.stringify( {
-    model: filePath,
+    model: path.resolve( filePath ),
     products: rows.length,
     assets: assets.size,
     failures,
@@ -546,10 +550,28 @@ async function main() {
   const KNOWN_FLAGS = new Set( [
     '--capture', '--emit', '--simulate', '--out', '--strategy', '--shards' ] )
 
-  for ( const token of argv ) {
-    if ( token.startsWith( '--' ) && !KNOWN_FLAGS.has( token ) ) {
+  // Every flag here takes an operand. A recognised flag with none —
+  // `--emit graph.json --shards` — leaves the flag reading `undefined` and
+  // falls through to its default, which is the same silent
+  // wrong-configuration failure as an ignored flag, one step later.
+  for ( let index = 0; index < argv.length; ++index ) {
+
+    const token = argv[ index ]
+
+    if ( !token.startsWith( '--' ) ) {
+      continue
+    }
+
+    if ( !KNOWN_FLAGS.has( token ) ) {
       console.error(
           `unknown flag ${token} (known: ${[ ...KNOWN_FLAGS ].join( ', ' )})` )
+      process.exit( 2 )
+    }
+
+    const value = argv[ index + 1 ]
+
+    if ( value === void 0 || value.startsWith( '--' ) ) {
+      console.error( `${token} requires a value` )
       process.exit( 2 )
     }
   }

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -125,6 +125,7 @@ async function capture( filePath, outPath ) {
   }
 
   const rows = []
+  let failures = 0
   const t0 = performance.now()
 
   for ( let index = 0; index < products.length; ++index ) {
@@ -134,11 +135,17 @@ async function capture( filePath, outPath ) {
 
     const start = performance.now()
 
+    let failed = false
+
     try {
       extraction.extractProductGeometryByLocalID( products[ index ] )
     } catch {
-      // A product that cannot extract still occupies a partition slot; record
-      // it with whatever it touched rather than dropping it from the graph.
+      // Record the failure rather than writing an ordinary-looking row: the
+      // row's assets and duration describe a partial extraction, and a
+      // partition scored or emitted from it would be built on work the real
+      // pump never completed. `--simulate` and `--emit` refuse such a graph.
+      failed = true
+      ++failures
     }
 
     rows.push( {
@@ -146,6 +153,7 @@ async function capture( filePath, outPath ) {
       ms: performance.now() - start,
       created: [ ...created ],
       reused: [ ...reused ],
+      ...( failed ? { failed: true } : {} ),
     } )
 
     if ( index > 0 && index % 20000 === 0 ) {
@@ -167,15 +175,43 @@ async function capture( filePath, outPath ) {
     model: filePath,
     products: rows.length,
     assets: assets.size,
+    failures,
     totalMs,
     rows,
   } )}\n` )
+
+  if ( failures > 0 ) {
+    console.error(
+        `${failures} of ${rows.length} products failed to extract — this graph ` +
+        'describes work the real pump would not have completed, and --simulate ' +
+        'and --emit will refuse it' )
+  }
 
   console.log(
       `${path.basename( filePath )}: ${rows.length} products, ` +
       `${assets.size} assets, ${( totalMs / 1000 ).toFixed( 1 )}s extract → ${outPath}` )
 
   api.CloseModel( modelID )
+}
+
+/**
+ * Reject a capture that contains failed extractions.
+ *
+ * A partition scored or emitted from partial rows would be a partition of
+ * work that never happened, and the numbers would look ordinary.
+ *
+ * @param graph The captured graph.
+ */
+function rejectIfIncomplete( graph ) {
+
+  const failed = graph.failures ?? graph.rows.filter( ( row ) => row.failed ).length
+
+  if ( failed > 0 ) {
+    console.error(
+        `capture has ${failed} failed extraction(s) of ${graph.rows.length} ` +
+        'products; re-capture before simulating or emitting from it' )
+    process.exit( 1 )
+  }
 }
 
 /**
@@ -347,6 +383,9 @@ function evaluate( rows, shardOf, count, cost ) {
 function simulate( graphPath, counts ) {
 
   const graph = JSON.parse( fs.readFileSync( graphPath, 'utf8' ) )
+
+  rejectIfIncomplete( graph )
+
   const rows = graph.rows
   const cost = costModel( rows )
 
@@ -413,6 +452,9 @@ function simulate( graphPath, counts ) {
 function emitAssignment( graphPath, count, strategy, outPath ) {
 
   const graph = JSON.parse( fs.readFileSync( graphPath, 'utf8' ) )
+
+  rejectIfIncomplete( graph )
+
   const rows = graph.rows
   const shardOf = assign( strategy, rows, count, costModel( rows ) )
   const shards = Array.from( { length: count }, () => [] )

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -63,6 +63,33 @@ const DEFAULT_SHARD_COUNTS = [ 2, 3, 4, 8 ]
 const STRATEGIES = [ 'roundrobin', 'contiguous', 'affinity', 'claim' ]
 
 /**
+ * Validate shard counts, or exit.
+ *
+ * `assign` builds `Array.from( {length: count} )` and indexes by `% count`, so
+ * a non-integer silently produces a partition of a different width than the
+ * one every printed line and the emitted `assignment.json` are labelled with —
+ * `2.5` allocates two shards and calls the result N=2.5 — or, with enough
+ * products, indexes a shard that was never allocated and crashes. Zero,
+ * negative, `NaN` and `Infinity` are all unusable in their own ways.
+ *
+ * @param counts The caller's `--shards` values.
+ * @return {number[]} The same counts, once known to be usable.
+ */
+function shardCounts( counts ) {
+
+  const invalid = counts.filter(
+      ( count ) => !Number.isInteger( count ) || count < 1 )
+
+  if ( invalid.length > 0 ) {
+    console.error(
+        `--shards must be positive integers; got ${invalid.join( ', ' )}` )
+    process.exit( 2 )
+  }
+
+  return counts
+}
+
+/**
  * Drive one real extraction pass with the geometry cache instrumented, and
  * record the product↔asset graph.
  *
@@ -514,7 +541,8 @@ async function main() {
   const emitFor = flag( '--emit' )
 
   if ( emitFor !== void 0 ) {
-    return emitAssignment( emitFor, Number( flag( '--shards', '4' ) ),
+    return emitAssignment( emitFor,
+        shardCounts( [ Number( flag( '--shards', '4' ) ) ] )[ 0 ],
         flag( '--strategy', 'claim' ), flag( '--out', 'assignment.json' ) )
   }
 
@@ -528,7 +556,8 @@ async function main() {
   }
 
   const counts = flag( '--shards' ) !== void 0 ?
-    flag( '--shards' ).split( ',' ).map( Number ) : DEFAULT_SHARD_COUNTS
+    shardCounts( flag( '--shards' ).split( ',' ).map( Number ) ) :
+    DEFAULT_SHARD_COUNTS
 
   simulate( graphPath, counts )
 }

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -421,7 +421,8 @@ function emitAssignment( graphPath, count, strategy, outPath ) {
     shards[ shardOf[ index ] ].push( rows[ index ].product )
   }
 
-  fs.writeFileSync( outPath, `${JSON.stringify( { model: graph.model, strategy, shards } )}\n` )
+  fs.writeFileSync( outPath,
+      `${JSON.stringify( { model: graph.model, strategy, count, shards } )}\n` )
 
   console.log(
       `${strategy} N=${count}: ${shards.map( ( s ) => s.length ).join( '/' )} products → ${outPath}` )

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -1,0 +1,469 @@
+/**
+ * M3 affinity spike (issue #394): how should the geometry work be partitioned
+ * across a worker pool?
+ *
+ * The shard sweep in `m3_pump_spike.mjs` showed the across-product axis is
+ * real (PSB 2.59x on 4 cores) but that the win is eaten on
+ * representation-heavy models by duplicated work: MB-Khaya costs +40 % total
+ * CPU under round-robin against PSB's +15 %. Products are only independent
+ * when they don't share a *definition* — the IfcMappedItem →
+ * IfcRepresentationMap → shape edge that makes "the same door on every floor"
+ * one asset and many occurrences.
+ *
+ * So the partition wants affinity by shared asset. This measures whether that
+ * works and how much it is worth, without building a worker pool, in two
+ * steps:
+ *
+ * 1. **Capture** (one real extraction pass, `--capture`). Drives the
+ *    production per-product seam directly, with the geometry cache
+ *    instrumented, and records for every product: which geometry assets it
+ *    CREATED, which it REUSED from an earlier product, and how long its
+ *    extraction took. That bipartite product↔asset graph plus the timings is
+ *    the ground truth everything else is derived from.
+ *
+ * 2. **Simulate** (`--simulate`). Replays that graph through candidate
+ *    partitions and reports, for each: how many asset extractions it causes
+ *    (an asset shared across shards is extracted once per shard), the
+ *    resulting duplicated CPU, and the makespan — the slowest shard, which is
+ *    what wall-clock actually becomes.
+ *
+ * Strategies, in increasing order of how much they know:
+ *
+ *   roundrobin : product index % N. The naive partition; the one measured.
+ *   contiguous : equal spans of file order. Exploits the locality that made
+ *                contiguous beat round-robin on MB-Khaya (1.52x vs 1.39x).
+ *   affinity   : hash the product's PRIMARY asset to a shard, so every
+ *                occurrence of one definition lands together. The cheap key —
+ *                no closure walk, just what the extraction already touches.
+ *   claim      : Pablo's adaptive shape — a worker rips through a run of
+ *                products; an asset is CLAIMED by the first worker to touch
+ *                it, and a later product whose assets are already claimed is
+ *                handed to the claiming worker. Otherwise it goes to the
+ *                least-loaded worker. Locality-following, no global plan.
+ *
+ * The simulation's cost model: each product costs its measured extraction
+ * time, except that a product which would have to re-create an asset another
+ * shard already made pays that asset's creation cost again. Creation cost is
+ * attributed from the measured time of the product that first built it. This
+ * is an approximation in one direction only — it cannot invent duplication
+ * that the real extractor wouldn't do, because the graph records exactly
+ * which assets each product touched.
+ *
+ * Usage:
+ *   node scripts/m3_affinity_spike.mjs --capture <model> --out graph.json
+ *   node scripts/m3_affinity_spike.mjs --simulate graph.json [--shards 2,3,4]
+ */
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as process from 'node:process'
+import { performance } from 'node:perf_hooks'
+
+const DEFAULT_SHARD_COUNTS = [ 2, 3, 4, 8 ]
+
+const STRATEGIES = [ 'roundrobin', 'contiguous', 'affinity', 'claim' ]
+
+/**
+ * Drive one real extraction pass with the geometry cache instrumented, and
+ * record the product↔asset graph.
+ *
+ * Deliberately bypasses `ExtractGeometryBatch` and calls the per-product seam
+ * directly: the batch pump's `streamNewMeshes_` re-walks the whole scene per
+ * call, which at the batch size needed for per-product attribution would be
+ * quadratic and would swamp the timings being captured.
+ *
+ * @param filePath The model.
+ * @param outPath Where to write the graph.
+ */
+async function capture( filePath, outPath ) {
+
+  const { IfcAPI, LogLevel } =
+    await import( '../compiled/src/compat/web-ifc/ifc_api.js' )
+
+  const api = new IfcAPI()
+
+  await api.Init()
+  api.SetLogLevel( LogLevel.LOG_LEVEL_ERROR )
+
+  const bytes = new Uint8Array( fs.readFileSync( filePath ) )
+  const modelID = await api.OpenModelStreamed( bytes,
+      { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true, DEFER_GEOMETRY: true } )
+
+  if ( modelID < 0 ) {
+    throw new Error( `open failed: ${filePath}` )
+  }
+
+  const passthrough = api.getPassthrough( modelID )
+
+  passthrough.ensureDemandWorklists_()
+
+  const products = passthrough.demandProducts_ ?? []
+  const geometry = passthrough.model[ 0 ].geometry
+  const extraction = passthrough.conwayGeometry_
+
+  // Instrument the cache rather than the extractor: `add` is every asset this
+  // product built, `getByLocalID` returning a hit is every asset it took from
+  // an earlier one. That is exactly the created/reused split a shard boundary
+  // would have to reproduce.
+  const created = new Set()
+  const reused = new Set()
+  const originalAdd = geometry.add.bind( geometry )
+  const originalGet = geometry.getByLocalID.bind( geometry )
+
+  geometry.add = ( mesh ) => {
+    created.add( mesh.localID )
+    return originalAdd( mesh )
+  }
+
+  geometry.getByLocalID = ( localID ) => {
+    const hit = originalGet( localID )
+
+    if ( hit !== void 0 && !created.has( localID ) ) {
+      reused.add( localID )
+    }
+
+    return hit
+  }
+
+  const rows = []
+  const t0 = performance.now()
+
+  for ( let index = 0; index < products.length; ++index ) {
+
+    created.clear()
+    reused.clear()
+
+    const start = performance.now()
+
+    try {
+      extraction.extractProductGeometryByLocalID( products[ index ] )
+    } catch {
+      // A product that cannot extract still occupies a partition slot; record
+      // it with whatever it touched rather than dropping it from the graph.
+    }
+
+    rows.push( {
+      product: products[ index ],
+      ms: performance.now() - start,
+      created: [ ...created ],
+      reused: [ ...reused ],
+    } )
+
+    if ( index > 0 && index % 20000 === 0 ) {
+      console.log( `  ${index}/${products.length} products, ` +
+        `${( ( performance.now() - t0 ) / 1000 ).toFixed( 1 )}s` )
+    }
+  }
+
+  const totalMs = performance.now() - t0
+  const assets = new Set()
+
+  for ( const row of rows ) {
+    for ( const asset of row.created ) {
+      assets.add( asset )
+    }
+  }
+
+  fs.writeFileSync( outPath, `${JSON.stringify( {
+    model: filePath,
+    products: rows.length,
+    assets: assets.size,
+    totalMs,
+    rows,
+  } )}\n` )
+
+  console.log(
+      `${path.basename( filePath )}: ${rows.length} products, ` +
+      `${assets.size} assets, ${( totalMs / 1000 ).toFixed( 1 )}s extract → ${outPath}` )
+
+  api.CloseModel( modelID )
+}
+
+/**
+ * Per-asset creation cost, attributed from the product that first built it.
+ *
+ * A product's measured time covers everything it created, so the time is
+ * split evenly across the assets it created. Products that create nothing
+ * (pure instancing) contribute a fixed per-product cost instead, which is
+ * what a shard pays for them regardless of partition.
+ *
+ * @param rows The captured graph.
+ * @return {object} `{assetCost, ownCost}` — per-asset creation ms, and
+ * per-product non-asset ms.
+ */
+function costModel( rows ) {
+
+  const assetCost = new Map()
+  const ownCost = new Map()
+
+  for ( const row of rows ) {
+
+    if ( row.created.length === 0 ) {
+      ownCost.set( row.product, row.ms )
+      continue
+    }
+
+    const share = row.ms / row.created.length
+
+    for ( const asset of row.created ) {
+      assetCost.set( asset, share )
+    }
+
+    ownCost.set( row.product, 0 )
+  }
+
+  return { assetCost, ownCost }
+}
+
+/**
+ * Assign products to shards by strategy.
+ *
+ * @param strategy One of STRATEGIES.
+ * @param rows The captured graph.
+ * @param count Shard count.
+ * @param cost The cost model, for load-aware strategies.
+ * @return {number[]} Shard index per row.
+ */
+function assign( strategy, rows, count, cost ) {
+
+  if ( strategy === 'roundrobin' ) {
+    return rows.map( ( _, index ) => index % count )
+  }
+
+  if ( strategy === 'contiguous' ) {
+    const span = Math.ceil( rows.length / count )
+    return rows.map( ( _, index ) => Math.min( Math.floor( index / span ), count - 1 ) )
+  }
+
+  // Placement must consider EVERY asset a product touches, not just the ones
+  // it creates. A product that creates three private assets and reuses one
+  // shared definition is exactly the case that matters, and voting on the
+  // created set alone ignores the only edge that can duplicate work.
+  const assetsOf = ( row ) => [ ...row.created, ...row.reused ]
+
+  if ( strategy === 'affinity' ) {
+    // Primary asset = the lowest-numbered asset the product touches: a stable
+    // identity for the definition that doesn't depend on visit order, so every
+    // occurrence of one definition hashes to the same shard.
+    return rows.map( ( row, index ) => {
+      const assets = assetsOf( row )
+      return assets.length === 0 ?
+        index % count : Math.min( ...assets ) % count
+    } )
+  }
+
+  // claim: first worker to touch an asset owns it; a product whose assets are
+  // already owned follows them. Ties (a product spanning two owners) go to the
+  // owner of the most of its assets, then to the lighter shard.
+  const owner = new Map()
+  const load = new Array( count ).fill( 0 )
+  const out = []
+
+  for ( const row of rows ) {
+
+    const assets = assetsOf( row )
+    const votes = new Map()
+
+    for ( const asset of assets ) {
+
+      const held = owner.get( asset )
+
+      if ( held !== void 0 ) {
+        votes.set( held, ( votes.get( held ) ?? 0 ) + 1 )
+      }
+    }
+
+    let shard
+
+    if ( votes.size > 0 ) {
+      shard = [ ...votes.entries() ].sort(
+          ( a, b ) => ( b[ 1 ] - a[ 1 ] ) || ( load[ a[ 0 ] ] - load[ b[ 0 ] ] ) )[ 0 ][ 0 ]
+    } else {
+      shard = load.indexOf( Math.min( ...load ) )
+    }
+
+    for ( const asset of assets ) {
+      if ( !owner.has( asset ) ) {
+        owner.set( asset, shard )
+      }
+    }
+
+    load[ shard ] += row.ms
+    out.push( shard )
+  }
+
+  return out
+}
+
+/**
+ * Cost one assignment: an asset is extracted once per shard that needs it, so
+ * duplication is what the partition adds over the ideal single-pass total.
+ *
+ * @param rows The captured graph.
+ * @param shardOf Shard index per row.
+ * @param count Shard count.
+ * @param cost The cost model.
+ * @return {object} Totals and makespan.
+ */
+function evaluate( rows, shardOf, count, cost ) {
+
+  const shardAssets = Array.from( { length: count }, () => new Set() )
+  const shardMs = new Array( count ).fill( 0 )
+  const shardProducts = new Array( count ).fill( 0 )
+
+  for ( let index = 0; index < rows.length; ++index ) {
+
+    const row = rows[ index ]
+    const shard = shardOf[ index ]
+
+    ++shardProducts[ shard ]
+    shardMs[ shard ] += cost.ownCost.get( row.product ) ?? 0
+
+    // Every asset this product needs must exist in ITS shard: created there,
+    // or re-created because the shard that made it is a different one.
+    for ( const asset of [ ...row.created, ...row.reused ] ) {
+
+      if ( shardAssets[ shard ].has( asset ) ) {
+        continue
+      }
+
+      shardAssets[ shard ].add( asset )
+      shardMs[ shard ] += cost.assetCost.get( asset ) ?? 0
+    }
+  }
+
+  const extractions = shardAssets.reduce( ( sum, set ) => sum + set.size, 0 )
+  const totalMs = shardMs.reduce( ( sum, ms ) => sum + ms, 0 )
+  const makespan = Math.max( ...shardMs )
+
+  return { extractions, totalMs, makespan, shardMs, shardProducts }
+}
+
+/**
+ * Replay the captured graph through every strategy at every shard count.
+ *
+ * @param graphPath The captured graph.
+ * @param counts Shard counts to sweep.
+ */
+function simulate( graphPath, counts ) {
+
+  const graph = JSON.parse( fs.readFileSync( graphPath, 'utf8' ) )
+  const rows = graph.rows
+  const cost = costModel( rows )
+
+  const idealAssets = new Set()
+  let idealMs = 0
+
+  for ( const row of rows ) {
+    idealMs += row.ms
+
+    for ( const asset of row.created ) {
+      idealAssets.add( asset )
+    }
+  }
+
+  // How much sharing is there at all? Without this the strategy comparison
+  // has no scale: a model where nothing is shared cannot show duplication.
+  const users = new Map()
+
+  for ( const row of rows ) {
+    for ( const asset of [ ...row.created, ...row.reused ] ) {
+      users.set( asset, ( users.get( asset ) ?? 0 ) + 1 )
+    }
+  }
+
+  const shared = [ ...users.values() ].filter( ( n ) => n > 1 )
+  const instances = [ ...users.values() ].reduce( ( sum, n ) => sum + n, 0 )
+
+  console.log(
+      `${path.basename( graph.model )}: ${rows.length} products, ` +
+      `${idealAssets.size} assets, ${instances} asset-uses, ` +
+      `${shared.length} shared assets (${( 100 * shared.length / users.size ).toFixed( 1 )}%), ` +
+      `max users ${Math.max( ...users.values() )}, ` +
+      `serial extract ${( idealMs / 1000 ).toFixed( 1 )}s` )
+
+  for ( const count of counts ) {
+
+    const line = []
+
+    for ( const strategy of STRATEGIES ) {
+
+      const shardOf = assign( strategy, rows, count, cost )
+      const result = evaluate( rows, shardOf, count, cost )
+      const duplication = 100 * ( result.totalMs / idealMs - 1 )
+      const speedup = idealMs / result.makespan
+
+      line.push(
+          `${strategy}=${speedup.toFixed( 2 )}x/+${duplication.toFixed( 0 )}%` )
+    }
+
+    console.log( `  N=${count}  ${line.join( '  ' )}` )
+  }
+}
+
+/**
+ * Write one strategy's partition out as per-shard product lists, so the real
+ * extractor can be run against it and the simulation checked rather than
+ * believed.
+ *
+ * @param graphPath The captured graph.
+ * @param count Shard count.
+ * @param strategy One of STRATEGIES.
+ * @param outPath Where to write the assignment.
+ */
+function emitAssignment( graphPath, count, strategy, outPath ) {
+
+  const graph = JSON.parse( fs.readFileSync( graphPath, 'utf8' ) )
+  const rows = graph.rows
+  const shardOf = assign( strategy, rows, count, costModel( rows ) )
+  const shards = Array.from( { length: count }, () => [] )
+
+  for ( let index = 0; index < rows.length; ++index ) {
+    shards[ shardOf[ index ] ].push( rows[ index ].product )
+  }
+
+  fs.writeFileSync( outPath, `${JSON.stringify( { model: graph.model, strategy, shards } )}\n` )
+
+  console.log(
+      `${strategy} N=${count}: ${shards.map( ( s ) => s.length ).join( '/' )} products → ${outPath}` )
+}
+
+/**
+ * Entry point.
+ */
+async function main() {
+
+  const argv = process.argv.slice( 2 )
+  const flag = ( name, fallback ) => {
+    const index = argv.indexOf( name )
+    return index >= 0 ? argv[ index + 1 ] : fallback
+  }
+
+  const captureModel = flag( '--capture' )
+
+  if ( captureModel !== void 0 ) {
+    return capture( captureModel, flag( '--out', 'graph.json' ) )
+  }
+
+  const emitFor = flag( '--emit' )
+
+  if ( emitFor !== void 0 ) {
+    return emitAssignment( emitFor, Number( flag( '--shards', '4' ) ),
+        flag( '--strategy', 'claim' ), flag( '--out', 'assignment.json' ) )
+  }
+
+  const graphPath = flag( '--simulate' )
+
+  if ( graphPath === void 0 ) {
+    console.error(
+        'usage: m3_affinity_spike.mjs --capture <model> --out graph.json\n' +
+        '       m3_affinity_spike.mjs --simulate graph.json [--shards 2,3,4]' )
+    process.exit( 2 )
+  }
+
+  const counts = flag( '--shards' ) !== void 0 ?
+    flag( '--shards' ).split( ',' ).map( Number ) : DEFAULT_SHARD_COUNTS
+
+  simulate( graphPath, counts )
+}
+
+await main()

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -538,6 +538,22 @@ async function main() {
     return index >= 0 ? argv[ index + 1 ] : fallback
   }
 
+  // Reject flags this script doesn't know rather than ignoring them. `--count 2`
+  // (the pump spike's spelling of `--shards`) silently emitted the default
+  // 4-way assignment, which the sweep then refused as "cut for 4, running 2" —
+  // a confusing failure two commands downstream of the typo. Same reason the
+  // pump spike validates its own flags before measuring anything.
+  const KNOWN_FLAGS = new Set( [
+    '--capture', '--emit', '--simulate', '--out', '--strategy', '--shards' ] )
+
+  for ( const token of argv ) {
+    if ( token.startsWith( '--' ) && !KNOWN_FLAGS.has( token ) ) {
+      console.error(
+          `unknown flag ${token} (known: ${[ ...KNOWN_FLAGS ].join( ', ' )})` )
+      process.exit( 2 )
+    }
+  }
+
   const captureModel = flag( '--capture' )
 
   if ( captureModel !== void 0 ) {
@@ -556,8 +572,10 @@ async function main() {
 
   if ( graphPath === void 0 ) {
     console.error(
-        'usage: m3_affinity_spike.mjs --capture <model> --out graph.json\n' +
-        '       m3_affinity_spike.mjs --simulate graph.json [--shards 2,3,4]' )
+        'usage: m3_affinity_spike.mjs --capture <model> [--out graph.json]\n' +
+        '       m3_affinity_spike.mjs --simulate graph.json [--shards 2,3,4]\n' +
+        '       m3_affinity_spike.mjs --emit graph.json [--strategy claim] ' +
+        '[--shards 4] [--out assignment.json]' )
     process.exit( 2 )
   }
 

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -207,18 +207,24 @@ async function capture( filePath, outPath ) {
     rows,
   } )}\n` )
 
-  if ( failures > 0 ) {
-    console.error(
-        `${failures} of ${rows.length} products failed to extract — this graph ` +
-        'describes work the real pump would not have completed, and --simulate ' +
-        'and --emit will refuse it' )
-  }
-
   console.log(
       `${path.basename( filePath )}: ${rows.length} products, ` +
       `${assets.size} assets, ${( totalMs / 1000 ).toFixed( 1 )}s extract → ${outPath}` )
 
   api.CloseModel( modelID )
+
+  // Non-zero, not just a printed warning. `--simulate` and `--emit` refuse an
+  // incomplete graph, but that only helps if one of them runs next; a capture
+  // step in a script or CI job reads the exit status, and a graph the script
+  // itself says cannot represent completed work must not be reported as a
+  // successful capture.
+  if ( failures > 0 ) {
+    console.error(
+        `${failures} of ${rows.length} products failed to extract — this graph ` +
+        'describes work the real pump would not have completed, and --simulate ' +
+        'and --emit will refuse it' )
+    process.exit( 1 )
+  }
 }
 
 /**

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -1369,10 +1369,30 @@ function main() {
     '--models', '--batch', '--repeats', '--json', '--phases', '--shards',
     '--shard-mode' ] )
 
-  for ( const token of argv ) {
-    if ( token.startsWith( '--' ) && !KNOWN_FLAGS.has( token ) ) {
+  // Every flag here takes an operand, and a flag whose operand is missing is
+  // worse than an unknown one: `--phases pump --shards` leaves `--shards`
+  // undefined, so the sweep silently takes the unsharded path and exits 0
+  // having measured a configuration the caller did not ask for. A value that
+  // itself looks like a flag is the same mistake with the operand eaten by the
+  // next token.
+  for ( let index = 0; index < argv.length; ++index ) {
+
+    const token = argv[ index ]
+
+    if ( !token.startsWith( '--' ) ) {
+      continue
+    }
+
+    if ( !KNOWN_FLAGS.has( token ) ) {
       console.error(
           `unknown flag ${token} (known: ${[ ...KNOWN_FLAGS ].join( ', ' )})` )
+      process.exit( 2 )
+    }
+
+    const value = argv[ index + 1 ]
+
+    if ( value === void 0 || value.startsWith( '--' ) ) {
+      console.error( `${token} requires a value` )
       process.exit( 2 )
     }
   }

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -27,8 +27,8 @@
  *              everything, retain nothing).
  *
  * Every phase copies out the same payloads (`classic`/`copyout`/`bounded`)
- * or none (`pump`), and hashes them into a digest so the M3 exit criterion —
- * *M3 changes when work happens, not what it produces* — is checked rather
+ * or none (`pump`), and hashes them into a digest so the M3 exit criterion
+ * (M3 changes when work happens, not what it produces) is checked rather
  * than assumed. `bounded` releasing everything is expected to LOSE instances
  * whose geometry is shared with a later product (the scene walk skips a
  * released geometry); the digest and instance counts are what size that
@@ -45,7 +45,7 @@
  *                                  [--batch 64] [--repeats 1] [--json out]
  *   node scripts/m3_pump_spike.mjs --child <phase> <path> <batch>  # internal
  */
-import { execFileSync } from 'node:child_process'
+import { execFile, execFileSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as process from 'node:process'
@@ -163,7 +163,11 @@ function quantise( value ) {
   return Math.round( value * 1024 )
 }
 
-/** Retained JS working set, after a collect so transient garbage isn't counted. */
+/**
+ * Retained JS working set, after a collect so transient garbage isn't counted.
+ *
+ * @return {number} Megabytes.
+ */
 function retainedMB() {
   globalThis.gc?.()
   const usage = process.memoryUsage()
@@ -274,13 +278,62 @@ function releaseGeometries( api, modelID, geometryExpressIDs ) {
 }
 
 /**
+ * Cut the pump's worklists down to one shard, round-robin by position.
+ *
+ * This is the across-product parallelism axis the design doc specifies
+ * ("products are naturally independent at tessellation time") — the one a
+ * pool of workers, each holding its OWN wasm instance, would exploit. It is
+ * NOT the axis the MT build parallelises: pthreads inside one instance split
+ * the work *within* a product's tessellation while a single JS driver feeds
+ * them serially. Each process here is one such worker, minus the postMessage
+ * plumbing: own instance, own heap, own driver.
+ *
+ * Round-robin rather than contiguous ranges, because product cost varies by
+ * orders of magnitude and file order is spatially clustered — contiguous
+ * shards would measure the imbalance rather than the scaling.
+ *
+ * Reaches into the passthrough's worklist fields deliberately: the shard is a
+ * measurement fixture, not a proposed API. What ships is a queue that hands
+ * out product IDs, which is `DemandGeometryQueue`'s job.
+ *
+ * @param api The IfcAPI instance.
+ * @param modelID The open model.
+ * @param shard `{index, count}`.
+ * @return {object|undefined} What this shard owns.
+ */
+function shardWorklists( api, modelID, shard ) {
+
+  const passthrough = api.getPassthrough( modelID )
+
+  if ( passthrough?.ensureDemandWorklists_ === void 0 ) {
+    return void 0
+  }
+
+  passthrough.ensureDemandWorklists_()
+
+  const products = passthrough.demandProducts_ ?? []
+  const aggregates = passthrough.demandAggregates_ ?? []
+  const mine = ( _, index ) => index % shard.count === shard.index
+
+  passthrough.demandProducts_ = products.filter( mine )
+  passthrough.demandAggregates_ = aggregates.filter( mine )
+
+  return {
+    products: passthrough.demandProducts_.length,
+    ofProducts: products.length,
+    aggregates: passthrough.demandAggregates_.length,
+  }
+}
+
+/**
  * Run one phase against one model in this (child) process.
  *
  * @param phase One of PHASES.
  * @param filePath The model.
  * @param batchSize Products per pump call.
+ * @param shard Optional `{index, count}` — extract only this shard's products.
  */
-async function runChild( phase, filePath, batchSize ) {
+async function runChild( phase, filePath, batchSize, shard ) {
 
   const { IfcAPI, LogLevel } =
     await import( '../compiled/src/compat/web-ifc/ifc_api.js' )
@@ -318,6 +371,9 @@ async function runChild( phase, filePath, batchSize ) {
     console.log( JSON.stringify( { phase, failed: 'open' } ) )
     return
   }
+
+  const sharded = deferred && shard !== void 0 ?
+    shardWorklists( api, modelID, shard ) : void 0
 
   let wasmPeakMB = wasmMB( api, wasmHeapByteLength )
   const wasmAfterOpenMB = wasmPeakMB
@@ -386,6 +442,8 @@ async function runChild( phase, filePath, batchSize ) {
     totalMs: openMs + geometryMs,
     batches,
     released,
+    shard,
+    sharded,
     wasmAfterOpenMB,
     wasmPeakMB,
     wasmEndMB: wasmMB( api, wasmHeapByteLength ),
@@ -405,27 +463,148 @@ async function runChild( phase, filePath, batchSize ) {
  * @param phase One of PHASES.
  * @param filePath The model.
  * @param batchSize Products per pump call.
+ * @param shard Optional `{index, count}` — extract only this shard's products.
  * @return {object} The child's JSON result.
  */
-function spawnChild( phase, filePath, batchSize ) {
+function spawnChild( phase, filePath, batchSize, shard ) {
 
-  const out = execFileSync( process.execPath, [
+  const args = [
     '--expose-gc', `--max-old-space-size=${CHILD_MAX_OLD_SPACE_MB}`,
     process.argv[ 1 ], '--child', phase, filePath, String( batchSize ),
-  ], { encoding: 'utf8', maxBuffer: 1 << 26, cwd: REPO_ROOT } )
+  ]
+
+  if ( shard !== void 0 ) {
+    args.push( `${shard.index}/${shard.count}` )
+  }
+
+  const out = execFileSync( process.execPath, args,
+      { encoding: 'utf8', maxBuffer: 1 << 26, cwd: REPO_ROOT } )
 
   return JSON.parse( out.trim().split( '\n' ).at( -1 ) )
 }
 
 /**
- * Sweep phases over models.
+ * Run one phase as N concurrent shards, each in its own process with its own
+ * wasm instance — the worker-pool shape, measured without building workers.
+ * Wall-clock is the slowest shard, since they run at the same time.
+ *
+ * @param phase One of PHASES.
+ * @param filePath The model.
+ * @param batchSize Products per pump call.
+ * @param count How many shards.
+ * @return {Promise<object[]>} One result per shard.
+ */
+function spawnShards( phase, filePath, batchSize, count ) {
+
+  const running = []
+
+  for ( let index = 0; index < count; ++index ) {
+
+    const args = [
+      '--expose-gc', `--max-old-space-size=${CHILD_MAX_OLD_SPACE_MB}`,
+      process.argv[ 1 ], '--child', phase, filePath, String( batchSize ),
+      `${index}/${count}`,
+    ]
+
+    running.push( new Promise( ( resolve, reject ) => {
+      execFile( process.execPath, args,
+          { encoding: 'utf8', maxBuffer: 1 << 26, cwd: REPO_ROOT },
+          ( error, stdout ) => {
+            if ( error !== null ) {
+              reject( error )
+              return
+            }
+            resolve( JSON.parse( stdout.trim().split( '\n' ).at( -1 ) ) )
+          } )
+    } ) )
+  }
+
+  return Promise.all( running )
+}
+
+/**
+ * Scaling sweep for the across-product axis: run the same extraction as N
+ * concurrent one-shard processes and report wall-clock against N = 1.
+ *
+ * Each shard pays its own parse, so only the GEOMETRY phase is comparable —
+ * in the real design the index is built once and shared with the pool as
+ * typed-array columns (transferable / SAB), which is exactly what M2's
+ * columns-from-birth index made possible. Shards also re-extract any geometry
+ * they share, so sub-linear scaling here has two distinct causes worth
+ * separating before drawing conclusions: real serialisation, and duplicated
+ * shared work (visible as a rising payload count).
+ *
+ * @param models Model paths.
+ * @param phase The phase to run.
+ * @param batchSize Products per pump call.
+ * @param counts Shard counts to sweep.
+ * @param jsonOut Optional output path.
+ */
+async function runShardSweep( models, phase, batchSize, counts, jsonOut ) {
+
+  const rows = []
+
+  for ( const model of models ) {
+
+    const name = path.basename( model )
+    const byCount = {}
+
+    for ( const count of counts ) {
+
+      const t0 = performance.now()
+      const results = await spawnShards( phase, model, batchSize, count )
+      const wallMs = performance.now() - t0
+
+      const total = ( key ) => results.reduce( ( sum, r ) => sum + ( r[ key ] ?? 0 ), 0 )
+      const slowestGeometryMs = Math.max( ...results.map( ( r ) => r.geometryMs ) )
+
+      byCount[ count ] = {
+        count,
+        wallMs,
+        slowestGeometryMs,
+        geometryMsPerShard: results.map( ( r ) => Math.round( r.geometryMs ) ),
+        instances: total( 'instances' ),
+        payloads: total( 'payloads' ),
+        wasmPeakMBSum: results.reduce( ( sum, r ) => sum + r.wasmPeakMB, 0 ),
+        wasmPeakMBMax: Math.max( ...results.map( ( r ) => r.wasmPeakMB ) ),
+      }
+
+      const base = byCount[ counts[ 0 ] ]
+      const speedup = base.slowestGeometryMs / slowestGeometryMs
+
+      console.log(
+          `${name} shards=${count} geometry=${( slowestGeometryMs / 1000 ).toFixed( 1 )}s ` +
+          `(${speedup.toFixed( 2 )}x) per-shard=${byCount[ count ].geometryMsPerShard.join( '/' )} ` +
+          `inst=${byCount[ count ].instances} payloads=${byCount[ count ].payloads} ` +
+          `wasmMax=${byCount[ count ].wasmPeakMBMax.toFixed( 0 )}MB ` +
+          `wasmSum=${byCount[ count ].wasmPeakMBSum.toFixed( 0 )}MB` )
+    }
+
+    rows.push( { name, model, batchSize, phase, byCount } )
+  }
+
+  if ( jsonOut !== void 0 ) {
+    fs.writeFileSync( jsonOut, `${JSON.stringify( rows, null, 2 )}\n` )
+  }
+}
+
+/**
+ * Sweep phases over models, or shard counts when `--shards` is given.
+ *
+ * @return {Promise<void>|void} The shard sweep's promise, when sweeping.
  */
 function main() {
 
   const argv = process.argv.slice( 2 )
 
   if ( argv[ 0 ] === '--child' ) {
-    return runChild( argv[ 1 ], argv[ 2 ], Number( argv[ 3 ] ) )
+    const spec = argv[ 4 ]
+    const shard = spec !== void 0 ? {
+      index: Number( spec.split( '/' )[ 0 ] ),
+      count: Number( spec.split( '/' )[ 1 ] ),
+    } : void 0
+
+    return runChild( argv[ 1 ], argv[ 2 ], Number( argv[ 3 ] ), shard )
   }
 
   const flag = ( name, fallback ) => {
@@ -439,6 +618,7 @@ function main() {
   const jsonOut = flag( '--json' )
   const only = flag( '--phases' )
   const phases = only !== void 0 ? only.split( ',' ) : PHASES
+  const shards = flag( '--shards' )
 
   if ( modelsFile === void 0 ) {
     console.error(
@@ -453,6 +633,10 @@ function main() {
       .filter( ( line ) => line.length > 0 && !line.startsWith( '#' ) )
 
   const rows = []
+
+  if ( shards !== void 0 ) {
+    return runShardSweep( models, phases[ 0 ], batchSize, shards.split( ',' ).map( Number ), jsonOut )
+  }
 
   for ( const model of models ) {
 

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -1213,6 +1213,24 @@ function main() {
   const phases = only !== void 0 ? only.split( ',' ) : PHASES
   const shards = flag( '--shards' )
 
+  // Validate every requested phase centrally, so a typo cannot reach either
+  // exit path. `runChild` derives its behaviour by exclusion — `deferred =
+  // phase !== 'classic'`, `copies = phase === 'copyout' || 'bounded'` — so an
+  // unrecognised name silently becomes a deferred, non-copying hybrid that
+  // resembles no supported phase, runs, and publishes a timing row. That is
+  // the mislabelled-experiment failure again (`--shard-mode contigous`,
+  // `--strategy cliam`), and the shard path reached it after rejecting only
+  // `classic`.
+  const unknownPhases = phases.filter(
+      ( phase ) => !PHASES.includes( phase ) && !EXTRACT_ONLY_PHASES.has( phase ) )
+
+  if ( unknownPhases.length > 0 ) {
+    console.error(
+        `unknown phase(s) ${unknownPhases.join( ', ' )} — expected one of ` +
+        `${[ ...PHASES, ...EXTRACT_ONLY_PHASES ].join( ', ' )}` )
+    process.exit( 2 )
+  }
+
   if ( modelsFile === void 0 ) {
     console.error(
         'usage: m3_pump_spike.mjs --models <file with one path per line> ' +
@@ -1237,10 +1255,11 @@ function main() {
 
   if ( shards !== void 0 ) {
 
-    // `classic` opens without DEFER_GEOMETRY, so the pump worklists never
+    // The phase name is already known-valid (checked above). What remains is
+    // that `classic` opens without DEFER_GEOMETRY, so the pump worklists never
     // exist and the shard filter never runs: every child would extract the
     // WHOLE model while the output labelled them shards and computed a
-    // speedup from them. Default to the deferred extract phase, and refuse a
+    // speedup from them. Default to the deferred extract phase, and refuse the
     // non-deferred one rather than publishing invalid scaling.
     const shardPhase = only !== void 0 ? phases[ 0 ] : 'extractonly'
 

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -96,21 +96,37 @@ class Digest {
   /**
    * Hash one placed instance into the order-independent accumulator.
    *
+   * @param placedGeometry The placed instance as delivered to the consumer.
    * @param expressID The product's express ID.
-   * @param geometryExpressID The geometry's express ID.
-   * @param transform The 16-element placement.
    */
-  placed( expressID, geometryExpressID, transform ) {
+  placed( placedGeometry, expressID ) {
 
     ++this.instances
 
     let hash = 2166136261
 
     hash = mix32( hash, expressID )
-    hash = mix32( hash, geometryExpressID )
+    hash = mix32( hash, placedGeometry.geometryExpressID )
 
-    for ( const component of transform ) {
+    for ( const component of placedGeometry.flatTransformation ) {
       hash = mix32( hash, quantise( component ) )
+    }
+
+    // Colour and occurrence path are delivered output, not metadata: colour is
+    // what the instance looks like, and `occurrencePath` is what a pick
+    // resolves to on an AP214 assembly where one definition appears many
+    // times. A batching or release regression that swapped either while
+    // preserving counts and transforms would otherwise pass this check.
+    const colour = placedGeometry.color
+
+    if ( colour !== void 0 ) {
+      for ( const channel of [ colour.x, colour.y, colour.z, colour.w ] ) {
+        hash = mix32( hash, quantise( channel ) )
+      }
+    }
+
+    for ( const step of placedGeometry.occurrencePath ?? [] ) {
+      hash = mix32( hash, step )
     }
 
     this.placedHash = ( this.placedHash + hash ) >>> 0
@@ -212,7 +228,7 @@ function copyBatchPayloads( api, modelID, meshes, seen, digest, retained ) {
 
       const placed = placedVector.get( i )
 
-      digest.placed( mesh.expressID, placed.geometryExpressID, placed.flatTransformation )
+      digest.placed( placed, mesh.expressID )
 
       if ( seen.has( placed.geometryExpressID ) ) {
         continue
@@ -389,10 +405,24 @@ function shardWorklists( api, modelID, shard, filePath ) {
     const assigned = assignment.shards.flat()
     const unique = new Set( assigned )
 
-    if ( assigned.length !== unique.size || unique.size !== products.length ) {
+    if ( assigned.length !== unique.size ) {
       throw new Error(
-          `assignment covers ${unique.size} unique products ` +
-          `(${assigned.length} entries) against a worklist of ${products.length}` )
+          `assignment lists ${assigned.length} entries for ${unique.size} ` +
+          `unique products — a product assigned twice is extracted twice` )
+    }
+
+    // Membership, not cardinality: an assignment of the right SIZE built from
+    // ids this worklist doesn't contain filters everything out and still
+    // prints a speedup (a one-product model with `[[999999999], []]` reported
+    // 40.63x on zero assets). Compare the sets.
+    const worklist = new Set( products )
+    const foreign = [ ...unique ].filter( ( id ) => !worklist.has( id ) )
+    const missing = products.filter( ( id ) => !unique.has( id ) )
+
+    if ( foreign.length > 0 || missing.length > 0 ) {
+      throw new Error(
+          `assignment does not match this worklist: ${foreign.length} ids ` +
+          `absent from it, ${missing.length} of its products unassigned` )
     }
 
     const mineSet = new Set( assignment.shards[ shard.index ] )
@@ -749,6 +779,95 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
   if ( jsonOut !== void 0 ) {
     fs.writeFileSync( jsonOut, `${JSON.stringify( rows, null, 2 )}\n` )
   }
+
+  if ( failures.length > 0 ) {
+    console.error( `\n${failures.length} model(s) failed the delivery check:` )
+
+    for ( const failure of failures ) {
+      console.error( `  ${failure}` )
+    }
+
+    process.exit( 1 )
+  }
+}
+
+/**
+ * Turn the phase rows into explicit verdicts, so a sweep that measured
+ * nothing fails instead of printing agreeable zeros.
+ *
+ * The digest comparison is the spike's whole correctness argument, and it has
+ * a vacuous mode: if no mesh callback ever fires, every payload phase reports
+ * `inst=0` with equal digests and the run looks like a clean pass. That is
+ * indistinguishable from success by eye, which is exactly how the other
+ * harness defects in this branch survived. So:
+ *
+ *  - `classic` delivering no instances on a geometry-producing model is a
+ *    FAILURE, not a silent zero. (A model that genuinely has no geometry is
+ *    reported as SKIP — its own row proves it, since classic is the
+ *    unmodified whole-model walk.)
+ *  - `copyout` must match `classic` exactly. It changes only WHEN extraction
+ *    happens, so any divergence is a real regression.
+ *  - `bounded` divergence is reported as a labelled DIFF rather than a
+ *    failure: retain-nothing release is expected to duplicate instances on a
+ *    model with shared geometry (`supercap.step`), and that finding is the
+ *    reason the phase exists.
+ *
+ * @param byPhase Results keyed by phase.
+ * @param phases The phases that ran.
+ * @return {object[]} `{text, failed}` lines.
+ */
+function verdicts( byPhase, phases ) {
+
+  const out = []
+  const classic = byPhase.classic
+
+  if ( classic?.instances === void 0 || !phases.includes( 'classic' ) ) {
+    return out
+  }
+
+  if ( classic.instances === 0 ) {
+    out.push( { text: 'SKIP  classic delivered no instances — model has no geometry', failed: false } )
+    return out
+  }
+
+  for ( const phase of [ 'copyout', 'bounded' ] ) {
+
+    const row = byPhase[ phase ]
+
+    if ( row?.instances === void 0 ) {
+      continue
+    }
+
+    if ( row.instances === 0 ) {
+      out.push( {
+        text: `FAIL  ${phase} delivered 0 instances against classic's ${classic.instances} ` +
+          '— the phase produced nothing, so its digest proves nothing',
+        failed: true,
+      } )
+      continue
+    }
+
+    const same = row.placedDigest === classic.placedDigest &&
+      row.payloadDigest === classic.payloadDigest
+
+    if ( same ) {
+      out.push( { text: `OK    ${phase} identical to classic (${row.instances} instances)`, failed: false } )
+      continue
+    }
+
+    const line =
+      `${phase} differs from classic: ${row.instances} instances vs ` +
+      `${classic.instances}, placed ${row.placedDigest} vs ${classic.placedDigest}, ` +
+      `payload ${row.payloadDigest} vs ${classic.payloadDigest}`
+
+    // Only `bounded` is allowed to differ, and only because retaining nothing
+    // is a deliberately unshippable policy — see the doc's retention section.
+    out.push( phase === 'bounded' ?
+      { text: `DIFF  ${line}`, failed: false } :
+      { text: `FAIL  ${line}`, failed: true } )
+  }
+
+  return out
 }
 
 /**
@@ -797,6 +916,7 @@ function main() {
       .filter( ( line ) => line.length > 0 && !line.startsWith( '#' ) )
 
   const rows = []
+  const failures = []
 
   if ( shards !== void 0 ) {
 
@@ -870,10 +990,31 @@ function main() {
     }
 
     console.log( `${name}\n  ${phases.map( cell ).join( '\n  ' )}` )
+
+    for ( const line of verdicts( byPhase, phases ) ) {
+      console.log( `  ${line.text}` )
+
+      if ( line.failed ) {
+        // `import * as process` gives a frozen namespace, so exitCode cannot
+        // be assigned — record and exit explicitly once every model is
+        // reported, so a failure never costs the rest of the sweep's output.
+        failures.push( `${name}: ${line.text}` )
+      }
+    }
   }
 
   if ( jsonOut !== void 0 ) {
     fs.writeFileSync( jsonOut, `${JSON.stringify( rows, null, 2 )}\n` )
+  }
+
+  if ( failures.length > 0 ) {
+    console.error( `\n${failures.length} model(s) failed the delivery check:` )
+
+    for ( const failure of failures ) {
+      console.error( `  ${failure}` )
+    }
+
+    process.exit( 1 )
   }
 }
 

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -63,6 +63,33 @@ const PHASES = [ 'classic', 'pump', 'copyout', 'bounded' ]
  */
 const EXTRACT_ONLY_PHASES = new Set( [ 'extractonly' ] )
 
+/**
+ * How `--shards` splits the worklists. Anything else is a caller error, not a
+ * silent default: an unrecognised mode used to fall through to round-robin
+ * while every printed line and the JSON kept the label the caller typed, so
+ * `--shard-mode contigous` produced a plausible "contiguous" table measuring
+ * round-robin. Same failure the `--strategy` validation fixes in the affinity
+ * harness.
+ */
+const SHARD_MODES = [ 'roundrobin', 'contiguous' ]
+
+/**
+ * Validate a shard mode, or exit.
+ *
+ * @param mode The caller's `--shard-mode`.
+ * @return {string} The same mode, once known to be supported.
+ */
+function shardMode( mode ) {
+
+  if ( !SHARD_MODES.includes( mode ) ) {
+    console.error(
+        `unknown shard mode '${mode}' — expected one of ${SHARD_MODES.join( ', ' )}` )
+    process.exit( 2 )
+  }
+
+  return mode
+}
+
 const DEFAULT_BATCH = 64
 const BYTES_PER_MB = 1024 * 1024
 
@@ -817,6 +844,22 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
       const results = await spawnShards( phase, model, batchSize, count, shardMode )
       const wallMs = performance.now() - t0
 
+      // Shard sweeps never reach `verdicts()`, so nothing else here can refuse
+      // a child that didn't run. A child whose open failed reports
+      // `{failed: 'open'}` with no `geometryMs`, and the aggregation below
+      // happily turns that into `Math.max( ..., undefined )` → `geometry=NaNs`
+      // beside a zero asset count, and exits 0. A sweep that measured nothing
+      // must not print a scaling table.
+      const broken = results.filter(
+          ( result ) => result.failed !== void 0 || result.geometryMs === void 0 )
+
+      if ( broken.length > 0 ) {
+        throw new Error(
+            `${name}: ${broken.length} of ${count} shard child(ren) did not ` +
+            `complete (${broken.map( ( r ) => r.failed ?? 'no timing' ).join( ', ' )}) ` +
+            '— refusing to report a sweep over work that did not happen' )
+      }
+
       const total = ( key ) => results.reduce( ( sum, r ) => sum + ( r[ key ] ?? 0 ), 0 )
       const slowestGeometryMs = Math.max( ...results.map( ( r ) => r.geometryMs ) )
 
@@ -919,12 +962,27 @@ function verdicts( byPhase, phases, allowEmpty ) {
 
     // `pump` deliberately passes no meshCallback, so it delivers no instances
     // by construction; its purpose is the wasm/timing columns. Judging it on
-    // instance count would fail every healthy run.
+    // instance count would fail every healthy run — but "no instances by
+    // construction" is not "no evidence required". A regression in the demand
+    // worklist or in `ExtractGeometryBatch` that made the pump extract nothing
+    // leaves `failed` undefined and every count at zero, and a timing probe
+    // that never fired would report a healthy-looking run.
+    //
+    // `assetsCreated` is the evidence: the child wraps `geometry.add`, so a
+    // non-zero count means tessellation actually produced assets. Sharded runs
+    // are exempt because a shard can legitimately own no products.
     if ( EXTRACT_ONLY_PHASES.has( phase ) || phase === 'pump' ) {
 
       if ( row.failed !== void 0 ) {
         out.push( {
           text: `FAIL  ${phase} did not complete (${row.failed})`,
+          failed: true,
+        } )
+      } else if ( row.shard === void 0 && !allowEmpty && ( row.assetsCreated ?? 0 ) === 0 ) {
+        out.push( {
+          text: `FAIL  ${phase} created 0 geometry assets on a model not ` +
+            'declared geometry-free — the extraction never fired, so its ' +
+            'timing and memory columns measure nothing',
           failed: true,
         } )
       }
@@ -1135,7 +1193,7 @@ function main() {
     }
 
     return runShardSweep( models.map( ( entry ) => entry.path ), shardPhase,
-        batchSize, counts, jsonOut, flag( '--shard-mode', 'roundrobin' ) )
+        batchSize, counts, jsonOut, shardMode( flag( '--shard-mode', 'roundrobin' ) ) )
   }
 
   for ( const { path: model, allowEmpty } of models ) {

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -528,7 +528,13 @@ function shardWorklists( api, modelID, shard, filePath ) {
     // filters to an arbitrary overlapping subset and drops the rest — which
     // still runs, and still prints a speedup. Refuse instead: a wrong number
     // is worse than no number.
-    if ( assignment.model !== void 0 && assignment.model !== filePath ) {
+    //
+    // Compare resolved paths, not the raw strings: the capture is normally
+    // taken with a relative path (`data/block.ifc`) while the sweep re-invokes
+    // its children with an absolute one, and a guard that rejects a model for
+    // being spelled differently than itself is a guard nobody can use.
+    if ( assignment.model !== void 0 &&
+         path.resolve( assignment.model ) !== path.resolve( filePath ) ) {
       throw new Error(
           `assignment was captured from ${assignment.model}, running ${filePath}` )
     }
@@ -1354,6 +1360,23 @@ function main() {
     return index >= 0 ? argv[ index + 1 ] : fallback
   }
 
+  // Reject flags this script doesn't know rather than ignoring them. A
+  // near-miss spelling (`--model` for `--models`, `--count` for `--shards`)
+  // otherwise falls through to the flag's default and measures a
+  // configuration nobody asked for — the same mislabelled-experiment failure
+  // the phase and shard-mode validation above exists to prevent, one level up.
+  const KNOWN_FLAGS = new Set( [
+    '--models', '--batch', '--repeats', '--json', '--phases', '--shards',
+    '--shard-mode' ] )
+
+  for ( const token of argv ) {
+    if ( token.startsWith( '--' ) && !KNOWN_FLAGS.has( token ) ) {
+      console.error(
+          `unknown flag ${token} (known: ${[ ...KNOWN_FLAGS ].join( ', ' )})` )
+      process.exit( 2 )
+    }
+  }
+
   const modelsFile = flag( '--models' )
   const batchSize = Number( flag( '--batch', DEFAULT_BATCH ) )
 
@@ -1404,7 +1427,8 @@ function main() {
   if ( modelsFile === void 0 ) {
     console.error(
         'usage: m3_pump_spike.mjs --models <file with one path per line> ' +
-        '[--batch N] [--repeats N] [--phases a,b] [--json out]' )
+        '[--batch N] [--repeats N] [--phases a,b] [--json out] ' +
+        '[--shards 1,2,4] [--shard-mode roundrobin|contiguous]' )
     process.exit( 2 )
   }
 

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -934,6 +934,23 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
             'nothing to scale' )
       }
 
+      // Creating assets is not delivering them. `copyout` and `bounded` exist
+      // to measure what a CONSUMER pays — the per-batch copy out of the wasm
+      // heap — so a regression in `streamNewMeshes_` or its callback that
+      // extracts normally while delivering nothing leaves `assetsCreated`
+      // healthy, every child completed, and (for `bounded`) every created
+      // asset released, so the release check passes too. The sweep would then
+      // publish copy and memory timings for copying that never happened.
+      // Delivery is the evidence those phases specifically need.
+      if ( count === 1 && ( phase === 'copyout' || phase === 'bounded' ) &&
+           byCount[ count ].payloads === 0 && !allowEmpty ) {
+        throw new Error(
+            `${name}: the N=1 baseline delivered 0 instances and 0 payloads on a ` +
+            `model not declared geometry-free, despite creating ` +
+            `${byCount[ count ].assetsCreated} assets — ${phase} measures the ` +
+            'copy-out of delivered geometry, and none was delivered' )
+      }
+
       // `bounded` is defined by its release policy, so a sweep of it that did
       // not release measured a different phase than the one it reports. The
       // sweep never reaches `verdicts()`, and `releaseGeometries` swallows
@@ -1376,9 +1393,34 @@ function main() {
         runs.push( spawnChild( phase, model, batchSize ) )
       }
 
-      // Min of N: wall-clock noise is one-sided, so the minimum is the
-      // least-contaminated estimate. Memory is taken from the same run so
-      // the row describes one coherent execution.
+      // Correctness is checked on EVERY repeat; only the timing comes from the
+      // fastest. Keeping just the minimum meant an intermittent failure — a
+      // flaky open, a callback that stopped firing, a release-count mismatch,
+      // a digest divergence — was discarded whenever a healthy sibling ran
+      // faster, which made `--repeats` least trustworthy for exactly the
+      // flakiness repetition exists to expose. Repeats disagreeing with each
+      // other is itself a finding: the same phase on the same model must
+      // deliver the same geometry every time.
+      const reference = runs[ 0 ]
+      const divergent = runs.filter( ( run ) =>
+        run.failed !== reference.failed ||
+        run.instances !== reference.instances ||
+        run.payloads !== reference.payloads ||
+        run.released !== reference.released ||
+        run.assetsCreated !== reference.assetsCreated ||
+        run.placedDigest !== reference.placedDigest ||
+        run.payloadDigest !== reference.payloadDigest )
+
+      if ( divergent.length > 0 ) {
+        failures.push( `${name}: ${phase} was not reproducible across ` +
+          `${repeats} repeats — ${divergent.length} run(s) differ from the ` +
+          'first in delivery, release or digest; the fastest row would have ' +
+          'hidden it' )
+      }
+
+      // Min of N for the reported row: wall-clock noise is one-sided, so the
+      // minimum is the least-contaminated estimate. Memory is taken from the
+      // same run so the row describes one coherent execution.
       byPhase[ phase ] =
         runs.reduce( ( a, b ) => ( ( a.totalMs ?? Infinity ) <= ( b.totalMs ?? Infinity ) ? a : b ) )
     }

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -46,6 +46,7 @@
  *   node scripts/m3_pump_spike.mjs --child <phase> <path> <batch>  # internal
  */
 import { execFile, execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as process from 'node:process'
@@ -72,8 +73,10 @@ const CHILD_MAX_OLD_SPACE_MB = 12288
 
 /**
  * A digest of the geometry a phase delivers: each instance and each payload
- * is hashed on its own, and the per-item hashes are combined **commutatively**
- * (summed mod 2^32). Order-independent by construction, because emission
+ * is SHA-256'd on its own, and the per-item digests are combined by sorting
+ * them and hashing the concatenation — **order-independent**, and unlike a
+ * modular sum it preserves multiplicity, so a dropped or duplicated item
+ * still moves the result. Order-independent by construction, because emission
  * order is exactly what M3 is allowed to change — the classic walk emits in
  * scene order, the pump in batch order, and the delta contract already tells
  * consumers to accumulate additively. An order-sensitive rolling hash reports
@@ -86,7 +89,7 @@ const CHILD_MAX_OLD_SPACE_MB = 12288
 class Digest {
 
   constructor() {
-    this.placedHash = 0
+    this.placedRecords = []
     this.instances = 0
     this.payloads = 0
     this.payloadBytes = 0
@@ -102,13 +105,14 @@ class Digest {
 
     ++this.instances
 
-    let hash = 2166136261
-
-    hash = mix32( hash, expressID )
-    hash = mix32( hash, placedGeometry.geometryExpressID )
+    // Record the canonical field list; hash it at report time. Hashing here
+    // would put the cost of the check inside the measurement the check exists
+    // to validate, and the instance count is small next to the payloads this
+    // run already retains.
+    const record = [ expressID, placedGeometry.geometryExpressID ]
 
     for ( const component of placedGeometry.flatTransformation ) {
-      hash = mix32( hash, quantise( component ) )
+      record.push( quantise( component ) )
     }
 
     // Colour and occurrence path are delivered output, not metadata: colour is
@@ -118,17 +122,11 @@ class Digest {
     // preserving counts and transforms would otherwise pass this check.
     const colour = placedGeometry.color
 
-    if ( colour !== void 0 ) {
-      for ( const channel of [ colour.x, colour.y, colour.z, colour.w ] ) {
-        hash = mix32( hash, quantise( channel ) )
-      }
-    }
+    record.push( colour === void 0 ? 'nocolour' :
+      [ colour.x, colour.y, colour.z, colour.w ].map( quantise ).join( ',' ) )
+    record.push( ( placedGeometry.occurrencePath ?? [] ).join( '.' ) )
 
-    for ( const step of placedGeometry.occurrencePath ?? [] ) {
-      hash = mix32( hash, step )
-    }
-
-    this.placedHash = ( this.placedHash + hash ) >>> 0
+    this.placedRecords.push( record.join( '|' ) )
   }
 
   /**
@@ -148,61 +146,91 @@ class Digest {
 }
 
 /**
- * Hash EVERY delivered byte, commutatively across payloads.
+ * Combine per-item digests into one order-independent digest.
  *
- * Sampling (this previously hashed one element in 97) cannot support a
- * "same payloads" claim: a tessellation change touching only unsampled
- * vertices, with the array lengths preserved, produces an identical digest.
- * Run at report time, after the timers have stopped, so exactness costs the
- * measurement nothing.
+ * Sorting the hex digests and hashing the concatenation is order-independent
+ * without being lossy the way a modular sum is: a sum mod 2^32 lets distinct
+ * SETS of per-item hashes collide (and lets two changes cancel), whereas the
+ * sorted list preserves multiplicity, so a duplicated or dropped item moves
+ * the result.
  *
- * @param payloads `{geometryExpressID, vertices, indices}` in emission order.
- * @return {number} Order-independent digest.
+ * @param itemDigests Hex digests, one per item, in any order.
+ * @return {string} Hex digest of the multiset.
  */
-function exactPayloadDigest( payloads ) {
+function combineDigests( itemDigests ) {
 
-  let total = 0
+  const combined = createHash( 'sha256' )
 
-  for ( const { geometryExpressID, vertices, indices } of payloads ) {
-
-    let hash = 2166136261
-
-    hash = mix32( hash, geometryExpressID )
-    hash = mix32( hash, vertices.length )
-    hash = mix32( hash, indices.length )
-
-    // RAW BITS, not quantised values. `quantise` exists for placement, where
-    // the two paths compose f64 matrices differently and the last bits
-    // legitimately differ; applying it to vertices would put 1.0 and 1.0001
-    // in the same bucket and let a small tessellation change pass a check
-    // that claims byte-identical payloads. Vertices come from the same frozen
-    // native mirror on every path, so they are comparable bit-for-bit.
-    const vertexBits = new Uint32Array(
-        vertices.buffer, vertices.byteOffset, vertices.length )
-
-    for ( let i = 0; i < vertexBits.length; ++i ) {
-      hash = mix32( hash, vertexBits[ i ] )
-    }
-
-    for ( let i = 0; i < indices.length; ++i ) {
-      hash = mix32( hash, indices[ i ] )
-    }
-
-    total = ( total + hash ) >>> 0
+  for ( const digest of itemDigests.slice().sort() ) {
+    combined.update( digest )
   }
 
-  return total
+  return combined.digest( 'hex' )
 }
 
 /**
- * One FNV-1a step.
+ * Digest EVERY delivered byte, commutatively across payloads.
  *
- * @param hash The running hash.
- * @param value A 32-bit value.
- * @return {number} The updated hash.
+ * SHA-256 over the raw bytes, not a 32-bit rolling hash. The claim this
+ * supports is "two runs delivering different payloads do not agree", and a
+ * 32-bit value cannot support it: an arbitrarily large payload collapsed to
+ * 32 bits has collisions by counting alone, so a real tessellation change
+ * could print OK. At 256 bits, disagreeing runs colliding requires a SHA-256
+ * collision — which is the honest bound, and is why the digest is stated as
+ * cryptographic rather than exact.
+ *
+ * Byte-for-byte comparison is not available here: each phase runs in its own
+ * child process and reports over stdout, so the parent never holds two
+ * phases' payloads at once. A digest is what crosses that boundary.
+ *
+ * Lengths and the geometry ID are framed into the hash separately so that
+ * concatenation cannot alias — a payload of (a, b) and one of (ab, ) are
+ * different inputs.
+ *
+ * Runs at report time, after the timers have stopped, so exactness costs the
+ * measurement nothing.
+ *
+ * @param payloads `{geometryExpressID, vertices, indices}` in emission order.
+ * @return {string} Order-independent hex digest.
  */
-function mix32( hash, value ) {
-  return Math.imul( hash ^ ( value | 0 ), 16777619 ) >>> 0
+function exactPayloadDigest( payloads ) {
+
+  const itemDigests = []
+
+  for ( const { geometryExpressID, vertices, indices } of payloads ) {
+
+    const item = createHash( 'sha256' )
+
+    item.update(
+        `${geometryExpressID}:${vertices.length}:${indices.length}:` )
+
+    // RAW BYTES, not quantised values. `quantise` exists for placement, where
+    // the two paths compose f64 matrices differently and the last bits
+    // legitimately differ; applying it to vertices would put 1.0 and 1.0001
+    // in the same bucket and let a small tessellation change pass a check
+    // that claims identical payloads. Vertices come from the same frozen
+    // native mirror on every path, so they are comparable bit-for-bit.
+    item.update( new Uint8Array(
+        vertices.buffer, vertices.byteOffset, vertices.byteLength ) )
+    item.update( new Uint8Array(
+        indices.buffer, indices.byteOffset, indices.byteLength ) )
+
+    itemDigests.push( item.digest( 'hex' ) )
+  }
+
+  return combineDigests( itemDigests )
+}
+
+/**
+ * Digest the placed instances a phase delivered.
+ *
+ * @param records Canonical per-instance field strings from {@link Digest}.
+ * @return {string} Order-independent hex digest.
+ */
+function exactPlacedDigest( records ) {
+
+  return combineDigests( records.map(
+      ( record ) => createHash( 'sha256' ).update( record ).digest( 'hex' ) ) )
 }
 
 /**
@@ -476,13 +504,25 @@ function shardWorklists( api, modelID, shard, filePath ) {
   // and exporters emit spatially and structurally clustered — so instances
   // sharing a representation tend to land on the same shard. Which one wins
   // says whether the ceiling is imbalance or duplicated shared work.
-  const perShard = Math.ceil( products.length / shard.count )
-  const mine = shard.mode === 'contiguous' ?
-    ( _, index ) => Math.floor( index / perShard ) === shard.index :
-    ( _, index ) => index % shard.count === shard.index
+  // Each worklist gets its own span: products and aggregates are independent
+  // lists of different lengths, so a span sized from the products would push
+  // the (shorter) aggregate list entirely into the early shards — 2/1/0/0 on
+  // index.ifc's 7 products and 3 aggregates, where a contiguous split is
+  // 1/1/1/0. Aggregate extraction is real geometry work, so that imbalance
+  // lands in the slowest-shard timing the scaling table reports.
+  const mineOf = ( length ) => {
 
-  passthrough.demandProducts_ = products.filter( mine )
-  passthrough.demandAggregates_ = aggregates.filter( mine )
+    if ( shard.mode !== 'contiguous' ) {
+      return ( _, index ) => index % shard.count === shard.index
+    }
+
+    const perShard = Math.ceil( length / shard.count )
+
+    return ( _, index ) => Math.floor( index / perShard ) === shard.index
+  }
+
+  passthrough.demandProducts_ = products.filter( mineOf( products.length ) )
+  passthrough.demandAggregates_ = aggregates.filter( mineOf( aggregates.length ) )
 
   return {
     products: passthrough.demandProducts_.length,
@@ -652,7 +692,7 @@ async function runChild( phase, filePath, batchSize, shard ) {
     payloads: digest.payloads,
     payloadMB: digest.payloadBytes / BYTES_PER_MB,
     retainedPayloadBuffers: retainedPayloads.length,
-    placedDigest: digest.placedHash,
+    placedDigest: exactPlacedDigest( digest.placedRecords ),
     payloadDigest: exactPayloadDigest( retainedPayloads ),
   } ) )
 }
@@ -837,6 +877,8 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
  *
  * @param byPhase Results keyed by phase.
  * @param phases The phases that ran.
+ * @param allowEmpty The caller's declaration (`#empty` in the models file)
+ * that this model genuinely has no geometry, so a zero is not a broken probe.
  * @return {object[]} `{text, failed}` lines.
  */
 function verdicts( byPhase, phases, allowEmpty ) {
@@ -856,11 +898,37 @@ function verdicts( byPhase, phases, allowEmpty ) {
   // reads as agreement. Neither can support a comparison, so say so rather
   // than passing quietly. (`allowEmpty` is the caller's declaration that the
   // model genuinely has no geometry.)
-  for ( const phase of [ 'copyout', 'bounded' ] ) {
+  //
+  // Every REQUESTED phase is checked, not just the ones a later comparison
+  // happens to name. Restricting this to `copyout`/`bounded` left `--phases
+  // classic` and `--phases pump` exiting 0 on a failed open: the row printed
+  // `failed`, no comparison referenced it, and the guards below returned
+  // early. A phase the caller asked for and did not get is a failed run
+  // whether or not anything compares it.
+  for ( const phase of phases ) {
 
     const row = byPhase[ phase ]
 
-    if ( row === void 0 || !phases.includes( phase ) ) {
+    if ( row === void 0 ) {
+      out.push( {
+        text: `FAIL  ${phase} produced no result at all — the child did not report`,
+        failed: true,
+      } )
+      continue
+    }
+
+    // `pump` deliberately passes no meshCallback, so it delivers no instances
+    // by construction; its purpose is the wasm/timing columns. Judging it on
+    // instance count would fail every healthy run.
+    if ( EXTRACT_ONLY_PHASES.has( phase ) || phase === 'pump' ) {
+
+      if ( row.failed !== void 0 ) {
+        out.push( {
+          text: `FAIL  ${phase} did not complete (${row.failed})`,
+          failed: true,
+        } )
+      }
+
       continue
     }
 
@@ -870,6 +938,15 @@ function verdicts( byPhase, phases, allowEmpty ) {
           '— nothing to compare',
         failed: true,
       } )
+    } else if ( phase === 'classic' ) {
+
+      // Zero instances on `classic` is judged by the dedicated block below,
+      // which is the only place that can report SKIP: classic is the
+      // unmodified whole-model walk, so its own row is what distinguishes a
+      // geometry-free model from a broken probe. Falling through here too
+      // would file the same failure twice.
+      continue
+
     } else if ( row.instances === 0 && !allowEmpty ) {
       out.push( {
         text: `FAIL  ${phase} delivered 0 instances on a model not declared ` +

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -53,6 +53,15 @@ import { performance } from 'node:perf_hooks'
 
 const PHASES = [ 'classic', 'pump', 'copyout', 'bounded' ]
 
+/**
+ * Phases that never pass a meshCallback, so `streamNewMeshes_` — the
+ * full-scene re-walk the pump does per batch — never runs. Differencing one
+ * of these against `pump` prices the walk separately from the extraction,
+ * which is what says whether the parallel ceiling is in the work or in the
+ * bookkeeping around it.
+ */
+const EXTRACT_ONLY_PHASES = new Set( [ 'extractonly' ] )
+
 const DEFAULT_BATCH = 64
 const BYTES_PER_MB = 1024 * 1024
 
@@ -313,7 +322,16 @@ function shardWorklists( api, modelID, shard ) {
 
   const products = passthrough.demandProducts_ ?? []
   const aggregates = passthrough.demandAggregates_ ?? []
-  const mine = ( _, index ) => index % shard.count === shard.index
+
+  // Round-robin spreads cost evenly but scatters shared geometry across every
+  // shard, so each one re-extracts it. Contiguous keeps file-order locality —
+  // and exporters emit spatially and structurally clustered — so instances
+  // sharing a representation tend to land on the same shard. Which one wins
+  // says whether the ceiling is imbalance or duplicated shared work.
+  const perShard = Math.ceil( products.length / shard.count )
+  const mine = shard.mode === 'contiguous' ?
+    ( _, index ) => Math.floor( index / perShard ) === shard.index :
+    ( _, index ) => index % shard.count === shard.index
 
   passthrough.demandProducts_ = products.filter( mine )
   passthrough.demandAggregates_ = aggregates.filter( mine )
@@ -349,6 +367,7 @@ async function runChild( phase, filePath, batchSize, shard ) {
   const seen = new Set()
   const deferred = phase !== 'classic'
   const copies = phase === 'copyout' || phase === 'bounded'
+  const emits = !EXTRACT_ONLY_PHASES.has( phase )
 
   const settings = {
     COORDINATE_TO_ORIGIN: true,
@@ -381,6 +400,7 @@ async function runChild( phase, filePath, batchSize, shard ) {
   let released = 0
   let copyMs = 0
 
+  const cpuBefore = process.cpuUsage()
   const tGeometry = performance.now()
 
   if ( !deferred ) {
@@ -405,10 +425,11 @@ async function runChild( phase, filePath, batchSize, shard ) {
     for ( ;; ) {
 
       const batchMeshes = []
-      const { extracted, remaining } =
+      const { extracted, remaining } = emits ?
         api.ExtractGeometryBatch( modelID, batchSize, ( mesh ) => {
           batchMeshes.push( mesh )
-        } )
+        } ) :
+        api.ExtractGeometryBatch( modelID, batchSize )
 
       ++batches
 
@@ -433,11 +454,14 @@ async function runChild( phase, filePath, batchSize, shard ) {
   }
 
   const geometryMs = performance.now() - tGeometry
+  const cpu = process.cpuUsage( cpuBefore )
+  const geometryCpuMs = ( cpu.user + cpu.system ) / 1000
 
   console.log( JSON.stringify( {
     phase,
     openMs,
     geometryMs,
+    geometryCpuMs,
     copyMs,
     totalMs: openMs + geometryMs,
     batches,
@@ -492,9 +516,10 @@ function spawnChild( phase, filePath, batchSize, shard ) {
  * @param filePath The model.
  * @param batchSize Products per pump call.
  * @param count How many shards.
+ * @param shardMode 'roundrobin' or 'contiguous'.
  * @return {Promise<object[]>} One result per shard.
  */
-function spawnShards( phase, filePath, batchSize, count ) {
+function spawnShards( phase, filePath, batchSize, count, shardMode ) {
 
   const running = []
 
@@ -503,7 +528,7 @@ function spawnShards( phase, filePath, batchSize, count ) {
     const args = [
       '--expose-gc', `--max-old-space-size=${CHILD_MAX_OLD_SPACE_MB}`,
       process.argv[ 1 ], '--child', phase, filePath, String( batchSize ),
-      `${index}/${count}`,
+      `${index}/${count}`, shardMode,
     ]
 
     running.push( new Promise( ( resolve, reject ) => {
@@ -539,8 +564,9 @@ function spawnShards( phase, filePath, batchSize, count ) {
  * @param batchSize Products per pump call.
  * @param counts Shard counts to sweep.
  * @param jsonOut Optional output path.
+ * @param shardMode 'roundrobin' or 'contiguous'.
  */
-async function runShardSweep( models, phase, batchSize, counts, jsonOut ) {
+async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMode ) {
 
   const rows = []
 
@@ -552,7 +578,7 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut ) {
     for ( const count of counts ) {
 
       const t0 = performance.now()
-      const results = await spawnShards( phase, model, batchSize, count )
+      const results = await spawnShards( phase, model, batchSize, count, shardMode )
       const wallMs = performance.now() - t0
 
       const total = ( key ) => results.reduce( ( sum, r ) => sum + ( r[ key ] ?? 0 ), 0 )
@@ -563,6 +589,7 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut ) {
         wallMs,
         slowestGeometryMs,
         geometryMsPerShard: results.map( ( r ) => Math.round( r.geometryMs ) ),
+        cpuMsTotal: total( 'geometryCpuMs' ),
         instances: total( 'instances' ),
         payloads: total( 'payloads' ),
         wasmPeakMBSum: results.reduce( ( sum, r ) => sum + r.wasmPeakMB, 0 ),
@@ -573,8 +600,9 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut ) {
       const speedup = base.slowestGeometryMs / slowestGeometryMs
 
       console.log(
-          `${name} shards=${count} geometry=${( slowestGeometryMs / 1000 ).toFixed( 1 )}s ` +
+          `${name} ${shardMode} shards=${count} geometry=${( slowestGeometryMs / 1000 ).toFixed( 1 )}s ` +
           `(${speedup.toFixed( 2 )}x) per-shard=${byCount[ count ].geometryMsPerShard.join( '/' )} ` +
+          `cpu=${( byCount[ count ].cpuMsTotal / 1000 ).toFixed( 1 )}s ` +
           `inst=${byCount[ count ].instances} payloads=${byCount[ count ].payloads} ` +
           `wasmMax=${byCount[ count ].wasmPeakMBMax.toFixed( 0 )}MB ` +
           `wasmSum=${byCount[ count ].wasmPeakMBSum.toFixed( 0 )}MB` )
@@ -602,6 +630,7 @@ function main() {
     const shard = spec !== void 0 ? {
       index: Number( spec.split( '/' )[ 0 ] ),
       count: Number( spec.split( '/' )[ 1 ] ),
+      mode: argv[ 5 ] ?? 'roundrobin',
     } : void 0
 
     return runChild( argv[ 1 ], argv[ 2 ], Number( argv[ 3 ] ), shard )
@@ -635,7 +664,8 @@ function main() {
   const rows = []
 
   if ( shards !== void 0 ) {
-    return runShardSweep( models, phases[ 0 ], batchSize, shards.split( ',' ).map( Number ), jsonOut )
+    return runShardSweep( models, phases[ 0 ], batchSize,
+        shards.split( ',' ).map( Number ), jsonOut, flag( '--shard-mode', 'roundrobin' ) )
   }
 
   for ( const model of models ) {

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -343,6 +343,29 @@ function shardWorklists( api, modelID, shard ) {
 
     const assignment =
       JSON.parse( fs.readFileSync( process.env.M3_ASSIGNMENT, 'utf8' ) )
+
+    // An assignment is cut for ONE shard count. The sweep always runs an N=1
+    // baseline (see the count normalisation in main), and handing that child
+    // `shards[0]` would give it a quarter of the products while the sweep
+    // treated it as the whole model — every ratio computed against it would be
+    // silently wrong. The baseline runs the full unassigned worklist; any
+    // other mismatch is a caller error rather than something to paper over.
+    if ( shard.count === 1 ) {
+
+      return {
+        products: products.length,
+        ofProducts: products.length,
+        aggregates: aggregates.length,
+        strategy: `${assignment.strategy} (baseline: full worklist)`,
+      }
+    }
+
+    if ( assignment.shards.length !== shard.count ) {
+      throw new Error(
+          `assignment is cut for ${assignment.shards.length} shards, ` +
+          `sweep is running ${shard.count}` )
+    }
+
     const mineSet = new Set( assignment.shards[ shard.index ] )
 
     passthrough.demandProducts_ = products.filter( ( id ) => mineSet.has( id ) )

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -1352,6 +1352,22 @@ function main() {
     // WHOLE model while the output labelled them shards and computed a
     // speedup from them. Default to the deferred extract phase, and refuse the
     // non-deferred one rather than publishing invalid scaling.
+    // `--repeats` is consumed by the per-model path only; the sweep ignores
+    // it entirely, so `--shards 4 --repeats 3` ran ONE sweep and published a
+    // single-sample timing to a caller who asked for three. Rejected rather
+    // than honoured, for the same reason as a phase list: the sweep is a
+    // different experiment shape (N shard counts, each a concurrent fan-out),
+    // and repeating it is a change to what is measured rather than a knob —
+    // the round-16 cross-repeat agreement check is defined over per-phase
+    // child rows, which a sweep does not produce.
+    if ( repeats !== 1 ) {
+      console.error(
+          `--repeats is not supported with --shards (got ${repeats}); the sweep ` +
+          'measures scaling across shard counts, not repeated samples. Run the ' +
+          'sweep more than once if you need repeats.' )
+      process.exit( 2 )
+    }
+
     // One sweep runs one phase, and taking `phases[0]` from a list meant
     // `--phases pump,bounded` ran `pump` and reported it while the caller
     // believed they had also measured the release. Reject rather than pick:

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -29,11 +29,21 @@
  * Every phase copies out the same payloads (`classic`/`copyout`/`bounded`)
  * or none (`pump`), and hashes them into a digest so the M3 exit criterion
  * (M3 changes when work happens, not what it produces) is checked rather
- * than assumed. `bounded` releasing everything is expected to LOSE instances
- * whose geometry is shared with a later product (the scene walk skips a
- * released geometry); the digest and instance counts are what size that
- * loss, and therefore what sizes the retention/refcount rule the production
- * pump needs (SharedAssetPool, per the design doc).
+ * than assumed. A `bounded`/`copyout` difference is a FAILURE: those two run
+ * identical extraction and differ only in that `bounded` releases, so any
+ * divergence means release changed what a consumer receives.
+ *
+ * Retain-nothing release CAN lose instances in principle — the scene walk
+ * resolves geometry through `getByLocalID` and skips what it cannot find, so
+ * releasing an asset a later product shares makes that product re-extract —
+ * but this corpus never triggers it at batch 64, because shared geometry is
+ * released within the batch that emits all of its instances. (An earlier
+ * version of this comment said the loss was expected and measured, citing
+ * 169 instances against 101 on `supercap.step`. That came from the
+ * payload-keyed release this harness no longer uses; `bounded` is now
+ * identical to `copyout` on all 12 models. Retracted — see the design doc.)
+ * The retention rule the production pump needs (SharedAssetPool) is
+ * therefore justified by the code path, not by a number from here.
  *
  * The headline number is `wasmPeakMB`: the high-water mark of the wasm
  * linear memory, read through `wasmHeapByteLength` (the module's cached
@@ -645,15 +655,17 @@ async function runChild( phase, filePath, batchSize, shard ) {
 
   // Adds that land on a local ID the cache ALREADY holds. `IfcModelGeometry.add`
   // is a bare `meshes_.set( localID, mesh )` (ifc_model_geometry.ts:75), so a
-  // replacement drops the previous `CanonicalMesh` from the map without calling
-  // `.delete()` on its native. That native is then unreachable — not by
-  // `releaseGeometries`, not by anything — so it leaks for the life of the
-  // model, in production as well as here. The rel-aggregates pass does exactly
-  // this (`aggregate_master_voids.ifc`: 2 created, 1 payload).
+  // replacement would drop the previous `CanonicalMesh` from the map without
+  // calling `.delete()` on its native, leaving it unreachable — not by
+  // `releaseGeometries`, not by anything — for the life of the model.
   //
-  // Counted rather than worked around: a `bounded` run on a model with
-  // replacements cannot bound the heap, and the harness must say so instead of
-  // reporting the release of the survivors as success.
+  // NOT observed. This counter exists because that leak is possible by
+  // inspection, not because anything here exhibits it: every model measured
+  // reports `assetsReplaced = 0`, `aggregate_master_voids.ifc` included. Its
+  // 2-created/1-delivered split is two DISTINCT assets, one of them never
+  // handed out — which is the create-vs-deliver gap the release keying fixes,
+  // a different mechanism entirely. Counted so that a model which does
+  // overwrite is visible rather than silently unbounded.
   let assetsReplaced = 0
 
   // Local IDs the cache created since the last release. `bounded` frees these

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -403,6 +403,15 @@ function releaseGeometries( api, modelID, localIDs, geometryExpressIDs ) {
 
   let freed = 0
 
+  // Created natives the ENGINE already reclaimed before we got here.
+  // `IfcGeometryExtraction` calls `model.geometry.deleteTemporaries()`
+  // (ifc_geometry_extraction.ts:7690), which drops temporary meshes AND
+  // deletes their natives, so a localID counted at `add` can legitimately be
+  // gone by release time. Tracked separately rather than ignored: what must
+  // hold is that nothing created is still resident, and "we freed it" and
+  // "the engine freed it" are both ways of satisfying that.
+  let alreadyGone = 0
+
   // Release by LOCAL ID, taken from the cache's own `add` calls, rather than by
   // the express IDs of the payloads this batch copied. The two sets are not the
   // same: the extractor creates natives that are never delivered as a payload —
@@ -414,8 +423,23 @@ function releaseGeometries( api, modelID, localIDs, geometryExpressIDs ) {
   for ( const localID of localIDs ) {
 
     try {
+
+      // `IfcModelGeometry.delete` returns void and silently returns when the
+      // local ID is absent, so "the call did not throw" is not evidence that
+      // anything was freed — and `released === assetsCreated` was resting on
+      // exactly that. Require the observable transition instead: present
+      // before, absent after. A no-op now fails to increment, which is what
+      // makes the release counters mean what the verdicts claim they mean.
+      if ( model.geometry.getByLocalID( localID ) === void 0 ) {
+        ++alreadyGone
+        continue
+      }
+
       model.geometry.delete( localID )
-      ++freed
+
+      if ( model.geometry.getByLocalID( localID ) === void 0 ) {
+        ++freed
+      }
     } catch {
       // Never let a free break the measurement — a phase that cannot free
       // is a finding, not a crash.
@@ -428,7 +452,7 @@ function releaseGeometries( api, modelID, localIDs, geometryExpressIDs ) {
     geometryMap?.delete( expressID )
   }
 
-  return freed
+  return { freed, alreadyGone }
 }
 
 /**
@@ -700,6 +724,11 @@ async function runChild( phase, filePath, batchSize, shard ) {
   const wasmAfterOpenMB = wasmPeakMB
   let batches = 0
   let released = 0
+
+  // Created natives the engine reclaimed itself (temporaries). Reported so the
+  // release invariant can be "nothing created is still resident" rather than
+  // "we personally freed everything", which is false by construction.
+  let selfFreed = 0
   let copyMs = 0
 
   const cpuBefore = process.cpuUsage()
@@ -744,7 +773,12 @@ async function runChild( phase, filePath, batchSize, shard ) {
         copyMs += performance.now() - tCopy
 
         if ( phase === 'bounded' ) {
-          released += releaseGeometries( api, modelID, createdThisBatch, copied )
+
+          const release =
+            releaseGeometries( api, modelID, createdThisBatch, copied )
+
+          released += release.freed
+          selfFreed += release.alreadyGone
           createdThisBatch.clear()
         }
       }
@@ -770,6 +804,7 @@ async function runChild( phase, filePath, batchSize, shard ) {
     totalMs: openMs + geometryMs,
     batches,
     released,
+    selfFreed,
     assetsCreated,
     assetsReplaced,
     shard,
@@ -939,6 +974,7 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
         assetsCreated: total( 'assetsCreated' ),
         assetsReplaced: total( 'assetsReplaced' ),
         released: total( 'released' ),
+        selfFreed: total( 'selfFreed' ),
         payloads: total( 'payloads' ),
         wasmPeakMBSum: results.reduce( ( sum, r ) => sum + r.wasmPeakMB, 0 ),
         wasmPeakMBMax: Math.max( ...results.map( ( r ) => r.wasmPeakMB ) ),
@@ -981,13 +1017,16 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
       // aggregate count is the only evidence. Summed across shards, because
       // each child releases only what it created.
       if ( phase === 'bounded' &&
-           byCount[ count ].released !== byCount[ count ].assetsCreated ) {
+           byCount[ count ].released + byCount[ count ].selfFreed !==
+             byCount[ count ].assetsCreated ) {
         throw new Error(
-            `${name}: at N=${count}, bounded released ` +
-            `${byCount[ count ].released} of ${byCount[ count ].assetsCreated} ` +
-            'geometries the extractor created — the release policy that defines ' +
-            'this phase did not run, so its timing and memory rows describe ' +
-            'something else' )
+            `${name}: at N=${count}, bounded accounted for ` +
+            `${byCount[ count ].released + byCount[ count ].selfFreed} of ` +
+            `${byCount[ count ].assetsCreated} geometries the extractor ` +
+            `created (${byCount[ count ].released} released, ` +
+            `${byCount[ count ].selfFreed} reclaimed by the engine) — the ` +
+            'release policy that defines this phase did not run, so its ' +
+            'timing and memory rows describe something else' )
       }
 
       const base = byCount[ counts[ 0 ] ]
@@ -1039,10 +1078,18 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
  *    unmodified whole-model walk.)
  *  - `copyout` must match `classic` exactly. It changes only WHEN extraction
  *    happens, so any divergence is a real regression.
- *  - `bounded` divergence is reported as a labelled DIFF rather than a
- *    failure: retain-nothing release is expected to duplicate instances on a
- *    model with shared geometry (`supercap.step`), and that finding is the
- *    reason the phase exists.
+ *  - `bounded` must match `copyout` exactly. Those two run identical
+ *    extraction and differ ONLY in that `bounded` releases, so any divergence
+ *    means release changed what a consumer receives — a failure, not a
+ *    finding. Measured: identical on all 12 corpus models.
+ *  - `bounded` vs `classic` is reported without failing, because on a model
+ *    where the deferred path itself diverges the `copyout`-vs-`classic`
+ *    comparison already reports it, and failing twice for one cause would
+ *    read as two. (`supercap.step` is that model, and the cause is the
+ *    deferred pump — #532 — not release. An earlier version of this comment
+ *    said retain-nothing release was expected to duplicate instances there;
+ *    that came from the payload-keyed release replaced in round 11.
+ *    Retracted.)
  *
  * @param byPhase Results keyed by phase.
  * @param phases The phases that ran.
@@ -1159,13 +1206,21 @@ function verdicts( byPhase, phases, allowEmpty ) {
   // exactly there, so a bounded run could retain the created native and still
   // exit 0. What must hold is "everything created was released", which is
   // meaningful whenever the phase ran at all.
+  // The invariant is "nothing the extractor created is still resident", which
+  // `released` alone cannot express: the engine reclaims its own temporaries
+  // via `deleteTemporaries`, so some created natives are legitimately gone
+  // before release runs (91 of 11 357 on MB-Khaya). Those count as accounted
+  // for, not as released. A native that is neither freed by us nor already
+  // gone is the actual leak, and only that fails.
   if ( bounded !== void 0 && bounded.failed === void 0 &&
-       bounded.released !== bounded.assetsCreated ) {
+       bounded.released + ( bounded.selfFreed ?? 0 ) !== bounded.assetsCreated ) {
     out.push( {
-      text: `FAIL  bounded released ${bounded.released} of ` +
+      text: `FAIL  bounded accounted for ` +
+        `${bounded.released + ( bounded.selfFreed ?? 0 )} of ` +
         `${bounded.assetsCreated} geometries the extractor created ` +
-        `(${bounded.payloads} of them delivered as payloads) — the heap still ` +
-        'holds what was built but never handed out, so this run is not bounded',
+        `(${bounded.released} released here, ${bounded.selfFreed ?? 0} already ` +
+        'freed by the engine) — the remainder is still resident, so this run ' +
+        'is not bounded',
       failed: true,
     } )
   }
@@ -1458,6 +1513,7 @@ function main() {
         run.instances !== reference.instances ||
         run.payloads !== reference.payloads ||
         run.released !== reference.released ||
+        run.selfFreed !== reference.selfFreed ||
         run.assetsCreated !== reference.assetsCreated ||
         run.placedDigest !== reference.placedDigest ||
         run.payloadDigest !== reference.payloadDigest )

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -780,15 +780,6 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
     fs.writeFileSync( jsonOut, `${JSON.stringify( rows, null, 2 )}\n` )
   }
 
-  if ( failures.length > 0 ) {
-    console.error( `\n${failures.length} model(s) failed the delivery check:` )
-
-    for ( const failure of failures ) {
-      console.error( `  ${failure}` )
-    }
-
-    process.exit( 1 )
-  }
 }
 
 /**
@@ -816,7 +807,7 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
  * @param phases The phases that ran.
  * @return {object[]} `{text, failed}` lines.
  */
-function verdicts( byPhase, phases ) {
+function verdicts( byPhase, phases, allowEmpty ) {
 
   const out = []
   const classic = byPhase.classic
@@ -826,7 +817,20 @@ function verdicts( byPhase, phases ) {
   }
 
   if ( classic.instances === 0 ) {
-    out.push( { text: 'SKIP  classic delivered no instances — model has no geometry', failed: false } )
+
+    // A zero here has two causes that look identical from the outside: a model
+    // with no geometry, and a probe that stopped firing. Nothing in the run
+    // can tell them apart, so the caller declares the geometry-free models
+    // (`#empty` in the models file) and everything else fails.
+    out.push( allowEmpty ?
+      { text: 'SKIP  classic delivered no instances — model declared geometry-free', failed: false } :
+      {
+        text: 'FAIL  classic delivered no instances on a model not declared ' +
+          'geometry-free — the probe is broken, or the model belongs on the ' +
+          '#empty list',
+        failed: true,
+      } )
+
     return out
   }
 
@@ -860,15 +864,44 @@ function verdicts( byPhase, phases ) {
       `${classic.instances}, placed ${row.placedDigest} vs ${classic.placedDigest}, ` +
       `payload ${row.payloadDigest} vs ${classic.payloadDigest}`
 
-    // Only `bounded` is allowed to differ, and only because retaining nothing
-    // is a deliberately unshippable policy — see the doc's retention section.
     out.push( phase === 'bounded' ?
       { text: `DIFF  ${line}`, failed: false } :
       { text: `FAIL  ${line}`, failed: true } )
   }
 
+  // The comparison the release policy actually rests on. `bounded` and
+  // `copyout` run the SAME deferred extraction and differ only in that
+  // `bounded` releases; so if they agree, release changed nothing, and if they
+  // disagree, release alone changed delivery. Checking each against `classic`
+  // cannot see this: where the deferred path itself diverges (supercap.step,
+  // #532) both rows differ from classic and a release regression would hide
+  // inside a DIFF that is already expected.
+  const copyout = byPhase.copyout
+  const bounded = byPhase.bounded
+
+  if ( copyout?.instances !== void 0 && bounded?.instances !== void 0 ) {
+
+    const same = bounded.placedDigest === copyout.placedDigest &&
+      bounded.payloadDigest === copyout.payloadDigest
+
+    out.push( same ?
+      {
+        text: `OK    bounded identical to copyout — release changed nothing ` +
+          `(${bounded.instances} instances)`,
+        failed: false,
+      } :
+      {
+        text: 'FAIL  bounded differs from copyout: release alone changed delivery ' +
+          `(${bounded.instances} instances vs ${copyout.instances}, ` +
+          `placed ${bounded.placedDigest} vs ${copyout.placedDigest}, ` +
+          `payload ${bounded.payloadDigest} vs ${copyout.payloadDigest})`,
+        failed: true,
+      } )
+  }
+
   return out
 }
+
 
 /**
  * Sweep phases over models, or shard counts when `--shards` is given.
@@ -910,10 +943,17 @@ function main() {
     process.exit( 2 )
   }
 
+  // A models-file line may be annotated `<path> #empty` to declare that the
+  // model genuinely produces no geometry. Without that, a zero-instance
+  // classic run is a broken probe rather than an empty model.
   const models = fs.readFileSync( modelsFile, 'utf8' )
       .split( '\n' )
       .map( ( line ) => line.trim() )
       .filter( ( line ) => line.length > 0 && !line.startsWith( '#' ) )
+      .map( ( line ) => ( {
+        path: line.replace( /\s*#empty\s*$/, '' ),
+        allowEmpty: /\s#empty\s*$/.test( line ),
+      } ) )
 
   const rows = []
   const failures = []
@@ -946,11 +986,11 @@ function main() {
       console.log( `note: added an N=1 baseline (sweeping ${counts.join( ',' )})` )
     }
 
-    return runShardSweep( models, shardPhase, batchSize, counts, jsonOut,
-        flag( '--shard-mode', 'roundrobin' ) )
+    return runShardSweep( models.map( ( entry ) => entry.path ), shardPhase,
+        batchSize, counts, jsonOut, flag( '--shard-mode', 'roundrobin' ) )
   }
 
-  for ( const model of models ) {
+  for ( const { path: model, allowEmpty } of models ) {
 
     const name = path.basename( model )
     const byPhase = {}
@@ -991,7 +1031,7 @@ function main() {
 
     console.log( `${name}\n  ${phases.map( cell ).join( '\n  ' )}` )
 
-    for ( const line of verdicts( byPhase, phases ) ) {
+    for ( const line of verdicts( byPhase, phases, allowEmpty ) ) {
       console.log( `  ${line.text}` )
 
       if ( line.failed ) {

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -1064,28 +1064,32 @@ function verdicts( byPhase, phases, allowEmpty ) {
     }
   }
 
+  // Release is a property of `bounded` ALONE, so it is checked whenever a
+  // completed `bounded` row exists — not from inside the cross-phase guard
+  // below. `--phases bounded` is a supported invocation and has no `copyout`
+  // row, so gating this on both phases meant the one filter that runs *only*
+  // the release phase was the one that never verified the release.
+  //
+  // `releaseGeometries` swallows per-geometry failures so a single bad free
+  // can't end a measurement; the count is therefore the only evidence release
+  // actually happened. Compared against CREATIONS, not copied payloads: the
+  // extractor makes natives that are never delivered (void/opening geometry
+  // consumed by a boolean), so `released === payloads` can hold while the heap
+  // still carries everything built but not handed out.
+  if ( ( bounded?.instances ?? 0 ) > 0 &&
+       bounded.released !== bounded.assetsCreated ) {
+    out.push( {
+      text: `FAIL  bounded released ${bounded.released} of ` +
+        `${bounded.assetsCreated} geometries the extractor created ` +
+        `(${bounded.payloads} of them delivered as payloads) — the heap still ` +
+        'holds what was built but never handed out, so this run is not bounded',
+      failed: true,
+    } )
+  }
+
   const bothDelivered = ( copyout?.instances ?? 0 ) > 0 && ( bounded?.instances ?? 0 ) > 0
 
   if ( bothDelivered ) {
-
-    // A release that THREW on every geometry also produces bounded ≡ copyout,
-    // and would read as "release changed nothing" while nothing was released.
-    // `releaseGeometries` swallows per-geometry failures so one bad free can't
-    // end a run, so the count is the only evidence release actually happened.
-    // Against CREATIONS, not copied payloads. The extractor makes natives that
-    // are never delivered (void/opening geometry consumed by a boolean), so
-    // `released === payloads` can hold while the heap still carries everything
-    // that was built but not handed out — the phase would look bounded and not
-    // be. `assetsCreated` comes from wrapping the cache's own `add`.
-    if ( bounded.released !== bounded.assetsCreated ) {
-      out.push( {
-        text: `FAIL  bounded released ${bounded.released} of ` +
-          `${bounded.assetsCreated} geometries the extractor created ` +
-          `(${bounded.payloads} of them delivered as payloads) — the heap still ` +
-          'holds what was built but never handed out, so this run is not bounded',
-        failed: true,
-      } )
-    }
 
     const same = bounded.placedDigest === copyout.placedDigest &&
       bounded.payloadDigest === copyout.payloadDigest
@@ -1192,6 +1196,17 @@ function main() {
 
   const modelsFile = flag( '--models' )
   const batchSize = Number( flag( '--batch', DEFAULT_BATCH ) )
+
+  // `pumpGeometryBatch_` clamps with `Math.max( batchSize, 1 )`, so `--batch 0`
+  // runs at 1 while every printed line and the JSON still say 0 — and the whole
+  // point of the batch sweep is that the label identifies the configuration
+  // that ran. A non-numeric value is worse: `NaN` never advances the demand
+  // cursor, so the child loops forever rather than failing.
+  if ( !Number.isInteger( batchSize ) || batchSize < 1 ) {
+    console.error(
+        `--batch must be a positive integer; got ${flag( '--batch' )}` )
+    process.exit( 2 )
+  }
   const repeats = Number( flag( '--repeats', 1 ) )
   const jsonOut = flag( '--json' )
   const only = flag( '--phases' )

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -87,7 +87,6 @@ class Digest {
 
   constructor() {
     this.placedHash = 0
-    this.payloadHash = 0
     this.instances = 0
     this.payloads = 0
     this.payloadBytes = 0
@@ -133,16 +132,38 @@ class Digest {
   }
 
   /**
-   * Hash one geometry payload (once per geometry, as it is emitted).
+   * Record one geometry payload. The bytes are NOT hashed here: hashing every
+   * float inside the copy loop would put the cost of the check inside the
+   * measurement the check exists to validate. The payloads are retained
+   * anyway (a consumer keeps them), so the exact digest is computed once at
+   * report time by {@link exactPayloadDigest}.
    *
-   * @param geometryExpressID The geometry's express ID.
    * @param vertices Interleaved position+normal floats.
    * @param indices Triangle indices.
    */
-  payload( geometryExpressID, vertices, indices ) {
-
+  payload( vertices, indices ) {
     ++this.payloads
     this.payloadBytes += vertices.byteLength + indices.byteLength
+  }
+}
+
+/**
+ * Hash EVERY delivered byte, commutatively across payloads.
+ *
+ * Sampling (this previously hashed one element in 97) cannot support a
+ * "same payloads" claim: a tessellation change touching only unsampled
+ * vertices, with the array lengths preserved, produces an identical digest.
+ * Run at report time, after the timers have stopped, so exactness costs the
+ * measurement nothing.
+ *
+ * @param payloads `{geometryExpressID, vertices, indices}` in emission order.
+ * @return {number} Order-independent digest.
+ */
+function exactPayloadDigest( payloads ) {
+
+  let total = 0
+
+  for ( const { geometryExpressID, vertices, indices } of payloads ) {
 
     let hash = 2166136261
 
@@ -150,20 +171,18 @@ class Digest {
     hash = mix32( hash, vertices.length )
     hash = mix32( hash, indices.length )
 
-    // Sample rather than hash every float: a full hash of PSB's ~2 GB of
-    // vertex data would dominate the measurement it is there to validate.
-    // Stride 97 (prime, > any vertex stride) so the sample can't alias to
-    // one component of the interleaved layout.
-    for ( let i = 0; i < vertices.length; i += 97 ) {
+    for ( let i = 0; i < vertices.length; ++i ) {
       hash = mix32( hash, quantise( vertices[ i ] ) )
     }
 
-    for ( let i = 0; i < indices.length; i += 97 ) {
+    for ( let i = 0; i < indices.length; ++i ) {
       hash = mix32( hash, indices[ i ] )
     }
 
-    this.payloadHash = ( this.payloadHash + hash ) >>> 0
+    total = ( total + hash ) >>> 0
   }
+
+  return total
 }
 
 /**
@@ -248,8 +267,8 @@ function copyBatchPayloads( api, modelID, meshes, seen, digest, retained ) {
       const indices = api.GetIndexArray(
           geometry.GetIndexData(), geometry.GetIndexDataSize() )
 
-      digest.payload( placed.geometryExpressID, vertices, indices )
-      retained.push( vertices, indices )
+      digest.payload( vertices, indices )
+      retained.push( { geometryExpressID: placed.geometryExpressID, vertices, indices } )
       copied.push( placed.geometryExpressID )
 
       // `GetGeometry` hands back `geometryObject.clone()` — an OWNING native
@@ -621,7 +640,7 @@ async function runChild( phase, filePath, batchSize, shard ) {
     payloadMB: digest.payloadBytes / BYTES_PER_MB,
     retainedPayloadBuffers: retainedPayloads.length,
     placedDigest: digest.placedHash,
-    payloadDigest: digest.payloadHash,
+    payloadDigest: exactPayloadDigest( retainedPayloads ),
   } ) )
 }
 
@@ -811,6 +830,46 @@ function verdicts( byPhase, phases, allowEmpty ) {
 
   const out = []
   const classic = byPhase.classic
+  const copyout = byPhase.copyout
+  const bounded = byPhase.bounded
+
+  // FIRST, and independent of `classic`: the comparison that isolates release.
+  // `copyout` and `bounded` run identical extraction and differ only in that
+  // `bounded` releases, so this is the check the release claim rests on — and
+  // `--phases copyout,bounded`, the most direct release-isolation run, has no
+  // `classic` row at all.
+  if ( copyout?.instances !== void 0 && bounded?.instances !== void 0 ) {
+
+    // A release that THREW on every geometry also produces bounded ≡ copyout,
+    // and would read as "release changed nothing" while nothing was released.
+    // `releaseGeometries` swallows per-geometry failures so one bad free can't
+    // end a run, so the count is the only evidence release actually happened.
+    if ( bounded.released !== bounded.payloads ) {
+      out.push( {
+        text: `FAIL  bounded released ${bounded.released} of ${bounded.payloads} ` +
+          'copied geometries — the release path is failing, so any agreement ' +
+          'with copyout is vacuous',
+        failed: true,
+      } )
+    }
+
+    const same = bounded.placedDigest === copyout.placedDigest &&
+      bounded.payloadDigest === copyout.payloadDigest
+
+    out.push( same ?
+      {
+        text: `OK    bounded identical to copyout — release changed nothing ` +
+          `(${bounded.instances} instances, ${bounded.released} released)`,
+        failed: false,
+      } :
+      {
+        text: 'FAIL  bounded differs from copyout: release alone changed delivery ' +
+          `(${bounded.instances} instances vs ${copyout.instances}, ` +
+          `placed ${bounded.placedDigest} vs ${copyout.placedDigest}, ` +
+          `payload ${bounded.payloadDigest} vs ${copyout.payloadDigest})`,
+        failed: true,
+      } )
+  }
 
   if ( classic?.instances === void 0 || !phases.includes( 'classic' ) ) {
     return out
@@ -869,39 +928,8 @@ function verdicts( byPhase, phases, allowEmpty ) {
       { text: `FAIL  ${line}`, failed: true } )
   }
 
-  // The comparison the release policy actually rests on. `bounded` and
-  // `copyout` run the SAME deferred extraction and differ only in that
-  // `bounded` releases; so if they agree, release changed nothing, and if they
-  // disagree, release alone changed delivery. Checking each against `classic`
-  // cannot see this: where the deferred path itself diverges (supercap.step,
-  // #532) both rows differ from classic and a release regression would hide
-  // inside a DIFF that is already expected.
-  const copyout = byPhase.copyout
-  const bounded = byPhase.bounded
-
-  if ( copyout?.instances !== void 0 && bounded?.instances !== void 0 ) {
-
-    const same = bounded.placedDigest === copyout.placedDigest &&
-      bounded.payloadDigest === copyout.payloadDigest
-
-    out.push( same ?
-      {
-        text: `OK    bounded identical to copyout — release changed nothing ` +
-          `(${bounded.instances} instances)`,
-        failed: false,
-      } :
-      {
-        text: 'FAIL  bounded differs from copyout: release alone changed delivery ' +
-          `(${bounded.instances} instances vs ${copyout.instances}, ` +
-          `placed ${bounded.placedDigest} vs ${copyout.placedDigest}, ` +
-          `payload ${bounded.payloadDigest} vs ${copyout.payloadDigest})`,
-        failed: true,
-      } )
-  }
-
   return out
 }
-
 
 /**
  * Sweep phases over models, or shard counts when `--shards` is given.

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -1,0 +1,477 @@
+/**
+ * M3 pump spike (issue #394): what does the durable demand pump cost, and
+ * does per-batch copy-out + native release actually bound the wasm heap?
+ *
+ * M3 as re-scoped (2026-08-16 triage on #390) is no longer "conway-geom
+ * needs a per-product free into the general heap" — eviction into mimalloc
+ * freelists measured ~0 RSS back. It is: **the durable pump must not leave
+ * the tab holding the whole model's geometry**. Today it extracts every
+ * product into `model.geometry` and keeps it there for the session, so the
+ * wasm heap's high-water mark is O(model) and permanent. The preview
+ * channels already copy each payload out of the wasm heap at emission; the
+ * durable pump does not.
+ *
+ * Phases (child process per phase — wasm heaps and JIT state never bleed
+ * across measurements):
+ *
+ *   classic  : OpenModel + StreamAllMeshes. Today's whole-model extraction,
+ *              the baseline every other row is measured against.
+ *   pump     : OpenModelStreamed + DEFER_GEOMETRY, drained through
+ *              ExtractGeometryBatch. Same work, batched — isolates what the
+ *              batching itself costs before any memory discipline.
+ *   copyout  : pump + copy each new geometry's vertex/index payload out of
+ *              the wasm heap per batch (what a consumer building its own
+ *              scene does). Isolates the copy from the release.
+ *   bounded  : copyout + release this batch's natives once copied. This is
+ *              the M3 discipline, in its most aggressive form (release
+ *              everything, retain nothing).
+ *
+ * Every phase copies out the same payloads (`classic`/`copyout`/`bounded`)
+ * or none (`pump`), and hashes them into a digest so the M3 exit criterion —
+ * *M3 changes when work happens, not what it produces* — is checked rather
+ * than assumed. `bounded` releasing everything is expected to LOSE instances
+ * whose geometry is shared with a later product (the scene walk skips a
+ * released geometry); the digest and instance counts are what size that
+ * loss, and therefore what sizes the retention/refcount rule the production
+ * pump needs (SharedAssetPool, per the design doc).
+ *
+ * The headline number is `wasmPeakMB`: the high-water mark of the wasm
+ * linear memory, read through `wasmHeapByteLength` (the module's cached
+ * HEAPU8 view can be a growth step behind the real heap — #485), sampled
+ * after every batch.
+ *
+ * Usage:
+ *   node scripts/m3_pump_spike.mjs --models <file with one path per line>
+ *                                  [--batch 64] [--repeats 1] [--json out]
+ *   node scripts/m3_pump_spike.mjs --child <phase> <path> <batch>  # internal
+ */
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as process from 'node:process'
+import { performance } from 'node:perf_hooks'
+
+const PHASES = [ 'classic', 'pump', 'copyout', 'bounded' ]
+
+const DEFAULT_BATCH = 64
+const BYTES_PER_MB = 1024 * 1024
+
+const REPO_ROOT = path.dirname( path.dirname( new URL( import.meta.url ).pathname ) )
+
+/** Node heap ceiling for the children — PSB-class models need the headroom. */
+const CHILD_MAX_OLD_SPACE_MB = 12288
+
+/**
+ * FNV-1a over the geometry a phase actually delivers. Fed the placement and
+ * the payload bytes, so a phase that drops an instance, reorders placement,
+ * or serves different vertices diverges — the "same output, different
+ * timing" invariant M3 is held to.
+ */
+class Digest {
+
+  constructor() {
+    this.hash = 2166136261
+    this.instances = 0
+    this.payloads = 0
+    this.payloadBytes = 0
+  }
+
+  /**
+   * Mix one 32-bit value in.
+   *
+   * @param value Any number; non-integers are mixed through their float bits.
+   */
+  mix( value ) {
+    this.hash = Math.imul( this.hash ^ ( value | 0 ), 16777619 ) >>> 0
+  }
+
+  /**
+   * Mix a float, quantised so f32/f64 round-trips through the two paths
+   * (native dmat4 vs copied floats) don't produce spurious divergence.
+   *
+   * @param value The float to mix.
+   */
+  mixFloat( value ) {
+    this.mix( Math.round( value * 1024 ) )
+  }
+
+  /**
+   * Mix one placed instance.
+   *
+   * @param expressID The product's express ID.
+   * @param geometryExpressID The geometry's express ID.
+   * @param transform The 16-element placement.
+   */
+  placed( expressID, geometryExpressID, transform ) {
+    ++this.instances
+    this.mix( expressID )
+    this.mix( geometryExpressID )
+
+    for ( const component of transform ) {
+      this.mixFloat( component )
+    }
+  }
+
+  /**
+   * Mix one geometry payload (mixed once per geometry, as it is emitted).
+   *
+   * @param vertices Interleaved position+normal floats.
+   * @param indices Triangle indices.
+   */
+  payload( vertices, indices ) {
+    ++this.payloads
+    this.payloadBytes += vertices.byteLength + indices.byteLength
+    this.mix( vertices.length )
+    this.mix( indices.length )
+
+    // Sample rather than hash every float: a full hash of PSB's ~2 GB of
+    // vertex data would dominate the measurement it is there to validate.
+    // Stride 97 (prime, > any vertex stride) so the sample can't alias to
+    // one component of the interleaved layout.
+    for ( let i = 0; i < vertices.length; i += 97 ) {
+      this.mixFloat( vertices[ i ] )
+    }
+
+    for ( let i = 0; i < indices.length; i += 97 ) {
+      this.mix( indices[ i ] )
+    }
+  }
+}
+
+/** Retained JS working set, after a collect so transient garbage isn't counted. */
+function retainedMB() {
+  globalThis.gc?.()
+  const usage = process.memoryUsage()
+  return ( usage.heapUsed + usage.arrayBuffers ) / BYTES_PER_MB
+}
+
+/**
+ * Copy every geometry a batch's meshes newly reference out of the wasm heap,
+ * exactly as a consumer building its own scene does, and record which
+ * geometries were touched so the caller can release them.
+ *
+ * @param api The IfcAPI instance.
+ * @param modelID The open model.
+ * @param meshes FlatMesh deltas from this batch.
+ * @param seen Geometry express IDs already copied (shared/mapped geometry is
+ * copied once, like the preview channel's emittedGeometry_).
+ * @param digest Digest to feed.
+ * @return {number[]} Geometry express IDs copied by this call.
+ */
+function copyBatchPayloads( api, modelID, meshes, seen, digest ) {
+
+  const copied = []
+
+  for ( const mesh of meshes ) {
+
+    const placedVector = mesh.geometries
+
+    for ( let i = 0; i < placedVector.size(); ++i ) {
+
+      const placed = placedVector.get( i )
+
+      digest.placed( mesh.expressID, placed.geometryExpressID, placed.flatTransformation )
+
+      if ( seen.has( placed.geometryExpressID ) ) {
+        continue
+      }
+
+      seen.add( placed.geometryExpressID )
+
+      const geometry = api.GetGeometry( modelID, placed.geometryExpressID )
+      const vertices = api.GetVertexArray(
+          geometry.GetVertexData(), geometry.GetVertexDataSize() ).slice()
+      const indices = api.GetIndexArray(
+          geometry.GetIndexData(), geometry.GetIndexDataSize() ).slice()
+
+      digest.payload( vertices, indices )
+      copied.push( placed.geometryExpressID )
+    }
+  }
+
+  return copied
+}
+
+/**
+ * The wasm heap's current byte length — the number M3's memory gate is
+ * written against.
+ *
+ * @param api The IfcAPI instance.
+ * @param wasmHeapByteLength The imported accessor.
+ * @return {number} Megabytes.
+ */
+function wasmMB( api, wasmHeapByteLength ) {
+  return api.wasmModule !== void 0 ?
+    wasmHeapByteLength( api.wasmModule ) / BYTES_PER_MB : 0
+}
+
+/**
+ * Release the natives behind a set of geometry express IDs, dropping them
+ * from the GetGeometry map too so a later lookup degrades to the dummy
+ * instead of touching freed memory.
+ *
+ * @param api The IfcAPI instance.
+ * @param modelID The open model.
+ * @param geometryExpressIDs Geometry express IDs to free.
+ * @return {number} How many were actually freed.
+ */
+function releaseGeometries( api, modelID, geometryExpressIDs ) {
+
+  const passthrough = api.getPassthrough( modelID )
+  const model = passthrough?.model?.[ 0 ]
+  const geometryMap = passthrough?.model?.[ 3 ]
+
+  if ( model === void 0 ) {
+    return 0
+  }
+
+  let freed = 0
+
+  for ( const expressID of geometryExpressIDs ) {
+
+    const localID = model.getElementByExpressID?.( expressID )?.localID
+
+    if ( localID === void 0 ) {
+      continue
+    }
+
+    try {
+      model.geometry.delete( localID )
+      geometryMap?.delete( expressID )
+      ++freed
+    } catch {
+      // Never let a free break the measurement — a phase that cannot free
+      // is a finding, not a crash.
+    }
+  }
+
+  return freed
+}
+
+/**
+ * Run one phase against one model in this (child) process.
+ *
+ * @param phase One of PHASES.
+ * @param filePath The model.
+ * @param batchSize Products per pump call.
+ */
+async function runChild( phase, filePath, batchSize ) {
+
+  const { IfcAPI, LogLevel } =
+    await import( '../compiled/src/compat/web-ifc/ifc_api.js' )
+  const { wasmHeapByteLength } =
+    await import( '../compiled/src/core/wasm_heap.js' )
+
+  const api = new IfcAPI()
+
+  await api.Init()
+  api.SetLogLevel( LogLevel.LOG_LEVEL_ERROR )
+
+  const digest = new Digest()
+  const seen = new Set()
+  const deferred = phase !== 'classic'
+  const copies = phase === 'copyout' || phase === 'bounded'
+
+  const settings = {
+    COORDINATE_TO_ORIGIN: true,
+    USE_FAST_BOOLS: true,
+  }
+
+  if ( deferred ) {
+    settings.DEFER_GEOMETRY = true
+  }
+
+  const bytes = new Uint8Array( fs.readFileSync( filePath ) )
+
+  const tOpen = performance.now()
+  const modelID = deferred ?
+    await api.OpenModelStreamed( bytes, settings ) :
+    api.OpenModel( bytes, settings )
+  const openMs = performance.now() - tOpen
+
+  if ( modelID < 0 ) {
+    console.log( JSON.stringify( { phase, failed: 'open' } ) )
+    return
+  }
+
+  let wasmPeakMB = wasmMB( api, wasmHeapByteLength )
+  const wasmAfterOpenMB = wasmPeakMB
+  let batches = 0
+  let released = 0
+  let copyMs = 0
+
+  const tGeometry = performance.now()
+
+  if ( !deferred ) {
+
+    // Classic: one whole-model walk. Payloads are copied inside the callback
+    // so the copy cost lands in the same place it does on the pump paths.
+    const meshes = []
+
+    api.StreamAllMeshes( modelID, ( mesh ) => {
+      meshes.push( mesh )
+    } )
+
+    const tCopy = performance.now()
+
+    copyBatchPayloads( api, modelID, meshes, seen, digest )
+    copyMs += performance.now() - tCopy
+
+    wasmPeakMB = Math.max( wasmPeakMB, wasmMB( api, wasmHeapByteLength ) )
+
+  } else {
+
+    for ( ;; ) {
+
+      const batchMeshes = []
+      const { extracted, remaining } =
+        api.ExtractGeometryBatch( modelID, batchSize, ( mesh ) => {
+          batchMeshes.push( mesh )
+        } )
+
+      ++batches
+
+      if ( copies ) {
+
+        const tCopy = performance.now()
+        const copied = copyBatchPayloads( api, modelID, batchMeshes, seen, digest )
+
+        copyMs += performance.now() - tCopy
+
+        if ( phase === 'bounded' ) {
+          released += releaseGeometries( api, modelID, copied )
+        }
+      }
+
+      wasmPeakMB = Math.max( wasmPeakMB, wasmMB( api, wasmHeapByteLength ) )
+
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+  }
+
+  const geometryMs = performance.now() - tGeometry
+
+  console.log( JSON.stringify( {
+    phase,
+    openMs,
+    geometryMs,
+    copyMs,
+    totalMs: openMs + geometryMs,
+    batches,
+    released,
+    wasmAfterOpenMB,
+    wasmPeakMB,
+    wasmEndMB: wasmMB( api, wasmHeapByteLength ),
+    retainedMB: retainedMB(),
+    rssMB: process.memoryUsage().rss / BYTES_PER_MB,
+    instances: digest.instances,
+    payloads: digest.payloads,
+    payloadMB: digest.payloadBytes / BYTES_PER_MB,
+    digest: digest.hash >>> 0,
+  } ) )
+}
+
+/**
+ * Spawn one phase in its own process.
+ *
+ * @param phase One of PHASES.
+ * @param filePath The model.
+ * @param batchSize Products per pump call.
+ * @return {object} The child's JSON result.
+ */
+function spawnChild( phase, filePath, batchSize ) {
+
+  const out = execFileSync( process.execPath, [
+    '--expose-gc', `--max-old-space-size=${CHILD_MAX_OLD_SPACE_MB}`,
+    process.argv[ 1 ], '--child', phase, filePath, String( batchSize ),
+  ], { encoding: 'utf8', maxBuffer: 1 << 26, cwd: REPO_ROOT } )
+
+  return JSON.parse( out.trim().split( '\n' ).at( -1 ) )
+}
+
+/**
+ * Sweep phases over models.
+ */
+function main() {
+
+  const argv = process.argv.slice( 2 )
+
+  if ( argv[ 0 ] === '--child' ) {
+    return runChild( argv[ 1 ], argv[ 2 ], Number( argv[ 3 ] ) )
+  }
+
+  const flag = ( name, fallback ) => {
+    const index = argv.indexOf( name )
+    return index >= 0 ? argv[ index + 1 ] : fallback
+  }
+
+  const modelsFile = flag( '--models' )
+  const batchSize = Number( flag( '--batch', DEFAULT_BATCH ) )
+  const repeats = Number( flag( '--repeats', 1 ) )
+  const jsonOut = flag( '--json' )
+  const only = flag( '--phases' )
+  const phases = only !== void 0 ? only.split( ',' ) : PHASES
+
+  if ( modelsFile === void 0 ) {
+    console.error(
+        'usage: m3_pump_spike.mjs --models <file with one path per line> ' +
+        '[--batch N] [--repeats N] [--phases a,b] [--json out]' )
+    process.exit( 2 )
+  }
+
+  const models = fs.readFileSync( modelsFile, 'utf8' )
+      .split( '\n' )
+      .map( ( line ) => line.trim() )
+      .filter( ( line ) => line.length > 0 && !line.startsWith( '#' ) )
+
+  const rows = []
+
+  for ( const model of models ) {
+
+    const name = path.basename( model )
+    const byPhase = {}
+
+    for ( const phase of phases ) {
+
+      const runs = []
+
+      for ( let repeat = 0; repeat < repeats; ++repeat ) {
+        runs.push( spawnChild( phase, model, batchSize ) )
+      }
+
+      // Min of N: wall-clock noise is one-sided, so the minimum is the
+      // least-contaminated estimate. Memory is taken from the same run so
+      // the row describes one coherent execution.
+      byPhase[ phase ] =
+        runs.reduce( ( a, b ) => ( ( a.totalMs ?? Infinity ) <= ( b.totalMs ?? Infinity ) ? a : b ) )
+    }
+
+    const base = byPhase[ phases[ 0 ] ]
+
+    rows.push( { name, model, batchSize, byPhase } )
+
+    const cell = ( phase ) => {
+      const row = byPhase[ phase ]
+
+      if ( row?.totalMs === void 0 ) {
+        return `${phase}=failed`
+      }
+
+      const pct = base?.totalMs !== void 0 ?
+        ` (${( ( row.totalMs / base.totalMs - 1 ) * 100 ).toFixed( 1 )}%)` : ''
+
+      return `${phase}=${row.totalMs.toFixed( 0 )}ms${pct} ` +
+        `wasm=${row.wasmPeakMB.toFixed( 0 )}MB inst=${row.instances} digest=${row.digest}`
+    }
+
+    console.log( `${name}\n  ${phases.map( cell ).join( '\n  ' )}` )
+  }
+
+  if ( jsonOut !== void 0 ) {
+    fs.writeFileSync( jsonOut, `${JSON.stringify( rows, null, 2 )}\n` )
+  }
+}
+
+await main()

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -62,80 +62,105 @@ const REPO_ROOT = path.dirname( path.dirname( new URL( import.meta.url ).pathnam
 const CHILD_MAX_OLD_SPACE_MB = 12288
 
 /**
- * FNV-1a over the geometry a phase actually delivers. Fed the placement and
- * the payload bytes, so a phase that drops an instance, reorders placement,
- * or serves different vertices diverges — the "same output, different
- * timing" invariant M3 is held to.
+ * A digest of the geometry a phase delivers: each instance and each payload
+ * is hashed on its own, and the per-item hashes are combined **commutatively**
+ * (summed mod 2^32). Order-independent by construction, because emission
+ * order is exactly what M3 is allowed to change — the classic walk emits in
+ * scene order, the pump in batch order, and the delta contract already tells
+ * consumers to accumulate additively. An order-sensitive rolling hash reports
+ * that reordering as a content change (it did, on `Right_Hand.step`, where a
+ * sorted dump of both paths is byte-identical).
+ *
+ * What still diverges: a dropped, duplicated, differently-placed or
+ * differently-tessellated instance — which is the invariant worth holding.
  */
 class Digest {
 
   constructor() {
-    this.hash = 2166136261
+    this.placedHash = 0
+    this.payloadHash = 0
     this.instances = 0
     this.payloads = 0
     this.payloadBytes = 0
   }
 
   /**
-   * Mix one 32-bit value in.
-   *
-   * @param value Any number; non-integers are mixed through their float bits.
-   */
-  mix( value ) {
-    this.hash = Math.imul( this.hash ^ ( value | 0 ), 16777619 ) >>> 0
-  }
-
-  /**
-   * Mix a float, quantised so f32/f64 round-trips through the two paths
-   * (native dmat4 vs copied floats) don't produce spurious divergence.
-   *
-   * @param value The float to mix.
-   */
-  mixFloat( value ) {
-    this.mix( Math.round( value * 1024 ) )
-  }
-
-  /**
-   * Mix one placed instance.
+   * Hash one placed instance into the order-independent accumulator.
    *
    * @param expressID The product's express ID.
    * @param geometryExpressID The geometry's express ID.
    * @param transform The 16-element placement.
    */
   placed( expressID, geometryExpressID, transform ) {
+
     ++this.instances
-    this.mix( expressID )
-    this.mix( geometryExpressID )
+
+    let hash = 2166136261
+
+    hash = mix32( hash, expressID )
+    hash = mix32( hash, geometryExpressID )
 
     for ( const component of transform ) {
-      this.mixFloat( component )
+      hash = mix32( hash, quantise( component ) )
     }
+
+    this.placedHash = ( this.placedHash + hash ) >>> 0
   }
 
   /**
-   * Mix one geometry payload (mixed once per geometry, as it is emitted).
+   * Hash one geometry payload (once per geometry, as it is emitted).
    *
+   * @param geometryExpressID The geometry's express ID.
    * @param vertices Interleaved position+normal floats.
    * @param indices Triangle indices.
    */
-  payload( vertices, indices ) {
+  payload( geometryExpressID, vertices, indices ) {
+
     ++this.payloads
     this.payloadBytes += vertices.byteLength + indices.byteLength
-    this.mix( vertices.length )
-    this.mix( indices.length )
+
+    let hash = 2166136261
+
+    hash = mix32( hash, geometryExpressID )
+    hash = mix32( hash, vertices.length )
+    hash = mix32( hash, indices.length )
 
     // Sample rather than hash every float: a full hash of PSB's ~2 GB of
     // vertex data would dominate the measurement it is there to validate.
     // Stride 97 (prime, > any vertex stride) so the sample can't alias to
     // one component of the interleaved layout.
     for ( let i = 0; i < vertices.length; i += 97 ) {
-      this.mixFloat( vertices[ i ] )
+      hash = mix32( hash, quantise( vertices[ i ] ) )
     }
 
     for ( let i = 0; i < indices.length; i += 97 ) {
-      this.mix( indices[ i ] )
+      hash = mix32( hash, indices[ i ] )
     }
+
+    this.payloadHash = ( this.payloadHash + hash ) >>> 0
   }
+}
+
+/**
+ * One FNV-1a step.
+ *
+ * @param hash The running hash.
+ * @param value A 32-bit value.
+ * @return {number} The updated hash.
+ */
+function mix32( hash, value ) {
+  return Math.imul( hash ^ ( value | 0 ), 16777619 ) >>> 0
+}
+
+/**
+ * Quantise a float so an f32/f64 round-trip (native dmat4 vs copied floats)
+ * doesn't read as divergence.
+ *
+ * @param value The float.
+ * @return {number} An integer.
+ */
+function quantise( value ) {
+  return Math.round( value * 1024 )
 }
 
 /** Retained JS working set, after a collect so transient garbage isn't counted. */
@@ -184,7 +209,7 @@ function copyBatchPayloads( api, modelID, meshes, seen, digest ) {
       const indices = api.GetIndexArray(
           geometry.GetIndexData(), geometry.GetIndexDataSize() ).slice()
 
-      digest.payload( vertices, indices )
+      digest.payload( placed.geometryExpressID, vertices, indices )
       copied.push( placed.geometryExpressID )
     }
   }
@@ -369,7 +394,8 @@ async function runChild( phase, filePath, batchSize ) {
     instances: digest.instances,
     payloads: digest.payloads,
     payloadMB: digest.payloadBytes / BYTES_PER_MB,
-    digest: digest.hash >>> 0,
+    placedDigest: digest.placedHash,
+    payloadDigest: digest.payloadHash,
   } ) )
 }
 
@@ -463,7 +489,8 @@ function main() {
         ` (${( ( row.totalMs / base.totalMs - 1 ) * 100 ).toFixed( 1 )}%)` : ''
 
       return `${phase}=${row.totalMs.toFixed( 0 )}ms${pct} ` +
-        `wasm=${row.wasmPeakMB.toFixed( 0 )}MB inst=${row.instances} digest=${row.digest}`
+        `wasm=${row.wasmPeakMB.toFixed( 0 )}MB inst=${row.instances} ` +
+        `placed=${row.placedDigest} payload=${row.payloadDigest}`
     }
 
     console.log( `${name}\n  ${phases.map( cell ).join( '\n  ' )}` )

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -375,7 +375,7 @@ function wasmMB( api, wasmHeapByteLength ) {
  * @param geometryExpressIDs Geometry express IDs to free.
  * @return {number} How many were actually freed.
  */
-function releaseGeometries( api, modelID, geometryExpressIDs ) {
+function releaseGeometries( api, modelID, localIDs, geometryExpressIDs ) {
 
   const passthrough = api.getPassthrough( modelID )
   const model = passthrough?.model?.[ 0 ]
@@ -387,22 +387,29 @@ function releaseGeometries( api, modelID, geometryExpressIDs ) {
 
   let freed = 0
 
-  for ( const expressID of geometryExpressIDs ) {
-
-    const localID = model.getElementByExpressID?.( expressID )?.localID
-
-    if ( localID === void 0 ) {
-      continue
-    }
+  // Release by LOCAL ID, taken from the cache's own `add` calls, rather than by
+  // the express IDs of the payloads this batch copied. The two sets are not the
+  // same: the extractor creates natives that are never delivered as a payload —
+  // void and opening geometry consumed by a boolean, for instance. On
+  // `aggregate_master_voids.ifc` that is 2 assets created against 1 payload, and
+  // a release keyed on payloads leaves the other resident for the life of the
+  // model while reporting that everything it copied was freed. Keying on
+  // creations is what makes `bounded` actually bound the heap.
+  for ( const localID of localIDs ) {
 
     try {
       model.geometry.delete( localID )
-      geometryMap?.delete( expressID )
       ++freed
     } catch {
       // Never let a free break the measurement — a phase that cannot free
       // is a finding, not a crash.
     }
+  }
+
+  // Drop the compat GetGeometry entries too, so a later lookup degrades to the
+  // dummy instead of handing back a handle to freed memory.
+  for ( const expressID of geometryExpressIDs ) {
+    geometryMap?.delete( expressID )
   }
 
   return freed
@@ -619,6 +626,23 @@ async function runChild( phase, filePath, batchSize, shard ) {
   // measured at the cache, not inferred from a captured graph.
   let assetsCreated = 0
 
+  // Adds that land on a local ID the cache ALREADY holds. `IfcModelGeometry.add`
+  // is a bare `meshes_.set( localID, mesh )` (ifc_model_geometry.ts:75), so a
+  // replacement drops the previous `CanonicalMesh` from the map without calling
+  // `.delete()` on its native. That native is then unreachable — not by
+  // `releaseGeometries`, not by anything — so it leaks for the life of the
+  // model, in production as well as here. The rel-aggregates pass does exactly
+  // this (`aggregate_master_voids.ifc`: 2 created, 1 payload).
+  //
+  // Counted rather than worked around: a `bounded` run on a model with
+  // replacements cannot bound the heap, and the harness must say so instead of
+  // reporting the release of the survivors as success.
+  let assetsReplaced = 0
+
+  // Local IDs the cache created since the last release. `bounded` frees these
+  // rather than the copied payload IDs — see releaseGeometries.
+  const createdThisBatch = new Set()
+
   if ( deferred ) {
 
     const geometry = api.getPassthrough( modelID )?.model?.[ 0 ]?.geometry
@@ -626,9 +650,18 @@ async function runChild( phase, filePath, batchSize, shard ) {
     if ( geometry !== void 0 ) {
 
       const originalAdd = geometry.add.bind( geometry )
+      const originalGet = geometry.getByLocalID.bind( geometry )
 
       geometry.add = ( mesh ) => {
+
         ++assetsCreated
+
+        if ( originalGet( mesh.localID ) !== void 0 ) {
+          ++assetsReplaced
+        }
+
+        createdThisBatch.add( mesh.localID )
+
         return originalAdd( mesh )
       }
     }
@@ -682,7 +715,8 @@ async function runChild( phase, filePath, batchSize, shard ) {
         copyMs += performance.now() - tCopy
 
         if ( phase === 'bounded' ) {
-          released += releaseGeometries( api, modelID, copied )
+          released += releaseGeometries( api, modelID, createdThisBatch, copied )
+          createdThisBatch.clear()
         }
       }
 
@@ -708,6 +742,7 @@ async function runChild( phase, filePath, batchSize, shard ) {
     batches,
     released,
     assetsCreated,
+    assetsReplaced,
     shard,
     sharded,
     wasmAfterOpenMB,
@@ -822,7 +857,9 @@ function spawnShards( phase, filePath, batchSize, count, shardMode ) {
  * separating before drawing conclusions: real serialisation, and duplicated
  * shared work (visible as a rising payload count).
  *
- * @param models Model paths.
+ * @param models Model entries `{path, allowEmpty}` from the models file — the
+ * `#empty` declaration has to reach here too, since this path never runs
+ * `verdicts()` and would otherwise accept a sweep that extracted nothing.
  * @param phase The phase to run.
  * @param batchSize Products per pump call.
  * @param counts Shard counts to sweep.
@@ -833,7 +870,7 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
 
   const rows = []
 
-  for ( const model of models ) {
+  for ( const { path: model, allowEmpty } of models ) {
 
     const name = path.basename( model )
     const byCount = {}
@@ -874,6 +911,19 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
         payloads: total( 'payloads' ),
         wasmPeakMBSum: results.reduce( ( sum, r ) => sum + r.wasmPeakMB, 0 ),
         wasmPeakMBMax: Math.max( ...results.map( ( r ) => r.wasmPeakMB ) ),
+      }
+
+      // Completing is not the same as doing something. A sharded run on a
+      // geometry-producing model that creates no assets means the extraction
+      // never fired, and every ratio below it is a ratio of nothing — the same
+      // hole the unsharded `pump` verdict closes, which this path never reaches.
+      // Checked on the N=1 baseline, because an individual shard at N>1 can
+      // legitimately own no products.
+      if ( count === 1 && byCount[ count ].assetsCreated === 0 && !allowEmpty ) {
+        throw new Error(
+            `${name}: the N=1 baseline created 0 geometry assets on a model not ` +
+            'declared geometry-free — the extraction never fired, so there is ' +
+            'nothing to scale' )
       }
 
       const base = byCount[ counts[ 0 ] ]
@@ -1022,11 +1072,17 @@ function verdicts( byPhase, phases, allowEmpty ) {
     // and would read as "release changed nothing" while nothing was released.
     // `releaseGeometries` swallows per-geometry failures so one bad free can't
     // end a run, so the count is the only evidence release actually happened.
-    if ( bounded.released !== bounded.payloads ) {
+    // Against CREATIONS, not copied payloads. The extractor makes natives that
+    // are never delivered (void/opening geometry consumed by a boolean), so
+    // `released === payloads` can hold while the heap still carries everything
+    // that was built but not handed out — the phase would look bounded and not
+    // be. `assetsCreated` comes from wrapping the cache's own `add`.
+    if ( bounded.released !== bounded.assetsCreated ) {
       out.push( {
-        text: `FAIL  bounded released ${bounded.released} of ${bounded.payloads} ` +
-          'copied geometries — the release path is failing, so any agreement ' +
-          'with copyout is vacuous',
+        text: `FAIL  bounded released ${bounded.released} of ` +
+          `${bounded.assetsCreated} geometries the extractor created ` +
+          `(${bounded.payloads} of them delivered as payloads) — the heap still ` +
+          'holds what was built but never handed out, so this run is not bounded',
         failed: true,
       } )
     }
@@ -1186,13 +1242,27 @@ function main() {
     // worse. Normalise instead of trusting the caller: dedupe, sort ascending,
     // and run a one-shard baseline whether or not it was asked for.
     const requested = shards.split( ',' ).map( Number )
+    // Validate BEFORE normalisation: `--shards 0` sorts ahead of the injected
+    // N=1 baseline, so `spawnShards` launches no children, the empty result
+    // list slips past the broken-child check, and the sweep prints
+    // `geometry=-Infinitys` and `NaNx` ratios against a zero-shard row while
+    // exiting 0.
+    const invalid = requested.filter(
+        ( count ) => !Number.isInteger( count ) || count < 1 )
+
+    if ( invalid.length > 0 ) {
+      console.error(
+          `--shards must be positive integers; got ${invalid.join( ', ' )}` )
+      process.exit( 2 )
+    }
+
     const counts = [ ...new Set( [ 1, ...requested ] ) ].sort( ( a, b ) => a - b )
 
     if ( counts.length !== requested.length ) {
       console.log( `note: added an N=1 baseline (sweeping ${counts.join( ',' )})` )
     }
 
-    return runShardSweep( models.map( ( entry ) => entry.path ), shardPhase,
+    return runShardSweep( models, shardPhase,
         batchSize, counts, jsonOut, shardMode( flag( '--shard-mode', 'roundrobin' ) ) )
   }
 

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -391,58 +391,68 @@ function wasmMB( api, wasmHeapByteLength ) {
  * @param geometryExpressIDs Geometry express IDs to free.
  * @return {number} How many were actually freed.
  */
-function releaseGeometries( api, modelID, localIDs, geometryExpressIDs ) {
+function releaseGeometries( api, modelID, created, geometryExpressIDs ) {
 
   const passthrough = api.getPassthrough( modelID )
   const model = passthrough?.model?.[ 0 ]
   const geometryMap = passthrough?.model?.[ 3 ]
 
   if ( model === void 0 ) {
-    return 0
+    return { freed: 0, alreadyGone: 0 }
   }
 
   let freed = 0
 
   // Created natives the ENGINE already reclaimed before we got here.
-  // `IfcGeometryExtraction` calls `model.geometry.deleteTemporaries()`
-  // (ifc_geometry_extraction.ts:7690), which drops temporary meshes AND
+  // `IfcGeometryExtraction` calls `deleteTemporaries()` on both stores
+  // (ifc_geometry_extraction.ts:7690-7691), which drops temporary meshes AND
   // deletes their natives, so a localID counted at `add` can legitimately be
   // gone by release time. Tracked separately rather than ignored: what must
   // hold is that nothing created is still resident, and "we freed it" and
   // "the engine freed it" are both ways of satisfying that.
   let alreadyGone = 0
 
-  // Release by LOCAL ID, taken from the cache's own `add` calls, rather than by
-  // the express IDs of the payloads this batch copied. The two sets are not the
-  // same: the extractor creates natives that are never delivered as a payload —
-  // void and opening geometry consumed by a boolean, for instance. On
-  // `aggregate_master_voids.ifc` that is 2 assets created against 1 payload, and
-  // a release keyed on payloads leaves the other resident for the life of the
-  // model while reporting that everything it copied was freed. Keying on
-  // creations is what makes `bounded` actually bound the heap.
-  for ( const localID of localIDs ) {
+  // BOTH geometry stores. `IfcStepModel` carries `geometry` and a separate
+  // `voidGeometry` (ifc_step_model.ts:27), and extraction adds to both —
+  // opening and boolean-operand meshes land in `voidGeometry`
+  // (ifc_geometry_extraction.ts:995, 1112, 1595). Releasing only `geometry`
+  // left those resident for the life of the model while the counters, which
+  // also only watched `geometry`, reported everything freed. Local IDs are
+  // per-store, so the two sets are kept and released separately.
+  const stores = [
+    [ model.geometry, created.geometry ],
+    [ model.voidGeometry, created.voidGeometry ],
+  ]
 
-    try {
+  for ( const [ store, localIDs ] of stores ) {
 
-      // `IfcModelGeometry.delete` returns void and silently returns when the
-      // local ID is absent, so "the call did not throw" is not evidence that
-      // anything was freed — and `released === assetsCreated` was resting on
-      // exactly that. Require the observable transition instead: present
-      // before, absent after. A no-op now fails to increment, which is what
-      // makes the release counters mean what the verdicts claim they mean.
-      if ( model.geometry.getByLocalID( localID ) === void 0 ) {
-        ++alreadyGone
-        continue
+    if ( store === void 0 ) {
+      continue
+    }
+
+    for ( const localID of localIDs ) {
+
+      try {
+
+        // `IfcModelGeometry.delete` returns void and silently returns when the
+        // local ID is absent, so "the call did not throw" is not evidence that
+        // anything was freed — and `released === assetsCreated` was resting on
+        // exactly that. Require the observable transition instead: present
+        // before, absent after.
+        if ( store.getByLocalID( localID ) === void 0 ) {
+          ++alreadyGone
+          continue
+        }
+
+        store.delete( localID )
+
+        if ( store.getByLocalID( localID ) === void 0 ) {
+          ++freed
+        }
+      } catch {
+        // Never let a free break the measurement — a phase that cannot free
+        // is a finding, not a crash.
       }
-
-      model.geometry.delete( localID )
-
-      if ( model.geometry.getByLocalID( localID ) === void 0 ) {
-        ++freed
-      }
-    } catch {
-      // Never let a free break the measurement — a phase that cannot free
-      // is a finding, not a crash.
     }
   }
 
@@ -692,20 +702,31 @@ async function runChild( phase, filePath, batchSize, shard ) {
   // overwrite is visible rather than silently unbounded.
   let assetsReplaced = 0
 
-  // Local IDs the cache created since the last release. `bounded` frees these
-  // rather than the copied payload IDs — see releaseGeometries.
-  const createdThisBatch = new Set()
+  // Local IDs each store created since the last release. `bounded` frees these
+  // rather than the copied payload IDs — see releaseGeometries. Kept per store
+  // because local IDs are store-relative.
+  const createdThisBatch = { geometry: new Set(), voidGeometry: new Set() }
 
   if ( deferred ) {
 
-    const geometry = api.getPassthrough( modelID )?.model?.[ 0 ]?.geometry
+    const ifcModel = api.getPassthrough( modelID )?.model?.[ 0 ]
 
-    if ( geometry !== void 0 ) {
+    // Both stores: extraction adds opening and boolean-operand meshes to
+    // `voidGeometry`, and watching only `geometry` meant those natives were
+    // neither counted nor released while the counters reported everything
+    // freed.
+    for ( const store of [ 'geometry', 'voidGeometry' ] ) {
 
-      const originalAdd = geometry.add.bind( geometry )
-      const originalGet = geometry.getByLocalID.bind( geometry )
+      const cache = ifcModel?.[ store ]
 
-      geometry.add = ( mesh ) => {
+      if ( cache === void 0 ) {
+        continue
+      }
+
+      const originalAdd = cache.add.bind( cache )
+      const originalGet = cache.getByLocalID.bind( cache )
+
+      cache.add = ( mesh ) => {
 
         ++assetsCreated
 
@@ -713,7 +734,7 @@ async function runChild( phase, filePath, batchSize, shard ) {
           ++assetsReplaced
         }
 
-        createdThisBatch.add( mesh.localID )
+        createdThisBatch[ store ].add( mesh.localID )
 
         return originalAdd( mesh )
       }
@@ -779,7 +800,8 @@ async function runChild( phase, filePath, batchSize, shard ) {
 
           released += release.freed
           selfFreed += release.alreadyGone
-          createdThisBatch.clear()
+          createdThisBatch.geometry.clear()
+          createdThisBatch.voidGeometry.clear()
         }
       }
 

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -220,11 +220,17 @@ function copyBatchPayloads( api, modelID, meshes, seen, digest, retained ) {
 
       seen.add( placed.geometryExpressID )
 
+      // No .slice() here: `GetVertexArray`/`GetIndexArray` already return
+      // owning copies (`getSubArray` ends with `slice(0)`), so copying again
+      // would double every payload and leave the first generation as garbage —
+      // inflating copy time and GC pressure in exactly the measurement those
+      // columns exist to report. Retain what the API returns, which is what a
+      // consumer does.
       const geometry = api.GetGeometry( modelID, placed.geometryExpressID )
       const vertices = api.GetVertexArray(
-          geometry.GetVertexData(), geometry.GetVertexDataSize() ).slice()
+          geometry.GetVertexData(), geometry.GetVertexDataSize() )
       const indices = api.GetIndexArray(
-          geometry.GetIndexData(), geometry.GetIndexDataSize() ).slice()
+          geometry.GetIndexData(), geometry.GetIndexDataSize() )
 
       digest.payload( placed.geometryExpressID, vertices, indices )
       retained.push( vertices, indices )
@@ -327,6 +333,29 @@ function shardWorklists( api, modelID, shard ) {
 
   const products = passthrough.demandProducts_ ?? []
   const aggregates = passthrough.demandAggregates_ ?? []
+
+  // An explicit assignment (from m3_affinity_spike's --emit) overrides the
+  // positional rules: this is how a SIMULATED partition gets checked against
+  // the real extractor instead of being believed. Aggregates stay positional
+  // because the captured graph does not cover the rel-aggregates pass — which
+  // is itself one of the open questions about where the duplication lives.
+  if ( process.env.M3_ASSIGNMENT !== void 0 ) {
+
+    const assignment =
+      JSON.parse( fs.readFileSync( process.env.M3_ASSIGNMENT, 'utf8' ) )
+    const mineSet = new Set( assignment.shards[ shard.index ] )
+
+    passthrough.demandProducts_ = products.filter( ( id ) => mineSet.has( id ) )
+    passthrough.demandAggregates_ =
+      aggregates.filter( ( _, index ) => index % shard.count === shard.index )
+
+    return {
+      products: passthrough.demandProducts_.length,
+      ofProducts: products.length,
+      aggregates: passthrough.demandAggregates_.length,
+      strategy: assignment.strategy,
+    }
+  }
 
   // Round-robin spreads cost evenly but scatters shared geometry across every
   // shard, so each one re-extracts it. Contiguous keeps file-order locality —
@@ -733,8 +762,20 @@ function main() {
       process.exit( 2 )
     }
 
-    return runShardSweep( models, shardPhase, batchSize,
-        shards.split( ',' ).map( Number ), jsonOut, flag( '--shard-mode', 'roundrobin' ) )
+    // Every speedup in the sweep is a ratio against the FIRST count, and the
+    // function promises that is one shard. A list like `2,3,4` would silently
+    // make N=2 the baseline and print ratios against it; `4,1,2` would be
+    // worse. Normalise instead of trusting the caller: dedupe, sort ascending,
+    // and run a one-shard baseline whether or not it was asked for.
+    const requested = shards.split( ',' ).map( Number )
+    const counts = [ ...new Set( [ 1, ...requested ] ) ].sort( ( a, b ) => a - b )
+
+    if ( counts.length !== requested.length ) {
+      console.log( `note: added an N=1 baseline (sweeping ${counts.join( ',' )})` )
+    }
+
+    return runShardSweep( models, shardPhase, batchSize, counts, jsonOut,
+        flag( '--shard-mode', 'roundrobin' ) )
   }
 
   for ( const model of models ) {

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -450,8 +450,19 @@ function shardWorklists( api, modelID, shard, filePath ) {
 
   const passthrough = api.getPassthrough( modelID )
 
+  // No demand worklists means nothing to partition — AP214/STEP passthroughs
+  // don't carry the seam. Returning silently left the filter unapplied, so
+  // every "shard" extracted the WHOLE model while the sweep labelled them
+  // shards and computed a speedup from them: `ap214-multibody-part.step`
+  // reported 7 instances at N=1 and 14 at N=2, which is two full extractions,
+  // not a partition. Refuse — a shard sweep of a format whose demand units
+  // aren't shardable is not a measurement.
   if ( passthrough?.ensureDemandWorklists_ === void 0 ) {
-    return void 0
+    throw new Error(
+        `${filePath}: this model's passthrough has no demand worklists ` +
+        '(AP214/STEP), so the shard filter cannot apply and every child would ' +
+        'extract the whole model — shard sweeps need an IFC model until ' +
+        'AP214 demand units are shardable' )
   }
 
   passthrough.ensureDemandWorklists_()
@@ -970,8 +981,20 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
       const base = byCount[ counts[ 0 ] ]
       const speedup = base.slowestGeometryMs / slowestGeometryMs
 
+      // Label by what RAN, not by what was requested. With `M3_ASSIGNMENT`
+      // set, `shardWorklists` ignores the positional mode entirely and applies
+      // the emitted partition, so printing the CLI mode attributed an affinity
+      // or claim measurement to `roundrobin`. The children report the strategy
+      // they actually used; take it from them.
+      const strategies = [ ...new Set(
+          results.map( ( r ) => r.sharded?.strategy ).filter(
+              ( strategy ) => strategy !== void 0 ) ) ]
+
+      byCount[ count ].strategy = strategies.length > 0 ?
+        strategies.join( '+' ) : shardMode
+
       console.log(
-          `${name} ${shardMode} shards=${count} geometry=${( slowestGeometryMs / 1000 ).toFixed( 1 )}s ` +
+          `${name} ${byCount[ count ].strategy} shards=${count} geometry=${( slowestGeometryMs / 1000 ).toFixed( 1 )}s ` +
           `(${speedup.toFixed( 2 )}x) per-shard=${byCount[ count ].geometryMsPerShard.join( '/' )} ` +
           `cpu=${( byCount[ count ].cpuMsTotal / 1000 ).toFixed( 1 )}s ` +
           `inst=${byCount[ count ].instances} assets=${byCount[ count ].assetsCreated} ` +

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -171,8 +171,17 @@ function exactPayloadDigest( payloads ) {
     hash = mix32( hash, vertices.length )
     hash = mix32( hash, indices.length )
 
-    for ( let i = 0; i < vertices.length; ++i ) {
-      hash = mix32( hash, quantise( vertices[ i ] ) )
+    // RAW BITS, not quantised values. `quantise` exists for placement, where
+    // the two paths compose f64 matrices differently and the last bits
+    // legitimately differ; applying it to vertices would put 1.0 and 1.0001
+    // in the same bucket and let a small tessellation change pass a check
+    // that claims byte-identical payloads. Vertices come from the same frozen
+    // native mirror on every path, so they are comparable bit-for-bit.
+    const vertexBits = new Uint32Array(
+        vertices.buffer, vertices.byteOffset, vertices.length )
+
+    for ( let i = 0; i < vertexBits.length; ++i ) {
+      hash = mix32( hash, vertexBits[ i ] )
     }
 
     for ( let i = 0; i < indices.length; ++i ) {
@@ -197,8 +206,12 @@ function mix32( hash, value ) {
 }
 
 /**
- * Quantise a float so an f32/f64 round-trip (native dmat4 vs copied floats)
- * doesn't read as divergence.
+ * Quantise a float for PLACEMENT comparison only.
+ *
+ * The two paths compose their f64 placement matrices in a different order, so
+ * the last bits legitimately differ; rounding to 1/1024 keeps that from
+ * reading as a divergence. Deliberately NOT used for vertex payloads, which
+ * are compared bit-for-bit — see {@link exactPayloadDigest}.
  *
  * @param value The float.
  * @return {number} An integer.
@@ -838,7 +851,37 @@ function verdicts( byPhase, phases, allowEmpty ) {
   // `bounded` releases, so this is the check the release claim rests on — and
   // `--phases copyout,bounded`, the most direct release-isolation run, has no
   // `classic` row at all.
-  if ( copyout?.instances !== void 0 && bounded?.instances !== void 0 ) {
+  // A phase that never opened the model has no `instances` at all, and one
+  // that delivered nothing has zero — and `0 === 0` with equal empty digests
+  // reads as agreement. Neither can support a comparison, so say so rather
+  // than passing quietly. (`allowEmpty` is the caller's declaration that the
+  // model genuinely has no geometry.)
+  for ( const phase of [ 'copyout', 'bounded' ] ) {
+
+    const row = byPhase[ phase ]
+
+    if ( row === void 0 || !phases.includes( phase ) ) {
+      continue
+    }
+
+    if ( row.instances === void 0 ) {
+      out.push( {
+        text: `FAIL  ${phase} did not complete (${row.failed ?? 'no result'}) ` +
+          '— nothing to compare',
+        failed: true,
+      } )
+    } else if ( row.instances === 0 && !allowEmpty ) {
+      out.push( {
+        text: `FAIL  ${phase} delivered 0 instances on a model not declared ` +
+          'geometry-free — extraction produced nothing, so its digest proves nothing',
+        failed: true,
+      } )
+    }
+  }
+
+  const bothDelivered = ( copyout?.instances ?? 0 ) > 0 && ( bounded?.instances ?? 0 ) > 0
+
+  if ( bothDelivered ) {
 
     // A release that THREW on every geometry also produces bounded ≡ copyout,
     // and would read as "release changed nothing" while nothing was released.

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -394,6 +394,26 @@ async function runChild( phase, filePath, batchSize, shard ) {
   const sharded = deferred && shard !== void 0 ?
     shardWorklists( api, modelID, shard ) : void 0
 
+  // Count what this process actually builds. Summed across shards against a
+  // single-shard run, this is the REAL duplication a partition causes —
+  // measured at the cache, not inferred from a captured graph.
+  let assetsCreated = 0
+
+  if ( deferred ) {
+
+    const geometry = api.getPassthrough( modelID )?.model?.[ 0 ]?.geometry
+
+    if ( geometry !== void 0 ) {
+
+      const originalAdd = geometry.add.bind( geometry )
+
+      geometry.add = ( mesh ) => {
+        ++assetsCreated
+        return originalAdd( mesh )
+      }
+    }
+  }
+
   let wasmPeakMB = wasmMB( api, wasmHeapByteLength )
   const wasmAfterOpenMB = wasmPeakMB
   let batches = 0
@@ -466,6 +486,7 @@ async function runChild( phase, filePath, batchSize, shard ) {
     totalMs: openMs + geometryMs,
     batches,
     released,
+    assetsCreated,
     shard,
     sharded,
     wasmAfterOpenMB,
@@ -591,6 +612,7 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
         geometryMsPerShard: results.map( ( r ) => Math.round( r.geometryMs ) ),
         cpuMsTotal: total( 'geometryCpuMs' ),
         instances: total( 'instances' ),
+        assetsCreated: total( 'assetsCreated' ),
         payloads: total( 'payloads' ),
         wasmPeakMBSum: results.reduce( ( sum, r ) => sum + r.wasmPeakMB, 0 ),
         wasmPeakMBMax: Math.max( ...results.map( ( r ) => r.wasmPeakMB ) ),
@@ -603,7 +625,7 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
           `${name} ${shardMode} shards=${count} geometry=${( slowestGeometryMs / 1000 ).toFixed( 1 )}s ` +
           `(${speedup.toFixed( 2 )}x) per-shard=${byCount[ count ].geometryMsPerShard.join( '/' )} ` +
           `cpu=${( byCount[ count ].cpuMsTotal / 1000 ).toFixed( 1 )}s ` +
-          `inst=${byCount[ count ].instances} payloads=${byCount[ count ].payloads} ` +
+          `inst=${byCount[ count ].instances} assets=${byCount[ count ].assetsCreated} ` +
           `wasmMax=${byCount[ count ].wasmPeakMBMax.toFixed( 0 )}MB ` +
           `wasmSum=${byCount[ count ].wasmPeakMBSum.toFixed( 0 )}MB` )
     }

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -908,6 +908,8 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
         cpuMsTotal: total( 'geometryCpuMs' ),
         instances: total( 'instances' ),
         assetsCreated: total( 'assetsCreated' ),
+        assetsReplaced: total( 'assetsReplaced' ),
+        released: total( 'released' ),
         payloads: total( 'payloads' ),
         wasmPeakMBSum: results.reduce( ( sum, r ) => sum + r.wasmPeakMB, 0 ),
         wasmPeakMBMax: Math.max( ...results.map( ( r ) => r.wasmPeakMB ) ),
@@ -924,6 +926,22 @@ async function runShardSweep( models, phase, batchSize, counts, jsonOut, shardMo
             `${name}: the N=1 baseline created 0 geometry assets on a model not ` +
             'declared geometry-free — the extraction never fired, so there is ' +
             'nothing to scale' )
+      }
+
+      // `bounded` is defined by its release policy, so a sweep of it that did
+      // not release measured a different phase than the one it reports. The
+      // sweep never reaches `verdicts()`, and `releaseGeometries` swallows
+      // per-geometry failures so a broken free surfaces nowhere else — the
+      // aggregate count is the only evidence. Summed across shards, because
+      // each child releases only what it created.
+      if ( phase === 'bounded' &&
+           byCount[ count ].released !== byCount[ count ].assetsCreated ) {
+        throw new Error(
+            `${name}: at N=${count}, bounded released ` +
+            `${byCount[ count ].released} of ${byCount[ count ].assetsCreated} ` +
+            'geometries the extractor created — the release policy that defines ' +
+            'this phase did not run, so its timing and memory rows describe ' +
+            'something else' )
       }
 
       const base = byCount[ counts[ 0 ] ]
@@ -1250,6 +1268,16 @@ function main() {
         allowEmpty: /\s#empty\s*$/.test( line ),
       } ) )
 
+  // An empty or comment-only manifest yields an empty `models` array, and both
+  // exit paths then complete having probed nothing — with `--json`, publishing
+  // `[]` as a successful artifact. A generated or mis-pathed corpus must fail
+  // rather than pass vacuously.
+  if ( models.length === 0 ) {
+    console.error(
+        `${modelsFile} lists no models — nothing to measure` )
+    process.exit( 2 )
+  }
+
   const rows = []
   const failures = []
 
@@ -1261,6 +1289,18 @@ function main() {
     // WHOLE model while the output labelled them shards and computed a
     // speedup from them. Default to the deferred extract phase, and refuse the
     // non-deferred one rather than publishing invalid scaling.
+    // One sweep runs one phase, and taking `phases[0]` from a list meant
+    // `--phases pump,bounded` ran `pump` and reported it while the caller
+    // believed they had also measured the release. Reject rather than pick:
+    // the sweep is a per-phase experiment, so asking for two is a question
+    // this invocation cannot answer, not a preference to be resolved silently.
+    if ( only !== void 0 && phases.length > 1 ) {
+      console.error(
+          `--shards runs one phase per sweep; got ${phases.length} ` +
+          `(${phases.join( ', ' )}). Run them as separate invocations.` )
+      process.exit( 2 )
+    }
+
     const shardPhase = only !== void 0 ? phases[ 0 ] : 'extractonly'
 
     if ( shardPhase === 'classic' ) {

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -149,8 +149,14 @@ class Digest {
     // preserving counts and transforms would otherwise pass this check.
     const colour = placedGeometry.color
 
+    // Colour is recorded RAW. `quantise` exists for the placement transform,
+    // where the two paths compose f64 matrices in a different order so the last
+    // bits legitimately differ. Colour has no such phase-dependent arithmetic —
+    // it is carried through unchanged — so rounding it to 1/1024 only creates a
+    // bucket in which a real appearance change (1 vs 1.0001) compares equal,
+    // against a check that claims delivery is invariant.
     record.push( colour === void 0 ? 'nocolour' :
-      [ colour.x, colour.y, colour.z, colour.w ].map( quantise ).join( ',' ) )
+      [ colour.x, colour.y, colour.z, colour.w ].join( ',' ) )
     record.push( ( placedGeometry.occurrencePath ?? [] ).join( '.' ) )
 
     this.placedRecords.push( record.join( '|' ) )
@@ -1094,7 +1100,14 @@ function verdicts( byPhase, phases, allowEmpty ) {
   // extractor makes natives that are never delivered (void/opening geometry
   // consumed by a boolean), so `released === payloads` can hold while the heap
   // still carries everything built but not handed out.
-  if ( ( bounded?.instances ?? 0 ) > 0 &&
+  // Gated on the row having COMPLETED, not on it having delivered instances.
+  // A model can create native intermediates without emitting any placed
+  // instance — an `IfcOpeningElement`-only fixture reports `assetsCreated = 1`
+  // with `instances = 0` — and an instance-count gate skipped the release check
+  // exactly there, so a bounded run could retain the created native and still
+  // exit 0. What must hold is "everything created was released", which is
+  // meaningful whenever the phase ran at all.
+  if ( bounded !== void 0 && bounded.failed === void 0 &&
        bounded.released !== bounded.assetsCreated ) {
     out.push( {
       text: `FAIL  bounded released ${bounded.released} of ` +
@@ -1226,6 +1239,16 @@ function main() {
     process.exit( 2 )
   }
   const repeats = Number( flag( '--repeats', 1 ) )
+
+  // Fractional values were silently rounded up by the loop (`1.5` ran two
+  // children) — a sampling configuration different from the one reported.
+  // `Infinity` spawned children forever, and zero/negative/non-numeric left
+  // `runs` empty so the later `reduce` threw with nothing useful to say.
+  if ( !Number.isInteger( repeats ) || repeats < 1 ) {
+    console.error(
+        `--repeats must be a positive integer; got ${flag( '--repeats' )}` )
+    process.exit( 2 )
+  }
   const jsonOut = flag( '--json' )
   const only = flag( '--phases' )
   const phases = only !== void 0 ? only.split( ',' ) : PHASES

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -194,9 +194,13 @@ function retainedMB() {
  * @param seen Geometry express IDs already copied (shared/mapped geometry is
  * copied once, like the preview channel's emittedGeometry_).
  * @param digest Digest to feed.
+ * @param retained Array the copied payloads are appended to, so they stay
+ * reachable for the life of the measurement — a consumer building a navigable
+ * scene keeps its vertex and index buffers, so dropping them here would report
+ * a JS working set no real consumer has.
  * @return {number[]} Geometry express IDs copied by this call.
  */
-function copyBatchPayloads( api, modelID, meshes, seen, digest ) {
+function copyBatchPayloads( api, modelID, meshes, seen, digest, retained ) {
 
   const copied = []
 
@@ -223,6 +227,7 @@ function copyBatchPayloads( api, modelID, meshes, seen, digest ) {
           geometry.GetIndexData(), geometry.GetIndexDataSize() ).slice()
 
       digest.payload( placed.geometryExpressID, vertices, indices )
+      retained.push( vertices, indices )
       copied.push( placed.geometryExpressID )
     }
   }
@@ -365,6 +370,11 @@ async function runChild( phase, filePath, batchSize, shard ) {
 
   const digest = new Digest()
   const seen = new Set()
+
+  // Every payload a phase copies out, held until the child reports. This is
+  // what a consumer that renders the model holds, so retained/RSS describe the
+  // real cost of delivery rather than the cost of hashing and forgetting.
+  const retainedPayloads = []
   const deferred = phase !== 'classic'
   const copies = phase === 'copyout' || phase === 'bounded'
   const emits = !EXTRACT_ONLY_PHASES.has( phase )
@@ -435,7 +445,7 @@ async function runChild( phase, filePath, batchSize, shard ) {
 
     const tCopy = performance.now()
 
-    copyBatchPayloads( api, modelID, meshes, seen, digest )
+    copyBatchPayloads( api, modelID, meshes, seen, digest, retainedPayloads )
     copyMs += performance.now() - tCopy
 
     wasmPeakMB = Math.max( wasmPeakMB, wasmMB( api, wasmHeapByteLength ) )
@@ -456,7 +466,8 @@ async function runChild( phase, filePath, batchSize, shard ) {
       if ( copies ) {
 
         const tCopy = performance.now()
-        const copied = copyBatchPayloads( api, modelID, batchMeshes, seen, digest )
+        const copied =
+          copyBatchPayloads( api, modelID, batchMeshes, seen, digest, retainedPayloads )
 
         copyMs += performance.now() - tCopy
 
@@ -497,6 +508,7 @@ async function runChild( phase, filePath, batchSize, shard ) {
     instances: digest.instances,
     payloads: digest.payloads,
     payloadMB: digest.payloadBytes / BYTES_PER_MB,
+    retainedPayloadBuffers: retainedPayloads.length,
     placedDigest: digest.placedHash,
     payloadDigest: digest.payloadHash,
   } ) )
@@ -529,6 +541,26 @@ function spawnChild( phase, filePath, batchSize, shard ) {
 }
 
 /**
+ * Environment for a shard child: single-threaded wasm, unconditionally.
+ *
+ * A shard models ONE worker holding one wasm instance, so it must be one
+ * core. `pThreadsAllowed()` returns true in node whenever `SharedArrayBuffer`
+ * exists unless `FORCE_SINGLE_THREAD` is exactly `'true'`, so a shard child
+ * that merely inherits the ambient environment loads the MT module and starts
+ * its own pthread pool. N shards then measure N nested thread pools
+ * oversubscribing the box — which is not the across-product axis this sweep
+ * exists to isolate, and reads as a scaling ceiling that isn't one.
+ *
+ * Set here rather than left to the caller: an invocation that forgets it
+ * produces plausible, wrong numbers rather than an error.
+ *
+ * @return {object} The child environment.
+ */
+function shardEnv() {
+  return { ...process.env, FORCE_SINGLE_THREAD: 'true' }
+}
+
+/**
  * Run one phase as N concurrent shards, each in its own process with its own
  * wasm instance — the worker-pool shape, measured without building workers.
  * Wall-clock is the slowest shard, since they run at the same time.
@@ -554,7 +586,7 @@ function spawnShards( phase, filePath, batchSize, count, shardMode ) {
 
     running.push( new Promise( ( resolve, reject ) => {
       execFile( process.execPath, args,
-          { encoding: 'utf8', maxBuffer: 1 << 26, cwd: REPO_ROOT },
+          { encoding: 'utf8', maxBuffer: 1 << 26, cwd: REPO_ROOT, env: shardEnv() },
           ( error, stdout ) => {
             if ( error !== null ) {
               reject( error )
@@ -686,7 +718,22 @@ function main() {
   const rows = []
 
   if ( shards !== void 0 ) {
-    return runShardSweep( models, phases[ 0 ], batchSize,
+
+    // `classic` opens without DEFER_GEOMETRY, so the pump worklists never
+    // exist and the shard filter never runs: every child would extract the
+    // WHOLE model while the output labelled them shards and computed a
+    // speedup from them. Default to the deferred extract phase, and refuse a
+    // non-deferred one rather than publishing invalid scaling.
+    const shardPhase = only !== void 0 ? phases[ 0 ] : 'extractonly'
+
+    if ( shardPhase === 'classic' ) {
+      console.error(
+          'shard sweeps need a deferred phase (extractonly/pump/copyout/bounded); ' +
+          '`classic` extracts the whole model in every child' )
+      process.exit( 2 )
+    }
+
+    return runShardSweep( models, shardPhase, batchSize,
         shards.split( ',' ).map( Number ), jsonOut, flag( '--shard-mode', 'roundrobin' ) )
   }
 

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -235,6 +235,14 @@ function copyBatchPayloads( api, modelID, meshes, seen, digest, retained ) {
       digest.payload( placed.geometryExpressID, vertices, indices )
       retained.push( vertices, indices )
       copied.push( placed.geometryExpressID )
+
+      // `GetGeometry` hands back `geometryObject.clone()` — an OWNING native
+      // copy, not a view (`IfcApiProxyIfc.getGeometry` → C++ `Geometry::Clone`,
+      // which copies the vectors). Embind will not free it until finalization,
+      // which is nondeterministic, so a harness that forgets this accumulates
+      // one clone per geometry inside the very wasm heap it is measuring.
+      // Delete it the moment its bytes are in JS.
+      geometry.delete()
     }
   }
 
@@ -319,9 +327,10 @@ function releaseGeometries( api, modelID, geometryExpressIDs ) {
  * @param api The IfcAPI instance.
  * @param modelID The open model.
  * @param shard `{index, count}`.
+ * @param filePath The model being run, checked against the assignment's own.
  * @return {object|undefined} What this shard owns.
  */
-function shardWorklists( api, modelID, shard ) {
+function shardWorklists( api, modelID, shard, filePath ) {
 
   const passthrough = api.getPassthrough( modelID )
 
@@ -344,6 +353,15 @@ function shardWorklists( api, modelID, shard ) {
     const assignment =
       JSON.parse( fs.readFileSync( process.env.M3_ASSIGNMENT, 'utf8' ) )
 
+    // Local IDs are model-relative, so an assignment from another model
+    // filters to an arbitrary overlapping subset and drops the rest — which
+    // still runs, and still prints a speedup. Refuse instead: a wrong number
+    // is worse than no number.
+    if ( assignment.model !== void 0 && assignment.model !== filePath ) {
+      throw new Error(
+          `assignment was captured from ${assignment.model}, running ${filePath}` )
+    }
+
     // An assignment is cut for ONE shard count. The sweep always runs an N=1
     // baseline (see the count normalisation in main), and handing that child
     // `shards[0]` would give it a quarter of the products while the sweep
@@ -364,6 +382,17 @@ function shardWorklists( api, modelID, shard ) {
       throw new Error(
           `assignment is cut for ${assignment.shards.length} shards, ` +
           `sweep is running ${shard.count}` )
+    }
+
+    // Every product exactly once across shards, or the sweep is measuring a
+    // partition of something other than this model's worklist.
+    const assigned = assignment.shards.flat()
+    const unique = new Set( assigned )
+
+    if ( assigned.length !== unique.size || unique.size !== products.length ) {
+      throw new Error(
+          `assignment covers ${unique.size} unique products ` +
+          `(${assigned.length} entries) against a worklist of ${products.length}` )
     }
 
     const mineSet = new Set( assignment.shards[ shard.index ] )
@@ -454,7 +483,7 @@ async function runChild( phase, filePath, batchSize, shard ) {
   }
 
   const sharded = deferred && shard !== void 0 ?
-    shardWorklists( api, modelID, shard ) : void 0
+    shardWorklists( api, modelID, shard, filePath ) : void 0
 
   // Count what this process actually builds. Summed across shards against a
   // single-shard run, this is the REAL duplication a partition causes —


### PR DESCRIPTION
Initial spike for M3 (#394). No production behaviour changes — this adds the harnesses, measures the baseline on the regression smoke corpus and PSB, and records the design status the measurements settle.

Design status audit: [#394](https://github.com/bldrs-ai/conway/issues/394#issuecomment-5323516586). Worker-pool correction: [#394](https://github.com/bldrs-ai/conway/issues/394#issuecomment-5323775352). Sequencing: [#390](https://github.com/bldrs-ai/conway/issues/390#issuecomment-5323523999), [#390 reorder correction](https://github.com/bldrs-ai/conway/issues/390#issuecomment-5323780847).

## Why a spike first

#394 was written around a blocker (a conway-geom per-product native free) and a worker pool, and the issue's machinery all shipped in the meantime — `grep` outside tests returns the export barrel and nothing else. So the question was not "what is left to build" but "what does the path Share actually runs cost, and what would the discipline buy", and nothing had measured it.

## Part 1 — memory: the pump discipline clears M3's gate

`scripts/m3_pump_spike.mjs`, child process per phase, every payload-carrying phase hashing what it delivers so M3's "changes *when*, not *what*" invariant is a check rather than a claim. `wasmPeak` via `wasmHeapByteLength` (the cached `HEAPU8` view can lag a growth step — #485). Payload phases hold their copied buffers until they report (334 MB on PSB), and delete the native clone `GetGeometry` hands back.

**PSB.ifc — 902 MB, node, 4-core box, batch = 256:**

| phase | open | geometry | total | wasm peak | RSS | JS retained |
|---|---|---|---|---|---|---|
| `classic` — `OpenModel` + `StreamAllMeshes` | 48 s | 8 s | 56 s | **1283 MB** | 3577 MB | 1566 MB |
| `pump` — deferred, batched, no copy-out | 13 s | 35 s | 48 s | 1283 MB | 2827 MB | 1255 MB |
| `copyout` — + per-batch payload copy-out | 13 s | 33 s | 46 s | 1283 MB | 3025 MB | 1597 MB |
| `bounded` — + per-batch native release | 13 s | 25 s | **38 s** | **342 MB** | 2048 MB | 1589 MB |

Identical placement and payload digests across the three payload phases on PSB. Compare rows *within* the table: wall-clock on this box moves ±25 % between runs; the memory columns are stable.

1. **The geometry residency is the entire wasm heap.** The deferred open reaches end-of-parse at **16 MB**; classic is at 1283 MB when `OpenModel` returns. Parsing costs no meaningful wasm — which redirects the Share-side "+1.7 GB parsing" hunt away from wasm ArrayBuffers.
2. **The tab holds ~4× the geometry it delivers** — 334 MB of payload behind a 1283 MB high-water. The gap is never releasing, not the model.
3. **Reading vertices costs no extra wasm.** `pump` and `copyout` peak identically, so serving a consumer its own geometry is free wasm-side.
4. **Releasing costs nothing measurable.** `bounded` is the fastest row, but that spread sits inside the box's variance, so the supported claim is the negative one. `bounded` holds the *same* delivered payload as `classic` (1589 vs 1566 MB) with 1.5 GB less RSS — the difference is entirely native geometry nobody needed to keep.
5. **The high-water becomes O(batch), which is the whole point.** `bounded` at batch 32 reaches **84 MB** against 342 MB at batch 256 (identical digests). Residency tracks the in-flight working set: 1283 → 342 → 84 MB, at no wall-clock cost.

**Release is keyed on what the extractor *creates*, not on what it delivers.** The two sets differ — void and opening geometry consumed by a boolean is built, cached, and never handed to a consumer — so a release keyed on delivered payloads leaves those resident for the life of the model. On PSB that is 403 of 20 581 assets; on MB-Khaya 3 347 of 8 947 (37 %). Correcting it is what moves the batch-32 row from 100 MB to 84 MB; batch 256 is unchanged, because there the in-flight set dominates the residue.

**This clears M3's memory gate on PSB** — "steady-state wasm heap under a configured budget (e.g. 512 MB) with the full model navigable" — with room to spare, and *without* the dedicated chunk region. That doesn't retire the region: this is a drain-once pass, and the region exists for evict/refill *churn* where a general allocator fragments and never returns pages. But it reorders the milestone — the pump discipline alone reaches the gate; the region is what keeps it there.

**Smoke corpus (12 models): release-neutral on all 12, classic-identical on 11.** `bounded` is identical to `copyout` — same instances, same payloads, same placement, every model — which is the comparison the release claim rests on, since those two run identical extraction and differ only in that one releases. So the corpus provides **no evidence that per-batch release changes what a consumer receives**.

Retention is still required, but as a **design argument rather than a measured one**. The mechanism is real: the scene walk resolves geometry through `getByLocalID` and skips what it cannot find, so releasing an asset a later product shares makes that product re-extract. This corpus never triggers it at batch 64, because shared geometry is released within the batch that emits all of its instances. Finding or building a fixture that instances one definition across widely separated products is the next thing this harness needs. The shippable policy is unchanged — refcount-on-asset (`SharedAssetPool`) plus an asset-keyed delta capture, which also deletes the pump's O(batches × scene) re-walk.

**The 12th model is a production bug, not a release effect.** On `supercap.step` (AP214) the *deferred pump itself* diverges from the classic walk before any release: `ExtractGeometryBatch` delivers **21 instances over 2 geometries** where `StreamAllMeshes` delivers **101 over 6**. `copyout`, which releases nothing, diverges identically to `bounded`. Filed as #532.

## Part 2 — parallelism: the worker pool is a live lever

My first audit recorded the worker pool as superseded by conway-geom#148. That was wrong: **#148 measured pthreads inside one instance** (work split *within* a product's tessellation, shared heap, one serial JS driver), and its three suspects — main-thread `Atomics.wait` busy-spin, `memory.grow` stalling every thread, oversubscription — are all properties of that shape. The design specifies the other axis: N workers, own instance and heap and driver, pulling disjoint products. #148's own listed fix is "run extraction in a dedicated worker".

`--shards N` runs the extraction as N independent processes (a worker minus postMessage), each forced to single-threaded wasm so one worker means one core:

| model | N=1 | N=2 | N=3 | N=4 | total CPU N=1 → N=4 |
|---|---|---|---|---|---|
| **PSB.ifc** geometry | 23.1 s | 12.6 s (1.84×) | 9.8 s (2.37×) | **8.9 s (2.59×)** | 30.5 s → 35.2 s (+15 %) |
| **MB-Khaya.ifc** geometry | 4.0 s | 2.9 s (1.37×) | 2.8 s (1.41×) | 2.9 s (1.39×) | 7.2 s → 10.1 s (+40 %) |

Box calibrated first — 4 pure-CPU processes and 4 memory-bound processes both scale perfectly — so a negative result could not have been blamed on the sandbox.

**PSB scales: 2.59× is 86 % of this box's ceiling.** One extraction process already burns 1.32 cores (main thread + V8 GC/JIT — the JS driver's own allocation tax), capping achievable speedup at ~3.0×. Per-worker wasm peak falls 1283 → 364 MB, so the two halves compose: bound what a worker holds, multiply how many there are.

**MB-Khaya doesn't under round-robin, and the CPU column says why** — +40 % total CPU vs PSB's +15 %. A model reusing representations heavily has products that are *not* independent; round-robin scatters shared geometry so every shard re-extracts it. Which is what Part 3 addresses.

**M2 is the enabler:** columns-from-birth lets a worker take transferable index columns and *pull* by localID with no scheduling channel. Transferables need no cross-origin isolation; only SAB-shared columns do, so a pool can ship without Share#1610.

Shard sweeps are IFC-only: AP214/STEP passthroughs carry no demand worklists, so the filter cannot apply and every child would extract the whole model. The harness refuses rather than reporting that as scaling.

## Part 3 — partitioning: an oracle bound, not yet a scheduler

`scripts/m3_affinity_spike.mjs` captures the real product↔asset graph (one instrumented extraction pass recording, per product, which assets it **created**, which it **reused**, and how long it took), replays candidate partitions against it, and emits any of them as per-shard product lists so the **real extractor** runs the partition the simulation scored.

**MB-Khaya, N=4, single-threaded shards, against a one-shard baseline of 4.3 s / 7.5 s CPU / 6851 assets:**

| partition | geometry | total CPU | assets created |
|---|---|---|---|
| round-robin | 3.2 s | 11.2 s | 8678 (**+27 %**) |
| affinity — hash the product's primary asset | 2.3 s | **7.5 s** | **6851** (+0 %) |
| claim — first toucher owns the asset | **2.2 s** | 7.8 s | **6851** (+0 %) |

**Both asset-aware partitions eliminate the duplication completely** — four shards create exactly the assets one shard does, total CPU returns to the serial baseline, and per-worker wasm peak drops 83 → 33 MB, because a shard that doesn't re-extract shared geometry doesn't hold it either.

**What this validates is a precomputed partition — an oracle.** Both strategies are scored offline from a graph that already knows every product's assets and cost before dispatch. That establishes the *ceiling*: duplication is entirely addressable by placement, and asset-aware placement reaches the serial CPU floor. It is not a scheduler. A live worker cannot know a pending product follows an existing owner until it discovers that product's assets, and discovering them by extracting is the duplication the rule exists to avoid.

An online rule needs a **dispatch-time key** derivable from the index without extracting — the product's representation / mapped-source ID read straight from the columns is the natural candidate, and it is cheap. Whether it approximates the oracle well is the next measurement, and is stated as such rather than assumed.

## What is in this PR

- `scripts/m3_pump_spike.mjs` — phases, shard modes, assignment consumption, digests, per-shard asset-creation counts.
- `scripts/m3_affinity_spike.mjs` — graph capture, partition simulation, assignment emit for real-extractor validation.
- `design/new/streaming-federated-loader.md` § M3 — status, tables, the two-axis distinction, and the scope moved by measurement.

No engine code changes. Implementation follows on this stack.

## Review rounds

Nineteen rounds with codex, and **six published claims retracted**. Every one had the same root cause: a harness that could produce a plausible number without the thing being measured actually happening.

Rounds 1–4 (8 findings) established the pattern and cost four retractions: shard children inheriting the ambient environment so a "one-core" shard ran its own pthread pool; a dropped `M3_ASSIGNMENT` branch that made "affinity and claim change nothing" into *round-robin under three names*; `GetVertexArray` already returning owning copies, so the harness double-copied; and `GetGeometry` returning `geometryObject.clone()`, an owning native the harness never deleted — which had inflated "GetGeometry costs +672 MB" and masked the batch-size effect entirely. Also: both partitions are **oracles**, so "build this first-touch scheduler" narrowed to "the ceiling is real; an online approximation needs a dispatch-time key".

Rounds 5–10 hardened the verdicts, and each fix revealed the next hole: cardinality-not-membership in assignment validation; a corpus sweep with no verdicts at all; an unconditional SKIP that couldn't tell "no geometry" from "the probe stopped firing"; a swallowed release failure; a digest ignoring colour and `occurrencePath`; the release claim checked against the wrong pair, then put behind a guard that skipped the one invocation testing it; and payload hashing that sampled at stride 97, then quantised to 1/1024 — **retraction 5**, the "every byte, exactly" wording. Both are now SHA-256 over raw bytes.

**Round 11 found the one defect that moved a number.** `bounded` released the geometries whose payloads it copied and checked itself against that same set, so `released === payloads` held while the heap still carried everything built but never handed out. Release is now keyed on creations. PSB batch 32 improves 100 MB → **84 MB**; batch 256 unchanged.

Rounds 12–19 (15 findings) were guards and labels, no number moved: the release check gated on the wrong preconditions twice; four more ways for a shard sweep — a parallel exit path reproducing none of `verdicts()`'s checks — to publish a measurement of nothing; `--repeats` discarding the flaky run it exists to expose; every experiment-naming flag validated (`--phases`, `--shards`, `--shard-mode`, `--batch`, `--repeats`, `--strategy`), because the failure mode here is a plausible number under the wrong label rather than a crash; STEP shard sweeps that never sharded; and assignment sweeps labelled with the CLI mode instead of the strategy that ran.

**Retraction 6** landed in round 19, and it is the one I should have caught myself: the earlier claim that retain-nothing release loses instances on `supercap.step` (169 against 101) came from the payload-keyed release replaced in round 11. `bounded` is now identical to `copyout` on all 12 models. The `supercap.step` divergence is the deferred pump (#532), not release. The design doc carried that retraction; this description did not until now, which is the same durable-artefact-lags-the-thread failure codex filed against me in round 1.

## Notes for review

- **Corrections on the record**, beyond the retractions: the digest first chained items into a rolling hash and flagged emission order as a content change on `Right_Hand.step` (now combined commutatively); an early shard sweep reporting 1.25× at N=2 and a 20× collapse at N=4 shared the box with a commit hook running the full Jest suite, and is void; and a failure epilogue spliced into `runShardSweep` instead of `main` crashed every shard sweep on an undefined `failures`.
- The payload and placement digests are SHA-256 over raw bytes, combined by sorting the per-item digests and hashing the concatenation — order-independent (which the emission contract requires) while preserving multiplicity. Byte-for-byte comparison isn't available: each phase runs in its own child process, so a digest is what crosses that boundary. Two runs delivering different geometry agreeing would require a SHA-256 collision.
- `bounded` retains nothing native: that is what makes it an upper bound. The corpus doesn't exercise the case where that loses instances (see Part 1), which is a gap in the fixtures, not evidence of safety.
- `shardWorklists` and the affinity capture reach into the passthrough's worklist fields and wrap the geometry cache. Deliberate: measurement fixtures, not proposed APIs.
- The affinity capture doesn't cover the rel-aggregates pass (5363 assets recorded against 6851 really created), and that pass is sharded positionally. Not load-bearing for Part 3's conclusion, but next to close alongside the dispatch-time key. `--capture` also assumes IFC, and dies on the same missing seam that makes STEP unshardable.
- A 4-core box cannot say how this scales at 8–16 cores; it can only show the axis is real.

Part of #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsjeKsTaAMGnhj2UCJFfCa