### PR TITLE
#549: stop the rel-aggregates pass retaining the model, and let it yield

### DIFF
--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -287,6 +287,31 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   private demandAggregatesCursor_ = 0
 
   /**
+   * The relationship at demandAggregatesCursor_, part-way through its
+   * related products. A batch budget subdivides ONE relationship rather
+   * than being spent whole on it: an aggregate-structured model puts all
+   * of its geometry in this pass, so budgeting per relationship makes the
+   * budget meaningless and gives the caller a single unyielding call for
+   * the whole model (conway#549 §7 — SKYLARK250 gets two budget units for
+   * 1,992 products). Undefined between relationships.
+   */
+  private demandAggregateStepper_?: Generator< number, void, undefined >
+
+  /**
+   * Source pins and leaf spans held for the relationship
+   * demandAggregateStepper_ is walking, released when it finishes. They
+   * have to outlive the batch that started it: the pins are what keep the
+   * relationship's products readable, and re-running the prefetch per batch
+   * would re-walk every related product's closure per batch. This holds the
+   * same pins for the same span of work as before — that span just no
+   * longer has to fit in one pump call.
+   */
+  private demandAggregatePins_?: Set< number >
+
+  /** Leaf byte ranges pinned alongside demandAggregatePins_. */
+  private demandAggregateSpans_?: { address: number, length: number }[]
+
+  /**
    * Coordination matrix the deferred capture derived (or adopted from
    * the parse-time preview channel). Kept OFF the model tuple's slot 5
    * deliberately: classic streamAllMeshes derives its coordination into
@@ -2124,36 +2149,49 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       }
     }
 
-    if (this.demandCursor_ >= products.length &&
-        this.demandAggregatesCursor_ < aggregates.length) {
+    // Budget spent per RELATED PRODUCT, stepping one relationship across as
+    // many batches as it takes, rather than per relationship — see
+    // demandAggregateStepper_ and conway#549 §7. The prefetch and its pins
+    // stay attached to the relationship, not to the batch, so a relationship
+    // that spans batches is paged in once.
+    if (this.demandCursor_ >= products.length) {
 
-      const aggregatesEnd = Math.min(
-          this.demandAggregatesCursor_ + (budget - extracted),
-          aggregates.length)
-
-      for (; this.demandAggregatesCursor_ < aggregatesEnd;
-        ++this.demandAggregatesCursor_) {
+      while (extracted < budget &&
+          (this.demandAggregateStepper_ !== void 0 ||
+            this.demandAggregatesCursor_ < aggregates.length)) {
 
         const relAggregate = aggregates[this.demandAggregatesCursor_]
-        const leafSpans: { address: number, length: number }[] = []
-        const pins =
-          await this.conwayGeometry_.ensureResidentForAggregateExtract(
-              relAggregate, leafSpans)
+
+        if (this.demandAggregateStepper_ === void 0) {
+
+          const leafSpans: { address: number, length: number }[] = []
+
+          this.demandAggregatePins_ =
+            await this.conwayGeometry_.ensureResidentForAggregateExtract(
+                relAggregate, leafSpans)
+          this.demandAggregateSpans_ = leafSpans
+          this.demandAggregateStepper_ =
+            this.conwayGeometry_.extractRelAggregateGeometryIncremental(
+                relAggregate)
+        }
+
+        let done = false
 
         try {
-          this.conwayGeometry_.extractRelAggregateGeometry(relAggregate)
-          ++extracted
+          done = this.demandAggregateStepper_.next().done === true
         } catch (error) {
           Logger.error(
               `Error extracting aggregate ${relAggregate.expressID}: ` +
               `${error instanceof Error ? error.message : String(error)}`)
-        } finally {
-          this.model[0].releaseSourceViews(pins)
-          this.model[0].unpinLocalIDs(pins)
-          for (const span of leafSpans) {
-            this.model[0].unpinAddressRange(span.address, span.length)
-          }
+          done = true
         }
+
+        if (done) {
+          this.releaseDemandAggregate_()
+          ++this.demandAggregatesCursor_
+        }
+
+        ++extracted
       }
     }
 
@@ -2366,6 +2404,8 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       products: number[],
       aggregates: IfcRelAggregates[]): void {
 
+    this.releaseDemandAggregate_()
+
     this.demandProducts_ = products
     this.demandAggregates_ = aggregates
     this.demandCursor_ = 0
@@ -2435,6 +2475,8 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // look identical).
     this.demandAggregates_ = aggregates.filter((relAggregate, where) =>
       shardOfDispatchKey(aggregateKeys[where], shard.count) === shard.index)
+
+    this.releaseDemandAggregate_()
 
     this.demandCursor_ = 0
     this.demandAggregatesCursor_ = 0
@@ -2794,6 +2836,37 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   }
 
 
+  /**
+   * Finish with the relationship demandAggregateStepper_ is on: close a
+   * stepper that has not run out (its finally frees the master rel-voids
+   * vector, which is native memory), and drop the source pins the async
+   * prefetch took for it.
+   *
+   * Safe to call when nothing is in flight — that is the whole point of
+   * calling it from the worklist installers, where a stepper left over from
+   * a previous walk would otherwise hold both.
+   */
+  private releaseDemandAggregate_(): void {
+
+    this.demandAggregateStepper_?.return()
+    this.demandAggregateStepper_ = void 0
+
+    const pins = this.demandAggregatePins_
+
+    if (pins !== void 0) {
+      this.model[0].releaseSourceViews(pins)
+      this.model[0].unpinLocalIDs(pins)
+      this.demandAggregatePins_ = void 0
+    }
+
+    for (const span of this.demandAggregateSpans_ ?? []) {
+      this.model[0].unpinAddressRange(span.address, span.length)
+    }
+
+    this.demandAggregateSpans_ = void 0
+  }
+
+
   private pumpGeometryBatch_(
       batchSize: number,
       meshCallback?: (mesh: FlatMesh) => void ): {extracted: number, remaining: number} {
@@ -2827,19 +2900,42 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // whole-model walk's second (rel-aggregates master-voids) pass with
     // the same per-call budget — batch-by-batch, not as one end-of-load
     // stall — so aggregate parts stream in cut, exactly once, with
-    // final content (see demandAggregates_).
-    if (this.demandCursor_ >= products.length &&
-        this.demandAggregatesCursor_ < aggregates.length) {
+    // final content (see demandAggregates_). The budget is spent per
+    // RELATED PRODUCT, stepping through one relationship across as many
+    // batches as it takes (demandAggregateStepper_), plus one unit for
+    // reaching the end of each relationship so an empty one still costs
+    // what it used to.
+    if (this.demandCursor_ >= products.length) {
 
-      const aggregatesEnd = Math.min(
-          this.demandAggregatesCursor_ + (budget - extracted),
-          aggregates.length)
+      while (extracted < budget &&
+          (this.demandAggregateStepper_ !== void 0 ||
+            this.demandAggregatesCursor_ < aggregates.length)) {
 
-      for (; this.demandAggregatesCursor_ < aggregatesEnd;
-        ++this.demandAggregatesCursor_) {
+        if (this.demandAggregateStepper_ === void 0) {
+          this.demandAggregateStepper_ =
+            this.conwayGeometry_.extractRelAggregateGeometryIncremental(
+                aggregates[this.demandAggregatesCursor_])
+        }
 
-        this.conwayGeometry_.extractRelAggregateGeometry(
-            aggregates[this.demandAggregatesCursor_])
+        let done: boolean
+
+        try {
+          done = this.demandAggregateStepper_.next().done === true
+        } catch (error) {
+          // Strict mode (MATERIAL_RELATED_OBJECTS_PERMISSIVE off) is the only
+          // way out of the stepper by exception. Drop the half-consumed
+          // stepper but leave the cursor, so a retry re-runs the
+          // relationship from the top exactly as it did when this was one
+          // unyielding call.
+          this.demandAggregateStepper_ = void 0
+          throw error
+        }
+
+        if (done) {
+          this.demandAggregateStepper_ = void 0
+          ++this.demandAggregatesCursor_
+        }
+
         ++extracted
       }
     }

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -180,6 +180,7 @@ import {
   IfcTShapeProfileDef,
   IfcZShapeProfileDef,
   IfcRelAggregates,
+  IfcObjectDefinition,
   IfcTriangulatedFaceSet,
   IfcPolygonalBoundedHalfSpace,
   IfcSurface,
@@ -7381,13 +7382,37 @@ export class IfcGeometryExtraction {
             relating.localID, pinned, leafSpans )
       }
 
-      const related = relAggregate.RelatedObjects
+      // By express ID rather than through `relAggregate.RelatedObjects`, for
+      // the reason relatedObjectExpressIDs_ documents: the getter memoizes
+      // the whole related-product array onto the relationship, and this
+      // prefetch runs immediately before the extract that must not retain
+      // it (conway#549 §4). Falls back to the getter for a list holding a
+      // non-reference entry, so the two paths agree on what is in the list.
+      const relatedExpressIDs = this.relatedObjectExpressIDs_( relAggregate )
 
-      if ( related !== null && related !== void 0 ) {
+      if ( relatedExpressIDs === void 0 ) {
 
-        for ( const product of related ) {
+        const related = relAggregate.RelatedObjects
+
+        if ( related !== null && related !== void 0 ) {
+
+          for ( const product of related ) {
+            await this.ensureResidentForProductExtract(
+                product.localID, pinned, leafSpans )
+          }
+        }
+      } else {
+
+        for ( const relatedExpressID of relatedExpressIDs ) {
+
+          const relatedLocalID = this.model.resolveExpressID( relatedExpressID )
+
+          if ( relatedLocalID === void 0 ) {
+            continue
+          }
+
           await this.ensureResidentForProductExtract(
-              product.localID, pinned, leafSpans )
+              relatedLocalID, pinned, leafSpans )
         }
       }
 
@@ -7423,6 +7448,59 @@ export class IfcGeometryExtraction {
   }
 
   /**
+   * Express IDs of one IfcRelAggregates' RelatedObjects, read straight off
+   * the relationship's own record.
+   *
+   * Deliberately NOT `relAggregate.RelatedObjects`: that generated getter
+   * memoizes the materialised entity array onto the relationship as
+   * `RelatedObjects_` (IfcRelAggregates.gen.ts), so every related product
+   * stays reachable for as long as the relationship does — and each product
+   * in turn memoizes the tessellation subtree its own getters walk
+   * (IfcPolyLoop.Polygon_, IfcCartesianPoint.Coordinates_, ...). The
+   * per-product graphs therefore SUM instead of overlapping. On SKYLARK250,
+   * whose 1,992 products are all aggregate targets, that is 2.7 GB of a
+   * 5.4 GB peak (conway#549 §4). Resolving one product at a time from IDs
+   * lets each graph die with its iteration, exactly as the ordinary product
+   * loop's iterator already does.
+   *
+   * The scan mirrors the getter's own parse — `forEachReferenceInField`
+   * runs the same optional/array-token walk over the same field
+   * coordinates — so it sees the same entries in the same order.
+   *
+   * @param relAggregate The relationship to read.
+   * @return {number[] | undefined} The related objects' express IDs in
+   * record order, or undefined when the list holds an entry that is not a
+   * `#N` reference — an inline entity, `$`, or junk. Only the generated
+   * getter can resolve (or reject) those, so the caller falls back to it
+   * rather than guessing.
+   */
+  private relatedObjectExpressIDs_(
+      relAggregate: IfcRelAggregates ): number[] | undefined {
+
+    const expressIDs: number[] = []
+
+    let allReferences = true
+
+    relAggregate.forEachReferenceInField(
+        REL_AGGREGATES_RELATED_OFFSET,
+        REL_AGGREGATES_RELATED_BASE,
+        REL_AGGREGATES_RELATED_DEPTH,
+        ( expressID ) => {
+
+          if ( expressID === void 0 ) {
+            allReferences = false
+            return false
+          }
+
+          expressIDs.push( expressID )
+
+          return true
+        } )
+
+    return allReferences ? expressIDs : void 0
+  }
+
+  /**
    * Extract one IfcRelAggregates' related products with the relating
    * object's ("master") rel-voids — the shared per-item body of the
    * whole-model walk's rel-aggregates loop and
@@ -7434,6 +7512,49 @@ export class IfcGeometryExtraction {
    */
   public extractRelAggregateGeometry( relAggregate: IfcRelAggregates ): void {
 
+    const stepper = this.extractRelAggregateGeometryIncremental( relAggregate )
+
+    let step = stepper.next()
+
+    while ( step.done !== true ) {
+      step = stepper.next()
+    }
+  }
+
+  /**
+   * Incremental twin of {@link extractRelAggregateGeometry}: identical
+   * extraction, suspending after each related product so a driver can
+   * report progress and yield to the event loop *inside* the relationship.
+   *
+   * Without this the whole rel-aggregates pass is a single unyielding call.
+   * On SKYLARK250 all 2,002 of the cooperative walk's suspension points
+   * fire in 16 ms — every product is an aggregate target, so the product
+   * loop skips them all — and the remaining ~60 s of real work runs inside
+   * two `extractRelAggregateGeometry` calls with no suspension point at
+   * all. That is the browser-tab hang in conway#549 §7, and it is
+   * independent of the memory fix: a small model with one big aggregate
+   * freezes the same way.
+   *
+   * Suspending here cannot show a caller a half-built product: the split is
+   * BETWEEN products, and each product's scene content is complete before
+   * the yield. Nor does it reorder emission — the products are visited in
+   * record order either way. Aggregate targets are skipped by the product
+   * pass (see aggregateTargetLocalIDs) and by the pump's product worklist,
+   * so a consumer that streams meshes mid-relationship sees the
+   * not-yet-reached products as absent rather than as uncut placeholders.
+   *
+   * @param relAggregate The rel-aggregates relationship to process.
+   * @yields {number} The number of related products extracted so far from
+   * THIS relationship, after each one.
+   */
+  public* extractRelAggregateGeometryIncremental(
+      relAggregate: IfcRelAggregates ): Generator< number, void, undefined > {
+
+    // Held outside the try so the finally can free it on the abandonment
+    // path too: a driver that stops consuming (stepper.return()) unwinds
+    // through here, and the vector is native memory the GC cannot reclaim.
+    let masterRelVoids: [ NativeVectorGeometry, number[] ] | undefined
+
     try {
 
       // Note, this is required because the relating object
@@ -7442,23 +7563,59 @@ export class IfcGeometryExtraction {
       // for all objects in the aggregate - CS
       const relatingObject = relAggregate.RelatingObject
 
-      const masterRelVoids =
+      masterRelVoids =
         relatingObject instanceof IfcProduct ?
           this.extractRelVoids( relatingObject ) :
           void 0
 
-      const relatedObjects = relAggregate.RelatedObjects
+      // Read before the first suspension point, deliberately: the scan
+      // reads the relationship's own record bytes, and a windowed source
+      // can page that record out while a later product is extracted.
+      const relatedExpressIDs = this.relatedObjectExpressIDs_( relAggregate )
 
-      for ( const productRepresentation of relatedObjects ) {
+      let extractedCount = 0
 
-        if ( productRepresentation instanceof IfcProduct ) {
+      if ( relatedExpressIDs === void 0 ) {
 
-          this.extractProductGeometry( productRepresentation, masterRelVoids )
+        // Non-reference entry in the list — fall back to the generated
+        // getter, the only thing that can resolve an inline entity (and the
+        // only thing that decides an entry is unresolvable). Rare enough
+        // that keeping its retention is the right trade against duplicating
+        // inline resolution here.
+        for ( const productRepresentation of relAggregate.RelatedObjects ) {
+
+          if ( productRepresentation instanceof IfcProduct ) {
+
+            this.extractProductGeometry( productRepresentation, masterRelVoids )
+
+            yield ++extractedCount
+          }
         }
-      }
+      } else {
 
-      if ( masterRelVoids !== void 0 ) {
-        masterRelVoids[ 0 ].delete()
+        for ( const relatedExpressID of relatedExpressIDs ) {
+
+          const relatedObject =
+            this.model.getTypedElementByExpressID(
+                relatedExpressID, IfcObjectDefinition )
+
+          if ( relatedObject === void 0 ) {
+
+            // What the getter does with the same entry: extractBufferElement
+            // returns undefined for a reference that resolves to nothing (or
+            // to something that is not an IfcObjectDefinition) and the getter
+            // throws this exact message. The catch below then skips the whole
+            // relationship, permissively, as it always has.
+            throw new Error( 'Value in STEP was incorrectly typed' )
+          }
+
+          if ( relatedObject instanceof IfcProduct ) {
+
+            this.extractProductGeometry( relatedObject, masterRelVoids )
+
+            yield ++extractedCount
+          }
+        }
       }
     } catch (ex) {
       if (ex instanceof Error) {
@@ -7471,6 +7628,11 @@ export class IfcGeometryExtraction {
         }
       } else {
         Logger.error('Unknown exception processing IfcRelAssociateMaterials.')
+      }
+    } finally {
+
+      if ( masterRelVoids !== void 0 ) {
+        masterRelVoids[ 0 ].delete()
       }
     }
   }
@@ -7798,18 +7960,26 @@ export class IfcGeometryExtraction {
 
       const products = this.model.types(IfcProduct)
 
-      // Prefix-sum counts (no iteration/materialization) — see typeCount.
-      // Slight over-count from multi-mapped elements just leaves the bar
-      // shy of 100% until endPhase; fine for progress.
-      const totalItems =
-        this.model.typeCount(IfcProduct) + this.model.typeCount(IfcRelAggregates)
-      let completedItems = 0
-
       // Products the aggregates pass re-extracts are SKIPPED here and
       // extracted exactly once, below, with the master rel-voids — one
       // scene instance per placement and no content replacement after
       // emission (see aggregateTargetLocalIDs).
       const aggregateTargets = this.aggregateTargetLocalIDs()
+
+      // Prefix-sum counts (no iteration/materialization) — see typeCount.
+      // Slight over-count from multi-mapped elements just leaves the bar
+      // shy of 100% until endPhase; fine for progress.
+      //
+      // Aggregate targets are counted TWICE on purpose — once for the tick
+      // the product loop spends skipping each of them, once for the tick
+      // the rel-aggregates pass spends extracting it. On a model whose
+      // products are all aggregate targets that is the difference between
+      // a bar that reaches 100% in the first 16 ms and then sits there for
+      // the entire extraction, and one that tracks the work.
+      let totalItems =
+        this.model.typeCount(IfcProduct) + this.model.typeCount(IfcRelAggregates) +
+        aggregateTargets.size
+      let completedItems = 0
 
       for (const product of products) {
 
@@ -7849,7 +8019,27 @@ export class IfcGeometryExtraction {
 
         yield [++completedItems, totalItems]
 
-        this.extractRelAggregateGeometry( relAggregate )
+        // Step the relationship rather than running it in one call: on an
+        // aggregate-structured model this pass IS the extraction, and
+        // without a suspension point inside it the cooperative driver
+        // awaits nothing for the whole of it (conway#549 §7). for-of, not a
+        // manual next() loop, so abandoning this generator closes the inner
+        // one and frees its master rel-voids vector.
+        const aggregateBase = completedItems
+
+        for ( const extractedInAggregate of
+          this.extractRelAggregateGeometryIncremental( relAggregate ) ) {
+
+          completedItems = aggregateBase + extractedInAggregate
+
+          // The total counts one item per product and one per relationship,
+          // so a product reached through more than one relationship can
+          // push completed past it. Widen rather than let the bar exceed
+          // 100% or go backwards.
+          totalItems = Math.max( totalItems, completedItems )
+
+          yield [completedItems, totalItems]
+        }
       }
 
       if ( RegressionCaptureState.memoization !== MemoizationCapture.FULL ) {

--- a/src/ifc/ifc_rel_aggregate_extraction.test.ts
+++ b/src/ifc/ifc_rel_aggregate_extraction.test.ts
@@ -1,0 +1,161 @@
+import fs from 'fs'
+import { beforeAll, describe, expect, test } from '@jest/globals'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { IfcGeometryExtraction } from './ifc_geometry_extraction'
+import IfcStepModel from './ifc_step_model'
+import IfcStepParser from './ifc_step_parser'
+import { IfcProduct, IfcRelAggregates } from './ifc4_gen'
+
+
+const conwayGeometry = new ConwayGeometry()
+
+/** Wasm init plus two full extractions per test; CI runners are slow. */
+// eslint-disable-next-line no-magic-numbers
+const TEST_TIMEOUT_MS = 120 * 1000
+
+/** Fixtures that carry at least one IfcRelAggregates. */
+const AGGREGATE_FIXTURES = [
+  'data/index.ifc',
+  'data/aggregate_master_voids.ifc',
+]
+
+/**
+ * Parse a fixture into a fresh model.
+ *
+ * @param fixturePath The IFC file to parse.
+ * @return {IfcStepModel} The parsed model.
+ */
+function parseFixtureModel( fixturePath: string ): IfcStepModel {
+
+  const parser = IfcStepParser.Instance
+  const bufferInput = new ParsingBuffer( fs.readFileSync( fixturePath ) )
+
+  parser.parseHeader( bufferInput )
+
+  const model = parser.parseDataToModel( bufferInput )[ 1 ]
+
+  expect( model ).toBeDefined()
+
+  return model!
+}
+
+/**
+ * Count the IfcProducts the rel-aggregates pass will extract — the related
+ * objects of every IfcRelAggregates, which is one extraction each.
+ *
+ * @param model The model to count over.
+ * @return {number} The number of related products.
+ */
+function relatedProductCount( model: IfcStepModel ): number {
+
+  let count = 0
+
+  for ( const relAggregate of model.types( IfcRelAggregates ) ) {
+
+    for ( const relatedObject of relAggregate.RelatedObjects ) {
+
+      if ( relatedObject instanceof IfcProduct ) {
+        ++count
+      }
+    }
+  }
+
+  return count
+}
+
+beforeAll( async () => {
+  await conwayGeometry.initialize()
+} )
+
+describe( 'rel-aggregates extraction (conway#549)', () => {
+
+  test( 'suspends once per related product, not once per relationship', () => {
+
+    // The tab-hang half of #549. The whole-model walk skips every aggregate
+    // target in its product loop and does the real work in the
+    // rel-aggregates pass, so a pass that suspends only between
+    // RELATIONSHIPS gives a cooperative driver nothing to yield on: on
+    // SKYLARK250 all 2,002 suspension points fire in 16 ms and the
+    // remaining ~60 s runs inside two calls with none at all.
+    //
+    // Counted rather than merely "more than before", so this fails on a
+    // pass that suspends per relationship AND on one that suspends at some
+    // other granularity.
+    for ( const fixturePath of AGGREGATE_FIXTURES ) {
+
+      const model = parseFixtureModel( fixturePath )
+
+      const products = model.typeCount( IfcProduct )
+      const relationships = model.typeCount( IfcRelAggregates )
+      const relatedProducts = relatedProductCount( model )
+
+      expect( relationships ).toBeGreaterThan( 0 )
+      expect( relatedProducts ).toBeGreaterThan( 0 )
+
+      const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+
+      const ticks: [number, number][] = []
+
+      extraction.extractIFCGeometryData(
+          ( completed, total ) => ticks.push( [completed, total] ) )
+
+      expect( ticks.length )
+          .toBe( products + relationships + relatedProducts )
+
+      // Still monotonic, still bounded by the total it reports.
+      for ( let where = 1; where < ticks.length; ++where ) {
+        expect( ticks[ where ][ 0 ] ).toBeGreaterThan( ticks[ where - 1 ][ 0 ] )
+        expect( ticks[ where ][ 0 ] ).toBeLessThanOrEqual( ticks[ where ][ 1 ] )
+      }
+    }
+  }, TEST_TIMEOUT_MS )
+
+  test( 'does not leave the related-product array memoized on the relationship',
+      () => {
+
+        // The memory half of #549. `RelatedObjects` memoizes the
+        // materialised entity array onto the relationship as
+        // `RelatedObjects_`, and each of those products in turn memoizes the
+        // tessellation subtree its getters walk — so a pass that reads the
+        // getter keeps the whole model's face/loop/point graph alive for the
+        // length of the relationship instead of one product at a time. On
+        // SKYLARK250 that is 2.7 GB of a 5.4 GB peak.
+        //
+        // White-box on the generated field name deliberately: the retention
+        // IS the field, and there is no black-box way to observe reachability
+        // from a test. If codegen renames it, this test stops testing
+        // anything, so it also asserts the field exists to be set.
+        for ( const fixturePath of AGGREGATE_FIXTURES ) {
+
+          const model = parseFixtureModel( fixturePath )
+          const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+
+          extraction.extractIFCGeometryData()
+
+          let checked = 0
+
+          for ( const relAggregate of model.types( IfcRelAggregates ) ) {
+
+            const memo =
+              ( relAggregate as unknown as
+                { RelatedObjects_?: unknown } ).RelatedObjects_
+
+            expect( memo ).toBeUndefined()
+
+            // Reading the getter must still populate it — i.e. the field is
+            // the one the getter memoizes into, so the assertion above is
+            // meaningful rather than vacuous.
+            expect( relAggregate.RelatedObjects ).toBeDefined()
+            expect(
+                ( relAggregate as unknown as
+                  { RelatedObjects_?: unknown } ).RelatedObjects_ )
+                .toBeDefined()
+
+            ++checked
+          }
+
+          expect( checked ).toBeGreaterThan( 0 )
+        }
+      }, TEST_TIMEOUT_MS )
+} )


### PR DESCRIPTION
Closes #549.

Two independent defects in the same loop, both measured on `SKYLARK250_design-kit_blocks_detailed.ifc` (400 MB, 7,818,778 records, 1,992 products, **2** `IfcRelAggregates`).

## 1. Retention — the memory

`extractRelAggregateGeometry` read `relAggregate.RelatedObjects`. That generated getter memoizes the materialised entity array onto the relationship as `RelatedObjects_` (`IfcRelAggregates.gen.ts:24,61`), so every related product stayed reachable for the whole loop — and each product in turn memoizes the tessellation subtree its own getters walk (`IfcPolyLoop.Polygon_`, `IfcCartesianPoint.Coordinates_`, …). The per-product B-rep graphs therefore **summed instead of overlapping**. The ordinary product loop never had this: its iterator holds one product at a time. SKYLARK's products are *all* aggregate targets, so it got the summed version of the whole model.

The pass now reads the relationship's own record for its `RelatedObjects` express IDs and resolves one product at a time, so each graph dies with its iteration.

- The scan is `forEachReferenceInField` over the same field coordinates (`REL_AGGREGATES_RELATED_OFFSET/BASE/DEPTH`) the getter parses, and the same `stepExtractOptional` / `stepExtractArrayBegin` / `skipValue` / `stepExtractArrayToken` walk — same entries, same order. `addAggregateTargets_` already reads the field this way.
- Resolution is `getTypedElementByExpressID(id, IfcObjectDefinition)` — the exact call `extractBufferElement` makes for each entry — and an entry that does not resolve throws the getter's own `'Value in STEP was incorrectly typed'`, which the pass's permissive catch turns into a skipped relationship exactly as before.
- A list holding an entry that is **not** a `#N` reference (inline entity, `$`, junk) falls back to the getter, the only thing that can resolve an inline entity. That path keeps today's retention; it is not reachable from valid IFC, where `IfcObjectDefinition` is rooted.
- `ensureResidentForAggregateExtract`, which prefetches immediately before this and read the same getter (materialising and memoizing the whole array right before the extract that must not retain it), walks IDs too.

**What I checked before freeing anything.** `RelatedObjects` is a public memo, so the question is who else reads it. Repo-wide, `\.RelatedObjects\b` outside generated code has exactly **two** call sites, and they are the two changed here. The `'RelatedObjects'` strings in `src/compat/web-ifc/ifc_properties.ts` are property-name keys applied to `GetLine` tape objects, not to conway entities. So nothing observes the memo, and the change drops it rather than mutating it — a later reader re-parses and gets a fresh, correct array (the new test asserts exactly that).

| SKYLARK250 | before | after |
|---|---:|---:|
| peak live JS heap | 3784.1 MB | **981.8 MB** (−74%) |
| end live JS heap | 981.3 MB | 981.3 MB |
| peak RSS (VmHWM) | 5314.4 MB | **3152.1 MB** (−41%) |
| wall (parse + geometry) | 66.3 s | **55.3 s** |

Peak live heap now **equals** the end state — the 2.8 GB transient is gone rather than moved. The 981 MB floor that remains is #371's descriptor floor, untouched here.

## 2. Missing yields — the tab freeze

The pass had no suspension point inside it. On SKYLARK all 2,002 of the cooperative walk's yields fire in 16 ms — every product is an aggregate target and is `continue`d — and the rest of the extraction runs inside two `extractRelAggregateGeometry` calls with none at all.

`extractRelAggregateGeometryIncremental` suspends after each related product. The whole-model walk steps it (via `for…of`, so abandoning the outer generator closes the inner one and frees its master rel-voids vector), and **both** demand pumps step it too, so the batch budget subdivides one relationship instead of being spent whole on it — `demandAggregateStepper_` carries the in-flight relationship across pump calls, with its prefetch pins attached to the relationship rather than to the batch.

Measured with a 10 ms `setInterval` heartbeat during `extractIFCGeometryDataAsync` — how long the event loop was actually starved, which is what freezes a tab:

| SKYLARK250, yield budget 50 ms | before | after |
|---|---:|---:|
| heartbeat firings during geometry | **1** | **597** |
| firings/second | 0.01 | 11.98 |
| max stall | **104,303 ms** | 1,766 ms |
| p50 / p99 stall | 104,303 / 104,303 ms | **65 / 218 ms** |

Probe validation (a probe that never fires looks like a clean model): re-run on the **unmodified** tree with the budget forced to 0, so the driver yields on every product tick — the heartbeat fires 16 times in the first ~300 ms of the product pass (p50 12 ms) and then records **one 100,877 ms stall** covering 100% of the real work. The instrumentation fires; the aggregate pass is what kills it.

The residual >1 s stalls after the fix are 2 individual products whose tessellation is a single atomic call — the same granularity the product path already has.

**Emission order and half-built scenes.** Order is unchanged: products are visited in record order either way, and the split is *between* products, with each product's scene content complete before the yield. Aggregate targets are excluded from the product pass (`aggregateTargetLocalIDs`) and from the pump's product worklist, so a consumer that streams meshes mid-relationship sees a not-yet-reached product as **absent**, never as uncut placeholder content — which is the failure mode the aggregate pass exists to prevent.

Two smaller behaviour notes, both deliberate:
- The master rel-voids vector moved to a `finally`. It has to be, so abandoning a part-consumed relationship frees it; it also closes a pre-existing leak on the throwing path.
- Progress totals now count aggregate targets **twice** — once for the tick the product loop spends skipping each, once for the tick the aggregates pass spends extracting it. Both `CountProgressCallback` consumers call `setPhaseTotal` per tick, so a widened total is handled by design. Without it the bar reached 100% in the first 16 ms on SKYLARK and sat there.

## Verification

**Digests byte-identical** (sha256, before vs after on the same tree) for all 14 models — the 12-model smoke subset, plus `Schependomlaan.ifc` (11,180 rows) and `FM_ARC_DigitalHub.ifc` (27,481 rows) — **and for SKYLARK250 itself** (5,850 rows), the model whose path changed most. Error manifests identical too. No baseline needs re-blessing.

**Gate:** `yarn lint` 0 errors / 680 warnings (unchanged), `yarn build-incremental` clean, `yarn test` **97 suites / 641 tests** — from a re-established baseline of 96/639 on `origin/main`.

**Tests pin the change, not the language.** `src/ifc/ifc_rel_aggregate_extraction.test.ts` adds two, run against `data/index.ifc` and `data/aggregate_master_voids.ifc`. Against a stash of the source change they fail — `suspends once per related product` gets 13 ticks where it expects 16, and `does not leave the related-product array memoized` finds the array still on the relationship.

## Not done

Deliberately out of scope, per the issue's own ranking, and left recorded there: presizing the generated getters' small arrays (#549 §3a, ~789 MB of short-lived churn after this change rather than peak), and re-justifying `MEMOIZATION_THRESHOLD` (§4.4) — a global tuning knob that needs corpus-wide evidence, not one model. Note §5 E3: with `elementMemoization` on, `descriptorCache_[i].entity` re-pins the graph this change releases, so the win lands on models over the 256 MB threshold, which is where it is needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_013RHVKvZN2erpMD7svDWALU)_