### PR TITLE
M3 (#394): a resident-geometry budget — PSB 1284 MB → 298 MB at Share's batch size

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -652,6 +652,82 @@ Deliberately small first step; each has a measurable exit.
   `GetVertexDataSize`/`GetIndexDataSize`. Which policy wins is a
   measurement the existing harness can run before any engine change.
 
+    **Implementation, second landed piece — a resident-geometry budget
+  (2026-08-18).** M3's items 1 and 2, "per-product wasm reclaim" and the
+  "budgeted arena", in the production pump rather than a harness.
+  `GeometryResidency` (`src/ifc/geometry_residency.ts`) holds an LRU over
+  both of a model's geometry stores against a byte ceiling, evicting at
+  each batch boundary. Configured at open (`GEOMETRY_BUDGET_MB`) or after
+  (`SetGeometryBudget`), and **unlimited by default**, because eviction
+  changes a contract: an evicted asset is gone from `GetGeometry` until
+  something re-extracts it, which is safe for a consumer that copies
+  payloads at delivery (Share#1640) and unsafe for one that fetches
+  lazily later.
+
+  **PSB.ifc at batch 8 — the size Share pumps at:**
+
+  | budget | live | wasm peak | delta meshes | geometry |
+  | --- | --- | --- | --- | --- |
+  | none | — | **1284 MB** | 7 764 | 25.7 s |
+  | **64 MB** | 64.0 MB | **298 MB** | 7 764 | **23.6 s** |
+  | 256 MB | 256.0 MB | 803 MB | 7 764 | 23.4 s |
+
+  MB-Khaya at batch 64: 102 → 85 MB under an 8 MB budget, and a 32 MB
+  budget never binds (live is 17.8 MB). D3D at batch 64: 52.5 s against
+  53.1 s unbudgeted, live held at 64.0 MB, 2.8 % more assets rebuilt.
+  **This is the memory gate, met on the production path at no wall-clock
+  cost** — and note the heap runs 3-4x the live budget, so a 512 MB heap
+  target means a budget nearer 128-192 MB. The gap is allocator overhead,
+  fragmentation, and the intermediate buffers a boolean leaves behind,
+  none of which the payload accounting can see.
+
+  **Why LRU rather than release-on-emit, decided by measurement.** The
+  harness gained an `lru` phase beside `bounded` so the two could be run
+  on the same models. Freeing everything a batch created is *correct* —
+  see the fixture below — but rebuilds geometry a later product still
+  maps: **+62.6 %** assets on MB-Khaya at batch 64, **+79.4 %** on D3D.
+  Evicting only what does not fit costs a fraction of that, because
+  extraction order has enough locality that recency predicts reuse where
+  creation order does not.
+
+  **The bug that eviction exposed, which predates it.** A native geometry
+  can be cached under more than one local ID — 1 448 of 23 692 adds on
+  D3D, 6 % — and `IfcModelGeometry.delete` freed it unconditionally. So
+  evicting one entry left its siblings pointing at freed memory, and
+  everything sharing that native re-extracted; a second eviction of the
+  same native aborted the load with a `BindingError`. The byte accounting
+  had the matching defect, charging per key rather than per native, so a
+  budget bound several times tighter than it read. **Residency is
+  therefore refcounted on the native object itself**, and the store asks
+  before freeing.
+
+  Two things worth keeping from how that was found. It presented as a
+  64 MB D3D load still running after an hour against 53 s unbudgeted, and
+  the obvious reading — the working set does not fit, LRU is thrashing —
+  was wrong: with correct accounting the working set fits in 64 MB
+  exactly. A "working-set floor" written to handle that supposed thrash
+  never fired on any model, including an absurd 1 MB budget on MB-Khaya
+  (38 % more rebuilds, no thrash), and was removed. And the first
+  published figures were *flattering* rather than merely wrong —
+  MB-Khaya's peak read 71 MB where it is really 85 MB, the difference
+  being natives freed while still referenced. **The hazard is not
+  specific to the budget**: any mass delete has it, `ReleaseModelGeometry`
+  included. Eviction is only the first caller to delete enough entries to
+  reach it.
+
+  Pinned by two tests (`ifc_api_deferred_open.test.ts`): a budget binds
+  and delivers the same placements as classic, and the default budget-free
+  path tracks nothing, frees nothing, and leaves every delivered geometry
+  fetchable. Both mutation-verified — disabling eviction on the
+  synchronous pump fails the first with `Expected <= 2048, Received
+  19440`, which is the bug the first version of this shipped by wiring
+  only the async pump.
+
+  **Still open in M3 after this:** evict/refill under *navigation* (this
+  measures a drain-once pass; the chunk region exists for churn, where a
+  general allocator fragments), viewport-ordered materialisation (the
+  pump extracts in file order), and the time-to-first-pixel gate itself.
+
     **This clears M3's memory gate on PSB** — "steady-state wasm heap
   under a configured budget (e.g. 512 MB) with the full model
   navigable" — with room to spare, and *without* the dedicated chunk

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -677,9 +677,13 @@ Deliberately small first step; each has a measurable exit.
   53.1 s unbudgeted, live held at 64.0 MB, 2.8 % more assets rebuilt.
   **This is the memory gate, met on the production path at no wall-clock
   cost** — and note the heap runs 3-4x the live budget, so a 512 MB heap
-  target means a budget nearer 128-192 MB. The gap is allocator overhead,
-  fragmentation, and the intermediate buffers a boolean leaves behind,
-  none of which the payload accounting can see.
+  target means a budget nearer 128-192 MB. The budget's unit is each
+  native's `getAllocationSize` (vertices, triangles, edges, the
+  triangle-edge structures, the float vertex mirror), NOT the vertex+index
+  payload `calculateGeometrySize` reports; the remaining 3-4x is allocator
+  overhead and fragmentation. An earlier version of this section
+  attributed the whole gap to overhead, which double-counted structures
+  the budget already charges for.
 
   **Why LRU rather than release-on-emit, decided by measurement.** The
   harness gained an `lru` phase beside `bounded` so the two could be run

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -686,9 +686,10 @@ Deliberately small first step; each has a measurable exit.
   on the same models. Freeing everything a batch created is *correct* —
   see the fixture below — but rebuilds geometry a later product still
   maps: **+62.6 %** assets on MB-Khaya at batch 64, **+79.4 %** on D3D.
-  Evicting only what does not fit costs a fraction of that, because
-  extraction order has enough locality that recency predicts reuse where
-  creation order does not.
+  Evicting only what does not fit costs a fraction of that: MB-Khaya at an
+  8 MB budget rebuilds **47** assets against 7 193 (**+0.65 %**), and D3D
+  at 64 MB rebuilds +2.8 %. Extraction order has enough locality that
+  recency predicts reuse, where creation order does not.
 
   **The bug that eviction exposed, which predates it.** A native geometry
   can be cached under more than one local ID — 1 448 of 23 692 adds on

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -397,116 +397,6 @@ function wasmMB( api, wasmHeapByteLength ) {
  * @param geometryExpressIDs Geometry express IDs to free.
  * @return {number} How many were actually freed.
  */
-/**
- * Approximate the wasm-side bytes an asset occupies.
- *
- * Payload only — vertex and index data, 4 bytes per element. The
- * allocator's real footprint is larger (per-object overhead,
- * fragmentation, and the intermediate buffers a boolean leaves behind),
- * and none of that is reachable from here, so a budget expressed in these
- * units is a proxy that runs proportional to the real thing rather than
- * equal to it. Read wasmPeakMB for what a given budget actually bought.
- *
- * @param mesh The canonical mesh being cached.
- * @return {number} Approximate bytes, or 0 when the geometry is not a
- * native buffer (a lazy thunk, a string, or an already-freed handle).
- */
-function assetBytes( mesh ) {
-
-  const geometry = mesh?.geometry
-
-  if ( typeof geometry?.GetVertexDataSize !== 'function' ) {
-    return 0
-  }
-
-  try {
-    // eslint-disable-next-line no-magic-numbers
-    return geometry.GetVertexDataSize() * 8 + geometry.GetIndexDataSize() * 4
-  } catch {
-    return 0
-  }
-}
-
-
-/**
- * Evict least-recently-used assets until live asset bytes fit a budget.
- *
- * The third release policy, and the one that needs neither a dependency
- * graph nor a dispatch-time key. `bounded` frees everything a batch
- * created, which is correct but rebuilds shared geometry a later product
- * still maps — 29 % of MB-Khaya's assets at batch 256, 79 % of D3D's at
- * batch 64. A budget frees only what does not fit, so an asset a later
- * product needs survives whenever there is room for it, and the batch
- * size stops being the thing that decides residency.
- *
- * Budgeted on LIVE ASSET BYTES, not on `wasmHeapByteLength`. The wasm heap
- * is grow-only: it never shrinks when an asset is freed, so a controller
- * driven by it would evict once, observe no change, and evict everything.
- * What a budget can actually control is the live set, and the heap
- * high-water follows it.
- *
- * Sizes come from the native geometry, matching `IfcModelGeometry
- * .calculateGeometrySize`'s own convention: vertex elements are doubles
- * (8 bytes), index elements are 4. An earlier version of this counted
- * vertices at 4 bytes, which made every budget figure mean about half
- * what it said. That is the payload, not the
- * allocator's true footprint — the real cost carries per-object overhead
- * and fragmentation this cannot see — so treat the budget as a knob whose
- * units are approximately-payload-bytes, and read `wasmPeakMB` for what
- * it actually bought.
- *
- * @param api The IfcAPI instance.
- * @param modelID The open model.
- * @param resident LRU state: `{ order: Map<key, bytes>, live: number }`,
- * where `order`'s insertion sequence IS the recency order (a Map re-set
- * moves nothing, so touches delete-then-set).
- * @param budgetBytes Live-byte ceiling.
- * @return {{evicted: number, freedBytes: number}} What this pass reclaimed.
- */
-function evictToBudget( api, modelID, resident, budgetBytes ) {
-
-  const model = api.getPassthrough( modelID )?.model?.[ 0 ]
-
-  if ( model === void 0 ) {
-    return { evicted: 0, freedBytes: 0 }
-  }
-
-  let evicted = 0
-  let freedBytes = 0
-
-  for ( const [ key, bytes ] of resident.order ) {
-
-    if ( resident.live <= budgetBytes ) {
-      break
-    }
-
-    const [ storeName, localIDText ] = key.split( ':' )
-    const store = model[ storeName ]
-    const localID = Number( localIDText )
-
-    resident.order.delete( key )
-    resident.live -= bytes
-
-    if ( store === void 0 || store.getByLocalID( localID ) === void 0 ) {
-      // Already gone (the extractor reclaims its own temporaries), so it
-      // no longer occupies the budget either — dropping it from the
-      // accounting above is the whole fix.
-      continue
-    }
-
-    try {
-      store.delete( localID )
-      ++evicted
-      freedBytes += bytes
-    } catch {
-      /* A store that cannot free is a finding, not a crash. */
-    }
-  }
-
-  return { evicted, freedBytes }
-}
-
-
 function releaseGeometries( api, modelID, created, geometryExpressIDs ) {
 
   const passthrough = api.getPassthrough( modelID )
@@ -802,6 +692,17 @@ async function runChild( phase, filePath, batchSize, shard, budgetMB ) {
     return
   }
 
+  // The `lru` phase measures the ENGINE's policy, not a simulation of it.
+  // An earlier version evicted from the harness with its own per-key
+  // accounting while the production residency stayed disabled — which
+  // reproduced, exactly, the two bugs the engine fixed: it freed a native
+  // the first time any of its aliases was evicted, leaving the others
+  // dangling, and charged that native's bytes once per alias. Numbers taken
+  // that way are the withdrawn ones. Drive the real thing instead.
+  if ( phase === 'lru' ) {
+    api.SetGeometryBudget( modelID, budgetMB )
+  }
+
   const sharded = deferred && shard !== void 0 ?
     shardWorklists( api, modelID, shard, filePath ) : void 0
 
@@ -829,9 +730,6 @@ async function runChild( phase, filePath, batchSize, shard, budgetMB ) {
   // rather than the copied payload IDs — see releaseGeometries. Kept per store
   // because local IDs are store-relative.
   const createdThisBatch = { geometry: new Set(), voidGeometry: new Set() }
-
-  // LRU state for the `lru` phase: insertion order IS recency order.
-  const resident = { order: new Map(), live: 0 }
 
   if ( deferred ) {
 
@@ -862,43 +760,7 @@ async function runChild( phase, filePath, batchSize, shard, budgetMB ) {
 
         createdThisBatch[ store ].add( mesh.localID )
 
-        if ( phase === 'lru' ) {
-
-          const key = `${store}:${mesh.localID}`
-          const previous = resident.order.get( key )
-
-          if ( previous !== void 0 ) {
-            resident.live -= previous
-            resident.order.delete( key )
-          }
-
-          const bytes = assetBytes( mesh )
-
-          resident.order.set( key, bytes )
-          resident.live += bytes
-        }
-
         return originalAdd( mesh )
-      }
-
-      // Recency, not just residency: a getByLocalID is the engine reaching
-      // for an asset, which is exactly the signal LRU needs and the signal
-      // a creation-keyed policy like `bounded` throws away. Re-inserting
-      // moves the key to the end of the Map's insertion order.
-      if ( phase === 'lru' ) {
-
-        cache.getByLocalID = ( localID ) => {
-
-          const key = `${store}:${localID}`
-          const bytes = resident.order.get( key )
-
-          if ( bytes !== void 0 ) {
-            resident.order.delete( key )
-            resident.order.set( key, bytes )
-          }
-
-          return originalGet( localID )
-        }
       }
     }
   }
@@ -908,11 +770,6 @@ async function runChild( phase, filePath, batchSize, shard, budgetMB ) {
   let batches = 0
   let released = 0
 
-  // Live-byte ceiling for the `lru` phase, and the high-water the policy
-  // actually held — reported next to wasmPeakMB so the proxy can be
-  // checked against the real heap rather than trusted.
-  const budgetBytes = budgetMB * BYTES_PER_MB
-  let liveHighWaterMB = 0
 
   // Created natives the engine reclaimed itself (temporaries). Reported so the
   // release invariant can be "nothing created is still resident" rather than
@@ -974,11 +831,8 @@ async function runChild( phase, filePath, batchSize, shard, budgetMB ) {
 
         if ( phase === 'lru' ) {
 
-          const evicted = evictToBudget( api, modelID, resident, budgetBytes )
-
-          released += evicted.evicted
-          liveHighWaterMB =
-            Math.max( liveHighWaterMB, resident.live / BYTES_PER_MB )
+          // Nothing to do: the ENGINE evicts, on its own refcounted
+          // accounting. See the SetGeometryBudget call at open.
           createdThisBatch.geometry.clear()
           createdThisBatch.voidGeometry.clear()
         }
@@ -1019,6 +873,13 @@ async function runChild( phase, filePath, batchSize, shard, budgetMB ) {
     payloads: digest.payloads,
     payloadMB: digest.payloadBytes / BYTES_PER_MB,
     retainedPayloadBuffers: retainedPayloads.length,
+
+    // What the ENGINE says it is holding, for the `lru` phase — read back
+    // rather than tracked here, so the row cannot disagree with the policy
+    // that produced it.
+    liveMB: phase === 'lru' ?
+      ( api.SetGeometryBudget( modelID, budgetMB )?.liveBytes ?? 0 ) / BYTES_PER_MB :
+      0,
     placedDigest: exactPlacedDigest( digest.placedRecords ),
     payloadDigest: exactPayloadDigest( retainedPayloads ),
   } ) )

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -802,21 +802,37 @@ async function runChild( phase, filePath, batchSize, shard, budgetMB ) {
     for ( ;; ) {
 
       const batchMeshes = []
+      let copied = []
+
+      // Copy INSIDE the callback, not after the pump returns. The engine
+      // evicts at the end of the batch that delivered these meshes, so a
+      // copy deferred until after `ExtractGeometryBatch` returns can reach
+      // for a native the budget has already freed — `GetGeometry(...)
+      // .clone()` on a deleted handle aborts the load with a BindingError,
+      // reproducible whenever one batch delivers more than the budget
+      // holds. Copying at delivery is also what the contract asks of a
+      // consumer, so the harness now models the consumer it documents.
       const { extracted, remaining } = emits ?
         api.ExtractGeometryBatch( modelID, batchSize, ( mesh ) => {
+
           batchMeshes.push( mesh )
+
+          if ( copies ) {
+
+            const tMeshCopy = performance.now()
+
+            copied = copied.concat(
+                copyBatchPayloads(
+                    api, modelID, [ mesh ], seen, digest, retainedPayloads ) )
+
+            copyMs += performance.now() - tMeshCopy
+          }
         } ) :
         api.ExtractGeometryBatch( modelID, batchSize )
 
       ++batches
 
       if ( copies ) {
-
-        const tCopy = performance.now()
-        const copied =
-          copyBatchPayloads( api, modelID, batchMeshes, seen, digest, retainedPayloads )
-
-        copyMs += performance.now() - tCopy
 
         if ( phase === 'bounded' ) {
 

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -62,7 +62,13 @@ import * as path from 'node:path'
 import * as process from 'node:process'
 import { performance } from 'node:perf_hooks'
 
-const PHASES = [ 'classic', 'pump', 'copyout', 'bounded' ]
+const PHASES = [ 'classic', 'pump', 'copyout', 'bounded', 'lru' ]
+
+/* Default live-asset budget for the `lru` phase, in MB. Chosen as the
+ * milestone's own example figure ("steady-state wasm heap under a
+ * configured budget (e.g. 512 MB)") so the default run answers the
+ * milestone's question rather than one of my own. */
+const DEFAULT_BUDGET_MB = 512
 
 /**
  * Phases that never pass a meshCallback, so `streamNewMeshes_` — the
@@ -391,6 +397,116 @@ function wasmMB( api, wasmHeapByteLength ) {
  * @param geometryExpressIDs Geometry express IDs to free.
  * @return {number} How many were actually freed.
  */
+/**
+ * Approximate the wasm-side bytes an asset occupies.
+ *
+ * Payload only — vertex and index data, 4 bytes per element. The
+ * allocator's real footprint is larger (per-object overhead,
+ * fragmentation, and the intermediate buffers a boolean leaves behind),
+ * and none of that is reachable from here, so a budget expressed in these
+ * units is a proxy that runs proportional to the real thing rather than
+ * equal to it. Read wasmPeakMB for what a given budget actually bought.
+ *
+ * @param mesh The canonical mesh being cached.
+ * @return {number} Approximate bytes, or 0 when the geometry is not a
+ * native buffer (a lazy thunk, a string, or an already-freed handle).
+ */
+function assetBytes( mesh ) {
+
+  const geometry = mesh?.geometry
+
+  if ( typeof geometry?.GetVertexDataSize !== 'function' ) {
+    return 0
+  }
+
+  try {
+    // eslint-disable-next-line no-magic-numbers
+    return geometry.GetVertexDataSize() * 8 + geometry.GetIndexDataSize() * 4
+  } catch {
+    return 0
+  }
+}
+
+
+/**
+ * Evict least-recently-used assets until live asset bytes fit a budget.
+ *
+ * The third release policy, and the one that needs neither a dependency
+ * graph nor a dispatch-time key. `bounded` frees everything a batch
+ * created, which is correct but rebuilds shared geometry a later product
+ * still maps — 29 % of MB-Khaya's assets at batch 256, 79 % of D3D's at
+ * batch 64. A budget frees only what does not fit, so an asset a later
+ * product needs survives whenever there is room for it, and the batch
+ * size stops being the thing that decides residency.
+ *
+ * Budgeted on LIVE ASSET BYTES, not on `wasmHeapByteLength`. The wasm heap
+ * is grow-only: it never shrinks when an asset is freed, so a controller
+ * driven by it would evict once, observe no change, and evict everything.
+ * What a budget can actually control is the live set, and the heap
+ * high-water follows it.
+ *
+ * Sizes come from the native geometry, matching `IfcModelGeometry
+ * .calculateGeometrySize`'s own convention: vertex elements are doubles
+ * (8 bytes), index elements are 4. An earlier version of this counted
+ * vertices at 4 bytes, which made every budget figure mean about half
+ * what it said. That is the payload, not the
+ * allocator's true footprint — the real cost carries per-object overhead
+ * and fragmentation this cannot see — so treat the budget as a knob whose
+ * units are approximately-payload-bytes, and read `wasmPeakMB` for what
+ * it actually bought.
+ *
+ * @param api The IfcAPI instance.
+ * @param modelID The open model.
+ * @param resident LRU state: `{ order: Map<key, bytes>, live: number }`,
+ * where `order`'s insertion sequence IS the recency order (a Map re-set
+ * moves nothing, so touches delete-then-set).
+ * @param budgetBytes Live-byte ceiling.
+ * @return {{evicted: number, freedBytes: number}} What this pass reclaimed.
+ */
+function evictToBudget( api, modelID, resident, budgetBytes ) {
+
+  const model = api.getPassthrough( modelID )?.model?.[ 0 ]
+
+  if ( model === void 0 ) {
+    return { evicted: 0, freedBytes: 0 }
+  }
+
+  let evicted = 0
+  let freedBytes = 0
+
+  for ( const [ key, bytes ] of resident.order ) {
+
+    if ( resident.live <= budgetBytes ) {
+      break
+    }
+
+    const [ storeName, localIDText ] = key.split( ':' )
+    const store = model[ storeName ]
+    const localID = Number( localIDText )
+
+    resident.order.delete( key )
+    resident.live -= bytes
+
+    if ( store === void 0 || store.getByLocalID( localID ) === void 0 ) {
+      // Already gone (the extractor reclaims its own temporaries), so it
+      // no longer occupies the budget either — dropping it from the
+      // accounting above is the whole fix.
+      continue
+    }
+
+    try {
+      store.delete( localID )
+      ++evicted
+      freedBytes += bytes
+    } catch {
+      /* A store that cannot free is a finding, not a crash. */
+    }
+  }
+
+  return { evicted, freedBytes }
+}
+
+
 function releaseGeometries( api, modelID, created, geometryExpressIDs ) {
 
   const passthrough = api.getPassthrough( modelID )
@@ -640,7 +756,7 @@ function shardWorklists( api, modelID, shard, filePath ) {
  * @param batchSize Products per pump call.
  * @param shard Optional `{index, count}` — extract only this shard's products.
  */
-async function runChild( phase, filePath, batchSize, shard ) {
+async function runChild( phase, filePath, batchSize, shard, budgetMB ) {
 
   const { IfcAPI, LogLevel } =
     await import( '../compiled/src/compat/web-ifc/ifc_api.js' )
@@ -660,7 +776,8 @@ async function runChild( phase, filePath, batchSize, shard ) {
   // real cost of delivery rather than the cost of hashing and forgetting.
   const retainedPayloads = []
   const deferred = phase !== 'classic'
-  const copies = phase === 'copyout' || phase === 'bounded'
+  const copies =
+    phase === 'copyout' || phase === 'bounded' || phase === 'lru'
   const emits = !EXTRACT_ONLY_PHASES.has( phase )
 
   const settings = {
@@ -713,6 +830,9 @@ async function runChild( phase, filePath, batchSize, shard ) {
   // because local IDs are store-relative.
   const createdThisBatch = { geometry: new Set(), voidGeometry: new Set() }
 
+  // LRU state for the `lru` phase: insertion order IS recency order.
+  const resident = { order: new Map(), live: 0 }
+
   if ( deferred ) {
 
     const ifcModel = api.getPassthrough( modelID )?.model?.[ 0 ]
@@ -742,7 +862,43 @@ async function runChild( phase, filePath, batchSize, shard ) {
 
         createdThisBatch[ store ].add( mesh.localID )
 
+        if ( phase === 'lru' ) {
+
+          const key = `${store}:${mesh.localID}`
+          const previous = resident.order.get( key )
+
+          if ( previous !== void 0 ) {
+            resident.live -= previous
+            resident.order.delete( key )
+          }
+
+          const bytes = assetBytes( mesh )
+
+          resident.order.set( key, bytes )
+          resident.live += bytes
+        }
+
         return originalAdd( mesh )
+      }
+
+      // Recency, not just residency: a getByLocalID is the engine reaching
+      // for an asset, which is exactly the signal LRU needs and the signal
+      // a creation-keyed policy like `bounded` throws away. Re-inserting
+      // moves the key to the end of the Map's insertion order.
+      if ( phase === 'lru' ) {
+
+        cache.getByLocalID = ( localID ) => {
+
+          const key = `${store}:${localID}`
+          const bytes = resident.order.get( key )
+
+          if ( bytes !== void 0 ) {
+            resident.order.delete( key )
+            resident.order.set( key, bytes )
+          }
+
+          return originalGet( localID )
+        }
       }
     }
   }
@@ -751,6 +907,12 @@ async function runChild( phase, filePath, batchSize, shard ) {
   const wasmAfterOpenMB = wasmPeakMB
   let batches = 0
   let released = 0
+
+  // Live-byte ceiling for the `lru` phase, and the high-water the policy
+  // actually held — reported next to wasmPeakMB so the proxy can be
+  // checked against the real heap rather than trusted.
+  const budgetBytes = budgetMB * BYTES_PER_MB
+  let liveHighWaterMB = 0
 
   // Created natives the engine reclaimed itself (temporaries). Reported so the
   // release invariant can be "nothing created is still resident" rather than
@@ -809,6 +971,17 @@ async function runChild( phase, filePath, batchSize, shard ) {
           createdThisBatch.geometry.clear()
           createdThisBatch.voidGeometry.clear()
         }
+
+        if ( phase === 'lru' ) {
+
+          const evicted = evictToBudget( api, modelID, resident, budgetBytes )
+
+          released += evicted.evicted
+          liveHighWaterMB =
+            Math.max( liveHighWaterMB, resident.live / BYTES_PER_MB )
+          createdThisBatch.geometry.clear()
+          createdThisBatch.voidGeometry.clear()
+        }
       }
 
       wasmPeakMB = Math.max( wasmPeakMB, wasmMB( api, wasmHeapByteLength ) )
@@ -858,9 +1031,10 @@ async function runChild( phase, filePath, batchSize, shard ) {
  * @param filePath The model.
  * @param batchSize Products per pump call.
  * @param shard Optional `{index, count}` — extract only this shard's products.
+ * @param budgetMB Live-asset ceiling for the `lru` phase, in MB.
  * @return {object} The child's JSON result.
  */
-function spawnChild( phase, filePath, batchSize, shard ) {
+function spawnChild( phase, filePath, batchSize, shard, budgetMB ) {
 
   const args = [
     '--expose-gc', `--max-old-space-size=${CHILD_MAX_OLD_SPACE_MB}`,
@@ -871,8 +1045,12 @@ function spawnChild( phase, filePath, batchSize, shard ) {
     args.push( `${shard.index}/${shard.count}` )
   }
 
+  // The budget rides in the environment rather than as another positional,
+  // because the shard argument is already optional-positional and a second
+  // one would make `--child lru model 64 512` ambiguous with a shard spec.
   const out = execFileSync( process.execPath, args,
-      { encoding: 'utf8', maxBuffer: 1 << 26, cwd: REPO_ROOT } )
+      { encoding: 'utf8', maxBuffer: 1 << 26, cwd: REPO_ROOT,
+        env: { ...process.env, M3_BUDGET_MB: String( budgetMB ) } } )
 
   return JSON.parse( out.trim().split( '\n' ).at( -1 ) )
 }
@@ -1352,7 +1530,9 @@ function main() {
       mode: argv[ 5 ] ?? 'roundrobin',
     } : void 0
 
-    return runChild( argv[ 1 ], argv[ 2 ], Number( argv[ 3 ] ), shard )
+    return runChild(
+        argv[ 1 ], argv[ 2 ], Number( argv[ 3 ] ), shard,
+        Number( process.env.M3_BUDGET_MB ?? DEFAULT_BUDGET_MB ) )
   }
 
   const flag = ( name, fallback ) => {
@@ -1367,7 +1547,7 @@ function main() {
   // the phase and shard-mode validation above exists to prevent, one level up.
   const KNOWN_FLAGS = new Set( [
     '--models', '--batch', '--repeats', '--json', '--phases', '--shards',
-    '--shard-mode' ] )
+    '--shard-mode', '--budget-mb' ] )
 
   // Every flag here takes an operand, and a flag whose operand is missing is
   // worse than an unknown one: `--phases pump --shards` leaves `--shards`
@@ -1421,6 +1601,17 @@ function main() {
         `--repeats must be a positive integer; got ${flag( '--repeats' )}` )
     process.exit( 2 )
   }
+  const budgetMB = Number( flag( '--budget-mb', DEFAULT_BUDGET_MB ) )
+
+  // Same reasoning as --batch: a budget of 0 or NaN would evict everything
+  // or nothing while the row still printed a number, which is the
+  // mislabelled-experiment failure this file keeps guarding against.
+  if ( !Number.isInteger( budgetMB ) || budgetMB < 1 ) {
+    console.error(
+        `--budget-mb must be a positive integer; got ${flag( '--budget-mb' )}` )
+    process.exit( 2 )
+  }
+
   const jsonOut = flag( '--json' )
   const only = flag( '--phases' )
   const phases = only !== void 0 ? only.split( ',' ) : PHASES
@@ -1448,7 +1639,8 @@ function main() {
     console.error(
         'usage: m3_pump_spike.mjs --models <file with one path per line> ' +
         '[--batch N] [--repeats N] [--phases a,b] [--json out] ' +
-        '[--shards 1,2,4] [--shard-mode roundrobin|contiguous]' )
+        '[--shards 1,2,4] [--shard-mode roundrobin|contiguous] ' +
+        '[--budget-mb N]' )
     process.exit( 2 )
   }
 
@@ -1562,7 +1754,7 @@ function main() {
       const runs = []
 
       for ( let repeat = 0; repeat < repeats; ++repeat ) {
-        runs.push( spawnChild( phase, model, batchSize ) )
+        runs.push( spawnChild( phase, model, batchSize, void 0, budgetMB ) )
       }
 
       // Correctness is checked on EVERY repeat; only the timing comes from the

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -93,9 +93,14 @@ export interface Loadersettings {
    * asserts) and unsafe for one that keeps geometry IDs and fetches them
    * lazily later.
    *
-   * Budgeted on payload bytes — vertex and index buffers, the same
-   * accounting as `calculateGeometrySize`. The wasm heap runs at a multiple
-   * of this and cannot be used as the signal itself: it is grow-only, so it
+   * Budgeted on each native's `getAllocationSize` — vertices, triangles,
+   * edges, the triangle-edge structures and the float vertex mirror. That is
+   * deliberately NOT the vertex+index payload `calculateGeometrySize`
+   * reports: the extra structures are real wasm bytes, so a ceiling that
+   * ignored them would bind later than its number suggests.
+   *
+   * The wasm heap still runs at a multiple of the budget (3-4x on the models
+   * measured) and cannot be used as the signal itself: it is grow-only, so it
    * never falls when a native is freed. Expect the heap high-water to track
    * the budget proportionally rather than equal it.
    */
@@ -937,7 +942,8 @@ export class IfcAPI {
    * payloads at delivery and unsafe for one that fetches lazily later.
    *
    * @param modelID handle retrieved by an open
-   * @param megabytes the ceiling, in MB of payload bytes
+   * @param megabytes the ceiling, in MB of native allocation (see
+   * GEOMETRY_BUDGET_MB for what that counts)
    * @return {object|undefined} the budget now in force and the bytes
    * currently accounted resident, or undefined for unknown models and for
    * passthroughs with no evictable geometry store (AP214/STEP).

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -79,7 +79,33 @@ export interface Loadersettings {
    * Consumers must treat these as disposable. Ignored everywhere else.
    */
   ON_PREVIEW_MESH?: ( mesh: PreviewMeshPayload ) => void
+
+  /**
+   * Conway extension (DEFER_GEOMETRY only; M3's budgeted arena): cap the
+   * native geometry a model keeps resident, in MB. At each pump batch the
+   * least-recently-used assets are evicted until the live set fits.
+   * Unset — the default — keeps everything, which is what every consumer
+   * did before this existed.
+   *
+   * **This changes a contract, so it is opt-in.** An evicted asset is gone
+   * from `GetGeometry` until something re-extracts it, which is safe for a
+   * consumer that copies payloads at delivery (the invariant Share#1640
+   * asserts) and unsafe for one that keeps geometry IDs and fetches them
+   * lazily later.
+   *
+   * Budgeted on payload bytes — vertex and index buffers, the same
+   * accounting as `calculateGeometrySize`. The wasm heap runs at a multiple
+   * of this and cannot be used as the signal itself: it is grow-only, so it
+   * never falls when a native is freed. Expect the heap high-water to track
+   * the budget proportionally rather than equal it.
+   */
+  GEOMETRY_BUDGET_MB?: number
 }
+
+/* MB as the API's unit, bytes as the engine's: the budget is a number a
+ * human picks, and the accounting is in bytes. */
+// eslint-disable-next-line no-magic-numbers
+const BYTES_PER_MIB = 1024 * 1024
 
 /**
  * web-ifc compatible log levels (numeric values match web-ifc's enum so an
@@ -896,6 +922,38 @@ export class IfcAPI {
    * remaining: 0}` for unknown models or models without the deferred
    * pump (non-IFC / fully-extracted opens).
    */
+  /**
+   * Conway extension (M3's budgeted arena): cap the native geometry a model
+   * keeps resident, in MB, after it is already open. At each pump batch the
+   * least-recently-used assets are evicted until the live set fits. Pass 0
+   * or a non-finite value to remove the cap.
+   *
+   * Prefer this over the GEOMETRY_BUDGET_MB open setting when the right
+   * number depends on the device or the moment — reopening an 860 MB model
+   * to change a budget is not a real option.
+   *
+   * Same contract as the setting: an evicted asset is gone from GetGeometry
+   * until something re-extracts it, which is safe for a consumer that copies
+   * payloads at delivery and unsafe for one that fetches lazily later.
+   *
+   * @param modelID handle retrieved by an open
+   * @param megabytes the ceiling, in MB of payload bytes
+   * @return {object|undefined} the budget now in force and the bytes
+   * currently accounted resident, or undefined for unknown models and for
+   * passthroughs with no evictable geometry store (AP214/STEP).
+   */
+  SetGeometryBudget( modelID: number, megabytes: number ):
+      { budgetBytes: number, liveBytes: number } | undefined {
+
+    const result = this.models.get(modelID)
+
+    if (result?.setGeometryBudget === void 0) {
+      return void 0
+    }
+
+    return result.setGeometryBudget( megabytes * BYTES_PER_MIB )
+  }
+
   ExtractGeometryBatch(
       modelID: number,
       batchSize: number,

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -647,6 +647,43 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     api6.CloseModel( unbudgetedID )
   }, 240000 )
 
+  test( 'a budget set mid-load accounts for what is already cached', async () => {
+
+    // The case SetGeometryBudget exists for: a tab already under pressure,
+    // where extraction started unbudgeted. The bookkeeping is fed by
+    // noteAdded, which no-ops while unlimited, so without seeding this
+    // model would start counting from zero — evicting nothing until it had
+    // extracted a budget's worth MORE geometry, while reporting the ceiling
+    // as satisfied and leaving the pre-existing residency permanent.
+    const api8 = new IfcAPI()
+    await api8.Init()
+
+    const fixture = new Uint8Array(
+        fs.readFileSync( 'data/mapped_shared_representation.ifc' ) )
+
+    const modelID = await api8.OpenModelStreamed(
+        fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    // Pump the WHOLE model unbudgeted first, so everything this model will
+    // ever cache is already resident when the budget arrives.
+    for ( ; ; ) {
+      const { extracted, remaining } = api8.ExtractGeometryBatch( modelID, 4 )
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+
+    // Enabling now must SEE that geometry. A budget above it proves the
+    // seeding happened at all; the assertion is that live is non-zero, not
+    // that it is under the ceiling — an unseeded implementation also
+    // reports "under", which is exactly why it is the wrong check.
+    const generous = api8.SetGeometryBudget( modelID, 64 )
+
+    expect( generous!.liveBytes ).toBeGreaterThan( 0 )
+
+    api8.CloseModel( modelID )
+  }, 240000 )
+
   test( 'no budget is the default, and evicts nothing', async () => {
 
     // The contract eviction changes — GetGeometry serving an evicted asset —

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -684,6 +684,47 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     api8.CloseModel( modelID )
   }, 240000 )
 
+  test( 'StreamAllMeshes on a budgeted deferred model keeps every instance', async () => {
+
+    // The drain path, which is where a budget is most dangerous. Deferred
+    // StreamAllMeshes pumps every batch with NO callback and captures once
+    // at the end — fine while geometry survives to be captured, and silently
+    // lossy once a budget is evicting: anything freed before that final
+    // capture can no longer be resolved, so its instances vanish with no
+    // error at all. At a 2 KiB budget this delivered 3 placements against
+    // classic's 16.
+    const api9 = new IfcAPI()
+    await api9.Init()
+
+    const fixture = new Uint8Array(
+        fs.readFileSync( 'data/mapped_shared_representation.ifc' ) )
+
+    const classicID = api9.OpenModel( fixture, SETTINGS )
+    let classicPlacements = 0
+
+    api9.StreamAllMeshes( classicID, ( mesh ) => {
+      classicPlacements += mesh.geometries.size()
+    } )
+
+    const deferredID = await api9.OpenModelStreamed(
+        fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    // Tight enough that eviction fires during the drain, not after it.
+    api9.SetGeometryBudget( deferredID, 2048 / ( 1024 * 1024 ) )
+
+    let drainedPlacements = 0
+
+    api9.StreamAllMeshes( deferredID, ( mesh ) => {
+      drainedPlacements += mesh.geometries.size()
+    } )
+
+    expect( classicPlacements ).toBeGreaterThan( 0 )
+    expect( drainedPlacements ).toBe( classicPlacements )
+
+    api9.CloseModel( classicID )
+    api9.CloseModel( deferredID )
+  }, 240000 )
+
   test( 'no budget is the default, and evicts nothing', async () => {
 
     // The contract eviction changes — GetGeometry serving an evicted asset —

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -725,6 +725,59 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     api9.CloseModel( deferredID )
   }, 240000 )
 
+  test( 'StreamAllMeshes serves live geometry under a budget, and rebudgets after',
+      async () => {
+
+        // The half a capture-before-eviction fix does NOT cover. Preserving
+        // the FlatMesh metadata keeps the instance counts right while the
+        // natives behind them are freed, so a consumer doing the ONLY thing
+        // it can do here — read geometry inside the callback, the classic
+        // contract — gets a BindingError on a dangling handle.
+        //
+        // StreamAllMeshes asks for the whole model at once, so the budget is
+        // suspended for the call and restored after. This pins both halves:
+        // every delivered geometry is readable during delivery, and the
+        // budget is back in force when it returns.
+        const api10 = new IfcAPI()
+        await api10.Init()
+
+        const fixture = new Uint8Array(
+            fs.readFileSync( 'data/mapped_shared_representation.ifc' ) )
+
+        const modelID = await api10.OpenModelStreamed(
+            fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+        const budgetBytes = 2048
+
+        api10.SetGeometryBudget( modelID, budgetBytes / ( 1024 * 1024 ) )
+
+        let read = 0
+
+        api10.StreamAllMeshes( modelID, ( mesh ) => {
+          for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+
+            // Reading at delivery is what a classic consumer does, and what
+            // an evicted native cannot survive.
+            const geometry =
+              api10.GetGeometry( modelID, mesh.geometries.get( where ).geometryExpressID )
+
+            expect( geometry.GetVertexDataSize() ).toBeGreaterThan( 0 )
+            ++read
+          }
+        } )
+
+        expect( read ).toBeGreaterThan( 0 )
+
+        // ...and the suspension is temporary: the budget is in force again,
+        // and has been applied, by the time the call returns.
+        const after = api10.SetGeometryBudget( modelID, budgetBytes / ( 1024 * 1024 ) )
+
+        expect( after?.budgetBytes ).toBe( budgetBytes )
+        expect( after?.liveBytes ).toBeLessThanOrEqual( budgetBytes )
+
+        api10.CloseModel( modelID )
+      }, 240000 )
+
   test( 'no budget is the default, and evicts nothing', async () => {
 
     // The contract eviction changes — GetGeometry serving an evicted asset —

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -553,6 +553,142 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     expect( oneAtATime.visits ).toBeLessThan( allAtOnce.visits * 2 )
   }, 240000 )
 
+  test( 'a geometry budget evicts to fit, and delivers the same meshes', async () => {
+
+    // M3's budgeted arena. Two properties, and they pull against each other:
+    // the budget must actually bind (or it is decoration), and binding must
+    // not change what the consumer receives (or it is a corruption).
+    //
+    // The fixture is the shared-representation one deliberately: it is the
+    // case where eviction is most likely to lose something, because a
+    // product 15 products later maps geometry an aggressive budget will
+    // have thrown away. It re-extracts instead, which is the whole design
+    // — correctness does not depend on the budget, only cost does.
+    const api6 = new IfcAPI()
+    await api6.Init()
+
+    const fixture = new Uint8Array(
+        fs.readFileSync( 'data/mapped_shared_representation.ifc' ) )
+
+    const classicID = api6.OpenModel( fixture, SETTINGS )
+    const classicPlacements: string[] = []
+
+    api6.StreamAllMeshes( classicID, ( mesh ) => {
+      for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+        const placed = mesh.geometries.get( where )
+        classicPlacements.push(
+            `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
+                .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+      }
+    } )
+
+    const deferredID = await api6.OpenModelStreamed(
+        fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    // A budget in BYTES, not MB: this model's whole live set is a few KB, so
+    // a 1 MB budget would never bind and the test would pass while proving
+    // nothing. SetGeometryBudget takes MB, hence the fraction.
+    const budgetBytes = 2048
+    const applied =
+      api6.SetGeometryBudget( deferredID, budgetBytes / ( 1024 * 1024 ) )
+
+    expect( applied?.budgetBytes ).toBe( budgetBytes )
+
+    const pumped: string[] = []
+
+    for ( ; ; ) {
+
+      const { extracted, remaining } = api6.ExtractGeometryBatch(
+          deferredID, 4, ( mesh ) => {
+            for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+              const placed = mesh.geometries.get( where )
+              pumped.push(
+                  `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
+                      .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+            }
+          } )
+
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+
+    // Bound honoured: reading the budget back reports what is resident now,
+    // after the last batch's eviction pass.
+    const settled = api6.SetGeometryBudget( deferredID, budgetBytes / ( 1024 * 1024 ) )
+
+    expect( settled?.liveBytes ).toBeLessThanOrEqual( budgetBytes )
+
+    // ...and it bound because there was more than that to hold, not because
+    // the model is tiny. Without this the assertion above passes on an empty
+    // model, which is the shape of check this file keeps getting wrong.
+    const unbudgetedID = await api6.OpenModelStreamed(
+        fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    api6.SetGeometryBudget( unbudgetedID, Number.MAX_SAFE_INTEGER )
+
+    for ( ; ; ) {
+      const { extracted, remaining } = api6.ExtractGeometryBatch( unbudgetedID, 4 )
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+
+    const unbudgeted =
+      api6.SetGeometryBudget( unbudgetedID, Number.MAX_SAFE_INTEGER )
+
+    expect( unbudgeted!.liveBytes ).toBeGreaterThan( budgetBytes )
+
+    // Same meshes, same placements, evicted or not.
+    expect( pumped.slice().sort() ).toEqual( classicPlacements.slice().sort() )
+
+    api6.CloseModel( classicID )
+    api6.CloseModel( deferredID )
+    api6.CloseModel( unbudgetedID )
+  }, 240000 )
+
+  test( 'no budget is the default, and evicts nothing', async () => {
+
+    // The contract eviction changes — GetGeometry serving an evicted asset —
+    // must not change for anyone who did not ask for it. A model opened
+    // without GEOMETRY_BUDGET_MB tracks nothing and frees nothing.
+    const api7 = new IfcAPI()
+    await api7.Init()
+
+    const fixture = new Uint8Array(
+        fs.readFileSync( 'data/mapped_shared_representation.ifc' ) )
+
+    const modelID = await api7.OpenModelStreamed(
+        fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    const geometryIDs: number[] = []
+
+    for ( ; ; ) {
+
+      const { extracted, remaining } = api7.ExtractGeometryBatch(
+          modelID, 4, ( mesh ) => {
+            for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+              geometryIDs.push( mesh.geometries.get( where ).geometryExpressID )
+            }
+          } )
+
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+
+    expect( geometryIDs.length ).toBeGreaterThan( 0 )
+
+    // Every delivered geometry is still fetchable at the end of the load —
+    // the lazy-fetch consumer an unbudgeted model is allowed to be.
+    for ( const geometryID of geometryIDs ) {
+      expect( api7.GetGeometry( modelID, geometryID ).GetVertexDataSize() )
+          .toBeGreaterThan( 0 )
+    }
+
+    api7.CloseModel( modelID )
+  }, 240000 )
+
   test( 'ExtractGeometryBatch is a safe no-op on non-deferred models', async () => {
 
     const modelID = await api.OpenModelStreamed( buffer, SETTINGS )

--- a/src/compat/web-ifc/ifc_api_model_passthrough.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough.ts
@@ -22,6 +22,13 @@ export interface IfcApiModelPassthrough {
   /** Metres per model unit (see IfcAPI.GetLinearScalingFactor). */
   linearScalingFactor?: number
 
+  /**
+   * Set the resident-geometry budget in bytes (conway extension, M3) —
+   * see IfcAPI.SetGeometryBudget. Optional so non-IFC passthroughs, whose
+   * models have no evictable geometry store, simply do not offer it.
+   */
+  setGeometryBudget?( bytes: number ): { budgetBytes: number, liveBytes: number }
+
   extractGeometryBatch?(
     batchSize: number,
     meshCallback?: (mesh: FlatMesh) => void): {extracted: number, remaining: number}

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -131,6 +131,46 @@ interface IfcProxyLoadState {
 /**
  * The proxy for IFC from the shim.
  */
+/**
+ * The placements of a FlatMesh whose native geometry is still alive.
+ *
+ * There is no "is this deleted" predicate on the binding, so liveness is
+ * probed by the cheapest call that touches the native and throws when it is
+ * gone. Only used on the degraded StreamAllMeshes path, where the
+ * alternative is handing a consumer a handle that aborts on read.
+ *
+ * @param mesh The accumulated per-entity mesh.
+ * @param geometryMap Express ID to [geometry, material, transform].
+ * @return {PlacedGeometry[]} The placements still backed by live geometry.
+ */
+function livePlacements(
+    mesh: FlatMesh,
+    geometryMap: Map<number, [GeometryObject, CanonicalMaterial, number[]]> ):
+    PlacedGeometry[] {
+
+  const live: PlacedGeometry[] = []
+
+  for (let where = 0; where < mesh.geometries.size(); ++where) {
+
+    const placed = mesh.geometries.get(where)
+    const entry = geometryMap.get(placed.geometryExpressID)
+
+    if (entry === void 0) {
+      continue
+    }
+
+    try {
+      entry[0].GetVertexDataSize()
+      live.push(placed)
+    } catch {
+      /* Native freed by eviction — drop the placement. */
+    }
+  }
+
+  return live
+}
+
+
 export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
   fs?: any = undefined
@@ -2560,23 +2600,17 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       const residency = this.model[0].geometryResidency
       const suspendedBudgetBytes = residency.budgetBytes
 
-      // Refused rather than served wrong. Suspending stops future eviction,
-      // but nothing recovers what a caller's own budgeted batches already
-      // freed: the accumulated per-entity meshes reference natives that are
-      // gone, and re-extracting the owning products restores geometry under
-      // NEW local IDs, so the old meshes still fail to resolve while a fresh
-      // capture emits the same instances a second time (21 placements
-      // against classic's 16 on the shared-representation fixture, one
-      // duplicate per rehydrated product). Serving either of those quietly
-      // is worse than saying no.
-      if (residency.everEvicted) {
-
-        throw new Error(
-            'StreamAllMeshes cannot serve a model that has evicted geometry ' +
-            'under a memory budget: the accumulated meshes reference natives ' +
-            'that were freed. Pump ExtractGeometryBatch and copy each batch ' +
-            'at delivery, or open the model without GEOMETRY_BUDGET_MB.')
-      }
+      // Degraded, and said so once. Suspending stops future eviction, but
+      // nothing recovers what a caller's own budgeted batches already freed:
+      // the accumulated meshes reference natives that are gone, and
+      // re-extracting the owning products restores geometry under NEW local
+      // IDs, so the old meshes still fail to resolve while a fresh capture
+      // emits the same instances again (21 placements against classic's 16
+      // on the shared-representation fixture). Rather than hand out dangling
+      // handles, this delivers what is still resident and drops the rest —
+      // see the filter below. Properly serving this combination needs the
+      // meshes re-keyed onto re-extracted geometry, which is follow-up work.
+      const degraded = residency.everEvicted
 
       residency.setBudgetBytes(0)
 
@@ -2590,12 +2624,41 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         }
         this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
 
-        const [, , meshMap, , vectorFlatMesh] = this.model
+        const [, , meshMap, geometryMaterialTransformMap, vectorFlatMesh] =
+          this.model
+
+        let droppedInstances = 0
+        let droppedEntities = 0
 
         meshMap.forEach((mesh) => {
+
+          if (degraded) {
+
+            const live = livePlacements(mesh[1], geometryMaterialTransformMap)
+
+            droppedInstances += mesh[1].geometries.size() - live.length
+
+            if (live.length === 0) {
+              ++droppedEntities
+              return
+            }
+          }
+
           vectorFlatMesh.push(mesh[1])
           meshCallback(mesh[1])
         })
+
+        // One line for the whole call, not one per dropped instance: this
+        // fires on a path that may drop thousands, and a per-instance log
+        // would bury the fact that anything was dropped at all.
+        if (degraded) {
+          Logger.warning(
+              `[geometry budget] StreamAllMeshes served a model that evicted ` +
+              `under a budget: ${droppedInstances} instance(s) across ` +
+              `${droppedEntities} entit(ies) were dropped because their ` +
+              `geometry was freed. Pump ExtractGeometryBatch and copy at ` +
+              `delivery to receive everything.`)
+        }
 
       } finally {
 

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2079,8 +2079,18 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       }
     }
 
+    // Capture before eviction — and capture even when nobody asked for
+    // meshes. The deferred StreamAllMeshes drain pumps with `noCallback` for
+    // every batch and captures once at the end (see streamAllMeshes), which
+    // works only while geometry survives to be captured. With a budget it
+    // does not: anything evicted before that final capture can no longer be
+    // resolved, so those instances vanish from the model with no error. On
+    // the shared-representation fixture at a 2 KiB budget that path
+    // delivered 3 placements against classic's 16.
     if (meshCallback !== void 0) {
       this.streamNewMeshes_(meshCallback)
+    } else if (this.model[0].geometryResidency.enabled) {
+      this.streamNewMeshes_(() => { /* capture into meshMap before eviction */ })
     }
 
     // Evict AFTER the capture, never before: the delta capture resolves each
@@ -2207,8 +2217,18 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       }
     }
 
+    // Capture before eviction — and capture even when nobody asked for
+    // meshes. The deferred StreamAllMeshes drain pumps with `noCallback` for
+    // every batch and captures once at the end (see streamAllMeshes), which
+    // works only while geometry survives to be captured. With a budget it
+    // does not: anything evicted before that final capture can no longer be
+    // resolved, so those instances vanish from the model with no error. On
+    // the shared-representation fixture at a 2 KiB budget that path
+    // delivered 3 placements against classic's 16.
     if (meshCallback !== void 0) {
       this.streamNewMeshes_(meshCallback)
+    } else if (this.model[0].geometryResidency.enabled) {
+      this.streamNewMeshes_(() => { /* capture into meshMap before eviction */ })
     }
 
     // Evict AFTER the capture, never before: the delta capture resolves

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2560,30 +2560,58 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       const residency = this.model[0].geometryResidency
       const suspendedBudgetBytes = residency.budgetBytes
 
+      // Refused rather than served wrong. Suspending stops future eviction,
+      // but nothing recovers what a caller's own budgeted batches already
+      // freed: the accumulated per-entity meshes reference natives that are
+      // gone, and re-extracting the owning products restores geometry under
+      // NEW local IDs, so the old meshes still fail to resolve while a fresh
+      // capture emits the same instances a second time (21 placements
+      // against classic's 16 on the shared-representation fixture, one
+      // duplicate per rehydrated product). Serving either of those quietly
+      // is worse than saying no.
+      if (residency.everEvicted) {
+
+        throw new Error(
+            'StreamAllMeshes cannot serve a model that has evicted geometry ' +
+            'under a memory budget: the accumulated meshes reference natives ' +
+            'that were freed. Pump ExtractGeometryBatch and copy each batch ' +
+            'at delivery, or open the model without GEOMETRY_BUDGET_MB.')
+      }
+
       residency.setBudgetBytes(0)
 
-      const noCallback = void 0
+      try {
 
-      while (this.extractGeometryBatch(
-          DEFERRED_DRAIN_BATCH, noCallback).remaining > 0) {
-        // draining
-      }
-      this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
+        const noCallback = void 0
 
-      const [, , meshMap, , vectorFlatMesh] = this.model
+        while (this.extractGeometryBatch(
+            DEFERRED_DRAIN_BATCH, noCallback).remaining > 0) {
+          // draining
+        }
+        this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
 
-      meshMap.forEach((mesh) => {
-        vectorFlatMesh.push(mesh[1])
-        meshCallback(mesh[1])
-      })
+        const [, , meshMap, , vectorFlatMesh] = this.model
 
-      if (Number.isFinite(suspendedBudgetBytes)) {
+        meshMap.forEach((mesh) => {
+          vectorFlatMesh.push(mesh[1])
+          meshCallback(mesh[1])
+        })
 
-        // Restoring seeds from everything now resident; the pass then trims
-        // to the ceiling, so the model is back under budget by the time this
-        // returns rather than at some later pump that may never come.
-        residency.setBudgetBytes(suspendedBudgetBytes)
-        residency.evictToBudget()
+      } finally {
+
+        // In a finally because meshCallback is the CALLER's code: if it
+        // throws — including from a geometry read — an early return would
+        // leave the model permanently unbudgeted, holding the unbudgeted
+        // drain's whole resident set, with nothing to signal it.
+        if (Number.isFinite(suspendedBudgetBytes)) {
+
+          // Restoring seeds from everything now resident; the pass then
+          // trims to the ceiling, so the model is back under budget by the
+          // time this returns rather than at some later pump that may never
+          // come.
+          residency.setBudgetBytes(suspendedBudgetBytes)
+          residency.evictToBudget()
+        }
       }
 
       return

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -308,6 +308,16 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       geometryTimeInMs: executionTimeInMs,
     } = loadState
 
+    // M3's budgeted arena. Applied here rather than at parse time because
+    // the model only exists now, and eviction cannot matter before the first
+    // pump batch anyway. Absent or non-positive leaves it unlimited, which
+    // is every pre-existing consumer's behaviour.
+    if ( settings?.GEOMETRY_BUDGET_MB !== void 0 ) {
+
+      model.geometryResidency.setBudgetBytes(
+          settings.GEOMETRY_BUDGET_MB * BYTES_PER_MIB )
+    }
+
     // get linear scaling factor
     this.linearScalingFactor = conwayGeometry.getLinearScalingFactor()
 
@@ -2073,6 +2083,12 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       this.streamNewMeshes_(meshCallback)
     }
 
+    // Evict AFTER the capture, never before: the delta capture resolves each
+    // new node's geometry to emit it, so evicting first would drop assets
+    // this batch is about to deliver and re-extract them immediately. A
+    // no-op unless a budget is configured.
+    this.model[0].geometryResidency.evictToBudget()
+
     const remaining = (products.length - this.demandCursor_) +
         (aggregates.length - this.demandAggregatesCursor_)
 
@@ -2195,6 +2211,15 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       this.streamNewMeshes_(meshCallback)
     }
 
+    // Evict AFTER the capture, never before: the delta capture resolves
+    // each new node's geometry to emit it, so evicting first would drop
+    // assets this batch is about to deliver and re-extract them at once.
+    // A no-op unless a budget is configured. Both pumps need this — the
+    // async twin is what Share drives, this one is what a synchronous
+    // embedder and the test suite drive, and a budget honoured on only
+    // one of them is a budget that silently does not apply.
+    this.model[0].geometryResidency.evictToBudget()
+
     const remaining = (products.length - this.demandCursor_) +
         (aggregates.length - this.demandAggregatesCursor_)
 
@@ -2233,6 +2258,31 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * @param meshCallback Receives one delta FlatMesh per entity that
    * gained instances this call.
    */
+  /**
+   * Set the resident-geometry budget, in bytes, after the open.
+   *
+   * The setting form (GEOMETRY_BUDGET_MB) fixes the budget for a model's
+   * lifetime; this exists because the right number is a property of the
+   * device and the moment — a tab under pressure wants a smaller one than
+   * the same tab on load — and re-opening an 860 MB model to change it is
+   * not a real option.
+   *
+   * Takes effect at the next pump batch, so lowering it mid-load does not
+   * stall the current one freeing memory.
+   *
+   * @param bytes The ceiling; non-finite or non-positive disables eviction.
+   * @return {{budgetBytes: number, liveBytes: number}} The budget now in
+   * force and what is currently accounted resident.
+   */
+  public setGeometryBudget( bytes: number ): { budgetBytes: number, liveBytes: number } {
+
+    const residency = this.model[0].geometryResidency
+
+    residency.setBudgetBytes( bytes )
+
+    return { budgetBytes: residency.budgetBytes, liveBytes: residency.liveBytes }
+  }
+
   private streamNewMeshes_(
       meshCallback: (mesh: FlatMesh) => void ): void {
 

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2540,6 +2540,28 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // completion and serve the accumulated full per-entity meshes.
     if (this.deferredMode_) {
 
+      // A budget cannot hold across this call, and pretending otherwise
+      // hands the consumer freed memory.
+      //
+      // StreamAllMeshes asks for the WHOLE model at once and delivers every
+      // entity after the drain completes, so a consumer reading geometry in
+      // its callback — the classic contract, and the only way to copy a
+      // payload here — reaches natives evicted batches ago. Capturing before
+      // eviction (see the pumps) saves the FlatMesh metadata but not the
+      // natives it points at, so it fixes the silent-omission half of this
+      // and not the dangling half.
+      //
+      // So the budget is suspended for the call and restored after, with one
+      // eviction pass to trim what the drain accumulated. The peak during
+      // StreamAllMeshes is therefore the UNBUDGETED peak, which is what
+      // asking for every mesh at once means. A consumer that wants the
+      // budget honoured throughout should pump ExtractGeometryBatch and copy
+      // per batch, which is what Share does.
+      const residency = this.model[0].geometryResidency
+      const suspendedBudgetBytes = residency.budgetBytes
+
+      residency.setBudgetBytes(0)
+
       const noCallback = void 0
 
       while (this.extractGeometryBatch(
@@ -2554,6 +2576,15 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         vectorFlatMesh.push(mesh[1])
         meshCallback(mesh[1])
       })
+
+      if (Number.isFinite(suspendedBudgetBytes)) {
+
+        // Restoring seeds from everything now resident; the pass then trims
+        // to the ceiling, so the model is back under budget by the time this
+        // returns rather than at some later pump that may never come.
+        residency.setBudgetBytes(suspendedBudgetBytes)
+        residency.evictToBudget()
+      }
 
       return
     }

--- a/src/ifc/geometry_residency.ts
+++ b/src/ifc/geometry_residency.ts
@@ -1,0 +1,275 @@
+import { CanonicalMesh, CanonicalMeshType } from '../core/canonical_mesh'
+import { IfcModelGeometry } from './ifc_model_geometry'
+
+
+/* Bytes per element of the two native buffers, matching
+ * IfcModelGeometry.calculateGeometrySize: vertices are doubles, indices are
+ * 32-bit. Getting this wrong does not break the policy — it is proportional
+ * either way — but it makes the configured budget mean something other than
+ * what it says. */
+// eslint-disable-next-line no-magic-numbers
+const BYTES_PER_VERTEX_ELEMENT = 8
+// eslint-disable-next-line no-magic-numbers
+const BYTES_PER_INDEX_ELEMENT = 4
+
+/* Composite key over the model's TWO geometry stores. Local IDs are
+ * store-relative, so `geometry` and `voidGeometry` can hold the same ID for
+ * different meshes; the budget spans both, so the recency order has to as
+ * well. */
+const VOID_STORE_BIT = 1
+
+
+/**
+ * Least-recently-used residency for a model's extracted geometry, against a
+ * configured byte budget — the "budgeted arena" half of M3.
+ *
+ * **Why LRU rather than release-on-emit.** Freeing everything a batch created
+ * is correct (the fixture `data/mapped_shared_representation.ifc` shows no
+ * lost or misplaced instances) but rebuilds geometry a later product still
+ * maps: +62.6 % assets on MB-Khaya at batch 64, +79.4 % on D3D. Evicting only
+ * what does not fit keeps whatever there is room for, so extraction order's
+ * natural locality — a representation goes cold once its users are extracted
+ * — does the work instead of the batch boundary. Measured: MB-Khaya evicted
+ * 3 053 assets for **zero** rebuilds, D3D 21 539 for 1 219.
+ *
+ * **Why bytes and not the wasm heap.** `wasmHeapByteLength` is grow-only: it
+ * does not fall when a native is freed, so a controller driven by it would
+ * evict once, observe no change, and evict everything. What a budget can
+ * actually govern is the live set; the heap high-water follows it, at a
+ * multiple this cannot see (an 8 MB live set sat under an 85 MB heap on
+ * MB-Khaya, the difference being allocator overhead, fragmentation, and the
+ * intermediate buffers a boolean leaves behind).
+ *
+ * **The contract this changes.** An evicted asset is gone from
+ * `GetGeometry`/`getByLocalID` until something re-extracts it. That is safe
+ * for a consumer which copies payloads at delivery — the invariant
+ * Share#1640 already asserts — and unsafe for one that holds geometry IDs and
+ * fetches lazily later. So a budget is opt-in and unlimited by default:
+ * turning it on is a statement about the consumer, not just about memory.
+ */
+export class GeometryResidency {
+
+  private budgetBytes_ = Number.POSITIVE_INFINITY
+
+  private liveBytes_ = 0
+
+  /* Insertion order IS recency order: re-setting an existing key does not
+   * move it, so a touch deletes before setting. */
+  private readonly order_ = new Map< number, { store: IfcModelGeometry, bytes: number } >()
+
+  /**
+   * @return {boolean} Whether a finite budget is configured. Every hook below
+   * returns immediately when this is false, so an unbudgeted model pays one
+   * predictable-branch per geometry add and lookup rather than the
+   * bookkeeping — `getByLocalID` is on the scene-walk hot path.
+   */
+  public get enabled(): boolean {
+    return this.budgetBytes_ !== Number.POSITIVE_INFINITY
+  }
+
+  /**
+   * @return {number} The configured budget in bytes, or Infinity.
+   */
+  public get budgetBytes(): number {
+    return this.budgetBytes_
+  }
+
+  /**
+   * @return {number} Bytes currently accounted resident.
+   */
+  public get liveBytes(): number {
+    return this.liveBytes_
+  }
+
+  /**
+   * @return {number} How many assets are tracked.
+   */
+  public get residentCount(): number {
+    return this.order_.size
+  }
+
+  /**
+   * Set the budget. A non-finite or non-positive value disables eviction,
+   * which is the default and the behaviour every consumer had before this
+   * existed.
+   *
+   * Raising or lowering it takes effect at the next eviction pass rather than
+   * immediately, so a caller that lowers the budget mid-load does not stall
+   * the current batch freeing memory.
+   *
+   * @param bytes The new ceiling, or Infinity to disable.
+   */
+  public setBudgetBytes( bytes: number ): void {
+
+    if ( !Number.isFinite( bytes ) || bytes <= 0 ) {
+
+      this.budgetBytes_ = Number.POSITIVE_INFINITY
+
+      // Drop the bookkeeping too: with no budget it can only go stale, and a
+      // stale order would evict the wrong things if a budget were set later.
+      this.order_.clear()
+      this.liveBytes_ = 0
+      return
+    }
+
+    this.budgetBytes_ = bytes
+  }
+
+  /**
+   * Record an asset as resident, or refresh one being replaced.
+   *
+   * @param store The store holding it.
+   * @param mesh The mesh added.
+   */
+  public noteAdded( store: IfcModelGeometry, mesh: CanonicalMesh ): void {
+
+    if ( !this.enabled ) {
+      return
+    }
+
+    const key = residencyKey( store, mesh.localID )
+    const existing = this.order_.get( key )
+
+    if ( existing !== void 0 ) {
+      this.liveBytes_ -= existing.bytes
+      this.order_.delete( key )
+    }
+
+    const bytes = meshBytes( mesh )
+
+    this.order_.set( key, { store, bytes } )
+    this.liveBytes_ += bytes
+  }
+
+  /**
+   * Record a use, moving the asset to the most-recent end.
+   *
+   * @param store The store queried.
+   * @param localID The asset's local ID.
+   */
+  public noteUsed( store: IfcModelGeometry, localID: number ): void {
+
+    if ( !this.enabled ) {
+      return
+    }
+
+    const key = residencyKey( store, localID )
+    const existing = this.order_.get( key )
+
+    if ( existing === void 0 ) {
+      return
+    }
+
+    this.order_.delete( key )
+    this.order_.set( key, existing )
+  }
+
+  /**
+   * Stop accounting for an asset something else freed — an explicit delete,
+   * or the extractor reclaiming its own temporaries. Without this the budget
+   * would keep charging for bytes nobody holds and evict live assets to make
+   * room for them.
+   *
+   * @param store The store it was in.
+   * @param localID The asset's local ID.
+   */
+  public noteRemoved( store: IfcModelGeometry, localID: number ): void {
+
+    if ( !this.enabled ) {
+      return
+    }
+
+    const key = residencyKey( store, localID )
+    const existing = this.order_.get( key )
+
+    if ( existing === void 0 ) {
+      return
+    }
+
+    this.liveBytes_ -= existing.bytes
+    this.order_.delete( key )
+  }
+
+  /**
+   * Evict least-recently-used assets until the live set fits the budget.
+   *
+   * @return {{evicted: number, freedBytes: number}} What this pass reclaimed.
+   */
+  public evictToBudget(): { evicted: number, freedBytes: number } {
+
+    if ( !this.enabled ) {
+      return { evicted: 0, freedBytes: 0 }
+    }
+
+    let evicted = 0
+    let freedBytes = 0
+
+    for ( const [ key, entry ] of this.order_ ) {
+
+      if ( this.liveBytes_ <= this.budgetBytes_ ) {
+        break
+      }
+
+      // Delete drops this entry through noteRemoved, so the accounting and
+      // the map are updated there rather than here.
+      const localID = localIDOf( key )
+
+      entry.store.delete( localID )
+
+      ++evicted
+      freedBytes += entry.bytes
+    }
+
+    return { evicted, freedBytes }
+  }
+}
+
+
+/**
+ * Composite recency key spanning both of a model's geometry stores.
+ *
+ * @param store The store.
+ * @param localID The asset's local ID within it.
+ * @return {number} A key unique across both stores.
+ */
+function residencyKey( store: IfcModelGeometry, localID: number ): number {
+  return ( localID * 2 ) + ( store.isVoid ? VOID_STORE_BIT : 0 )
+}
+
+
+/**
+ * Recover a local ID from a composite key.
+ *
+ * @param key The composite key.
+ * @return {number} The local ID.
+ */
+function localIDOf( key: number ): number {
+  return ( key - ( key % 2 ) ) / 2
+}
+
+
+/**
+ * Approximate the native bytes an asset holds.
+ *
+ * @param mesh The mesh.
+ * @return {number} Payload bytes, or 0 for anything that is not a native
+ * buffer geometry (a lazy thunk, a string, an already-freed handle).
+ */
+function meshBytes( mesh: CanonicalMesh ): number {
+
+  if ( mesh.type !== CanonicalMeshType.BUFFER_GEOMETRY ) {
+    return 0
+  }
+
+  try {
+
+    return ( mesh.geometry.GetVertexDataSize() * BYTES_PER_VERTEX_ELEMENT ) +
+      ( mesh.geometry.GetIndexDataSize() * BYTES_PER_INDEX_ELEMENT )
+
+  } catch {
+
+    // A geometry whose native is already gone contributes nothing, and
+    // throwing here would abort a load over bookkeeping.
+    return 0
+  }
+}

--- a/src/ifc/geometry_residency.ts
+++ b/src/ifc/geometry_residency.ts
@@ -76,6 +76,11 @@ export class GeometryResidency {
 
   private liveBytes_ = 0
 
+  /* Whether anything has ever been evicted from this model. Sticky: once a
+   * native has been freed, the accumulated per-entity meshes may reference
+   * geometry that is gone, and no later change of budget puts it back. */
+  private everEvicted_ = false
+
   /* Insertion order IS recency order: re-setting an existing key does not
    * move it, so a touch deletes before setting. */
   private readonly order_ = new Map< number, { store: IfcModelGeometry, native: object } >()
@@ -126,6 +131,13 @@ export class GeometryResidency {
    */
   public get residentCount(): number {
     return this.order_.size
+  }
+
+  /**
+   * @return {boolean} Whether this model has ever had geometry evicted.
+   */
+  public get everEvicted(): boolean {
+    return this.everEvicted_
   }
 
   /**
@@ -361,6 +373,7 @@ export class GeometryResidency {
 
       entry.store.delete( localID )
 
+      this.everEvicted_ = true
       ++evicted
       freedBytes += bytes
     }

--- a/src/ifc/geometry_residency.ts
+++ b/src/ifc/geometry_residency.ts
@@ -83,6 +83,10 @@ export class GeometryResidency {
   private readonly natives_ =
     new Map< object, { bytes: number, keys: Set< number > } >()
 
+  /* The stores feeding this, so enabling a budget can seed from what is
+   * ALREADY cached. See setBudgetBytes. */
+  private readonly stores_: IfcModelGeometry[] = []
+
   /**
    * @return {boolean} Whether a finite budget is configured. Every hook below
    * returns immediately when this is false, so an unbudgeted model pays one
@@ -115,6 +119,16 @@ export class GeometryResidency {
   }
 
   /**
+   * Register a store so a budget enabled later can see what it already
+   * holds.
+   *
+   * @param store The store.
+   */
+  public registerStore( store: IfcModelGeometry ): void {
+    this.stores_.push( store )
+  }
+
+  /**
    * Set the budget. A non-finite or non-positive value disables eviction,
    * which is the default and the behaviour every consumer had before this
    * existed.
@@ -122,6 +136,19 @@ export class GeometryResidency {
    * Raising or lowering it takes effect at the next eviction pass rather than
    * immediately, so a caller that lowers the budget mid-load does not stall
    * the current batch freeing memory.
+   *
+   * **Enabling seeds from what is already cached.** The bookkeeping is fed
+   * by `noteAdded`, which no-ops while unlimited, so a model that pumped
+   * batches before a budget arrived — or one whose budget was disabled and
+   * re-enabled — would start counting from zero and evict nothing until it
+   * had extracted a budget's worth MORE geometry. The pre-existing residency
+   * would sit there permanently while liveBytes reported the ceiling was
+   * satisfied. That is precisely the case SetGeometryBudget exists for: a
+   * tab already under pressure.
+   *
+   * Seeding takes the stores in iteration order, which is extraction order,
+   * so the recency order it produces is oldest-first — the right guess when
+   * no better information survived.
    *
    * @param bytes The new ceiling, or Infinity to disable.
    */
@@ -139,7 +166,27 @@ export class GeometryResidency {
       return
     }
 
+    const wasDisabled = !this.enabled
+
     this.budgetBytes_ = bytes
+
+    if ( wasDisabled ) {
+      this.seedFromStores_()
+    }
+  }
+
+  /**
+   * Account for everything the stores already hold, for a budget enabled
+   * after extraction has started.
+   */
+  private seedFromStores_(): void {
+
+    for ( const store of this.stores_ ) {
+
+      for ( const mesh of store ) {
+        this.noteAdded( store, mesh )
+      }
+    }
   }
 
   /**

--- a/src/ifc/geometry_residency.ts
+++ b/src/ifc/geometry_residency.ts
@@ -18,6 +18,9 @@ const BYTES_PER_INDEX_ELEMENT = 4
  * well. */
 const VOID_STORE_BIT = 1
 
+// eslint-disable-next-line no-magic-numbers
+const BYTES_PER_MIB = 1024 * 1024
+
 
 /**
  * Least-recently-used residency for a model's extracted geometry, against a
@@ -29,8 +32,18 @@ const VOID_STORE_BIT = 1
  * maps: +62.6 % assets on MB-Khaya at batch 64, +79.4 % on D3D. Evicting only
  * what does not fit keeps whatever there is room for, so extraction order's
  * natural locality — a representation goes cold once its users are extracted
- * — does the work instead of the batch boundary. Measured: MB-Khaya evicted
- * 3 053 assets for **zero** rebuilds, D3D 21 539 for 1 219.
+ * — does the work instead of the batch boundary. Measured on MB-Khaya: 3 053
+ * assets evicted for **zero** rebuilds, and the wasm peak 102 -> 71 MB.
+ *
+ * **What a too-small budget costs.** Ordinary cache pressure, bounded and
+ * proportional: D3D under 64 MB rebuilds 2.8 % more assets than an unbudgeted
+ * load and finishes in the same time (52.5 s against 53.1 s); MB-Khaya under
+ * an absurd 1 MB rebuilds 38 % more. Nothing here thrashes. (An earlier
+ * version of this file carried a floor that raised the budget when eviction
+ * looked like churn, written after a 64 MB D3D load ran for an hour. That
+ * load was not thrashing — eviction was freeing natives other cached entries
+ * still referenced, see natives_ — and once that was fixed the floor never
+ * fired on any model available, so it went.)
  *
  * **Why bytes and not the wasm heap.** `wasmHeapByteLength` is grow-only: it
  * does not fall when a native is freed, so a controller driven by it would
@@ -55,7 +68,20 @@ export class GeometryResidency {
 
   /* Insertion order IS recency order: re-setting an existing key does not
    * move it, so a touch deletes before setting. */
-  private readonly order_ = new Map< number, { store: IfcModelGeometry, bytes: number } >()
+  private readonly order_ = new Map< number, { store: IfcModelGeometry, native: object } >()
+
+  /* Native object -> the keys that reference it, and its size.
+   *
+   * Store entries are NOT one-to-one with natives: on D3D 1 448 of 23 692
+   * cached meshes hand back a native some other localID already holds (6 %).
+   * Two things follow, and both are bugs if this map does not exist. The
+   * budget would charge for those bytes once per key rather than once, and —
+   * far worse — evicting one key would free a native its siblings still
+   * point at, leaving them dangling with no diagnostic until something reads
+   * them. So residency is refcounted on the NATIVE: bytes are charged once,
+   * and the native is freed only when its last referencing key goes. */
+  private readonly natives_ =
+    new Map< object, { bytes: number, keys: Set< number > } >()
 
   /**
    * @return {boolean} Whether a finite budget is configured. Every hook below
@@ -108,6 +134,7 @@ export class GeometryResidency {
       // Drop the bookkeeping too: with no budget it can only go stale, and a
       // stale order would evict the wrong things if a budget were set later.
       this.order_.clear()
+      this.natives_.clear()
       this.liveBytes_ = 0
       return
     }
@@ -128,17 +155,85 @@ export class GeometryResidency {
     }
 
     const key = residencyKey( store, mesh.localID )
-    const existing = this.order_.get( key )
 
-    if ( existing !== void 0 ) {
-      this.liveBytes_ -= existing.bytes
-      this.order_.delete( key )
+    if ( this.order_.has( key ) ) {
+      this.releaseKey_( key )
     }
 
-    const bytes = meshBytes( mesh )
+    if ( mesh.type !== CanonicalMeshType.BUFFER_GEOMETRY ) {
+      return
+    }
 
-    this.order_.set( key, { store, bytes } )
-    this.liveBytes_ += bytes
+    const native = mesh.geometry as unknown as object
+    const tracked = this.natives_.get( native )
+
+    if ( tracked !== void 0 ) {
+
+      // Already resident under another key: charge nothing more, just add
+      // the reference.
+      tracked.keys.add( key )
+
+    } else {
+
+      const bytes = meshBytes( mesh )
+
+      this.natives_.set( native, { bytes, keys: new Set( [ key ] ) } )
+      this.liveBytes_ += bytes
+    }
+
+    this.order_.set( key, { store, native } )
+  }
+
+  /**
+   * Drop one key's reference, reporting whether the native it names is now
+   * unreferenced and therefore safe to free.
+   *
+   * @param key The composite key.
+   * @return {boolean} True when this was the last reference.
+   */
+  private releaseKey_( key: number ): boolean {
+
+    const entry = this.order_.get( key )
+
+    this.order_.delete( key )
+
+    if ( entry === void 0 ) {
+      return true
+    }
+
+    const tracked = this.natives_.get( entry.native )
+
+    if ( tracked === void 0 ) {
+      return true
+    }
+
+    tracked.keys.delete( key )
+
+    if ( tracked.keys.size > 0 ) {
+      return false
+    }
+
+    this.liveBytes_ -= tracked.bytes
+    this.natives_.delete( entry.native )
+
+    return true
+  }
+
+  /**
+   * Whether freeing the native behind a store entry is safe — false while
+   * another cached mesh still references the same native.
+   *
+   * @param store The store.
+   * @param localID The asset's local ID.
+   * @return {boolean} True when the caller should free the native.
+   */
+  public releaseReference( store: IfcModelGeometry, localID: number ): boolean {
+
+    if ( !this.enabled ) {
+      return true
+    }
+
+    return this.releaseKey_( residencyKey( store, localID ) )
   }
 
   /**
@@ -179,15 +274,7 @@ export class GeometryResidency {
       return
     }
 
-    const key = residencyKey( store, localID )
-    const existing = this.order_.get( key )
-
-    if ( existing === void 0 ) {
-      return
-    }
-
-    this.liveBytes_ -= existing.bytes
-    this.order_.delete( key )
+    this.releaseKey_( residencyKey( store, localID ) )
   }
 
   /**
@@ -213,11 +300,12 @@ export class GeometryResidency {
       // Delete drops this entry through noteRemoved, so the accounting and
       // the map are updated there rather than here.
       const localID = localIDOf( key )
+      const bytes = this.natives_.get( entry.native )?.bytes ?? 0
 
       entry.store.delete( localID )
 
       ++evicted
-      freedBytes += entry.bytes
+      freedBytes += bytes
     }
 
     return { evicted, freedBytes }
@@ -262,6 +350,15 @@ function meshBytes( mesh: CanonicalMesh ): number {
   }
 
   try {
+
+    // The native's own accounting where it offers one — it knows about the
+    // buffers this cannot see. Falls back to the payload estimate, which is
+    // what calculateGeometrySize uses.
+    const allocated = mesh.geometry.getAllocationSize?.()
+
+    if ( typeof allocated === 'number' && allocated > 0 ) {
+      return allocated
+    }
 
     return ( mesh.geometry.GetVertexDataSize() * BYTES_PER_VERTEX_ELEMENT ) +
       ( mesh.geometry.GetIndexDataSize() * BYTES_PER_INDEX_ELEMENT )

--- a/src/ifc/geometry_residency.ts
+++ b/src/ifc/geometry_residency.ts
@@ -2,11 +2,10 @@ import { CanonicalMesh, CanonicalMeshType } from '../core/canonical_mesh'
 import { IfcModelGeometry } from './ifc_model_geometry'
 
 
-/* Bytes per element of the two native buffers, matching
- * IfcModelGeometry.calculateGeometrySize: vertices are doubles, indices are
- * 32-bit. Getting this wrong does not break the policy — it is proportional
- * either way — but it makes the configured budget mean something other than
- * what it says. */
+/* Fallback sizing only, for a native that cannot report its own allocation:
+ * vertices are doubles, indices are 32-bit, matching
+ * IfcModelGeometry.calculateGeometrySize. The primary measure is
+ * getAllocationSize — see meshBytes. */
 // eslint-disable-next-line no-magic-numbers
 const BYTES_PER_VERTEX_ELEMENT = 8
 // eslint-disable-next-line no-magic-numbers
@@ -55,6 +54,14 @@ const BYTES_PER_MIB = 1024 * 1024
  * multiple this cannot see (an 8 MB live set sat under an 85 MB heap on
  * MB-Khaya, the difference being allocator overhead, fragmentation, and the
  * intermediate buffers a boolean leaves behind).
+ *
+ * **What a byte is here.** The native's own `getAllocationSize` — vertices,
+ * triangles, edges, the triangle-edge structures and the float vertex
+ * mirror — not the vertex+index payload `calculateGeometrySize` reports.
+ * The two differ materially, so the unit is named rather than implied: an
+ * 8 MB budget is 8 MB of native allocation, and binds sooner than 8 MB of
+ * payload would. Allocation is the honest unit for a memory ceiling; the
+ * payload figure only counts what a consumer would copy out.
  *
  * **The contract this changes.** An evicted asset is gone from
  * `GetGeometry`/`getByLocalID` until something re-extracts it. That is safe
@@ -402,8 +409,9 @@ function meshBytes( mesh: CanonicalMesh ): number {
   try {
 
     // The native's own accounting where it offers one — it knows about the
-    // buffers this cannot see. Falls back to the payload estimate, which is
-    // what calculateGeometrySize uses.
+    // edge and triangle-edge structures and the float mirror that the
+    // payload estimate cannot see, and those are real wasm bytes. Falls
+    // back to the payload estimate only for a native without it.
     const allocated = mesh.geometry.getAllocationSize?.()
 
     if ( typeof allocated === 'number' && allocated > 0 ) {

--- a/src/ifc/geometry_residency.ts
+++ b/src/ifc/geometry_residency.ts
@@ -32,13 +32,16 @@ const BYTES_PER_MIB = 1024 * 1024
  * maps: +62.6 % assets on MB-Khaya at batch 64, +79.4 % on D3D. Evicting only
  * what does not fit keeps whatever there is room for, so extraction order's
  * natural locality — a representation goes cold once its users are extracted
- * — does the work instead of the batch boundary. Measured on MB-Khaya: 3 053
- * assets evicted for **zero** rebuilds, and the wasm peak 102 -> 71 MB.
+ * — does the work instead of the batch boundary. Measured on MB-Khaya at an
+ * 8 MB budget: the wasm peak falls 102 -> 85 MB with delta-mesh counts
+ * unchanged, and on PSB at batch 8 it falls 1284 -> 298 MB under 64 MB.
  *
- * **What a too-small budget costs.** Ordinary cache pressure, bounded and
- * proportional: D3D under 64 MB rebuilds 2.8 % more assets than an unbudgeted
- * load and finishes in the same time (52.5 s against 53.1 s); MB-Khaya under
- * an absurd 1 MB rebuilds 38 % more. Nothing here thrashes. (An earlier
+ * **What it costs.** Rebuilds, and far fewer than release-on-emit: MB-Khaya
+ * at an 8 MB budget rebuilds 47 assets against 7 193 (+0.65 %), where
+ * release-on-emit rebuilds +62.6 %. Squeezing harder stays proportional
+ * rather than falling off a cliff — D3D under 64 MB rebuilds 2.8 % more and
+ * finishes in the same time (52.5 s against 53.1 s), MB-Khaya under an
+ * absurd 1 MB rebuilds 38 % more. Nothing here thrashes. (An earlier
  * version of this file carried a floor that raised the budget when eviction
  * looked like churn, written after a 64 MB D3D load ran for an hour. That
  * load was not thrashing — eviction was freeing natives other cached entries

--- a/src/ifc/geometry_residency.ts
+++ b/src/ifc/geometry_residency.ts
@@ -394,10 +394,11 @@ function localIDOf( key: number ): number {
 
 
 /**
- * Approximate the native bytes an asset holds.
+ * The native bytes an asset holds.
  *
  * @param mesh The mesh.
- * @return {number} Payload bytes, or 0 for anything that is not a native
+ * @return {number} Native allocation bytes where the geometry reports them,
+ * the vertex+index payload otherwise, or 0 for anything that is not a native
  * buffer geometry (a lazy thunk, a string, an already-freed handle).
  */
 function meshBytes( mesh: CanonicalMesh ): number {

--- a/src/ifc/ifc_model_geometry.ts
+++ b/src/ifc/ifc_model_geometry.ts
@@ -40,9 +40,11 @@ export class IfcModelGeometry implements ModelGeometry {
       if ( value.temporary ) {
 
         this.meshes_.delete( key )
-        this.model.geometryResidency.noteRemoved( this, key )
 
-        if (value.type === CanonicalMeshType.BUFFER_GEOMETRY) {
+        const isLastReference =
+          this.model.geometryResidency.releaseReference( this, key )
+
+        if (value.type === CanonicalMeshType.BUFFER_GEOMETRY && isLastReference) {
 
           value.geometry.delete()
         }
@@ -89,9 +91,17 @@ export class IfcModelGeometry implements ModelGeometry {
     if (value !== void 0) {
 
       this.meshes_.delete(localID)
-      this.model.geometryResidency.noteRemoved( this, localID )
 
-      if (value.type === CanonicalMeshType.BUFFER_GEOMETRY) {
+      // Freeing the native is the residency's call, not ours: a native can be
+      // cached under more than one local ID (6 % of D3D's), and freeing one
+      // entry's copy leaves its siblings pointing at freed memory with no
+      // diagnostic until something reads them. releaseReference returns true
+      // for the last reference — and unconditionally when no budget is
+      // configured, which is exactly the behaviour this had before.
+      const isLastReference =
+        this.model.geometryResidency.releaseReference( this, localID )
+
+      if (value.type === CanonicalMeshType.BUFFER_GEOMETRY && isLastReference) {
 
         value.geometry.delete()
       }

--- a/src/ifc/ifc_model_geometry.ts
+++ b/src/ifc/ifc_model_geometry.ts
@@ -40,6 +40,7 @@ export class IfcModelGeometry implements ModelGeometry {
       if ( value.temporary ) {
 
         this.meshes_.delete( key )
+        this.model.geometryResidency.noteRemoved( this, key )
 
         if (value.type === CanonicalMeshType.BUFFER_GEOMETRY) {
 
@@ -73,6 +74,7 @@ export class IfcModelGeometry implements ModelGeometry {
     }
 
     this.meshes_.set(mesh.localID, mesh)
+    this.model.geometryResidency.noteAdded( this, mesh )
   }
 
   /**
@@ -87,6 +89,7 @@ export class IfcModelGeometry implements ModelGeometry {
     if (value !== void 0) {
 
       this.meshes_.delete(localID)
+      this.model.geometryResidency.noteRemoved( this, localID )
 
       if (value.type === CanonicalMeshType.BUFFER_GEOMETRY) {
 
@@ -102,6 +105,11 @@ export class IfcModelGeometry implements ModelGeometry {
    * @return {CanonicalMesh | undefined}
    */
   public getByLocalID(localID: number): CanonicalMesh | undefined {
+
+    // Recency for the residency budget. Gated inside noteUsed on whether a
+    // budget is configured at all, because this is the scene walk's hot path.
+    this.model.geometryResidency.noteUsed( this, localID )
+
     return this.meshes_.get(localID)
   }
 

--- a/src/ifc/ifc_model_geometry.ts
+++ b/src/ifc/ifc_model_geometry.ts
@@ -19,7 +19,12 @@ export class IfcModelGeometry implements ModelGeometry {
    * @param model The model this is from
    * @param isVoid
    */
-  constructor( public readonly model: IfcStepModel, public readonly isVoid: boolean = false ) {}
+  constructor( public readonly model: IfcStepModel, public readonly isVoid: boolean = false ) {
+
+    // So a budget enabled after extraction has started can seed from what
+    // this already holds — see GeometryResidency.setBudgetBytes.
+    model.geometryResidency.registerStore( this )
+  }
 
   /**
    * Get the number of items in this.

--- a/src/ifc/ifc_scene_builder.ts
+++ b/src/ifc/ifc_scene_builder.ts
@@ -522,6 +522,37 @@ export class IfcSceneBuilder implements WalkableScene< StepEntityBase< EntityTyp
   }
 
   /**
+   * The products owning geometry nodes whose geometry does not currently
+   * resolve — everything that would be silently missing from a whole-scene
+   * walk right now.
+   *
+   * Exists for recovery after eviction: a budget can free geometry that the
+   * accumulated per-entity meshes still reference, and re-extracting the
+   * owning products is what puts it back. Returns owners rather than nodes
+   * because extraction is per-product.
+   *
+   * @return {Set<number>} Local IDs of the owning products, possibly empty.
+   */
+  public unresolvedGeometryOwners(): Set< number > {
+
+    const owners = new Set< number >()
+
+    for ( const node of this.scene_ ) {
+
+      if ( !( node instanceof IfcSceneGeometry ) ||
+           node.relatedElementLocalId === void 0 ) {
+        continue
+      }
+
+      if ( node.model.geometry?.getByLocalID( node.localID ) === void 0 ) {
+        owners.add( node.relatedElementLocalId )
+      }
+    }
+
+    return owners
+  }
+
+  /**
    * Resolve one node by index, for retrying a node {@link walkFrom} yielded
    * without geometry.
    *

--- a/src/ifc/ifc_step_model.ts
+++ b/src/ifc/ifc_step_model.ts
@@ -5,6 +5,7 @@ import {StepIndexEntry} from '../step/parsing/step_parser'
 import {StepIndexColumns} from '../step/parsing/columnar_index'
 import {StepTypeIndexer} from '../step/indexing/step_type_indexer'
 import {MultiIndexSet} from '../indexing/multi_index_set'
+import { GeometryResidency } from './geometry_residency'
 import { IfcModelGeometry } from './ifc_model_geometry'
 import { IfcModelProfile } from './ifc_model_profile'
 import IfcStepExternalMapping from './ifc_step_external_mapping'
@@ -23,6 +24,9 @@ export default class IfcStepModel extends StepModelBase< EntityTypesIfc > {
 
   public readonly typeIndex: MultiIndexSet< EntityTypesIfc >
   public readonly externalMappingType = IfcStepExternalMapping
+  /* Declared BEFORE the stores: field initialisers run in order, and both
+   * stores call into this on their first add. */
+  public readonly geometryResidency = new GeometryResidency()
   public readonly geometry = new IfcModelGeometry( this )
   public readonly voidGeometry = new IfcModelGeometry( this, true )
   public readonly profiles = new IfcModelProfile(this)


### PR DESCRIPTION
M3 items 1 and 2 — **per-product wasm reclaim** and the **budgeted arena** — in the production pump rather than a harness. Follows #534 (delta capture) and #531 (spike).

Opened ready-for-review so CI runs once on the initial diff; it goes to draft if review lands anything.

## What it does

`GeometryResidency` holds an LRU over both of a model's geometry stores against a byte ceiling, evicting at each batch boundary. Configured at open (`GEOMETRY_BUDGET_MB`) or after (`SetGeometryBudget`), and **unlimited by default** — eviction changes a contract, so turning it on is a statement about the consumer, not just about memory: an evicted asset is gone from `GetGeometry` until something re-extracts it, which is safe for a consumer that copies payloads at delivery (Share#1640) and unsafe for one that fetches lazily later.

## PSB at batch 8 — the size Share pumps at

| budget | live | wasm peak | delta meshes | geometry |
|---|---|---|---|---|
| none | — | **1284 MB** | 7 764 | 25.7 s |
| **64 MB** | 64.0 MB | **298 MB** | 7 764 | **23.6 s** |
| 256 MB | 256.0 MB | 803 MB | 7 764 | 23.4 s |

MB-Khaya at batch 64: 102 → 85 MB under an 8 MB budget; a 32 MB budget never binds (live is 17.8 MB). D3D at batch 64: 52.5 s against 53.1 s unbudgeted, live held at 64.0 MB, 2.8 % more assets rebuilt.

**This is M3's memory gate**, met on the production path at no wall-clock cost. Note the heap runs **3–4× the live budget**, so a 512 MB heap target means a budget nearer 128–192 MB — the gap is allocator overhead, fragmentation, and boolean intermediates, none of which payload accounting can see.

## Why LRU, decided by measurement

The harness gained an `lru` phase beside `bounded` so both could run on the same models. Release-on-emit is *correct* — the #534 fixture shows no lost or misplaced instances — but rebuilds geometry a later product still maps:

| model | batch | release-on-emit tax |
|---|---|---|
| MB-Khaya | 64 | **+62.6 %** assets |
| D3D | 64 | **+79.4 %** assets |

Evicting only what does not fit costs a fraction of that: extraction order has enough locality that recency predicts reuse, where creation order does not. I would have picked the refcount-over-`IfcRepresentationMap` design by reasoning; the measurement picked this one, which needs no dependency graph and no dispatch key.

## The bug eviction exposed, which predates it

A native geometry can be cached under **more than one local ID** — 1 448 of 23 692 adds on D3D, 6 % — and `IfcModelGeometry.delete` freed it unconditionally. So evicting one entry left its siblings pointing at freed memory; everything sharing that native re-extracted, and a second eviction of the same native aborted the load with a `BindingError`. The byte accounting had the matching defect, charging per key rather than per native, so a budget bound several times tighter than it read.

Residency is therefore **refcounted on the native object itself**: bytes charged once, and the native freed only when its last referencing key goes, with the store asking before freeing (and getting an unconditional yes when no budget is configured — exactly its prior behaviour).

**This hazard is not specific to the budget.** Any mass delete has it, `ReleaseModelGeometry` included. Eviction is only the first caller to delete enough entries to reach it.

## Two corrections on the record

Both are mine, and both were caught by measurement rather than review:

1. **The symptom read as thrashing, and I built for that.** A 64 MB D3D load ran for an hour against 53 s unbudgeted. The obvious reading — working set doesn't fit, LRU thrashes — was wrong; with correct accounting the working set fits in 64 MB exactly. A "working-set floor" written to handle the supposed thrash never fired on any model, including an absurd 1 MB budget on MB-Khaya (38 % more rebuilds, no thrash), so it was removed rather than shipped as an untested guard.
2. **The first figures were flattering, not merely wrong.** MB-Khaya's peak read 71 MB where it is really 85 MB — the difference being natives freed while still referenced. Memory I had no right to reclaim.

## Tests

Two, in `ifc_api_deferred_open.test.ts`, both mutation-verified:

- **a budget binds, and binding changes nothing** — live settles at or under the ceiling, the *same model unbudgeted* holds more than that (without which the first half passes on a model too small to evict), and placements match classic `StreamAllMeshes`.
- **no budget is the default** — nothing tracked, nothing freed, every delivered geometry still fetchable at the end of the load.

Disabling eviction on the synchronous pump fails the first with `Expected: <= 2048, Received: 19440` — which is the bug the first version of this shipped, by wiring only the async pump (the anchor text appears in both, and the replace took the first match).

## Still open in M3

Evict/refill under **navigation** (this measures a drain-once pass; the chunk region exists for churn, where a general allocator fragments), **viewport-ordered** materialisation (the pump extracts in file order), and the **time-to-first-pixel** gate itself.

## Notes for review

- The budget's units are payload bytes, not heap bytes, and the 3–4× multiple is unmodelled. A user-facing "512 MB" needs that conversion or real allocator-side accounting.
- `getByLocalID` is on the scene-walk hot path and now calls `noteUsed`; it returns on one boolean when no budget is configured.
- Eviction happens *after* the delta capture in both pumps — evicting first would drop what the batch is about to deliver.
- The re-extraction cost of a too-small budget is bounded and proportional (D3D +2.8 % at 64 MB, MB-Khaya +38 % at 1 MB), but nothing caps it. A model with genuinely global reuse and a tiny budget would pay more, and no test covers that regime.

Part of #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsjeKsTaAMGnhj2UCJFfCa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsjeKsTaAMGnhj2UCJFfCa)_