### PR TITLE
M3 (#394): dispatch-time placement + SetGeometryShard — PSB geometry 40.5s → 7.4s across 4 workers

### DIFF
--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -60,7 +60,7 @@ import { performance } from 'node:perf_hooks'
 
 const DEFAULT_SHARD_COUNTS = [ 2, 3, 4, 8 ]
 
-const STRATEGIES = [ 'roundrobin', 'contiguous', 'affinity', 'claim' ]
+const STRATEGIES = [ 'roundrobin', 'contiguous', 'affinity', 'claim', 'dispatch' ]
 
 /**
  * Validate shard counts, or exit.
@@ -180,6 +180,11 @@ async function capture( filePath, outPath ) {
       ms: performance.now() - start,
       created: [ ...created ],
       reused: [ ...reused ],
+
+      // What a LIVE scheduler could know before extracting — see
+      // dispatchKeyOf. Captured beside the oracle's created/reused sets
+      // precisely so the two can be compared.
+      dispatchKey: dispatchKeyOf( passthrough.model[ 0 ], products[ index ] ),
       ...( failed ? { failed: true } : {} ),
     } )
 
@@ -303,6 +308,68 @@ function costModel( rows ) {
 }
 
 /**
+ * The identity a live scheduler could use to place a product, read from the
+ * index WITHOUT extracting it.
+ *
+ * This is the question the affinity result leaves open. `affinity` and
+ * `claim` place products using the assets they turn out to touch — knowledge
+ * that exists only after extraction, i.e. an oracle. A real worker decides
+ * before it starts, so its key must come from attributes:
+ *
+ *   IfcProduct.Representation -> IfcProductDefinitionShape.Representations[]
+ *     -> IfcShapeRepresentation.Items[] -> IfcMappedItem.MappingSource
+ *       -> IfcRepresentationMap
+ *
+ * Pointer-chasing over columns M2 already builds, so it costs nothing next
+ * to tessellation. What it CANNOT see is sharing below the representation:
+ * a profile swept along different directrices, boolean operands, void
+ * geometry. Whether that matters is exactly what comparing this key against
+ * the oracle measures.
+ *
+ * Falls back to the shape representation's own local ID, then to the product
+ * itself (unique, so placement degrades to positional for that product).
+ *
+ * @param model The IFC model.
+ * @param productLocalID The product.
+ * @return {number} A placement key.
+ */
+function dispatchKeyOf( model, productLocalID ) {
+
+  try {
+
+    const product = model.getElementByLocalID( productLocalID )
+    const definition = product?.Representation
+
+    if ( definition === void 0 || definition === null ) {
+      return productLocalID
+    }
+
+    for ( const representation of definition.Representations ?? [] ) {
+
+      for ( const item of representation?.Items ?? [] ) {
+
+        const source = item?.MappingSource
+
+        if ( source?.localID !== void 0 ) {
+          return source.localID
+        }
+      }
+
+      if ( representation?.localID !== void 0 ) {
+        return representation.localID
+      }
+    }
+
+    return productLocalID
+
+  } catch {
+
+    return productLocalID
+  }
+}
+
+
+/**
  * Assign products to shards by strategy.
  *
  * @param strategy One of STRATEGIES.
@@ -336,6 +403,12 @@ function assign( strategy, rows, count, cost ) {
   // shared definition is exactly the case that matters, and voting on the
   // created set alone ignores the only edge that can duplicate work.
   const assetsOf = ( row ) => [ ...row.created, ...row.reused ]
+
+  if ( strategy === 'dispatch' ) {
+    // The online candidate: placement from the pre-extraction key alone. Its
+    // distance from affinity/claim IS the cost of not having an oracle.
+    return rows.map( ( row, index ) => ( row.dispatchKey ?? index ) % count )
+  }
 
   if ( strategy === 'affinity' ) {
     // Primary asset = the lowest-numbered asset the product touches: a stable

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -119,6 +119,13 @@ async function capture( filePath, outPath ) {
     throw new Error( `open failed: ${filePath}` )
   }
 
+  // The SHIPPED key, imported rather than reimplemented. A copy drifts —
+  // this one already had a different fallback order than production, so the
+  // published dispatch comparisons were validating something the engine does
+  // not do.
+  const { geometryDispatchKey } =
+    await import( '../compiled/src/ifc/geometry_dispatch.js' )
+
   const passthrough = api.getPassthrough( modelID )
 
   passthrough.ensureDemandWorklists_()
@@ -203,7 +210,7 @@ async function capture( filePath, outPath ) {
       // What a LIVE scheduler could know before extracting — see
       // dispatchKeyOf. Captured beside the oracle's created/reused sets
       // precisely so the two can be compared.
-      dispatchKey: dispatchKeyOf( passthrough.model[ 0 ], products[ index ] ),
+      dispatchKey: geometryDispatchKey( passthrough.model[ 0 ], products[ index ] ),
       ...( failed ? { failed: true } : {} ),
     } )
 
@@ -249,7 +256,12 @@ async function capture( filePath, outPath ) {
       ms: performance.now() - start,
       created: [ ...created ],
       reused: [ ...reused ],
-      dispatchKey: dispatchKeyOf( passthrough.model[ 0 ], aggregateLocalID ),
+      // Aggregates key on their RELATING OBJECT, matching what
+      // SetGeometryShard does: the relationship record is not a product, so
+      // keying on it would shard by record position.
+      dispatchKey: geometryDispatchKey(
+          passthrough.model[ 0 ],
+          aggregates[ index ]?.RelatingObject?.localID ?? aggregateLocalID ),
       ...( failed ? { failed: true } : {} ),
     } )
   }
@@ -366,94 +378,6 @@ function costModel( rows ) {
 
   return { assetCost, ownCost }
 }
-
-/**
- * The identity a live scheduler could use to place a product, read from the
- * index WITHOUT extracting it.
- *
- * This is the question the affinity result leaves open. `affinity` and
- * `claim` place products using the assets they turn out to touch — knowledge
- * that exists only after extraction, i.e. an oracle. A real worker decides
- * before it starts, so its key must come from attributes:
- *
- *   IfcProduct.Representation -> IfcProductDefinitionShape.Representations[]
- *     -> IfcShapeRepresentation.Items[] -> IfcMappedItem.MappingSource
- *       -> IfcRepresentationMap
- *
- * Pointer-chasing over columns M2 already builds, so it costs nothing next
- * to tessellation. What it CANNOT see is sharing below the representation:
- * a profile swept along different directrices, boolean operands, void
- * geometry. Whether that matters is exactly what comparing this key against
- * the oracle measures.
- *
- * Falls back to the shape representation's own local ID, then to the product
- * itself (unique, so placement degrades to positional for that product).
- *
- * **Validated on MB-Khaya, inconclusive on D3D, and the difference is this
- * script's coverage rather than the key's.** MB-Khaya: 7 193 assets at N=4
- * against a 7 193 serial baseline, matching both oracles exactly. D3D: every
- * strategy lands within 0.8 % of round-robin, which reads like a negative
- * result until you check what the capture saw — 1 592 assets against the
- * 59 098 the real extraction creates, i.e. 2.7 %. Three strategies placing
- * from a graph that blind agree because none of them has information, not
- * because placement cannot help. On MB-Khaya the capture sees 75 %.
- *
- * With the capture fixed (both stores, the rel-aggregates pass, and
- * aggregates placed by assignment rather than positionally), D3D answers —
- * and splits the question in two. At N=4 against a 59 098 serial baseline:
- *
- *   roundrobin  83 177 assets (+40.7 %)  47.6s  1.18x
- *   dispatch    81 639 assets (+38.1 %)  23.7s  2.34x
- *   affinity    65 288 assets (+10.5 %)  29.0s  1.79x  shards 15896/29030/19585/2837
- *
- * Placement DOES help here — the oracle removes three quarters of the
- * duplication — but this key does not reach it: on an assembly-heavy model
- * the sharing lives below the representation, in profiles, boolean operands
- * and void geometry, exactly where an attribute walk cannot see. Yet the key
- * still wins the wall-clock, because it balances and the oracle does not.
- * Best duplication and best wall-clock are different strategies on this
- * model, and the gap between them (30 points, ~14s CPU) is the headroom a
- * better key would recover.
- *
- * @param model The IFC model.
- * @param productLocalID The product.
- * @return {number} A placement key.
- */
-function dispatchKeyOf( model, productLocalID ) {
-
-  try {
-
-    const product = model.getElementByLocalID( productLocalID )
-    const definition = product?.Representation
-
-    if ( definition === void 0 || definition === null ) {
-      return productLocalID
-    }
-
-    for ( const representation of definition.Representations ?? [] ) {
-
-      for ( const item of representation?.Items ?? [] ) {
-
-        const source = item?.MappingSource
-
-        if ( source?.localID !== void 0 ) {
-          return source.localID
-        }
-      }
-
-      if ( representation?.localID !== void 0 ) {
-        return representation.localID
-      }
-    }
-
-    return productLocalID
-
-  } catch {
-
-    return productLocalID
-  }
-}
-
 
 /**
  * Assign products to shards by strategy.

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -124,7 +124,16 @@ async function capture( filePath, outPath ) {
   passthrough.ensureDemandWorklists_()
 
   const products = passthrough.demandProducts_ ?? []
-  const geometry = passthrough.model[ 0 ].geometry
+
+  // Both stores: extraction puts opening and boolean-operand meshes in
+  // `voidGeometry`, and a capture watching only `geometry` records a graph
+  // missing every asset that lives there — the same blind spot the pump
+  // spike had before it was fixed.
+  const stores = [ passthrough.model[ 0 ].geometry, passthrough.model[ 0 ].voidGeometry ]
+    .filter( ( store ) => store !== void 0 )
+
+  const geometry = stores[ 0 ]
+  const aggregates = passthrough.demandAggregates_ ?? []
   const extraction = passthrough.conwayGeometry_
 
   // Instrument the cache rather than the extractor: `add` is every asset this
@@ -133,22 +142,32 @@ async function capture( filePath, outPath ) {
   // would have to reproduce.
   const created = new Set()
   const reused = new Set()
-  const originalAdd = geometry.add.bind( geometry )
-  const originalGet = geometry.getByLocalID.bind( geometry )
 
-  geometry.add = ( mesh ) => {
-    created.add( mesh.localID )
-    return originalAdd( mesh )
-  }
+  for ( const store of stores ) {
 
-  geometry.getByLocalID = ( localID ) => {
-    const hit = originalGet( localID )
+    const originalAdd = store.add.bind( store )
+    const originalGet = store.getByLocalID.bind( store )
 
-    if ( hit !== void 0 && !created.has( localID ) ) {
-      reused.add( localID )
+    // Keyed per store: local IDs are store-relative, so a bare ID would
+    // conflate an opening with an unrelated body and make two products look
+    // like they share an asset when they share nothing.
+    const key = ( localID ) => ( localID * 2 ) + ( store.isVoid ? 1 : 0 )
+
+    store.add = ( mesh ) => {
+      created.add( key( mesh.localID ) )
+      return originalAdd( mesh )
     }
 
-    return hit
+    store.getByLocalID = ( localID ) => {
+
+      const hit = originalGet( localID )
+
+      if ( hit !== void 0 && !created.has( key( localID ) ) ) {
+        reused.add( key( localID ) )
+      }
+
+      return hit
+    }
   }
 
   const rows = []
@@ -192,6 +211,47 @@ async function capture( filePath, outPath ) {
       console.log( `  ${index}/${products.length} products, ` +
         `${( ( performance.now() - t0 ) / 1000 ).toFixed( 1 )}s` )
     }
+  }
+
+  // The second pass, which this script used to skip entirely. On
+  // assembly-heavy models it is not a detail: D3D captured 1 592 assets
+  // against the 59 098 a real extraction creates — 2.7 % — because its
+  // geometry lives almost wholly under IfcElementAssembly aggregates, and a
+  // graph that blind makes every placement strategy look identical.
+  //
+  // Captured as rows like any other work unit, flagged so a partition can
+  // tell them apart: the pump shards aggregates separately from products.
+  for ( let index = 0; index < aggregates.length; ++index ) {
+
+    created.clear()
+    reused.clear()
+
+    const start = performance.now()
+
+    let failed = false
+
+    try {
+      extraction.extractRelAggregateGeometry( aggregates[ index ] )
+    } catch {
+      failed = true
+      ++failures
+    }
+
+    // demandAggregates_ holds ENTITIES, not local IDs, unlike
+    // demandProducts_. Serialising one directly makes the graph unwritable
+    // (circular structure), and using it as a key would compare by identity.
+    const aggregateLocalID =
+      aggregates[ index ]?.localID ?? aggregates[ index ]
+
+    rows.push( {
+      product: aggregateLocalID,
+      aggregate: true,
+      ms: performance.now() - start,
+      created: [ ...created ],
+      reused: [ ...reused ],
+      dispatchKey: dispatchKeyOf( passthrough.model[ 0 ], aggregateLocalID ),
+      ...( failed ? { failed: true } : {} ),
+    } )
   }
 
   const totalMs = performance.now() - t0
@@ -606,15 +666,27 @@ function emitAssignment( graphPath, count, strategy, outPath ) {
   const shardOf = assign( strategy, rows, count, costModel( rows ) )
   const shards = Array.from( { length: count }, () => [] )
 
+  // Products and aggregates are separate worklists in the pump, drained by
+  // separate cursors, so they are emitted separately. Placing only products
+  // would leave the pass that creates most of an assembly model's geometry
+  // spread positionally — which is how D3D came to look unshardable.
+  const aggregateShards = Array.from( { length: count }, () => [] )
+
   for ( let index = 0; index < rows.length; ++index ) {
-    shards[ shardOf[ index ] ].push( rows[ index ].product )
+
+    const target = rows[ index ].aggregate ? aggregateShards : shards
+
+    target[ shardOf[ index ] ].push( rows[ index ].product )
   }
 
   fs.writeFileSync( outPath,
-      `${JSON.stringify( { model: graph.model, strategy, count, shards } )}\n` )
+      `${JSON.stringify( {
+        model: graph.model, strategy, count, shards, aggregateShards,
+      } )}\n` )
 
   console.log(
-      `${strategy} N=${count}: ${shards.map( ( s ) => s.length ).join( '/' )} products → ${outPath}` )
+      `${strategy} N=${count}: ${shards.map( ( s ) => s.length ).join( '/' )} products, ` +
+      `${aggregateShards.map( ( s ) => s.length ).join( '/' )} aggregates → ${outPath}` )
 }
 
 /**

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -329,6 +329,19 @@ function costModel( rows ) {
  * Falls back to the shape representation's own local ID, then to the product
  * itself (unique, so placement degrades to positional for that product).
  *
+ * **Validated on MB-Khaya, inconclusive on D3D, and the difference is this
+ * script's coverage rather than the key's.** MB-Khaya: 7 193 assets at N=4
+ * against a 7 193 serial baseline, matching both oracles exactly. D3D: every
+ * strategy lands within 0.8 % of round-robin, which reads like a negative
+ * result until you check what the capture saw — 1 592 assets against the
+ * 59 098 the real extraction creates, i.e. 2.7 %. Three strategies placing
+ * from a graph that blind agree because none of them has information, not
+ * because placement cannot help. On MB-Khaya the capture sees 75 %.
+ *
+ * So D3D says nothing about the key either way until the capture covers the
+ * rel-aggregates pass (see the caveats in the design doc), which on that
+ * model evidently produces most of the geometry.
+ *
  * @param model The IFC model.
  * @param productLocalID The product.
  * @return {number} A placement key.

--- a/scripts/m3_affinity_spike.mjs
+++ b/scripts/m3_affinity_spike.mjs
@@ -398,9 +398,22 @@ function costModel( rows ) {
  * from a graph that blind agree because none of them has information, not
  * because placement cannot help. On MB-Khaya the capture sees 75 %.
  *
- * So D3D says nothing about the key either way until the capture covers the
- * rel-aggregates pass (see the caveats in the design doc), which on that
- * model evidently produces most of the geometry.
+ * With the capture fixed (both stores, the rel-aggregates pass, and
+ * aggregates placed by assignment rather than positionally), D3D answers —
+ * and splits the question in two. At N=4 against a 59 098 serial baseline:
+ *
+ *   roundrobin  83 177 assets (+40.7 %)  47.6s  1.18x
+ *   dispatch    81 639 assets (+38.1 %)  23.7s  2.34x
+ *   affinity    65 288 assets (+10.5 %)  29.0s  1.79x  shards 15896/29030/19585/2837
+ *
+ * Placement DOES help here — the oracle removes three quarters of the
+ * duplication — but this key does not reach it: on an assembly-heavy model
+ * the sharing lives below the representation, in profiles, boolean operands
+ * and void geometry, exactly where an attribute walk cannot see. Yet the key
+ * still wins the wall-clock, because it balances and the oracle does not.
+ * Best duplication and best wall-clock are different strategies on this
+ * model, and the gap between them (30 points, ~14s CPU) is the headroom a
+ * better key would recover.
  *
  * @param model The IFC model.
  * @param productLocalID The product.

--- a/scripts/m3_pump_spike.mjs
+++ b/scripts/m3_pump_spike.mjs
@@ -595,8 +595,25 @@ function shardWorklists( api, modelID, shard, filePath ) {
     const mineSet = new Set( assignment.shards[ shard.index ] )
 
     passthrough.demandProducts_ = products.filter( ( id ) => mineSet.has( id ) )
-    passthrough.demandAggregates_ =
-      aggregates.filter( ( _, index ) => index % shard.count === shard.index )
+
+    // Aggregates by assignment when the capture covered them, positionally
+    // otherwise. This matters more than it sounds: on an assembly-heavy
+    // model the rel-aggregates pass creates most of the geometry, so
+    // sharding it positionally while carefully placing products leaves the
+    // placement with almost nothing to control — which is exactly why D3D
+    // first appeared to be indifferent to strategy.
+    if ( Array.isArray( assignment.aggregateShards ) ) {
+
+      const mineAggregates = new Set( assignment.aggregateShards[ shard.index ] )
+
+      passthrough.demandAggregates_ = aggregates.filter(
+          ( aggregate ) => mineAggregates.has( aggregate?.localID ?? aggregate ) )
+
+    } else {
+
+      passthrough.demandAggregates_ =
+        aggregates.filter( ( _, index ) => index % shard.count === shard.index )
+    }
 
     return {
       products: passthrough.demandProducts_.length,

--- a/scripts/m3_worker_pool.mjs
+++ b/scripts/m3_worker_pool.mjs
@@ -23,6 +23,7 @@
  *
  *   node --expose-gc scripts/m3_worker_pool.mjs <model> [--workers 1,2,4]
  */
+import { Buffer } from 'node:buffer'
 import { createHash } from 'node:crypto'
 import * as path from 'node:path'
 import * as process from 'node:process'
@@ -34,6 +35,27 @@ const REPO_ROOT = path.resolve( fileURLToPath( new URL( '.', import.meta.url ) )
 const DEFAULT_WORKERS = [ 1, 2, 4 ]
 const BATCH_SIZE = 64
 const MS_PER_S = 1000
+
+
+/**
+ * A transform's exact bytes, as a comparable string.
+ *
+ * Rounding here would make the union check unable to fail: a shard that
+ * shifted a component by less than half the last printed digit would
+ * serialize identically to the reference and report OK on output that is
+ * not the same output. The whole point of this script is detecting that,
+ * so the encoding has to be lossless.
+ *
+ * @param {ArrayLike<number>} transform The flat transformation.
+ * @return {string} A lossless encoding of every component.
+ */
+function transformKey( transform ) {
+
+  const exact = new Float64Array( transform )
+
+  return Buffer.from( exact.buffer, exact.byteOffset, exact.byteLength )
+      .toString( 'base64' )
+}
 
 
 /**
@@ -101,8 +123,7 @@ async function runWorker( task ) {
             placements.push(
                 `${mesh.expressID}/${placed.geometryExpressID}` +
                 `#${placed.color.x},${placed.color.y},${placed.color.z},${placed.color.w}` +
-                `@${[ ...placed.flatTransformation ]
-                    .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+                `@${transformKey( placed.flatTransformation )}` )
 
             if ( !payloads.has( placed.geometryExpressID ) ) {
 

--- a/scripts/m3_worker_pool.mjs
+++ b/scripts/m3_worker_pool.mjs
@@ -71,6 +71,13 @@ async function runWorker( task ) {
   }
 
   const placements = []
+
+  // Payload digests too, not just placements. Identical express IDs and
+  // transforms can sit over different vertex data — a cache-order or
+  // master-void regression looks exactly like that — so a placement-only
+  // digest would report OK on visibly different geometry. Hashed once per
+  // geometry, since instances share it.
+  const payloads = new Map()
   const tGeometry = performance.now()
 
   for ( ;; ) {
@@ -85,6 +92,23 @@ async function runWorker( task ) {
             placements.push(
                 `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
                     .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+
+            if ( !payloads.has( placed.geometryExpressID ) ) {
+
+              const geometry = api.GetGeometry( modelID, placed.geometryExpressID )
+              const vertices = api.GetVertexArray(
+                  geometry.GetVertexData(), geometry.GetVertexDataSize() )
+              const indices = api.GetIndexArray(
+                  geometry.GetIndexData(), geometry.GetIndexDataSize() )
+
+              payloads.set( placed.geometryExpressID,
+                  createHash( 'sha256' )
+                      .update( new Uint8Array( vertices.buffer, vertices.byteOffset,
+                          vertices.byteLength ) )
+                      .update( new Uint8Array( indices.buffer, indices.byteOffset,
+                          indices.byteLength ) )
+                      .digest( 'hex' ) )
+            }
           }
         } )
 
@@ -98,6 +122,7 @@ async function runWorker( task ) {
     openMs,
     geometryMs: performance.now() - tGeometry,
     placements,
+    payloads: [ ...payloads ].map( ( [ id, hash ] ) => `${id}:${hash}` ),
   }
 }
 
@@ -164,16 +189,35 @@ if ( !isMainThread ) {
     // Order-independent: shards finish in any order, and the union is a
     // multiset. Sorting before hashing is what makes two runs comparable.
     const union = results.flatMap( ( result ) => result.placements ).sort()
-    const digest = createHash( 'sha256' ).update( union.join( '\n' ) ).digest( 'hex' )
+
+    // Payload hashes are per geometry, so shards that both touched one report
+    // it twice; dedupe before hashing or the digest would depend on how the
+    // partition happened to split shared geometry.
+    const payloadUnion =
+      [ ...new Set( results.flatMap( ( result ) => result.payloads ) ) ].sort()
+
+    const digest = createHash( 'sha256' )
+        .update( union.join( '\n' ) )
+        .update( '\u0000' )
+        .update( payloadUnion.join( '\n' ) )
+        .digest( 'hex' )
 
     if ( referenceDigest === void 0 ) {
       referenceDigest = digest
       referenceWall = wallMs
     }
 
-    const verdict = digest === referenceDigest ?
+    const matched = digest === referenceDigest
+
+    // A partition that loses or alters geometry is not a slow result, it is a
+    // wrong one, and anything scripting this must not keep the timings.
+    if ( !matched ) {
+      process.exitCode = 1
+    }
+
+    const verdict = matched ?
       'OK   union matches the single-worker load' :
-      'FAIL union DIFFERS from the single-worker load'
+      'FAIL union DIFFERS from the single-worker load (placements or payloads)'
 
     const slowestGeometry = Math.max( ...results.map( ( r ) => r.geometryMs ) )
     const slowestOpen = Math.max( ...results.map( ( r ) => r.openMs ) )

--- a/scripts/m3_worker_pool.mjs
+++ b/scripts/m3_worker_pool.mjs
@@ -58,8 +58,12 @@ async function runWorker( task ) {
   const bytes = new Uint8Array( fs.readFileSync( task.filePath ) )
   const tOpen = performance.now()
 
+  // No COORDINATE_TO_ORIGIN: the recentre anchor is derived from whichever
+  // product a model captures first, so shards would each derive their own
+  // and merge subsets shifted by whole grid cells on a model spanning more
+  // than one recentre cell. SetGeometryShard refuses the combination; this
+  // is the other half of that decision.
   const modelID = await api.OpenModelStreamed( bytes, {
-    COORDINATE_TO_ORIGIN: true,
     USE_FAST_BOOLS: true,
     DEFER_GEOMETRY: true,
   } )
@@ -89,25 +93,43 @@ async function runWorker( task ) {
 
             const placed = mesh.geometries.get( where )
 
+            // Entity, geometry, colour and transform. Without the entity a
+            // placement attributed to the wrong FlatMesh reads identical
+            // (picking and metadata differ, geometry does not); without the
+            // colour a different material resolving to the same mesh does
+            // too.
             placements.push(
-                `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
+                `${mesh.expressID}/${placed.geometryExpressID}` +
+                `#${placed.color.x},${placed.color.y},${placed.color.z},${placed.color.w}` +
+                `@${[ ...placed.flatTransformation ]
                     .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
 
             if ( !payloads.has( placed.geometryExpressID ) ) {
 
+              // GetGeometry hands back an OWNING clone, and embind
+              // finalization is nondeterministic — keeping one per geometry
+              // for the length of a run inflates both the timings this
+              // script reports and the memory it needs to report them.
               const geometry = api.GetGeometry( modelID, placed.geometryExpressID )
-              const vertices = api.GetVertexArray(
-                  geometry.GetVertexData(), geometry.GetVertexDataSize() )
-              const indices = api.GetIndexArray(
-                  geometry.GetIndexData(), geometry.GetIndexDataSize() )
 
-              payloads.set( placed.geometryExpressID,
-                  createHash( 'sha256' )
-                      .update( new Uint8Array( vertices.buffer, vertices.byteOffset,
-                          vertices.byteLength ) )
-                      .update( new Uint8Array( indices.buffer, indices.byteOffset,
-                          indices.byteLength ) )
-                      .digest( 'hex' ) )
+              try {
+
+                const vertices = api.GetVertexArray(
+                    geometry.GetVertexData(), geometry.GetVertexDataSize() )
+                const indices = api.GetIndexArray(
+                    geometry.GetIndexData(), geometry.GetIndexDataSize() )
+
+                payloads.set( placed.geometryExpressID,
+                    createHash( 'sha256' )
+                        .update( new Uint8Array( vertices.buffer, vertices.byteOffset,
+                            vertices.byteLength ) )
+                        .update( new Uint8Array( indices.buffer, indices.byteOffset,
+                            indices.byteLength ) )
+                        .digest( 'hex' ) )
+
+              } finally {
+                geometry.delete()
+              }
             }
           }
         } )

--- a/scripts/m3_worker_pool.mjs
+++ b/scripts/m3_worker_pool.mjs
@@ -1,0 +1,191 @@
+/**
+ * A worker pool for demand-driven geometry extraction — the across-product
+ * parallelism axis, running for real rather than simulated by processes.
+ *
+ * Each worker opens the model, claims a shard with `SetGeometryShard`, and
+ * pumps to completion. There is NO scheduling channel between them:
+ * placement is a pure function of the product (its representation's mapped
+ * source), so N workers independently agree on who owns what, and products
+ * sharing geometry land together instead of every shard rebuilding it.
+ *
+ * **Every worker parses.** The index could be transferred instead — the
+ * columns are four typed arrays and `IfcStepModel` takes them directly — but
+ * that needs a construct-from-columns entry on the open path, which does not
+ * exist yet. Parsing per worker costs N times the parse CPU and N copies of
+ * the index in memory, while costing only ONE parse of latency, because they
+ * run concurrently. So it is the right shape to measure first: if the
+ * geometry win covers it, transfer is an optimisation rather than a
+ * prerequisite, and this script is what says which.
+ *
+ * Correctness is checked, not assumed: the union of the shards' placements
+ * must equal what a single unsharded worker delivers. A pool that loses or
+ * duplicates instances is not faster, it is wrong.
+ *
+ *   node --expose-gc scripts/m3_worker_pool.mjs <model> [--workers 1,2,4]
+ */
+import { createHash } from 'node:crypto'
+import * as path from 'node:path'
+import * as process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { Worker, isMainThread, parentPort, workerData } from 'node:worker_threads'
+
+
+const REPO_ROOT = path.resolve( fileURLToPath( new URL( '.', import.meta.url ) ), '..' )
+const DEFAULT_WORKERS = [ 1, 2, 4 ]
+const BATCH_SIZE = 64
+const MS_PER_S = 1000
+
+
+/**
+ * One worker: open, claim a shard, pump it dry, report what it delivered.
+ *
+ * Reports per-placement digests rather than a count, so the union check can
+ * catch a shard that delivers the right NUMBER of instances at the wrong
+ * placements — which is what a mis-shared representation looks like.
+ *
+ * @param {object} task `{filePath, index, count}`.
+ * @return {Promise<object>} What this shard produced.
+ */
+async function runWorker( task ) {
+
+  const fs = await import( 'node:fs' )
+  const { IfcAPI } = await import( '../compiled/src/compat/web-ifc/ifc_api.js' )
+
+  const api = new IfcAPI()
+
+  await api.Init()
+
+  const bytes = new Uint8Array( fs.readFileSync( task.filePath ) )
+  const tOpen = performance.now()
+
+  const modelID = await api.OpenModelStreamed( bytes, {
+    COORDINATE_TO_ORIGIN: true,
+    USE_FAST_BOOLS: true,
+    DEFER_GEOMETRY: true,
+  } )
+
+  const openMs = performance.now() - tOpen
+
+  if ( task.count > 1 ) {
+    api.SetGeometryShard( modelID, { index: task.index, count: task.count } )
+  }
+
+  const placements = []
+  const tGeometry = performance.now()
+
+  for ( ;; ) {
+
+    const { extracted, remaining } = api.ExtractGeometryBatch(
+        modelID, BATCH_SIZE, ( mesh ) => {
+
+          for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+
+            const placed = mesh.geometries.get( where )
+
+            placements.push(
+                `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
+                    .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+          }
+        } )
+
+    if ( remaining === 0 && extracted === 0 ) {
+      break
+    }
+  }
+
+  return {
+    index: task.index,
+    openMs,
+    geometryMs: performance.now() - tGeometry,
+    placements,
+  }
+}
+
+
+if ( !isMainThread ) {
+
+  runWorker( workerData )
+      .then( ( result ) => parentPort.postMessage( { ok: true, ...result } ) )
+      .catch( ( error ) => parentPort.postMessage(
+          { ok: false, index: workerData.index, error: String( error ) } ) )
+
+} else {
+
+  const argv = process.argv.slice( 2 )
+  const filePath = argv.find( ( value ) => !value.startsWith( '--' ) )
+
+  if ( filePath === void 0 ) {
+    console.error(
+        'usage: m3_worker_pool.mjs <model> [--workers 1,2,4]' )
+    process.exit( 2 )
+  }
+
+  const workersFlag = argv.indexOf( '--workers' )
+  const counts = workersFlag >= 0 ?
+    argv[ workersFlag + 1 ].split( ',' ).map( Number ) : DEFAULT_WORKERS
+
+  if ( counts.some( ( count ) => !Number.isInteger( count ) || count < 1 ) ) {
+    console.error( `--workers must be positive integers; got ${counts.join( ',' )}` )
+    process.exit( 2 )
+  }
+
+  // Always run 1 first: every ratio below is against it, and it is also the
+  // reference the union is compared to.
+  const sweep = [ ...new Set( [ 1, ...counts ] ) ].sort( ( a, b ) => a - b )
+
+  let referenceDigest
+  let referenceWall
+
+  for ( const count of sweep ) {
+
+    const started = performance.now()
+
+    const results = await Promise.all(
+        Array.from( { length: count }, ( _, index ) =>
+          new Promise( ( resolve, reject ) => {
+
+            const worker = new Worker( fileURLToPath( import.meta.url ), {
+              // No execArgv: a worker inherits the parent's V8 flags, and
+              // passing --expose-gc explicitly is rejected as an invalid
+              // worker flag.
+              workerData: { filePath: path.resolve( REPO_ROOT, filePath ), index, count },
+            } )
+
+            worker.on( 'message', ( message ) => {
+              worker.terminate()
+              message.ok ? resolve( message ) : reject( new Error( message.error ) )
+            } )
+
+            worker.on( 'error', reject )
+          } ) ) )
+
+    const wallMs = performance.now() - started
+
+    // Order-independent: shards finish in any order, and the union is a
+    // multiset. Sorting before hashing is what makes two runs comparable.
+    const union = results.flatMap( ( result ) => result.placements ).sort()
+    const digest = createHash( 'sha256' ).update( union.join( '\n' ) ).digest( 'hex' )
+
+    if ( referenceDigest === void 0 ) {
+      referenceDigest = digest
+      referenceWall = wallMs
+    }
+
+    const verdict = digest === referenceDigest ?
+      'OK   union matches the single-worker load' :
+      'FAIL union DIFFERS from the single-worker load'
+
+    const slowestGeometry = Math.max( ...results.map( ( r ) => r.geometryMs ) )
+    const slowestOpen = Math.max( ...results.map( ( r ) => r.openMs ) )
+
+    console.log(
+        `workers=${count} wall=${( wallMs / MS_PER_S ).toFixed( 1 )}s ` +
+        `(${( referenceWall / wallMs ).toFixed( 2 )}x) ` +
+        `open=${( slowestOpen / MS_PER_S ).toFixed( 1 )}s ` +
+        `geometry=${( slowestGeometry / MS_PER_S ).toFixed( 1 )}s ` +
+        `instances=${union.length} ` +
+        `per-shard=${results.map( ( r ) => r.placements.length ).join( '/' )}` )
+
+    console.log( `  ${verdict}` )
+  }
+}

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -960,6 +960,42 @@ export class IfcAPI {
     return result.setGeometryBudget( megabytes * BYTES_PER_MIB )
   }
 
+  /**
+   * Conway extension (M3): extract only one shard of a deferred model's
+   * geometry, so N workers — each with its own instance and heap — can pump
+   * disjoint products with no scheduling channel between them.
+   *
+   * Placement is a pure function of the product (its representation's mapped
+   * source), so every worker independently agrees on who owns what, and
+   * products sharing geometry land together rather than each shard rebuilding
+   * it. Measured at N=4: +0 % extra assets on MB-Khaya and +38.1 % on D3D
+   * against round-robin's +25 % and +40.7 %, for 1.76x and 2.34x wall-clock.
+   *
+   * **A shard is a SUBSET of the model.** Pumping one to completion yields
+   * part of the geometry; the consumer unions the shards. Call before the
+   * first ExtractGeometryBatch — after that the worklists exist and narrowing
+   * them would drop products already reported as pending, so it throws.
+   *
+   * @param modelID handle from a DEFER_GEOMETRY open
+   * @param shard `{index, count}`, or omitted for the whole model
+   * @return {boolean} false for unknown models and for passthroughs with no
+   * demand worklists (AP214/STEP), which cannot shard
+   */
+  SetGeometryShard(
+      modelID: number,
+      shard?: { index: number, count: number } ): boolean {
+
+    const result = this.models.get(modelID)
+
+    if (result?.setGeometryShard === void 0) {
+      return false
+    }
+
+    result.setGeometryShard(shard)
+
+    return true
+  }
+
   ExtractGeometryBatch(
       modelID: number,
       batchSize: number,

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -948,6 +948,34 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     api.CloseModel( modelID )
   }, 240000 )
 
+  test( 'enabling COORDINATE_TO_ORIGIN after claiming a shard is refused', async () => {
+
+    // The claim-time check alone is not enforcement: the proxy holds the
+    // CALLER'S settings object by reference and reads COORDINATE_TO_ORIGIN
+    // live when it derives the recentre frame. A caller that opens without
+    // it, claims a shard, then flips the flag would get per-shard anchors —
+    // subsets of a large-coordinate model shifted by whole grid cells,
+    // which no union-of-placements check catches on a fixture at the origin.
+    const api = new IfcAPI()
+    await api.Init()
+
+    const settings =
+      { COORDINATE_TO_ORIGIN: false, USE_FAST_BOOLS: true, DEFER_GEOMETRY: true }
+
+    const modelID = await api.OpenModelStreamed(
+        new Uint8Array( fs.readFileSync( 'data/mapped_shared_representation.ifc' ) ),
+        settings )
+
+    expect( api.SetGeometryShard( modelID, { index: 0, count: 2 } ) ).toBe( true )
+
+    settings.COORDINATE_TO_ORIGIN = true
+
+    expect( () => api.ExtractGeometryBatch( modelID, 1 ) )
+        .toThrow( /COORDINATE_TO_ORIGIN was enabled on a sharded model/ )
+
+    api.CloseModel( modelID )
+  }, 240000 )
+
   test( 'ExtractGeometryBatch is a safe no-op on non-deferred models', async () => {
 
     const modelID = await api.OpenModelStreamed( buffer, SETTINGS )

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -820,6 +820,131 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     api7.CloseModel( modelID )
   }, 240000 )
 
+  test( 'shards partition the model: every instance exactly once', async () => {
+
+    // The property a worker pool rests on. Four instances each claim a shard
+    // and pump to completion; the union must equal what one unsharded load
+    // delivers — no instance lost, none built twice. Placement being a pure
+    // function of the product is what lets the shards agree without talking
+    // to each other, so this also pins that: the same product must land in
+    // the same shard from four independent decisions.
+    // Both fixtures deliberately: the mapped one exercises the product
+    // worklist, and aggregate_master_voids the rel-aggregates pass, which is
+    // a SEPARATE worklist with its own filter. Sharding one and not the other
+    // duplicates every aggregate across every shard — and on an
+    // assembly-heavy model that pass is most of the geometry, so this is the
+    // failure with real consequences, not the exotic one.
+    for ( const fixturePath of [
+      'data/mapped_shared_representation.ifc',
+      'data/aggregate_master_voids.ifc',
+    ] ) {
+      await partitionsExactlyOnce( fixturePath )
+    }
+  }, 240000 )
+
+  /**
+   * Assert that N shards of a model union to exactly what one unsharded load
+   * delivers.
+   *
+   * @param fixturePath The model to check.
+   */
+  async function partitionsExactlyOnce( fixturePath: string ): Promise<void> {
+
+    const fixture = new Uint8Array( fs.readFileSync( fixturePath ) )
+
+    const wholeApi = new IfcAPI()
+    await wholeApi.Init()
+
+    const wholeID = await wholeApi.OpenModelStreamed(
+        fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    const whole: string[] = []
+
+    for ( ; ; ) {
+      const { extracted, remaining } = wholeApi.ExtractGeometryBatch(
+          wholeID, 4, ( mesh ) => {
+            for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+              const placed = mesh.geometries.get( where )
+              whole.push(
+                  `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
+                      .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+            }
+          } )
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+
+    expect( whole.length ).toBeGreaterThan( 0 )
+
+    const shardCount = 4
+    const sharded: string[] = []
+    const perShard: number[] = []
+
+    for ( let index = 0; index < shardCount; ++index ) {
+
+      const api = new IfcAPI()
+      await api.Init()
+
+      const modelID = await api.OpenModelStreamed(
+          fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+      expect( api.SetGeometryShard( modelID, { index, count: shardCount } ) )
+          .toBe( true )
+
+      let delivered = 0
+
+      for ( ; ; ) {
+        const { extracted, remaining } = api.ExtractGeometryBatch(
+            modelID, 4, ( mesh ) => {
+              for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+                const placed = mesh.geometries.get( where )
+                sharded.push(
+                    `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
+                        .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+                ++delivered
+              }
+            } )
+        if ( remaining === 0 && extracted === 0 ) {
+          break
+        }
+      }
+
+      perShard.push( delivered )
+      api.CloseModel( modelID )
+    }
+
+    // The union is the model: same multiset, nothing lost or doubled.
+    expect( sharded.slice().sort() ).toEqual( whole.slice().sort() )
+
+    // ...and no shard delivered the whole thing, which the equality above
+    // would happily accept from one shard doing everything. A single-instance
+    // model legitimately lands in one shard, so this only asserts that no
+    // shard exceeded the total.
+    expect( Math.max( ...perShard ) ).toBeLessThanOrEqual( whole.length )
+
+    wholeApi.CloseModel( wholeID )
+  }
+
+  test( 'a shard cannot be claimed after pumping starts', async () => {
+
+    // Narrowing the worklists mid-load would drop products already reported
+    // as pending, so the model would quietly deliver less than it promised.
+    const api = new IfcAPI()
+    await api.Init()
+
+    const modelID = await api.OpenModelStreamed(
+        new Uint8Array( fs.readFileSync( 'data/mapped_shared_representation.ifc' ) ),
+        { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    api.ExtractGeometryBatch( modelID, 1 )
+
+    expect( () => api.SetGeometryShard( modelID, { index: 0, count: 2 } ) )
+        .toThrow( /before the first/ )
+
+    api.CloseModel( modelID )
+  }, 240000 )
+
   test( 'ExtractGeometryBatch is a safe no-op on non-deferred models', async () => {
 
     const modelID = await api.OpenModelStreamed( buffer, SETTINGS )

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -1089,6 +1089,89 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
         api.CloseModel( modelID )
       }, 240000 )
 
+  test( 'a sharded model does not recentre even if a callback enables it',
+      async () => {
+
+        // The window codex found in round 9: ON_PROGRESS is invoked
+        // synchronously from beginPhase, INSIDE the first pump — after the
+        // precondition check for that batch has passed and before the
+        // capture reads the flag. A handler enabling COORDINATE_TO_ORIGIN
+        // there would have each worker derive its own frame despite the
+        // guard.
+        //
+        // Two windows of this shape were patched individually in earlier
+        // rounds, so this asserts BOTH halves of closing the class:
+        //   1. geometry delivered inside the window is not recentred, and
+        //   2. the refusal still fires on the next batch, so the caller is
+        //      told rather than quietly given a subset it cannot merge.
+        const api = new IfcAPI()
+        await api.Init()
+
+        const settings: Record< string, unknown > = {
+          COORDINATE_TO_ORIGIN: false,
+          USE_FAST_BOOLS: true,
+          DEFER_GEOMETRY: true,
+          // Only once the GEOMETRY phase begins — inside the first pump,
+          // after the shard was claimed. Flipping it earlier is caught by
+          // the claim-time refusal, which is correct and not this window.
+          ON_PROGRESS: ( event: { phase: string } ) => {
+            if ( event.phase === 'geometry' ) {
+              settings.COORDINATE_TO_ORIGIN = true
+            }
+          },
+        }
+
+        const modelID = await api.OpenModelStreamed(
+            new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ),
+            settings as never )
+
+        expect( api.SetGeometryShard( modelID, { index: 0, count: 2 } ) )
+            .toBe( true )
+
+        const windowed: string[] = []
+
+        api.ExtractGeometryBatch( modelID, 4, ( mesh ) => {
+          for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+            windowed.push( transformKey(
+                mesh.geometries.get( where ).flatTransformation ) )
+          }
+        } )
+
+        // The handler really did flip it, mid-pump.
+        expect( settings.COORDINATE_TO_ORIGIN ).toBe( true )
+
+        // (2) The refusal fires now that the flag is observable.
+        expect( () => api.ExtractGeometryBatch( modelID, 4 ) )
+            .toThrow( /COORDINATE_TO_ORIGIN was enabled on a sharded model/ )
+
+        // (1) ...and nothing delivered inside the window was recentred:
+        // identical to a shard whose flag was never touched. A derived
+        // frame would move every transform.
+        const referenceApi = new IfcAPI()
+        await referenceApi.Init()
+
+        const referenceID = await referenceApi.OpenModelStreamed(
+            new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ),
+            SHARD_SETTINGS )
+
+        referenceApi.SetGeometryShard( referenceID, { index: 0, count: 2 } )
+
+        const reference: string[] = []
+
+        referenceApi.ExtractGeometryBatch( referenceID, 4, ( mesh ) => {
+          for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+            reference.push( transformKey(
+                mesh.geometries.get( where ).flatTransformation ) )
+          }
+        } )
+
+        expect( reference.length ).toBeGreaterThan( 0 )
+        expect( windowed ).toEqual( reference )
+
+        api.CloseModel( modelID )
+        referenceApi.CloseModel( referenceID )
+      }, 240000 )
+
   test( 'a shard descriptor is snapshotted, not retained', async () => {
 
     // A coordinator configuring several instances from one reused object is

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -855,8 +855,12 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     const wholeApi = new IfcAPI()
     await wholeApi.Init()
 
-    const wholeID = await wholeApi.OpenModelStreamed(
-        fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+    // Sharding refuses COORDINATE_TO_ORIGIN — each shard would derive its
+    // own recentre anchor — so both sides of this comparison open without it.
+    const SHARD_SETTINGS =
+      { COORDINATE_TO_ORIGIN: false, USE_FAST_BOOLS: true, DEFER_GEOMETRY: true }
+
+    const wholeID = await wholeApi.OpenModelStreamed( fixture, SHARD_SETTINGS )
 
     const whole: string[] = []
 
@@ -886,8 +890,7 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
       const api = new IfcAPI()
       await api.Init()
 
-      const modelID = await api.OpenModelStreamed(
-          fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+      const modelID = await api.OpenModelStreamed( fixture, SHARD_SETTINGS )
 
       expect( api.SetGeometryShard( modelID, { index, count: shardCount } ) )
           .toBe( true )
@@ -935,7 +938,7 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
 
     const modelID = await api.OpenModelStreamed(
         new Uint8Array( fs.readFileSync( 'data/mapped_shared_representation.ifc' ) ),
-        { ...SETTINGS, DEFER_GEOMETRY: true } )
+        { COORDINATE_TO_ORIGIN: false, USE_FAST_BOOLS: true, DEFER_GEOMETRY: true } )
 
     api.ExtractGeometryBatch( modelID, 1 )
 

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -982,6 +982,65 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     api.CloseModel( modelID )
   }, 240000 )
 
+  test( 'a one-worker claim is accepted, whatever the model settings',
+      async () => {
+
+        // {index: 0, count: 1} IS the unsharded model, and a coordinator
+        // that calls this uniformly for its N=1 baseline is doing nothing
+        // that needs cross-worker agreement. The guards below it exist only
+        // because workers must agree with each other, so applying them to a
+        // single worker would fail a configuration equivalent to never
+        // having claimed at all — including on a recentred model, which is
+        // how Share opens.
+        const api = new IfcAPI()
+        await api.Init()
+
+        const modelID = await api.OpenModelStreamed(
+            new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ),
+            { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true,
+              DEFER_GEOMETRY: true } )
+
+        expect( api.SetGeometryShard( modelID, { index: 0, count: 1 } ) )
+            .toBe( true )
+
+        let delivered = 0
+
+        for ( ; ; ) {
+          const { extracted, remaining } = api.ExtractGeometryBatch(
+              modelID, 4, ( mesh ) => {
+                delivered += mesh.geometries.size()
+              } )
+          if ( remaining === 0 && extracted === 0 ) {
+            break
+          }
+        }
+
+        // The whole model, not a subset, and no throw from the recentre
+        // guard on the pump either.
+        expect( delivered ).toBeGreaterThan( 0 )
+
+        api.CloseModel( modelID )
+      }, 240000 )
+
+  test( 'a malformed descriptor is reported as malformed', async () => {
+
+    // Validation runs before the incompatibility checks, so a bad
+    // descriptor on a recentred model says what is bad about it rather
+    // than blaming whichever guard it trips first.
+    const api = new IfcAPI()
+    await api.Init()
+
+    const modelID = await api.OpenModelStreamed(
+        new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ),
+        { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true,
+          DEFER_GEOMETRY: true } )
+
+    expect( () => api.SetGeometryShard( modelID, { index: 3, count: 2 } ) )
+        .toThrow( /invalid shard/ )
+
+    api.CloseModel( modelID )
+  }, 240000 )
+
   test( 'a shard descriptor is snapshotted, not retained', async () => {
 
     // A coordinator configuring several instances from one reused object is

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -1054,6 +1054,41 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     api.CloseModel( modelID )
   }, 240000 )
 
+  test( 'a model that already adopted a recentre frame cannot be sharded',
+      async () => {
+
+        // WHITE-BOX, and deliberately so. The reported route here is
+        // ON_PREVIEW_MESH: the preview channel can install a coordination
+        // frame at OPEN, before any pump, after which a caller may set
+        // COORDINATE_TO_ORIGIN false on its own settings object and claim a
+        // shard — passing a flag-only guard while already sitting in a
+        // frame derived from whichever geometry THIS instance previewed.
+        //
+        // I could not get the preview channel to install a frame from a
+        // test (tried index.ifc and index_georeferenced.ifc; demandCoordination_
+        // stayed undefined), so this pins the guard on the state itself
+        // rather than pretending to reproduce the route to it. If the route
+        // is unreachable the guard is merely cheap; if it is reachable, this
+        // is what stops it.
+        const api = new IfcAPI()
+        await api.Init()
+
+        const modelID = await api.OpenModelStreamed(
+            new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ), SHARD_SETTINGS )
+
+        const passthrough = api.getPassthrough( modelID ) as unknown as
+          { demandCoordination_?: number[] }
+
+        // A frame adopted from somewhere other than the current flag.
+        passthrough.demandCoordination_ =
+          [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1000, 2000, 3000, 1 ]
+
+        expect( () => api.SetGeometryShard( modelID, { index: 0, count: 2 } ) )
+            .toThrow( /already adopted a recentre frame/ )
+
+        api.CloseModel( modelID )
+      }, 240000 )
+
   test( 'a shard descriptor is snapshotted, not retained', async () => {
 
     // A coordinator configuring several instances from one reused object is

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -973,6 +973,42 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     expect( () => api.ExtractGeometryBatch( modelID, 1 ) )
         .toThrow( /COORDINATE_TO_ORIGIN was enabled on a sharded model/ )
 
+    // The async entry is a SEPARATE path — on an external source it never
+    // reaches pumpGeometryBatch_ at all — so the guard has to hold there
+    // independently. It was bypassed when the check lived in the pump.
+    await expect( api.ExtractGeometryBatchAsync( modelID, 1 ) )
+        .rejects.toThrow( /COORDINATE_TO_ORIGIN was enabled on a sharded model/ )
+
+    api.CloseModel( modelID )
+  }, 240000 )
+
+  test( 'an unsharded model is unaffected by the shard preconditions', async () => {
+
+    // The guards must be about workers agreeing with each other and nothing
+    // else. A model that never claims a shard recentres and pumps exactly as
+    // before — without this, the checks would be a behaviour change for
+    // every existing caller, Share included.
+    const api = new IfcAPI()
+    await api.Init()
+
+    const modelID = await api.OpenModelStreamed(
+        new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ),
+        { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true, DEFER_GEOMETRY: true } )
+
+    let delivered = 0
+
+    for ( ; ; ) {
+      const { extracted, remaining } = api.ExtractGeometryBatch(
+          modelID, 4, ( mesh ) => {
+            delivered += mesh.geometries.size()
+          } )
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+
+    expect( delivered ).toBeGreaterThan( 0 )
+
     api.CloseModel( modelID )
   }, 240000 )
 

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -1172,6 +1172,40 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
         referenceApi.CloseModel( referenceID )
       }, 240000 )
 
+  test( 'a model opened with ON_PREVIEW_MESH cannot be sharded', async () => {
+
+    // The preview channel runs during OPEN, before a shard can be claimed,
+    // so its payloads are never partitioned: every worker in a pool would
+    // perform the same capped preview extraction and emit the same
+    // imposters, and a consumer forwarding those callbacks would receive N
+    // overlapping copies while only the durable pump was split.
+    //
+    // Note this is NOT covered by the adopted-frame guard: that one keys on
+    // demandCoordination_, which the preview only installs when recentring
+    // is on. With COORDINATE_TO_ORIGIN false there is no frame to catch,
+    // and the duplicated preview output is the whole problem.
+    const api = new IfcAPI()
+    await api.Init()
+
+    let previews = 0
+
+    const modelID = await api.OpenModelStreamed(
+        new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ),
+        { ...SHARD_SETTINGS,
+          ON_PREVIEW_MESH: () => {
+            ++previews
+          } } as never )
+
+    // The preview really did run, so the refusal below is about something
+    // that happened rather than a flag nobody acted on.
+    expect( previews ).toBeGreaterThan( 0 )
+
+    expect( () => api.SetGeometryShard( modelID, { index: 0, count: 2 } ) )
+        .toThrow( /ON_PREVIEW_MESH/ )
+
+    api.CloseModel( modelID )
+  }, 240000 )
+
   test( 'a shard descriptor is snapshotted, not retained', async () => {
 
     // A coordinator configuring several instances from one reused object is

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -1206,6 +1206,33 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     api.CloseModel( modelID )
   }, 240000 )
 
+  test( 'a shard cannot be claimed on a model opened without DEFER_GEOMETRY',
+      async () => {
+
+        // Sharding only narrows the deferred pump's worklists. A classic
+        // open has already extracted everything, so the claim would be
+        // accepted and then do nothing: ExtractGeometryBatch returns zero
+        // work and StreamAllMeshes serves the whole scene. A coordinator
+        // that forgot the flag would get the COMPLETE model from every
+        // worker while believing it had a partition.
+        const api = new IfcAPI()
+        await api.Init()
+
+        const modelID = await api.OpenModelStreamed(
+            new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ),
+            { COORDINATE_TO_ORIGIN: false, USE_FAST_BOOLS: true } )
+
+        expect( () => api.SetGeometryShard( modelID, { index: 0, count: 2 } ) )
+            .toThrow( /requires DEFER_GEOMETRY/ )
+
+        // N=1 is still fine: it asks for the whole model, which is exactly
+        // what a classic open delivers.
+        expect( api.SetGeometryShard( modelID, { index: 0, count: 1 } ) )
+            .toBe( true )
+
+        api.CloseModel( modelID )
+      }, 240000 )
+
   test( 'a shard descriptor is snapshotted, not retained', async () => {
 
     // A coordinator configuring several instances from one reused object is

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -18,6 +18,25 @@ const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
 const SHARD_SETTINGS =
   { COORDINATE_TO_ORIGIN: false, USE_FAST_BOOLS: true, DEFER_GEOMETRY: true }
 
+/**
+ * A transform's exact bytes, as a comparable string.
+ *
+ * Rounding would make these comparisons unable to fail: a transform that
+ * moved by less than half the last printed digit would serialize identically
+ * to the one it is being checked against. Every use below is asserting that
+ * two paths produce the SAME output, so the encoding has to be lossless.
+ *
+ * @param transform The flat transformation.
+ * @return {string} A lossless encoding of every component.
+ */
+function transformKey( transform: ArrayLike< number > ): string {
+
+  const exact = new Float64Array( transform )
+
+  return Buffer.from( exact.buffer, exact.byteOffset, exact.byteLength )
+      .toString( 'base64' )
+}
+
 let api: IfcAPI
 let buffer: Uint8Array
 
@@ -419,8 +438,7 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
       for ( let where = 0; where < mesh.geometries.size(); ++where ) {
         const placed = mesh.geometries.get( where )
         classicPlacements.push(
-            `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
-                .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+            `${placed.geometryExpressID}@${transformKey( placed.flatTransformation )}` )
       }
     } )
 
@@ -436,8 +454,7 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
             for ( let where = 0; where < mesh.geometries.size(); ++where ) {
               const placed = mesh.geometries.get( where )
               pumpedPlacements.push(
-                  `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
-                      .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+                  `${placed.geometryExpressID}@${transformKey( placed.flatTransformation )}` )
             }
           } )
 
@@ -582,8 +599,7 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
       for ( let where = 0; where < mesh.geometries.size(); ++where ) {
         const placed = mesh.geometries.get( where )
         classicPlacements.push(
-            `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
-                .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+            `${placed.geometryExpressID}@${transformKey( placed.flatTransformation )}` )
       }
     } )
 
@@ -608,8 +624,7 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
             for ( let where = 0; where < mesh.geometries.size(); ++where ) {
               const placed = mesh.geometries.get( where )
               pumped.push(
-                  `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
-                      .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+                  `${placed.geometryExpressID}@${transformKey( placed.flatTransformation )}` )
             }
           } )
 
@@ -870,8 +885,7 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
             for ( let where = 0; where < mesh.geometries.size(); ++where ) {
               const placed = mesh.geometries.get( where )
               whole.push(
-                  `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
-                      .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+                  `${placed.geometryExpressID}@${transformKey( placed.flatTransformation )}` )
             }
           } )
       if ( remaining === 0 && extracted === 0 ) {
@@ -903,8 +917,7 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
               for ( let where = 0; where < mesh.geometries.size(); ++where ) {
                 const placed = mesh.geometries.get( where )
                 sharded.push(
-                    `${placed.geometryExpressID}@${[ ...placed.flatTransformation ]
-                        .map( ( value ) => value.toFixed( 3 ) ).join( ',' )}` )
+                    `${placed.geometryExpressID}@${transformKey( placed.flatTransformation )}` )
                 ++delivered
               }
             } )

--- a/src/compat/web-ifc/ifc_api_deferred_open.test.ts
+++ b/src/compat/web-ifc/ifc_api_deferred_open.test.ts
@@ -13,6 +13,11 @@ import { FlatMesh, IfcAPI } from './ifc_api'
 
 const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
 
+// Sharding refuses COORDINATE_TO_ORIGIN — each shard would derive its own
+// recentre anchor — so every sharded open here goes without it.
+const SHARD_SETTINGS =
+  { COORDINATE_TO_ORIGIN: false, USE_FAST_BOOLS: true, DEFER_GEOMETRY: true }
+
 let api: IfcAPI
 let buffer: Uint8Array
 
@@ -855,11 +860,6 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
     const wholeApi = new IfcAPI()
     await wholeApi.Init()
 
-    // Sharding refuses COORDINATE_TO_ORIGIN — each shard would derive its
-    // own recentre anchor — so both sides of this comparison open without it.
-    const SHARD_SETTINGS =
-      { COORDINATE_TO_ORIGIN: false, USE_FAST_BOOLS: true, DEFER_GEOMETRY: true }
-
     const wholeID = await wholeApi.OpenModelStreamed( fixture, SHARD_SETTINGS )
 
     const whole: string[] = []
@@ -980,6 +980,77 @@ describe( 'OpenModelStreamed + DEFER_GEOMETRY', () => {
         .rejects.toThrow( /COORDINATE_TO_ORIGIN was enabled on a sharded model/ )
 
     api.CloseModel( modelID )
+  }, 240000 )
+
+  test( 'a shard descriptor is snapshotted, not retained', async () => {
+
+    // A coordinator configuring several instances from one reused object is
+    // the natural way to write an in-process pool. If the descriptor were
+    // retained, every proxy would read its FINAL index at first pump —
+    // several workers claiming one shard, the rest of the model claimed by
+    // nobody — and each call would still have passed validation.
+    const api = new IfcAPI()
+    await api.Init()
+
+    const fixture = new Uint8Array(
+        fs.readFileSync( 'data/mapped_shared_representation.ifc' ) )
+
+    const descriptor = { index: 0, count: 2 }
+
+    const modelID = await api.OpenModelStreamed( fixture, SHARD_SETTINGS )
+
+    expect( api.SetGeometryShard( modelID, descriptor ) ).toBe( true )
+
+    // The coordinator moves on to configuring the next worker.
+    descriptor.index = 1
+
+    const delivered: string[] = []
+
+    for ( ; ; ) {
+      const { extracted, remaining } = api.ExtractGeometryBatch(
+          modelID, 4, ( mesh ) => {
+            for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+              delivered.push(
+                  `${mesh.expressID}/` +
+                  `${mesh.geometries.get( where ).geometryExpressID}` )
+            }
+          } )
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+
+    // Shard 0's contents, not shard 1's. Compared against a model that
+    // claims shard 0 from a descriptor nobody touches.
+    const referenceApi = new IfcAPI()
+    await referenceApi.Init()
+
+    const referenceID =
+      await referenceApi.OpenModelStreamed( fixture, SHARD_SETTINGS )
+
+    referenceApi.SetGeometryShard( referenceID, { index: 0, count: 2 } )
+
+    const reference: string[] = []
+
+    for ( ; ; ) {
+      const { extracted, remaining } = referenceApi.ExtractGeometryBatch(
+          referenceID, 4, ( mesh ) => {
+            for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+              reference.push(
+                  `${mesh.expressID}/` +
+                  `${mesh.geometries.get( where ).geometryExpressID}` )
+            }
+          } )
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+    }
+
+    expect( reference.length ).toBeGreaterThan( 0 )
+    expect( delivered.sort() ).toEqual( reference.sort() )
+
+    api.CloseModel( modelID )
+    referenceApi.CloseModel( referenceID )
   }, 240000 )
 
   test( 'an unsharded model is unaffected by the shard preconditions', async () => {

--- a/src/compat/web-ifc/ifc_api_model_passthrough.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough.ts
@@ -23,6 +23,13 @@ export interface IfcApiModelPassthrough {
   linearScalingFactor?: number
 
   /**
+   * Claim one shard of this model's geometry (conway extension, M3) — see
+   * IfcAPI.SetGeometryShard. Optional: passthroughs without demand worklists
+   * (AP214/STEP) have nothing to shard.
+   */
+  setGeometryShard?( shard?: { index: number, count: number } ): void
+
+  /**
    * Set the resident-geometry budget in bytes (conway extension, M3) —
    * see IfcAPI.SetGeometryBudget. Optional so non-IFC passthroughs, whose
    * models have no evictable geometry store, simply do not offer it.

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2198,11 +2198,37 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         aggregates.push(relAggregate)
       }
 
+      let placed = 0
+      let positional = 0
+
       this.demandProducts_ = this.shard_ === void 0 ?
-        products : products.filter( ( localID ) =>
-          shardOfDispatchKey(
-              geometryDispatchKey( this.model[0], localID ),
-              this.shard_!.count ) === this.shard_!.index )
+        products : products.filter( ( localID ) => {
+
+          const key = geometryDispatchKey( this.model[0], localID )
+
+          // A key equal to the product's own local ID means the walk found
+          // nothing to place by — no representation, or, on a windowed
+          // source, records that are not resident yet, since this filter
+          // runs before the pump's per-product prefetch. Placement then
+          // degrades to positional modulo, which is round-robin: it still
+          // partitions correctly, it just stops avoiding duplication.
+          // Counted so that degradation is visible rather than silent.
+          key === localID ? ++positional : ++placed
+
+          return shardOfDispatchKey( key, this.shard_!.count ) ===
+            this.shard_!.index
+        } )
+
+      if ( this.shard_ !== void 0 && positional > placed ) {
+
+        Logger.warning(
+            `[shard ${this.shard_.index}/${this.shard_.count}] ` +
+            `${positional} of ${positional + placed} products have no ` +
+            'placement key, so sharding is mostly positional and shared ' +
+            'geometry will be rebuilt per shard. On a windowed source this ' +
+            'means the key\'s records are not resident when the worklist ' +
+            'is built.')
+      }
 
       // Aggregates place by the RELATING OBJECT's key — the assembly whose
       // geometry the pass builds — not the relationship record's. An
@@ -2264,6 +2290,29 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     if (shard === void 0) {
       this.shard_ = void 0
       return
+    }
+
+    // Refused rather than silently wrong. With COORDINATE_TO_ORIGIN the
+    // recentre anchor is derived from the FIRST geometry a model captures
+    // (see demandCoordination_ in streamNewMeshes_), so shards that begin on
+    // different products derive different frames — and a model spanning more
+    // than one recentre cell then merges subsets shifted by whole grid cells.
+    // Nothing in a union-of-placements check catches that on a model sitting
+    // at the origin, which is every fixture here.
+    //
+    // Sharding a recentred model therefore needs one anchor agreed before
+    // the split: either derived independently of the shard, or established
+    // once and handed to every worker. Until that exists, the combination
+    // is an error rather than a quiet coordinate bug — which does mean the
+    // pool cannot serve Share's own open settings yet.
+    if (this.settings?.COORDINATE_TO_ORIGIN === true) {
+
+      throw new Error(
+          'SetGeometryShard cannot be combined with COORDINATE_TO_ORIGIN: ' +
+          'each shard would derive its own recentre anchor from whichever ' +
+          'product it happens to extract first, so merged output can be ' +
+          'shifted between shards. Open without COORDINATE_TO_ORIGIN, or ' +
+          'wait for a shared coordination frame.')
     }
 
     if (!Number.isInteger(shard.count) || shard.count < 1 ||

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2307,6 +2307,30 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       return
     }
 
+    // Validated before anything is decided from it, so a malformed
+    // descriptor is reported as malformed rather than as whichever
+    // incompatibility it happens to trip first.
+    if (!Number.isInteger(shard.count) || shard.count < 1 ||
+        !Number.isInteger(shard.index) || shard.index < 0 ||
+        shard.index >= shard.count) {
+
+      throw new Error(
+          `invalid shard ${shard.index}/${shard.count}: index must be an ` +
+          'integer in [0, count) and count a positive integer')
+    }
+
+    // A single worker is the unsharded model, so it is normalised here —
+    // BEFORE the checks below, every one of which exists because workers
+    // have to agree with each other. One worker agrees with nobody, and a
+    // coordinator that calls this uniformly for its N=1 baseline is doing
+    // nothing that needs a shared frame or a residency-independent key.
+    // Refusing it would fail a configuration that is exactly equivalent to
+    // never having called this at all.
+    if (shard.count === 1) {
+      this.shard_ = void 0
+      return
+    }
+
     // Refused rather than silently wrong. With COORDINATE_TO_ORIGIN the
     // recentre anchor is derived from the FIRST geometry a model captures
     // (see demandCoordination_ in streamNewMeshes_), so shards that begin on
@@ -2343,15 +2367,6 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
           'which products they own.')
     }
 
-    if (!Number.isInteger(shard.count) || shard.count < 1 ||
-        !Number.isInteger(shard.index) || shard.index < 0 ||
-        shard.index >= shard.count) {
-
-      throw new Error(
-          `invalid shard ${shard.index}/${shard.count}: index must be an ` +
-          'integer in [0, count) and count a positive integer')
-    }
-
     // Snapshotted, not retained. A coordinator configuring several engine
     // instances from one descriptor object — mutating `index` between calls
     // — would otherwise leave every proxy pointing at the same object, and
@@ -2361,8 +2376,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     //
     // Same class as the settings-object aliasing above: values validated at
     // one moment and consumed at another have to be copied at the boundary.
-    this.shard_ = shard.count === 1 ?
-      void 0 : { index: shard.index, count: shard.count }
+    this.shard_ = { index: shard.index, count: shard.count }
   }
 
   /**

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -1995,6 +1995,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
           'source — use ExtractGeometryBatchAsync' )
     }
 
+    this.checkShardPreconditions_()
     this.ensureDemandWorklists_()
 
     return this.pumpGeometryBatch_(batchSize, meshCallback)
@@ -2019,6 +2020,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       return {extracted: 0, remaining: 0}
     }
 
+    this.checkShardPreconditions_()
     this.ensureDemandWorklists_()
 
     if (!this.model[0].isSourceExternal) {
@@ -2207,12 +2209,16 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
           const key = geometryDispatchKey( this.model[0], localID )
 
           // A key equal to the product's own local ID means the walk found
-          // nothing to place by — no representation, or, on a windowed
-          // source, records that are not resident yet, since this filter
-          // runs before the pump's per-product prefetch. Placement then
-          // degrades to positional modulo, which is round-robin: it still
-          // partitions correctly, it just stops avoiding duplication.
-          // Counted so that degradation is visible rather than silent.
+          // nothing to place by — a product with no representation. That
+          // costs affinity, not correctness: the key is still a pure
+          // function of the product, so every worker computes the same one
+          // and the partition holds; it just stops avoiding duplication.
+          //
+          // Correctness would only break if the SAME product keyed
+          // differently in different workers, which is why windowed sources
+          // are refused outright (checkShardPreconditions_) rather than
+          // merely warned about — an earlier version of this comment had
+          // that wrong.
           key === localID ? ++positional : ++placed
 
           return shardOfDispatchKey( key, this.shard_!.count ) ===
@@ -2225,9 +2231,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
             `[shard ${this.shard_.index}/${this.shard_.count}] ` +
             `${positional} of ${positional + placed} products have no ` +
             'placement key, so sharding is mostly positional and shared ' +
-            'geometry will be rebuilt per shard. On a windowed source this ' +
-            'means the key\'s records are not resident when the worklist ' +
-            'is built.')
+            'geometry will be rebuilt per shard.')
       }
 
       // Aggregates place by the RELATING OBJECT's key — the assembly whose
@@ -2244,11 +2248,22 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       this.demandAggregates_ = this.shard_ === void 0 ?
         aggregates : aggregates.filter( ( relAggregate ) => {
 
-          const relating = relAggregate.RelatingObject
+          // Guarded even though sharding now refuses windowed sources:
+          // this getter reads a record synchronously, and geometryDispatchKey's
+          // own try/catch is INSIDE the call, so a throw here would abort
+          // worklist construction for the whole model rather than place one
+          // aggregate by fallback. Depth-in-depth for a total function.
+          let relating: number | undefined
+
+          try {
+            relating = relAggregate.RelatingObject?.localID
+          } catch {
+            relating = void 0
+          }
 
           return shardOfDispatchKey(
               geometryDispatchKey(
-                  this.model[0], relating?.localID ?? relAggregate.localID ),
+                  this.model[0], relating ?? relAggregate.localID ),
               this.shard_!.count ) === this.shard_!.index
         } )
 
@@ -2315,6 +2330,19 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
           'wait for a shared coordination frame.')
     }
 
+    // Refused at claim time as well as at every pump (see
+    // checkShardPreconditions_, which carries the reasoning): whether the
+    // dispatch key resolves depends on which pages are resident in this
+    // worker, so workers disagree and the partition stops being a partition.
+    if (this.model[0].isSourceExternal) {
+
+      throw new Error(
+          'SetGeometryShard cannot be used with a windowed external ' +
+          'source: the dispatch key walks attribute records, whose ' +
+          'residency differs per worker, so workers would disagree about ' +
+          'which products they own.')
+    }
+
     if (!Number.isInteger(shard.count) || shard.count < 1 ||
         !Number.isInteger(shard.index) || shard.index < 0 ||
         shard.index >= shard.count) {
@@ -2335,23 +2363,71 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * @param meshCallback Optional mesh consumer.
    * @return {object} `{extracted, remaining}`.
    */
-  private pumpGeometryBatch_(
-      batchSize: number,
-      meshCallback?: (mesh: FlatMesh) => void ): {extracted: number, remaining: number} {
+  /**
+   * The conditions a sharded pump requires, re-checked on every batch.
+   *
+   * Not only in setGeometryShard, because `this.settings` is the CALLER'S
+   * object, held by reference, and the model reads it live — a caller can
+   * open with a flag off, claim a shard past the claim-time check, then set
+   * the flag on its own object. The check that has to hold is the one at the
+   * point the property is consumed, so this runs from both pump entries,
+   * upstream of every capture.
+   *
+   * Unsharded models are unaffected: every condition here is about workers
+   * having to agree with each other.
+   */
+  private checkShardPreconditions_(): void {
 
-    // Re-checked here, not only in setGeometryShard. `this.settings` is the
-    // CALLER'S object, held by reference, and streamNewMeshes_ reads
-    // COORDINATE_TO_ORIGIN live — so a caller that opens without it, claims
-    // a shard, then flips the flag on its own object would derive exactly
-    // the per-shard anchor the claim-time check exists to prohibit. The
-    // check that has to hold is the one at the point the frame is derived.
-    if (this.shard_ !== void 0 && this.settings?.COORDINATE_TO_ORIGIN === true) {
+    if (this.shard_ === void 0) {
+      return
+    }
+
+    // Each shard would derive its own recentre anchor from whichever product
+    // it extracts first (see demandCoordination_ in streamNewMeshes_), so a
+    // model spanning more than one recentre cell merges subsets shifted by
+    // whole grid cells.
+    if (this.settings?.COORDINATE_TO_ORIGIN === true) {
 
       throw new Error(
           'COORDINATE_TO_ORIGIN was enabled on a sharded model: each shard ' +
           'would derive its own recentre anchor from whichever product it ' +
           'extracts first, so merged output can be shifted between shards.')
     }
+
+    // A windowed source breaks the property the whole partition rests on:
+    // that every worker computes the SAME key for a product. geometryDispatchKey
+    // walks attribute records, and on a windowed source whether that walk
+    // succeeds depends on which pages happen to be resident in THIS worker —
+    // so one worker returns the mapped-source key while another catches the
+    // non-resident read and falls back to the product's local ID.
+    //
+    // That is not weaker affinity, it is a wrong partition. Two workers
+    // disagreeing about a product's key can have both modulo results select
+    // it (extracted twice) or neither (dropped silently). The union check in
+    // m3_worker_pool.mjs cannot see it either, because it runs on resident
+    // buffers where the walk always succeeds.
+    //
+    // Making this work needs a key that does not depend on residency —
+    // derived from the reference columns, or from a closure paged
+    // deterministically before the split. Until then it is refused: workers
+    // on a windowed store were already out of scope for this change (they
+    // need the OPFS-backed source, not a resident buffer per worker), so
+    // this closes a path that has no caller rather than removing a feature.
+    if (this.model[0].isSourceExternal) {
+
+      throw new Error(
+          'a geometry shard cannot be claimed on a windowed external ' +
+          'source: the dispatch key walks attribute records, so whether it ' +
+          'resolves depends on which pages are resident in each worker, and ' +
+          'workers that disagree about a product would extract it twice or ' +
+          'not at all.')
+    }
+  }
+
+
+  private pumpGeometryBatch_(
+      batchSize: number,
+      meshCallback?: (mesh: FlatMesh) => void ): {extracted: number, remaining: number} {
 
     const products = this.demandProducts_ ?? []
     const aggregates = this.demandAggregates_ ?? []

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2339,6 +2339,20 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       batchSize: number,
       meshCallback?: (mesh: FlatMesh) => void ): {extracted: number, remaining: number} {
 
+    // Re-checked here, not only in setGeometryShard. `this.settings` is the
+    // CALLER'S object, held by reference, and streamNewMeshes_ reads
+    // COORDINATE_TO_ORIGIN live — so a caller that opens without it, claims
+    // a shard, then flips the flag on its own object would derive exactly
+    // the per-shard anchor the claim-time check exists to prohibit. The
+    // check that has to hold is the one at the point the frame is derived.
+    if (this.shard_ !== void 0 && this.settings?.COORDINATE_TO_ORIGIN === true) {
+
+      throw new Error(
+          'COORDINATE_TO_ORIGIN was enabled on a sharded model: each shard ' +
+          'would derive its own recentre anchor from whichever product it ' +
+          'extracts first, so merged output can be shifted between shards.')
+    }
+
     const products = this.demandProducts_ ?? []
     const aggregates = this.demandAggregates_ ?? []
     const totalWork = products.length + aggregates.length

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2352,7 +2352,17 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
           'integer in [0, count) and count a positive integer')
     }
 
-    this.shard_ = shard.count === 1 ? void 0 : shard
+    // Snapshotted, not retained. A coordinator configuring several engine
+    // instances from one descriptor object — mutating `index` between calls
+    // — would otherwise leave every proxy pointing at the same object, and
+    // ensureDemandWorklists_ reads it later, at first pump. Every descriptor
+    // would pass validation here and the partition would still collapse:
+    // several workers claiming the final index, nobody claiming the rest.
+    //
+    // Same class as the settings-object aliasing above: values validated at
+    // one moment and consumed at another have to be copied at the boundary.
+    this.shard_ = shard.count === 1 ?
+      void 0 : { index: shard.index, count: shard.count }
   }
 
   /**

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -119,6 +119,10 @@ interface IfcProxyLoadState {
   /** Coordination matrix the parse-time preview channel derived (slice
    * A2) — adopted by the durable capture so both share one frame. */
   previewCoordinationMatrix?: number[]
+  /** True when a parse-time preview channel ran and emitted. Recorded
+   * separately from the matrix above, which only exists when recentring
+   * was on — sharding has to know about the preview either way. */
+  previewEmitted?: boolean
   allTimeStart: number
   stepHeader: StepHeader
   model: IfcStepModel
@@ -287,6 +291,11 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * memory.
    */
   private demandCoordination_?: number[]
+
+  /** Whether a parse-time preview channel already emitted for this model.
+   * The preview runs during open, before a shard can be claimed, so its
+   * output is never partitioned (see setGeometryShard). */
+  private previewEmitted_ = false
 
   /**
    * True while an adopted preview-channel coordination frame is still
@@ -458,6 +467,8 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // derivation and places exactly where the preview did. (Internal
     // only — getCoordinationMatrix stays identity, see
     // demandCoordination_.)
+    this.previewEmitted_ = loadState.previewEmitted === true
+
     if (this.deferredMode_ && loadState.previewCoordinationMatrix !== void 0) {
       this.demandCoordination_ = loadState.previewCoordinationMatrix
       this._isCoordinated = true
@@ -1013,6 +1024,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         // (derived from the same first instance with the same math), so
         // preview payloads and durable meshes share one frame.
         previewCoordinationMatrix: previewChannel?.coordinationMatrix,
+        previewEmitted: previewChannel !== void 0,
         allTimeStart,
         stepHeader,
         model,
@@ -2344,6 +2356,26 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // once and handed to every worker. Until that exists, the combination
     // is an error rather than a quiet coordinate bug — which does mean the
     // pool cannot serve Share's own open settings yet.
+    // The preview channel runs during open, before a shard can be claimed,
+    // so its payloads are never partitioned: every worker performs the same
+    // capped preview extraction and emits the same imposters, and a pool
+    // forwarding those callbacks gets N overlapping copies. Only the
+    // durable pump is sharded.
+    //
+    // Refused rather than deduplicated, because the fix is to make the
+    // shard available during open so the preview path can filter by it —
+    // an open-signature change, not a dispatch one. Same shape as the
+    // other two refusals: close the path that has no caller, and name the
+    // precondition for reopening it.
+    if (this.previewEmitted_) {
+
+      throw new Error(
+          'SetGeometryShard cannot be used on a model opened with ' +
+          'ON_PREVIEW_MESH: the preview runs during open, before a shard ' +
+          'exists, so every worker would emit the same unpartitioned ' +
+          'preview payloads.')
+    }
+
     // Already-adopted frame, not just the current flag — see
     // checkShardPreconditions_, which carries the reasoning.
     if (this.demandCoordination_ !== void 0) {
@@ -2454,6 +2486,14 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // adopt a frame, then set the flag false on its own settings object
     // would pass a flag-only check while already sitting in a
     // preview-derived frame that other workers do not share.
+    if (this.previewEmitted_) {
+
+      throw new Error(
+          'a preview channel already emitted for this model, so it cannot ' +
+          'be sharded: the preview runs during open, before a shard ' +
+          'exists, so its payloads are not partitioned.')
+    }
+
     if (this.demandCoordination_ !== void 0) {
 
       throw new Error(

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2344,6 +2344,17 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // once and handed to every worker. Until that exists, the combination
     // is an error rather than a quiet coordinate bug — which does mean the
     // pool cannot serve Share's own open settings yet.
+    // Already-adopted frame, not just the current flag — see
+    // checkShardPreconditions_, which carries the reasoning.
+    if (this.demandCoordination_ !== void 0) {
+
+      throw new Error(
+          'SetGeometryShard cannot be used on a model that has already ' +
+          'adopted a recentre frame (for example via ON_PREVIEW_MESH): the ' +
+          'frame is derived from whichever geometry this instance saw ' +
+          'first, so workers would not share it.')
+    }
+
     if (this.settings?.COORDINATE_TO_ORIGIN === true) {
 
       throw new Error(
@@ -2410,6 +2421,22 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // it extracts first (see demandCoordination_ in streamNewMeshes_), so a
     // model spanning more than one recentre cell merges subsets shifted by
     // whole grid cells.
+    // Two questions, because neither answers the other. The FLAG says
+    // whether recentring is wanted from here on; demandCoordination_ says
+    // whether a frame has already been adopted. A caller that opened with
+    // ON_PREVIEW_MESH and COORDINATE_TO_ORIGIN, let the preview channel
+    // adopt a frame, then set the flag false on its own settings object
+    // would pass a flag-only check while already sitting in a
+    // preview-derived frame that other workers do not share.
+    if (this.demandCoordination_ !== void 0) {
+
+      throw new Error(
+          'a recentre frame has already been adopted on this model, so it ' +
+          'cannot be sharded: the frame came from whichever geometry this ' +
+          'instance saw first, and other workers will have adopted their ' +
+          'own.')
+    }
+
     if (this.settings?.COORDINATE_TO_ORIGIN === true) {
 
       throw new Error(

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2411,6 +2411,32 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * Unsharded models are unaffected: every condition here is about workers
    * having to agree with each other.
    */
+  /**
+   * Whether this model should recentre — the question the CAPTURE path asks.
+   *
+   * Distinct from the refusals in checkShardPreconditions_, and deliberately
+   * so. Those refuse the combination when they can observe it; this makes
+   * the combination harmless when they cannot. A guard checks at one moment
+   * and the frame is derived at another, and the caller owns the settings
+   * object throughout — so anything running in between can flip the flag.
+   * ON_PROGRESS is one such window (it is invoked synchronously from
+   * beginPhase, between the precondition check and the first capture), and
+   * it is the third such window found in this review; patching each one as
+   * it turns up is losing strategy.
+   *
+   * So a sharded model never recentres, whatever the flag says at the
+   * instant the frame would be derived. The refusals still fire first in
+   * every observable case, which is what a caller should see; this is what
+   * makes a missed one merely refused-late rather than silently wrong.
+   *
+   * @return {boolean} Whether to derive and apply a recentre frame.
+   */
+  private recentreEnabled_(): boolean {
+
+    return this.shard_ === void 0 && this.settings?.COORDINATE_TO_ORIGIN === true
+  }
+
+
   private checkShardPreconditions_(): void {
 
     if (this.shard_ === void 0) {
@@ -2695,11 +2721,11 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       }
 
       const validatePreviewFrame = this.demandCoordinationFromPreview_ &&
-        this.settings?.COORDINATE_TO_ORIGIN === true
+        this.recentreEnabled_()
 
       let nativePt: Vector3
       if ((!this._isCoordinated || validatePreviewFrame) &&
-          this.settings?.COORDINATE_TO_ORIGIN) {
+          this.recentreEnabled_()) {
         nativePt = geometry.geometry.getPoint(0)
       }
 
@@ -2714,7 +2740,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       // the recentre math runs in double precision (see coordination_f64).
       const geometryTransform = nativeTransform?.getValues()
 
-      if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
+      if (!this._isCoordinated && this.recentreEnabled_()) {
 
         const derived = deriveCoordinationF64(
             geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)
@@ -2977,7 +3003,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         }
 
         let nativePt:Vector3
-        if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
+        if (!this._isCoordinated && this.recentreEnabled_()) {
           nativePt = geometry.geometry.getPoint(0)
         }
 
@@ -2993,7 +3019,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         // the recentre math runs in double precision (see coordination_f64).
         const geometryTransform = nativeTransform?.getValues()
 
-        if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
+        if (!this._isCoordinated && this.recentreEnabled_()) {
           coordinationMatrix = deriveCoordinationF64(
               geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)
           // Persisted for getAppliedCoordination (Share#1634): report
@@ -3144,7 +3170,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         }
 
         let nativePt:Vector3
-        if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
+        if (!this._isCoordinated && this.recentreEnabled_()) {
           nativePt = geometry.geometry.getPoint(0)
         }
 
@@ -3160,7 +3186,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         // the recentre math runs in double precision (see coordination_f64).
         const geometryTransform = nativeTransform?.getValues()
 
-        if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
+        if (!this._isCoordinated && this.recentreEnabled_()) {
           Logger.info('Setting up coordinationMatrix')
           coordinationMatrix = deriveCoordinationF64(
               geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)
@@ -3292,7 +3318,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         }
 
         let nativePt:Vector3
-        if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
+        if (!this._isCoordinated && this.recentreEnabled_()) {
           nativePt = geometry.geometry.getPoint(0)
         }
 
@@ -3308,7 +3334,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         // the recentre math runs in double precision (see coordination_f64).
         const geometryTransform = nativeTransform?.getValues()
 
-        if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
+        if (!this._isCoordinated && this.recentreEnabled_()) {
           Logger.info('Setting up coordinationMatrix')
           coordinationMatrix = deriveCoordinationF64(
               geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2356,6 +2356,26 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // once and handed to every worker. Until that exists, the combination
     // is an error rather than a quiet coordinate bug — which does mean the
     // pool cannot serve Share's own open settings yet.
+    // Sharding only means anything on the deferred pump: it narrows the
+    // worklists ensureDemandWorklists_ builds. A classic open has already
+    // extracted everything, so ExtractGeometryBatch returns zero work and
+    // StreamAllMeshes serves the whole scene — a coordinator that forgot
+    // DEFER_GEOMETRY would see every worker claim successfully and then
+    // receive the COMPLETE model from each, which is the silent-wrong
+    // outcome every other check here exists to prevent.
+    //
+    // Placed after the N=1 normalisation above: {index: 0, count: 1} is a
+    // request for the whole model, which is exactly what a classic open
+    // delivers, so there is nothing to refuse.
+    if (!this.deferredMode_) {
+
+      throw new Error(
+          'SetGeometryShard requires DEFER_GEOMETRY: a classic open has ' +
+          'already extracted the whole model, so a shard claim would be ' +
+          'accepted and then ignored, and every worker would deliver ' +
+          'everything.')
+    }
+
     // The preview channel runs during open, before a shard can be claimed,
     // so its payloads are never partitioned: every worker performs the same
     // capped preview extraction and emits the same imposters, and a pool

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2204,16 +2204,27 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
               geometryDispatchKey( this.model[0], localID ),
               this.shard_!.count ) === this.shard_!.index )
 
-      // Aggregates place by the SAME key, on the relating object: on an
+      // Aggregates place by the RELATING OBJECT's key — the assembly whose
+      // geometry the pass builds — not the relationship record's. An
+      // IfcRelAggregates is not an IfcProduct, so keying on it would fall
+      // straight through geometryDispatchKey to its own local ID and shard
+      // by record position while claiming to place by representation.
+      //
+      // This matters most exactly where placement matters most: on an
       // assembly-heavy model the rel-aggregates pass creates most of the
-      // geometry, so leaving it positional while placing products carefully
-      // gives placement almost nothing to control (measured on D3D, where
-      // that mistake made every strategy look identical).
+      // geometry, so getting it wrong leaves placement with almost nothing
+      // to control (measured on D3D, where that mistake made every strategy
+      // look identical).
       this.demandAggregates_ = this.shard_ === void 0 ?
-        aggregates : aggregates.filter( ( relAggregate ) =>
-          shardOfDispatchKey(
-              geometryDispatchKey( this.model[0], relAggregate.localID ),
-              this.shard_!.count ) === this.shard_!.index )
+        aggregates : aggregates.filter( ( relAggregate ) => {
+
+          const relating = relAggregate.RelatingObject
+
+          return shardOfDispatchKey(
+              geometryDispatchKey(
+                  this.model[0], relating?.localID ?? relAggregate.localID ),
+              this.shard_!.count ) === this.shard_!.index
+        } )
 
       this.demandCursor_ = 0
       this.demandAggregatesCursor_ = 0

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -4,6 +4,7 @@ import {
 } from '../../index'
 import { Vector3 } from '../../../dependencies/conway-geom'
 import { CanonicalMaterial } from '../../index'
+import { geometryDispatchKey, shardOfDispatchKey } from '../../ifc/geometry_dispatch'
 import { IfcSceneBuilder } from '../../ifc/ifc_scene_builder'
 import IfcStepModel from '../../ifc/ifc_step_model'
 import {
@@ -242,6 +243,10 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   private readonly demandPendingNodes_ = new Map<number, number>()
 
   /** Cursor into demandProducts_ — products before it are extracted. */
+  /* Which shard of the model this instance extracts, or undefined for all
+   * of it. See setGeometryShard. */
+  private shard_?: { index: number, count: number }
+
   private demandCursor_ = 0
 
   /** Wall-clock split of the store-backed batch pump (profile script). */
@@ -2193,10 +2198,73 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         aggregates.push(relAggregate)
       }
 
-      this.demandProducts_ = products
-      this.demandAggregates_ = aggregates
+      this.demandProducts_ = this.shard_ === void 0 ?
+        products : products.filter( ( localID ) =>
+          shardOfDispatchKey(
+              geometryDispatchKey( this.model[0], localID ),
+              this.shard_!.count ) === this.shard_!.index )
+
+      // Aggregates place by the SAME key, on the relating object: on an
+      // assembly-heavy model the rel-aggregates pass creates most of the
+      // geometry, so leaving it positional while placing products carefully
+      // gives placement almost nothing to control (measured on D3D, where
+      // that mistake made every strategy look identical).
+      this.demandAggregates_ = this.shard_ === void 0 ?
+        aggregates : aggregates.filter( ( relAggregate ) =>
+          shardOfDispatchKey(
+              geometryDispatchKey( this.model[0], relAggregate.localID ),
+              this.shard_!.count ) === this.shard_!.index )
+
       this.demandCursor_ = 0
       this.demandAggregatesCursor_ = 0
+  }
+
+  /**
+   * Extract only one shard of this model's geometry — the across-product
+   * parallelism seam.
+   *
+   * Each worker in a pool opens the model, claims a shard, and pumps: no
+   * scheduling channel between them, because placement is a pure function of
+   * the product (see geometryDispatchKey). Products sharing a representation
+   * land on the same shard, so shards do not rebuild each other's geometry —
+   * round-robin costs +25 % assets on MB-Khaya and +40.7 % on D3D at N=4,
+   * where this key costs +0 % and +38.1 % respectively, for 1.76x and 2.34x
+   * wall-clock.
+   *
+   * **A shard extracts a SUBSET, and the consumer is responsible for the
+   * union.** One shard's output is not a model; assembling all of them is.
+   * Must be set before the first pump call, since the worklists are built
+   * once — setting it later throws rather than silently extracting the wrong
+   * subset.
+   *
+   * @param shard `{index, count}`, or undefined for the whole model.
+   */
+  public setGeometryShard( shard?: { index: number, count: number } ): void {
+
+    if (this.demandProducts_ !== void 0) {
+
+      throw new Error(
+          'setGeometryShard must be called before the first ' +
+          'ExtractGeometryBatch: the worklists are already built, and ' +
+          'narrowing them now would drop products this model has already ' +
+          'reported as pending.')
+    }
+
+    if (shard === void 0) {
+      this.shard_ = void 0
+      return
+    }
+
+    if (!Number.isInteger(shard.count) || shard.count < 1 ||
+        !Number.isInteger(shard.index) || shard.index < 0 ||
+        shard.index >= shard.count) {
+
+      throw new Error(
+          `invalid shard ${shard.index}/${shard.count}: index must be an ` +
+          'integer in [0, count) and count a positive integer')
+    }
+
+    this.shard_ = shard.count === 1 ? void 0 : shard
   }
 
   /**

--- a/src/ifc/geometry_dispatch.test.ts
+++ b/src/ifc/geometry_dispatch.test.ts
@@ -1,0 +1,119 @@
+/* eslint-disable no-magic-numbers */
+import * as fs from 'fs'
+
+import { describe, expect, test } from '@jest/globals'
+
+import { IfcAPI } from '../compat/web-ifc/ifc_api'
+import IfcStepModel from './ifc_step_model'
+import { geometryDispatchKey, shardOfDispatchKey } from './geometry_dispatch'
+
+
+const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
+
+
+describe( 'geometryDispatchKey', () => {
+
+  test( 'products sharing a representation map key together, and land together',
+      async () => {
+
+        // The whole claim in one assertion. data/mapped_shared_representation.ifc
+        // has two products 15 apart instancing one IfcRepresentationMap; a
+        // partition that splits them makes both shards build the same
+        // geometry, which is the +25% to +40% round-robin costs on real
+        // models. They must key identically WITHOUT anything having been
+        // extracted — that is what makes this usable at dispatch time.
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const fixture = new Uint8Array(
+            fs.readFileSync( 'data/mapped_shared_representation.ifc' ) )
+
+        const modelID = await api.OpenModelStreamed(
+            fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+        // The passthrough's internals are not on the public interface;
+        // reaching in is deliberate, as in the pump tests.
+        const passthrough = api.getPassthrough( modelID ) as unknown as {
+          model: [ IfcStepModel ],
+          ensureDemandWorklists_(): void,
+          demandProducts_?: number[],
+        }
+
+        const model = passthrough.model[ 0 ]
+
+        passthrough.ensureDemandWorklists_()
+
+        const products = passthrough.demandProducts_ ?? []
+
+        expect( products.length ).toBeGreaterThan( 2 )
+
+        const keys = products.map(
+            ( localID ) => geometryDispatchKey( model, localID ) )
+
+        // The two mapped products share a key; the fillers, which each own
+        // their geometry, do not join them.
+        const byKey = new Map< number, number >()
+
+        for ( const key of keys ) {
+          byKey.set( key, ( byKey.get( key ) ?? 0 ) + 1 )
+        }
+
+        const shared = [ ...byKey.values() ].filter( ( count ) => count > 1 )
+
+        expect( shared ).toEqual( [ 2 ] )
+
+        // ...and at every shard count they co-locate, which is the property
+        // the partition actually consumes.
+        for ( const shardCount of [ 2, 3, 4, 8 ] ) {
+
+          const sharedKey = [ ...byKey.entries() ]
+              .find( ( [ , count ] ) => count > 1 )![ 0 ]
+
+          const shards = new Set(
+              keys.filter( ( key ) => key === sharedKey )
+                  .map( ( key ) => shardOfDispatchKey( key, shardCount ) ) )
+
+          expect( shards.size ).toBe( 1 )
+        }
+
+        api.CloseModel( modelID )
+      }, 240000 )
+
+  test( 'a key is produced for every product, resolvable or not', async () => {
+
+    // Totality matters more than accuracy here: this runs per product on the
+    // dispatch path, and a product with no representation, or one whose
+    // attributes do not resolve, must still be placeable. A thrown error
+    // costs the model; a poor key costs one duplicated extraction.
+    const api = new IfcAPI()
+
+    await api.Init()
+
+    const fixture = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
+
+    const modelID = await api.OpenModelStreamed(
+        fixture, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+    const model = ( api.getPassthrough( modelID ) as unknown as
+      { model: [ IfcStepModel ] } ).model[ 0 ]
+
+    // Local IDs that exist, and one that does not.
+    for ( const localID of [ 0, 1, 2, 999999 ] ) {
+
+      const key = geometryDispatchKey( model, localID )
+
+      expect( Number.isFinite( key ) ).toBe( true )
+      expect( shardOfDispatchKey( key, 4 ) ).toBeGreaterThanOrEqual( 0 )
+      expect( shardOfDispatchKey( key, 4 ) ).toBeLessThan( 4 )
+    }
+
+    // Degenerate shard counts collapse rather than throwing or indexing out
+    // of range — a pool of one is a normal configuration.
+    expect( shardOfDispatchKey( 12345, 1 ) ).toBe( 0 )
+    expect( shardOfDispatchKey( 12345, 0 ) ).toBe( 0 )
+    expect( shardOfDispatchKey( -7, 4 ) ).toBeLessThan( 4 )
+
+    api.CloseModel( modelID )
+  }, 240000 )
+} )

--- a/src/ifc/geometry_dispatch.ts
+++ b/src/ifc/geometry_dispatch.ts
@@ -1,0 +1,143 @@
+import IfcStepModel from './ifc_step_model'
+import {
+  IfcMappedItem,
+  IfcProduct,
+  IfcProductDefinitionShape,
+  IfcRepresentation,
+} from './ifc4_gen'
+
+
+/**
+ * Placement keys for demand-driven geometry extraction: which shard — worker,
+ * process, queue — should own a product, decided BEFORE extracting it.
+ *
+ * **Why this exists as engine code rather than a heuristic in a driver.** The
+ * across-product parallelism axis (own instance, own heap, disjoint products)
+ * is bounded by duplication, not by cores: shards that do not agree on where
+ * shared representation geometry belongs each rebuild it. Round-robin costs
+ * +25 % assets on MB-Khaya and +40.7 % on D3D at N=4. Placement fixes that,
+ * but the strategies that fixed it completely in the spike scored products
+ * from a graph of what they turned out to touch — an oracle a live worker
+ * cannot have.
+ *
+ * This is the online form: an identity derived from attributes alone, over
+ * columns the streamed parse already builds, costing pointer-chasing against
+ * tessellation. Measured against those oracles by
+ * `scripts/m3_affinity_spike.mjs`:
+ *
+ * | model | round-robin | this key | oracle |
+ * | --- | --- | --- | --- |
+ * | MB-Khaya, N=4 | 9 020 assets (+25 %) | **7 193 (+0 %)** | 7 193 (+0 %) |
+ * | D3D, N=4 | 83 177 (+40.7 %) | 81 639 (+38.1 %) | 65 288 (+10.5 %) |
+ *
+ * **So it is exact on one model and weak on the other, and ships anyway**,
+ * because wall-clock is what a user feels: 1.76x on MB-Khaya and 2.34x on
+ * D3D, both better than the oracle's, which places well but balances badly
+ * (its D3D shards came out 15896/29030/19585/2837).
+ *
+ * The D3D gap is the honest limit. On an assembly-heavy model the sharing
+ * lives BELOW the representation — a profile swept along different
+ * directrices, boolean operands, void geometry — where an attribute walk
+ * cannot see it. Closing that needs a key with sub-representation reach and
+ * a load balancer to go with it; the headroom is ~30 points of duplication,
+ * about 14s of CPU on D3D at N=4.
+ */
+
+/**
+ * The identity a product should be placed by.
+ *
+ * Follows `IfcProduct.Representation` to its shape, then to the first mapped
+ * item's `MappingSource` — the shared definition every instance of a block
+ * points at, so all of them hash together. Falls back to the shape
+ * representation itself (products sharing a whole shape still co-locate),
+ * then to the product's own local ID, which is unique and therefore places
+ * that product positionally rather than pretending to know better.
+ *
+ * Total, and deliberately so: a product whose attributes do not resolve gets
+ * a usable key rather than aborting a load. A wrong placement costs a
+ * duplicated extraction; a thrown error costs the model.
+ *
+ * @param model The model to read attributes from.
+ * @param productLocalID The product's local ID.
+ * @return {number} A placement key, stable across runs of the same model.
+ */
+export function geometryDispatchKey(
+    model: IfcStepModel,
+    productLocalID: number ): number {
+
+  try {
+
+    const product = model.getElementByLocalID( productLocalID )
+
+    if ( !( product instanceof IfcProduct ) ) {
+      return productLocalID
+    }
+
+    const definition = product.Representation
+
+    if ( !( definition instanceof IfcProductDefinitionShape ) ) {
+      return productLocalID
+    }
+
+    for ( const representation of definition.Representations ) {
+
+      const mappedKey = mappedSourceOf( representation )
+
+      if ( mappedKey !== void 0 ) {
+        return mappedKey
+      }
+    }
+
+    // No mapped item: co-locate by the shape itself, which still groups
+    // products that share one representation.
+    const [ firstRepresentation ] = definition.Representations
+
+    return firstRepresentation?.localID ?? productLocalID
+
+  } catch {
+
+    return productLocalID
+  }
+}
+
+
+/**
+ * The shard a product belongs to.
+ *
+ * Modulo rather than a range: the keys are local IDs, which cluster by file
+ * position, and ranges over them would reproduce contiguous sharding's
+ * imbalance while looking like placement.
+ *
+ * @param key A key from {@link geometryDispatchKey}.
+ * @param shardCount How many shards; values below 1 collapse to one.
+ * @return {number} The owning shard index.
+ */
+export function shardOfDispatchKey( key: number, shardCount: number ): number {
+
+  if ( !Number.isFinite( shardCount ) || shardCount < 2 ) {
+    return 0
+  }
+
+  // Local IDs are non-negative, but a key that arrived negative would
+  // otherwise index outside the shard array.
+  return Math.abs( key ) % Math.floor( shardCount )
+}
+
+
+/**
+ * The mapped source behind a representation, if it has one.
+ *
+ * @param representation A shape representation.
+ * @return {number|undefined} The representation map's local ID.
+ */
+function mappedSourceOf( representation: IfcRepresentation ): number | undefined {
+
+  for ( const item of representation.Items ) {
+
+    if ( item instanceof IfcMappedItem ) {
+      return item.MappingSource?.localID
+    }
+  }
+
+  return void 0
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,4 +98,5 @@ export {
 export { IfcTileAssetExtractor, TileCommitBindings } from './ifc/ifc_tile_extractor'
 export { ChunkedPool, ChunkSpan } from './core/mem/chunked_pool'
 export { SharedAssetPool } from './core/mem/shared_asset_pool'
+export { geometryDispatchKey, shardOfDispatchKey } from './ifc/geometry_dispatch'
 export { GeometryTilePool, InstanceAssetSource, GeometryAsset } from './core/geometry_tile_pool'


### PR DESCRIPTION
The across-product parallelism axis, from &#34;measured in a spike&#34; to &#34;an API a worker can call&#34;. Follows #531 (spike), #534 (delta capture), #535 (budget).

## The problem this solves

Sharding extraction across workers is bounded by **duplication**, not cores: shards that disagree about where shared representation geometry belongs each rebuild it. Round-robin costs **+25 % assets on MB-Khaya** and **+40.7 % on D3D** at N=4.

#531 showed placement fixes that — but its strategies scored products from a graph of what they *turned out* to touch, an oracle no live worker has. This PR is the online form.

## `geometryDispatchKey` — placement from attributes alone

`IfcProduct.Representation → IfcProductDefinitionShape → IfcShapeRepresentation.Items → IfcMappedItem.MappingSource`, over columns the streamed parse already builds. Measured against the oracles by `m3_affinity_spike.mjs`:

| model | round-robin | **this key** | oracle |
|---|---|---|---|
| MB-Khaya, N=4 | 9 020 (+25 %) | **7 193 (+0 %)** | 7 193 (+0 %) |
| D3D, N=4 | 83 177 (+40.7 %) | **81 639 (+38.1 %)** | 65 288 (+10.5 %) |

**Exact on one model, weak on the other, and it ships anyway** — because wall-clock is what a user feels: **1.76× on MB-Khaya, 2.34× on D3D**, both better than the oracle&#39;s, which places well and balances badly (its D3D shards: 15896/29030/19585/2837).

The D3D gap is the documented limit: on an assembly-heavy model the sharing lives *below* the representation — profiles, boolean operands, void geometry — where an attribute walk cannot look. Headroom is ~30 points of duplication, ~14 s CPU.

## `SetGeometryShard(modelID, {index, count})`

A worker opens the model, claims a shard, pumps. No scheduling channel between workers, because placement is a pure function of the product. **Both** worklists are filtered — products *and* rel-aggregates — by the same key; leaving aggregates positional is what made D3D look indifferent to strategy in the first place.

`{index: 0, count: 1}` is accepted on any model and normalised to the unsharded state: one worker needs no agreement with anyone, so none of the refusals apply to it.

### ⚠️ What a shard claim refuses, and what that costs

Everything below is refused **loudly at claim time and again on every pump**, from both public entries. The settings object belongs to the caller and is held by reference, and the async path skips the sync pump entirely, so a check living anywhere else has a bypass — successive review rounds found three such bypasses.

| refused | why | precondition to reopen |
|---|---|---|
| a claim after pumping starts | worklists are built once; narrowing later silently drops products already reported as pending | — |
| **`COORDINATE_TO_ORIGIN`** | the recentre anchor comes from the first geometry a model captures, so shards derive different frames and a model spanning more than one recentre cell merges shifted by whole grid cells | a shard-independent anchor, derived before the split or handed to every worker |
| **a windowed external source** | `geometryDispatchKey` walks attribute records, and whether that walk *succeeds* depends on which pages are resident **per worker** — so two workers can disagree about a product and both extract it, or neither | a residency-independent key, from the reference columns or a closure paged before the split |
| **`ON_PREVIEW_MESH`** | the preview runs during open, before a shard exists, so every worker performs the same capped extraction and emits the same unpartitioned imposters | handing the shard to the open call so the preview path can filter by it |
| **no `DEFER_GEOMETRY`** | a classic open has already extracted everything, so the claim would be accepted and ignored, and every worker would deliver the complete model | — |

The windowed-source one is a **correctness** bug I had argued was merely degraded affinity and shipped a warning for. It is not: it is a partition that fails to partition.

Beyond refusing, the capture path no longer reads `COORDINATE_TO_ORIGIN` from the caller&#39;s object at all (`recentreEnabled_()` is false whenever a shard is claimed), so a flag flipped from inside `ON_PROGRESS` — which fires synchronously *within* the first pump — is refused-late rather than silently wrong.

**Consequence worth stating plainly: at N &gt; 1 the pool cannot serve Share&#39;s own open settings yet.** Share opens with `COORDINATE_TO_ORIGIN: true`. Multi-worker geometry in Share is gated on a shared coordination frame, not merely on wiring workers up. Every refusal above closes a path that has no caller today, so nothing is lost — they are the named preconditions for the next step.

## The pool, running for real

`scripts/m3_worker_pool.mjs` — N `worker_threads`, each claiming a shard. The union of the shards&#39; per-placement digests must equal a single unsharded load, where a placement is `mesh.expressID` + geometry ID + colour + transform (raw Float64 bytes, not rounded), over a per-geometry hash of the actual vertex and index bytes. Mismatch sets a nonzero exit code.

| model | workers | wall | open | geometry |
|---|---|---|---|---|
| MB-Khaya | 1 | 6.3 s | 0.7 s | 4.2 s |
| MB-Khaya | 4 | 4.9 s (1.28×) | 0.8 s | 2.3 s |
| **PSB** | 1 | 44.5 s | 14.1 s | 40.5 s |
| **PSB** | **4** | **29.1 s (1.53×)** | 15.2 s | **7.4 s** |

Union exact at every count, on all three models.

**Two known blind spots in that harness**, both found by review rather than by the harness itself, and both worth more attention than the API surface: it runs on resident buffers, so it cannot see a residency-dependent partition at all; and a union of N *complete* copies deduplicates to exactly the reference, so it cannot see a shard claim that was silently ignored.

**The bottleneck moved, and that is the result.** PSB&#39;s geometry stage drops 40.5 → 7.4 s, and parse now costs 15.2 s of a 29.1 s load. Sharding cannot help the half it does not touch, so construct-from-columns becomes the next lever rather than an optimisation — the columns are transferable and `IfcStepModel` takes them directly, but no open path constructs from them yet.

MB-Khaya shows the opposite limit honestly: geometry scales 1.83× while wall-clock plateaus at 1.28×, because worker startup and wasm init dominate a 4 s geometry stage. Small models do not need a pool.

## Capture fixes that made D3D measurable at all

The affinity capture recorded **1 592 assets against the 59 098** a real extraction creates — 2.7 % — so every strategy looked identical on D3D and I nearly reported &#34;the key does not generalise&#34;. Three gaps: it watched only `geometry` and never `voidGeometry`; it ran only the per-product pass, never rel-aggregates (where an assembly model&#39;s geometry lives); and the pump sharded aggregates positionally even when handed an assignment. Coverage is now 52 305 of 59 098 (88 %). The spike also imports the shipped `geometryDispatchKey` rather than carrying its own copy, which had already drifted.

## Tests

- **Shards partition the model** — four shards union to exactly one unsharded load, on `mapped_shared_representation.ifc` *and* `aggregate_master_voids.ifc`. Deliberately both: the first version passed against a mutant that left aggregates unsharded, because the mapped fixture has no aggregates at all.
- **Every refusal in the table above**, each with the condition asserted to have actually occurred — e.g. the preview test checks `previews > 0` before expecting the throw, so it cannot pass by refusing something that never happened.
- **A sharded model does not recentre even when `ON_PROGRESS` enables it mid-pump** — asserting both that nothing recentred inside the window and that the next batch still throws.
- **The descriptor is snapshotted, not retained**; **an unsharded model is unaffected** by any precondition; **N=1 succeeds** on recentred and classic opens alike.
- **`geometryDispatchKey`**: products sharing a representation key together and co-locate at N=2/3/4/8; every product gets a usable key, resolvable or not.
- Transform comparisons throughout are **lossless** (raw Float64 bytes). Every pre-existing parity test passes under exact comparison, so the deferred pump is bit-identical to classic, not merely identical to three decimals.

All mutation-verified except two, which say so in their comments: the `RelatingObject` fallback (needs a non-resident record, unreachable now that windowed sources are refused) and the adopted-frame guard (white-box; the `ON_PREVIEW_MESH` route to it could not be reproduced from a test).

## Not in this PR

The preconditions named in the refusal table, construct-from-columns (the parse bottleneck), workers on the OPFS store rather than a resident buffer (four workers × 860 MB is fine on a 12 GB box and fatal in a tab), delta merge, and Share routing.

Part of #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsjeKsTaAMGnhj2UCJFfCa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsjeKsTaAMGnhj2UCJFfCa)_