### PR TITLE
#552: measure the memory the bench was missing — peak wasm heap, peak RSS, external/arrayBuffers, and geometryMemoryMb restored

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1248,8 +1248,10 @@ jobs:
           rows.sort(key=lambda r: abs(pct(r.get('totalTimeMsPercentageChange',''))), reverse=True)
           # Δ peak RSS is the process high-water mark, Δ RSS a single end-of-load
           # sample; both are N/A against a baseline blessed before conway#552.
-          cols = ['filename','engine1TotalTimeMs','engine2TotalTimeMs','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','rssMbDelta','peakRssMbDelta']
-          headers = ['file','prev ms','curr ms','Δ ms','Δ %','Δ geomMem MB','Δ RSS MB','Δ peak RSS MB']
+          # Δ external is off-heap bytes heapUsed cannot see. Its arrayBuffers
+          # subset is in the CSV rather than here, to keep this table readable.
+          cols = ['filename','engine1TotalTimeMs','engine2TotalTimeMs','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','rssMbDelta','peakRssMbDelta','externalMbDelta']
+          headers = ['file','prev ms','curr ms','Δ ms','Δ %','Δ geomMem MB','Δ RSS MB','Δ peak RSS MB','Δ external MB']
           print(f"### Δ vs previous run [#{prev_run_id}](https://github.com/bldrs-ai/conway/actions/runs/{prev_run_id})")
           print()
           print("| " + " | ".join(headers) + " |")
@@ -1596,6 +1598,7 @@ jobs:
           gmem_d   = col_stats('geometryMemoryMbDelta', [parse_num(r.get('geometryMemoryMbDelta','')) for r in common])
           rss_d    = col_stats('rssMbDelta',         [parse_num(r.get('rssMbDelta','')) for r in common])
           peak_d   = col_stats('peakRssMbDelta',    [parse_num(r.get('peakRssMbDelta','')) for r in common])
+          ext_d    = col_stats('externalMbDelta',   [parse_num(r.get('externalMbDelta','')) for r in common])
           # Track regressions/improvements at a glance.
           pct_vals = [parse_pct(r.get('totalTimeMsPercentageChange','')) for r in common]
           pct_vals = [v for v in pct_vals if v is not None]
@@ -1607,9 +1610,9 @@ jobs:
           print(f"**Models compared (OK on both sides)**: {len(common)} of {len(rows)} delta rows.")
           print(f"**Regressed / improved / flat (by totalTimeMs)**: {regr} / {impr} / {flat}.")
           print()
-          cols = ['parseTimeMsDelta','geometryTimeMsDelta','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','rssMbDelta','peakRssMbDelta']
-          headers = ['stat','Δ parse ms','Δ geom ms','Δ total ms','Δ total %','Δ geomMem MB','Δ RSS MB','Δ peak RSS MB']
-          s = {'parseTimeMsDelta': parse_d, 'geometryTimeMsDelta': geom_d, 'totalTimeMsDelta': total_d, 'totalTimeMsPercentageChange': pct_d, 'geometryMemoryMbDelta': gmem_d, 'rssMbDelta': rss_d, 'peakRssMbDelta': peak_d}
+          cols = ['parseTimeMsDelta','geometryTimeMsDelta','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','rssMbDelta','peakRssMbDelta','externalMbDelta']
+          headers = ['stat','Δ parse ms','Δ geom ms','Δ total ms','Δ total %','Δ geomMem MB','Δ RSS MB','Δ peak RSS MB','Δ external MB']
+          s = {'parseTimeMsDelta': parse_d, 'geometryTimeMsDelta': geom_d, 'totalTimeMsDelta': total_d, 'totalTimeMsPercentageChange': pct_d, 'geometryMemoryMbDelta': gmem_d, 'rssMbDelta': rss_d, 'peakRssMbDelta': peak_d, 'externalMbDelta': ext_d}
           print("| " + " | ".join(headers) + " |")
           print("|" + " --- |" * len(headers))
           for stat in ['count', 'min', 'median', 'mean', 'max', 'stddev']:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1246,8 +1246,10 @@ jobs:
           if not rows:
               sys.exit(0)
           rows.sort(key=lambda r: abs(pct(r.get('totalTimeMsPercentageChange',''))), reverse=True)
-          cols = ['filename','engine1TotalTimeMs','engine2TotalTimeMs','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','rssMbDelta']
-          headers = ['file','prev ms','curr ms','Δ ms','Δ %','Δ geomMem MB','Δ RSS MB']
+          # Δ peak RSS is the process high-water mark, Δ RSS a single end-of-load
+          # sample; both are N/A against a baseline blessed before conway#552.
+          cols = ['filename','engine1TotalTimeMs','engine2TotalTimeMs','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','rssMbDelta','peakRssMbDelta']
+          headers = ['file','prev ms','curr ms','Δ ms','Δ %','Δ geomMem MB','Δ RSS MB','Δ peak RSS MB']
           print(f"### Δ vs previous run [#{prev_run_id}](https://github.com/bldrs-ai/conway/actions/runs/{prev_run_id})")
           print()
           print("| " + " | ".join(headers) + " |")
@@ -1593,6 +1595,7 @@ jobs:
           pct_d    = col_stats('pct',                [parse_pct(r.get('totalTimeMsPercentageChange','')) for r in common], suffix='%')
           gmem_d   = col_stats('geometryMemoryMbDelta', [parse_num(r.get('geometryMemoryMbDelta','')) for r in common])
           rss_d    = col_stats('rssMbDelta',         [parse_num(r.get('rssMbDelta','')) for r in common])
+          peak_d   = col_stats('peakRssMbDelta',    [parse_num(r.get('peakRssMbDelta','')) for r in common])
           # Track regressions/improvements at a glance.
           pct_vals = [parse_pct(r.get('totalTimeMsPercentageChange','')) for r in common]
           pct_vals = [v for v in pct_vals if v is not None]
@@ -1604,9 +1607,9 @@ jobs:
           print(f"**Models compared (OK on both sides)**: {len(common)} of {len(rows)} delta rows.")
           print(f"**Regressed / improved / flat (by totalTimeMs)**: {regr} / {impr} / {flat}.")
           print()
-          cols = ['parseTimeMsDelta','geometryTimeMsDelta','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','rssMbDelta']
-          headers = ['stat','Δ parse ms','Δ geom ms','Δ total ms','Δ total %','Δ geomMem MB','Δ RSS MB']
-          s = {'parseTimeMsDelta': parse_d, 'geometryTimeMsDelta': geom_d, 'totalTimeMsDelta': total_d, 'totalTimeMsPercentageChange': pct_d, 'geometryMemoryMbDelta': gmem_d, 'rssMbDelta': rss_d}
+          cols = ['parseTimeMsDelta','geometryTimeMsDelta','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','rssMbDelta','peakRssMbDelta']
+          headers = ['stat','Δ parse ms','Δ geom ms','Δ total ms','Δ total %','Δ geomMem MB','Δ RSS MB','Δ peak RSS MB']
+          s = {'parseTimeMsDelta': parse_d, 'geometryTimeMsDelta': geom_d, 'totalTimeMsDelta': total_d, 'totalTimeMsPercentageChange': pct_d, 'geometryMemoryMbDelta': gmem_d, 'rssMbDelta': rss_d, 'peakRssMbDelta': peak_d}
           print("| " + " | ".join(headers) + " |")
           print("|" + " --- |" * len(headers))
           for stat in ['count', 'min', 'median', 'mean', 'max', 'stddev']:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1180,7 +1180,7 @@ jobs:
               print("performance-detail.csv is empty.")
               sys.exit(0)
           rows.sort(key=lambda r: r.get('filename',''))
-          cols = ['filename','loadStatus','schemaVersion','parseTimeMs','geometryTimeMs','totalTimeMs','geometryMemoryMb','rssMb','heapUsedMb']
+          cols = ['filename','loadStatus','schemaVersion','parseTimeMs','geometryTimeMs','totalTimeMs','geometryMemoryMb','peakWasmHeapMb','rssMb','peakRssMb','heapUsedMb']
           print("| " + " | ".join(cols) + " |")
           print("|" + " --- |" * len(cols))
           for r in rows:
@@ -1250,8 +1250,8 @@ jobs:
           # sample; both are N/A against a baseline blessed before conway#552.
           # Δ external is off-heap bytes heapUsed cannot see. Its arrayBuffers
           # subset is in the CSV rather than here, to keep this table readable.
-          cols = ['filename','engine1TotalTimeMs','engine2TotalTimeMs','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','rssMbDelta','peakRssMbDelta','externalMbDelta']
-          headers = ['file','prev ms','curr ms','Δ ms','Δ %','Δ geomMem MB','Δ RSS MB','Δ peak RSS MB','Δ external MB']
+          cols = ['filename','engine1TotalTimeMs','engine2TotalTimeMs','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','peakWasmHeapMbDelta','rssMbDelta','peakRssMbDelta','externalMbDelta']
+          headers = ['file','prev ms','curr ms','Δ ms','Δ %','Δ geomMem MB','Δ wasm heap MB','Δ RSS MB','Δ peak RSS MB','Δ external MB']
           print(f"### Δ vs previous run [#{prev_run_id}](https://github.com/bldrs-ai/conway/actions/runs/{prev_run_id})")
           print()
           print("| " + " | ".join(headers) + " |")
@@ -1497,7 +1497,7 @@ jobs:
                   'max': f"{max(vals):.0f}",
                   'stddev': f"{(statistics.stdev(vals) if len(vals) > 1 else 0):.0f}",
               }
-          cols = ['parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb', 'rssMb']
+          cols = ['parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb', 'peakWasmHeapMb', 'rssMb', 'peakRssMb']
           s = {c: col_stats(c) for c in cols}
           print(f"**Pass/fail**: {len(ok_rows)} passing / {fail} failing of {total} total.")
           print()
@@ -1599,6 +1599,7 @@ jobs:
           rss_d    = col_stats('rssMbDelta',         [parse_num(r.get('rssMbDelta','')) for r in common])
           peak_d   = col_stats('peakRssMbDelta',    [parse_num(r.get('peakRssMbDelta','')) for r in common])
           ext_d    = col_stats('externalMbDelta',   [parse_num(r.get('externalMbDelta','')) for r in common])
+          wasm_d   = col_stats('peakWasmHeapMbDelta', [parse_num(r.get('peakWasmHeapMbDelta','')) for r in common])
           # Track regressions/improvements at a glance.
           pct_vals = [parse_pct(r.get('totalTimeMsPercentageChange','')) for r in common]
           pct_vals = [v for v in pct_vals if v is not None]
@@ -1610,9 +1611,9 @@ jobs:
           print(f"**Models compared (OK on both sides)**: {len(common)} of {len(rows)} delta rows.")
           print(f"**Regressed / improved / flat (by totalTimeMs)**: {regr} / {impr} / {flat}.")
           print()
-          cols = ['parseTimeMsDelta','geometryTimeMsDelta','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','rssMbDelta','peakRssMbDelta','externalMbDelta']
-          headers = ['stat','Δ parse ms','Δ geom ms','Δ total ms','Δ total %','Δ geomMem MB','Δ RSS MB','Δ peak RSS MB','Δ external MB']
-          s = {'parseTimeMsDelta': parse_d, 'geometryTimeMsDelta': geom_d, 'totalTimeMsDelta': total_d, 'totalTimeMsPercentageChange': pct_d, 'geometryMemoryMbDelta': gmem_d, 'rssMbDelta': rss_d, 'peakRssMbDelta': peak_d, 'externalMbDelta': ext_d}
+          cols = ['parseTimeMsDelta','geometryTimeMsDelta','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','peakWasmHeapMbDelta','rssMbDelta','peakRssMbDelta','externalMbDelta']
+          headers = ['stat','Δ parse ms','Δ geom ms','Δ total ms','Δ total %','Δ geomMem MB','Δ wasm heap MB','Δ RSS MB','Δ peak RSS MB','Δ external MB']
+          s = {'parseTimeMsDelta': parse_d, 'geometryTimeMsDelta': geom_d, 'totalTimeMsDelta': total_d, 'totalTimeMsPercentageChange': pct_d, 'geometryMemoryMbDelta': gmem_d, 'peakWasmHeapMbDelta': wasm_d, 'rssMbDelta': rss_d, 'peakRssMbDelta': peak_d, 'externalMbDelta': ext_d}
           print("| " + " | ".join(headers) + " |")
           print("|" + " --- |" * len(headers))
           for stat in ['count', 'min', 'median', 'mean', 'max', 'stddev']:

--- a/.github/workflows/perf-baseline-oneoff.yml
+++ b/.github/workflows/perf-baseline-oneoff.yml
@@ -318,7 +318,7 @@ jobs:
           import csv, sys
           rows = list(csv.DictReader(open(sys.argv[1])))
           rows.sort(key=lambda r: r.get('filename',''))
-          cols = ['filename','loadStatus','schemaVersion','parseTimeMs','geometryTimeMs','totalTimeMs','geometryMemoryMb','rssMb','heapUsedMb']
+          cols = ['filename','loadStatus','schemaVersion','parseTimeMs','geometryTimeMs','totalTimeMs','geometryMemoryMb','peakWasmHeapMb','rssMb','peakRssMb','heapUsedMb']
           print("| " + " | ".join(cols) + " |")
           print("|" + " --- |" * len(cols))
           for r in rows:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,7 @@ Check `scripts/` before building tooling — see
 | STEP support: schemas, coverage, known gaps | [design/new/step-support.md](design/new/step-support.md) |
 | STEP product structure and metadata (the AP242 wrinkle, NIST) | [design/new/step-metadata-nist.md](design/new/step-metadata-nist.md) |
 | Native GLB export from the CLI | [design/new/glb-native-export.md](design/new/glb-native-export.md) |
+| What the perf bench measures and why: peak vs retention, the three distinct native quantities, why `heapUsed + external` is not a stand-in for RSS, GC settling, and the rule for changing recorded fields | [design/new/perf-measurement.md](design/new/perf-measurement.md) |
 | Memory residency, streaming and federated loading | [design/new/memory-residency.md](design/new/memory-residency.md), [design/new/streaming-federated-loader.md](design/new/streaming-federated-loader.md) |
 | emsdk version, wasm build environment | [design/new/web-build-environment.md](design/new/web-build-environment.md), [design/new/emsdk-upgrade-scalable-allocator.md](design/new/emsdk-upgrade-scalable-allocator.md) |
 | Where a model lands in world space: `COORDINATE_TO_ORIGIN`, why the recentre snaps to a grid, why two exports of one object used to land 76m apart, what a frame change costs in re-blessing and saved cameras | [design/new/coordination-frame.md](design/new/coordination-frame.md) |

--- a/design/new/perf-measurement.md
+++ b/design/new/perf-measurement.md
@@ -1,0 +1,224 @@
+# Measuring memory and time in the perf bench
+
+What the benchmark records, why each metric exists, what we deliberately
+do **not** record, and the rule for changing any of it.
+
+Written after conway#552, when a bad measurement produced a false
+"conway#550's numbers don't reproduce" alarm that cost a round trip. The
+numbers were fine; the methodology used to check them was not.
+
+## The rule for changing fields
+
+**Comparability is a preference, not a constraint.** Carry columns
+forward when you can, but adding, removing or redefining a field is fine
+when the new methodology is better — a metric that measures the wrong
+thing consistently is worth less than one that measures the right thing
+from today.
+
+Two obligations come with that freedom:
+
+1. **Record the choice here**, in this file, with the reasoning and the
+   evidence. A column whose meaning changed silently is worse than no
+   column, because it invites a delta across the change.
+2. **A missing column must read `N/A`, never a fabricated value.** This
+   is not hypothetical: `gen_delta_csv.cjs`'s `parseValue` once returned
+   `0.0` for a missing value, so a snapshot lacking `geometryMemoryMb`
+   differenced as `-185.836` for SKYLARK250 — a phantom 100% memory win,
+   on precisely the model someone reads that delta for. Fixed in #548;
+   `src/scripts/perf_csv_quoting.test.ts` pins it. Any new column
+   inherits that obligation.
+
+Baselines do not need re-blessing when a column is added — the next rc
+picks it up, and older snapshots difference as `N/A` against it.
+
+## Peak and delta answer different questions
+
+Both matter; neither substitutes for the other.
+
+- **Peak** — the high-water mark. Answers *does this survive?* A tab dies
+  at its peak, not its average. SKYLARK250 was a peak-and-stall failure.
+- **Delta** — retained across a full load and teardown. Answers *do we
+  leak?* Share loads models repeatedly into one long-lived tab, so
+  retention compounds in a way a single load never shows.
+
+A retained-delta would have looked healthy on SKYLARK while the tab
+froze. A peak says nothing about whether the third load in a session
+starts from a clean floor. Record both.
+
+## The metrics
+
+### Process-level
+
+| column | source | peak or instant |
+|---|---|---|
+| `peakRssMb` | `process.resourceUsage().maxRSS` | **peak** (kernel-maintained) |
+| `rssMb` | `process.memoryUsage().rss` | instant |
+| `heapUsedMb`, `heapTotalMb` | `process.memoryUsage()` | instant |
+| `externalMb`, `arrayBuffersMb` | `process.memoryUsage()` | instant |
+
+`peakRssMb` is free: the kernel already maintains the high-water mark, so
+reading it costs nothing and perturbs nothing. `process.resourceUsage().maxRSS`
+agrees with `/proc/self/status` `VmHWM` and needs no `/proc`, so it works
+off Linux too. Note it is in **kB**, not bytes.
+
+`peakRssMb` is not merely decorative next to `rssMb`. On the native CLI the
+perf row is usually written at the load's peak by construction, so the two
+often agree to 2dp — but not always: `House Aarburg IFC (1).ifc` records
+peak **264.70** against end-of-load **260.44**. The gap is wherever a
+release happens before the sample, which is the normal case on the loader
+path (`model.invalidate(true)` runs before `setMemoryStatistics`).
+
+`externalMb` / `arrayBuffersMb` matter more than they look. `arrayBuffers`
+is a subset of `external`, and it is where Node puts Buffers and
+TypedArrays — including the source file. Measured on MB-Khaya (31 MB
+IFC), the source lands almost entirely in `arrayBuffers` and is
+**completely invisible to `heapUsed`**.
+
+### Native / wasm
+
+| column | source | what it is |
+|---|---|---|
+| `peakWasmHeapMb` | `wasmHeapByteLength()` | wasm linear-memory high-water |
+| `geometryMemoryMb` | `calculateGeometrySize()` | vertex+index **payload** |
+
+**Three native quantities exist and must never be collapsed.** They differ
+by an order of magnitude. `geometry_residency.ts` records an 8 MB live set
+sitting under an **85 MB** wasm heap on MB-Khaya — the gap being allocator
+overhead, fragmentation, and the intermediate buffers a boolean leaves
+behind.
+
+1. **wasm heap high-water** (`peakWasmHeapMb`) — everything the linear
+   memory ever grew to, overhead included. The "did it fit" number.
+2. **payload** (`geometryMemoryMb`) — what a consumer would copy out.
+3. **live native allocation** (the native's own `getAllocationSize`) —
+   what the residency budget governs. Not currently a perf column; see
+   `design/new/memory-residency.md` for why that is the honest unit for a
+   ceiling.
+
+One real MB-Khaya load through the IFC CLI, all four measured together:
+
+| quantity | value |
+|---|---|
+| payload (`geometryMemoryMb`) | 16.8 MB |
+| wasm heap high-water (`peakWasmHeapMb`) | 101.6 MB |
+| external / arrayBuffers | 58.2 / 56.3 MB |
+| RSS | 515.7 MB |
+
+No ratio converts one into another, and `box.ifc` shows why trying would be
+worse than useless: payload **0.00 MB** under a **16.00 MB** heap, which is
+just the initial arena. A column labelled only "geometry memory" invites
+exactly this conflation, so the log line keeps them distinct and a test
+pins that it does.
+
+`wasmHeapByteLength` is **grow-only**, which is exactly why it is the
+right peak metric and the wrong controller input. The residency doc spells
+out the second half: a budget driven by it "would evict once, observe no
+change, and evict everything." The first half is what we use here — being
+grow-only makes it a high-water mark for free, with no sampling.
+
+Use `wasmHeapByteLength`, **not** `HEAPU8.length`: the module's cached view
+can be a growth step behind the real heap (#485), and a high-water figure
+that under-reports is worse than none.
+
+## Rejected: `total = heapUsed + external` as the headline
+
+A reasonable-sounding suggestion — track a JS-side total instead of RSS,
+on the grounds that it is more portable and less noisy. Measured against a
+real conway load, it is structurally blind to the thing this bench exists
+to track. MB-Khaya, post-GC per stage:
+
+| stage | rss | heapUsed | external | arrayBuffers | total (h+e) |
+|---|---|---|---|---|---|
+| baseline | 105.7 | 19.8 | 1.7 | 0.1 | 21.5 |
+| after readFileSync | 137.1 | 19.8 | 33.1 | 31.5 | 52.9 |
+| after parse | 191.8 | 20.0 | 47.9 | 46.3 | 67.9 |
+| **after wasm init** | **256.9** | 25.2 | **49.6** | 47.8 | 74.9 |
+| after geometry | 510.5 | 225.9 | 58.1 | 56.3 | **284.0** |
+
+At the geometry stage `total` reads 284.0 MB against RSS 510.5 MB — it
+misses 44% of the process. The wasm-init row shows why: **+65 MB of RSS
+while `external` moves under 2 MB.** Emscripten's wasm heap does not
+surface in Node's ArrayBuffer accounting, so a JS-side total cannot see
+conway's geometry engine at all.
+
+The portability argument does not hold either — `process.memoryUsage().rss`
+is available on every platform Node supports. The real argument for
+JS-side accounting is *lower noise*: RSS carries allocator fragmentation
+and pages not yet returned to the OS. That argues for recording both,
+which we do. It does not argue for dropping the only process-level column
+that sees native memory.
+
+So: record `heapUsed`, `external` and `arrayBuffers` as their own columns.
+Do not derive a `total` from them and do not treat it as a stand-in for
+RSS. `peakWasmHeapMb` is what makes the native side visible.
+
+## Sampling: GC before you look, and mind what it costs
+
+`heapUsed` sampled without a collection is live set *plus* whatever
+garbage GC has not reached. On a model that allocates hard this is not a
+rounding error — SKYLARK250 reads **2547 MB** un-GC'd against **981 MB**
+as post-GC live heap. A 2.6× difference from sampling alone, and the
+direct cause of the #552 false alarm.
+
+No always-on perf column forces GC — the peaks above are all free. This
+settle is the rule for **probes and any opt-in live-heap pass**, and the
+standard to hold a one-off measurement to before quoting its number.
+
+Settle with:
+
+```js
+global.gc(); await new Promise((r) => setImmediate(r)); global.gc()
+```
+
+Each part earns its place. Two collections catch objects whose freeing
+makes more garbage unreachable. The interleaved turn lets queued frees
+actually run — notably ArrayBuffer backing-store release, without which
+`external` reads high. One GC plus an idle turn is not enough on its own
+(V8's GC has concurrent phases, so a turn does not imply a finished
+collection); two back-to-back GCs with no turn between is not enough
+either.
+
+**Forced-GC sampling perturbs timing badly.** This is a hard constraint,
+not a caveat: a run that samples live heap at frequency cannot also
+produce trustworthy timing columns. Peak RSS and peak wasm heap are free
+and carry no such cost, which is why they are the always-on peaks; live-heap
+peak sampling belongs in an opt-in pass writing its own CSV, explicitly
+not joined to timing from the same run.
+
+This is also why conway#550's four SKYLARK figures came from **three
+separate runs** — memory, timing, and event-loop cadence each measured in
+a mode that invalidates the others. Someone later tried to reproduce all
+four in one combined run, got numbers that disagreed with all of them, and
+filed a false contradiction. **Any quoted benchmark figure should say which
+run produced it.**
+
+## Known caveat: `geometryMemoryMb` differs by pipeline
+
+The IFC CLI and the IFC regression child report **different**
+`geometryMemoryMb` for the same model — 16.8 vs 22.3 MB on MB-Khaya. Same
+function, sampled at different points in two pipelines that run with
+different CSG options.
+
+This predates #552 and was not introduced by it, but it means the column is
+only comparable **within** a pipeline. Do not difference a CLI figure
+against a regression-child figure. Tracked separately.
+
+## Changelog of methodology changes
+
+| when | change | why |
+|---|---|---|
+| ≤1.451.1357 | `geometryMemoryMb` populated | headless path measured it |
+| 1.451 → 1.543 | `geometryMemoryMb` silently became `N/A` | the conway-native perf writers never emitted it; the gap was written into a test as intended behaviour rather than fixed |
+| #548 | delta stops fabricating values for missing columns | `parseValue` returned `0.0`; see "The rule for changing fields" |
+| #552 (via #553) | add `peakRssMb`, `externalMb`, `arrayBuffersMb`, `peakWasmHeapMb`; restore `geometryMemoryMb` | memory was one un-GC'd instant, and the wasm heap was invisible |
+| #554 | *open* — retention across a load/teardown cycle | nothing measures what is held after teardown |
+
+Restoring `geometryMemoryMb` checks out against history: SKYLARK250 reads
+**185.22** against the **185.836** recorded at 1.451.
+
+## Related
+
+- `design/new/memory-residency.md` — the residency budget, and why live
+  native allocation rather than heap high-water is the unit for a ceiling
+- `design/new/ci-regression-cost.md` — CI tiering, the rc / re-bless / LFS runbook
+- `regression/README.md` — corpus, digest CSVs, smoke subset vs rc pass

--- a/scripts/benchmark.cjs
+++ b/scripts/benchmark.cjs
@@ -327,8 +327,9 @@ async function main() {
   const DETAIL_COLUMNS = [
     'timestamp', 'loadStatus', 'uname', 'engine', 'filename', 'schemaVersion',
     'parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb',
-    'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb', 'externalMb',
-    'arrayBuffersMb', 'preprocessorVersion', 'originatingSystem',
+    'peakWasmHeapMb', 'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb',
+    'externalMb', 'arrayBuffersMb', 'preprocessorVersion',
+    'originatingSystem',
   ];
 
   fs.writeFileSync(newResults, csvRow(DETAIL_COLUMNS) + "\n", 'utf8');
@@ -474,6 +475,7 @@ async function main() {
       let geometryTimeMs = 'N/A';
       let totalTimeMs = 'N/A';
       let geometryMemoryMb = 'N/A';
+      let peakWasmHeapMb = 'N/A';
       let rssMb = 'N/A';
       let peakRssMb = 'N/A';
       let heapUsedMb = 'N/A';
@@ -495,6 +497,9 @@ async function main() {
           if (totalTimeMatch) totalTimeMs = totalTimeMatch[1];
           const geomMemMatch = logContents.match(/Geometry Memory: ([\d.]+) MB/);
           if (geomMemMatch) geometryMemoryMb = geomMemMatch[1];
+          const wasmHeapMatch =
+            logContents.match(/WASM Heap High-Water: ([\d.]+) MB/);
+          if (wasmHeapMatch) peakWasmHeapMb = wasmHeapMatch[1];
           const rssMatch = logContents.match(/RSS ([\d.]+) MB/);
           if (rssMatch) rssMb = rssMatch[1];
           const peakRssMatch = logContents.match(/Peak RSS: ([\d.]+) MB/);
@@ -520,6 +525,9 @@ async function main() {
         if (totalTimeMatch) totalTimeMs = totalTimeMatch[1];
         const geomMemMatch = logContents.match(/Geometry Memory: ([\d.]+) MB/);
         if (geomMemMatch) geometryMemoryMb = geomMemMatch[1];
+        const wasmHeapMatch =
+          logContents.match(/WASM Heap High-Water: ([\d.]+) MB/);
+        if (wasmHeapMatch) peakWasmHeapMb = wasmHeapMatch[1];
         const rssMatch = logContents.match(/RSS ([\d.]+) MB/);
         if (rssMatch) rssMb = rssMatch[1];
         const peakRssMatch = logContents.match(/Peak RSS: ([\d.]+) MB/);
@@ -549,6 +557,7 @@ async function main() {
         geometryTimeMs,
         totalTimeMs,
         geometryMemoryMb,
+        peakWasmHeapMb,
         rssMb,
         peakRssMb,
         heapUsedMb,
@@ -601,7 +610,7 @@ async function main() {
       const failLine = csvRow([
         timestamp, 'FAIL', unameVal, 'N/A', encodeFileName(displayName), 'N/A',
         'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
-        'N/A', 'N/A',
+        'N/A', 'N/A', 'N/A',
       ]);
       appendLineToFile(newResults, failLine);
 

--- a/scripts/benchmark.cjs
+++ b/scripts/benchmark.cjs
@@ -305,23 +305,30 @@ async function main() {
   //
   // PEAK vs INSTANT (conway#552): `peakRssMb` is the render server process's
   // high-water mark, scraped from the `Peak RSS:` the engine's Memory class
-  // logs (`process.resourceUsage().maxRSS`). `rssMb`, `heapUsedMb` and
-  // `heapTotalMb` are single `process.memoryUsage()` samples taken at the end
-  // of the load with no GC first — so `heapUsedMb` is live data plus
-  // uncollected garbage, and moves with GC timing. `geometryMemoryMb` is not
-  // a process metric at all: it is the vertex+index payload conway allocated
-  // for this model. Only the last of those is independent of what else the
-  // three.js host happens to be holding.
+  // logs (`process.resourceUsage().maxRSS`). `rssMb`, `heapUsedMb`,
+  // `heapTotalMb`, `externalMb` and `arrayBuffersMb` are single
+  // `process.memoryUsage()` samples taken at the end of the load with no GC
+  // first — so `heapUsedMb` is live data plus uncollected garbage, and moves
+  // with GC timing. `arrayBuffersMb` is a subset of `externalMb`; together
+  // they hold the source buffer and the parse structures, which `heapUsedMb`
+  // cannot see at all. `geometryMemoryMb` is not a process metric: it is the
+  // vertex+index payload conway allocated for this model, the only column
+  // independent of what else the three.js host happens to be holding.
   //
-  // Snapshots committed before #552 have neither `peakRssMb` in this header
-  // nor a `Peak RSS:` line to scrape; gen_delta_csv.cjs propagates the
-  // absence as N/A rather than differencing against zero, so old baselines
-  // stay readable and do not need re-blessing.
+  // No `heapUsed + external` total, deliberately: it misses the wasm heap
+  // (284 MB against an RSS of 510 MB on MB-Khaya after geometry), which in a
+  // three.js host is on top of a GL context and a scene graph it also cannot
+  // see. peakRssMb is the headline.
+  //
+  // Snapshots committed before #552 have none of these three columns in this
+  // header, nor the log lines to scrape them from; gen_delta_csv.cjs
+  // propagates the absence as N/A rather than differencing against zero, so
+  // old baselines stay readable and do not need re-blessing.
   const DETAIL_COLUMNS = [
     'timestamp', 'loadStatus', 'uname', 'engine', 'filename', 'schemaVersion',
     'parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb',
-    'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb', 'preprocessorVersion',
-    'originatingSystem',
+    'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb', 'externalMb',
+    'arrayBuffersMb', 'preprocessorVersion', 'originatingSystem',
   ];
 
   fs.writeFileSync(newResults, csvRow(DETAIL_COLUMNS) + "\n", 'utf8');
@@ -471,6 +478,8 @@ async function main() {
       let peakRssMb = 'N/A';
       let heapUsedMb = 'N/A';
       let heapTotalMb = 'N/A';
+      let externalMb = 'N/A';
+      let arrayBuffersMb = 'N/A';
       let preprocessorVersion = 'N/A';
       let originatingSystem = 'N/A';
 
@@ -494,6 +503,11 @@ async function main() {
           if (heapUsedMatch) heapUsedMb = heapUsedMatch[1];
           const heapTotalMatch = logContents.match(/Heap Total: ([\d.]+) MB/);
           if (heapTotalMatch) heapTotalMb = heapTotalMatch[1];
+          const externalMatch = logContents.match(/External: ([\d.]+) MB/);
+          if (externalMatch) externalMb = externalMatch[1];
+          const arrayBuffersMatch =
+            logContents.match(/ArrayBuffers: ([\d.]+) MB/);
+          if (arrayBuffersMatch) arrayBuffersMb = arrayBuffersMatch[1];
           const schemaVersionMatch = logContents.match(/Version: (IFC[^\s]+)/);
           if (schemaVersionMatch) schemaVersion = schemaVersionMatch[1].slice(0, -1);
           const ppVersionMatch = logContents.match(/Preprocessor Version: '([^']+)'/);
@@ -514,6 +528,10 @@ async function main() {
         if (heapUsedMatch) heapUsedMb = heapUsedMatch[1];
         const heapTotalMatch = logContents.match(/Heap Total: ([\d.]+) MB/);
         if (heapTotalMatch) heapTotalMb = heapTotalMatch[1];
+        const externalMatch = logContents.match(/External: ([\d.]+) MB/);
+        if (externalMatch) externalMb = externalMatch[1];
+        const arrayBuffersMatch = logContents.match(/ArrayBuffers: ([\d.]+) MB/);
+        if (arrayBuffersMatch) arrayBuffersMb = arrayBuffersMatch[1];
         parseTimeMs = 0;
         geometryTimeMs = 0;
         preprocessorVersion = 0;
@@ -535,6 +553,8 @@ async function main() {
         peakRssMb,
         heapUsedMb,
         heapTotalMb,
+        externalMb,
+        arrayBuffersMb,
         preprocessorVersion,
         originatingSystem
       ]);
@@ -581,6 +601,7 @@ async function main() {
       const failLine = csvRow([
         timestamp, 'FAIL', unameVal, 'N/A', encodeFileName(displayName), 'N/A',
         'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
+        'N/A', 'N/A',
       ]);
       appendLineToFile(newResults, failLine);
 

--- a/scripts/benchmark.cjs
+++ b/scripts/benchmark.cjs
@@ -302,10 +302,25 @@ async function main() {
 
   // Every row this file gets is written through csvRow, header included, so
   // the column list and the records that fill it cannot drift apart.
+  //
+  // PEAK vs INSTANT (conway#552): `peakRssMb` is the render server process's
+  // high-water mark, scraped from the `Peak RSS:` the engine's Memory class
+  // logs (`process.resourceUsage().maxRSS`). `rssMb`, `heapUsedMb` and
+  // `heapTotalMb` are single `process.memoryUsage()` samples taken at the end
+  // of the load with no GC first — so `heapUsedMb` is live data plus
+  // uncollected garbage, and moves with GC timing. `geometryMemoryMb` is not
+  // a process metric at all: it is the vertex+index payload conway allocated
+  // for this model. Only the last of those is independent of what else the
+  // three.js host happens to be holding.
+  //
+  // Snapshots committed before #552 have neither `peakRssMb` in this header
+  // nor a `Peak RSS:` line to scrape; gen_delta_csv.cjs propagates the
+  // absence as N/A rather than differencing against zero, so old baselines
+  // stay readable and do not need re-blessing.
   const DETAIL_COLUMNS = [
     'timestamp', 'loadStatus', 'uname', 'engine', 'filename', 'schemaVersion',
     'parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb',
-    'rssMb', 'heapUsedMb', 'heapTotalMb', 'preprocessorVersion',
+    'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb', 'preprocessorVersion',
     'originatingSystem',
   ];
 
@@ -453,6 +468,7 @@ async function main() {
       let totalTimeMs = 'N/A';
       let geometryMemoryMb = 'N/A';
       let rssMb = 'N/A';
+      let peakRssMb = 'N/A';
       let heapUsedMb = 'N/A';
       let heapTotalMb = 'N/A';
       let preprocessorVersion = 'N/A';
@@ -472,6 +488,8 @@ async function main() {
           if (geomMemMatch) geometryMemoryMb = geomMemMatch[1];
           const rssMatch = logContents.match(/RSS ([\d.]+) MB/);
           if (rssMatch) rssMb = rssMatch[1];
+          const peakRssMatch = logContents.match(/Peak RSS: ([\d.]+) MB/);
+          if (peakRssMatch) peakRssMb = peakRssMatch[1];
           const heapUsedMatch = logContents.match(/Heap Used: ([\d.]+) MB/);
           if (heapUsedMatch) heapUsedMb = heapUsedMatch[1];
           const heapTotalMatch = logContents.match(/Heap Total: ([\d.]+) MB/);
@@ -490,6 +508,8 @@ async function main() {
         if (geomMemMatch) geometryMemoryMb = geomMemMatch[1];
         const rssMatch = logContents.match(/RSS ([\d.]+) MB/);
         if (rssMatch) rssMb = rssMatch[1];
+        const peakRssMatch = logContents.match(/Peak RSS: ([\d.]+) MB/);
+        if (peakRssMatch) peakRssMb = peakRssMatch[1];
         const heapUsedMatch = logContents.match(/Heap Used: ([\d.]+) MB/);
         if (heapUsedMatch) heapUsedMb = heapUsedMatch[1];
         const heapTotalMatch = logContents.match(/Heap Total: ([\d.]+) MB/);
@@ -512,6 +532,7 @@ async function main() {
         totalTimeMs,
         geometryMemoryMb,
         rssMb,
+        peakRssMb,
         heapUsedMb,
         heapTotalMb,
         preprocessorVersion,
@@ -559,7 +580,7 @@ async function main() {
       // the row a release comparison is for. One writer, one convention.
       const failLine = csvRow([
         timestamp, 'FAIL', unameVal, 'N/A', encodeFileName(displayName), 'N/A',
-        'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
+        'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
       ]);
       appendLineToFile(newResults, failLine);
 

--- a/scripts/bless_perf_snapshot.cjs
+++ b/scripts/bless_perf_snapshot.cjs
@@ -20,17 +20,18 @@
  *
  *   perf.csv (input, written by src/ifc/ifc_regression_main.ts)
  *     file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,
- *     rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,arrayBuffersMb
+ *     peakWasmHeapMb,rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,
+ *     arrayBuffersMb
  *
  *   performance-detail.csv (output, the committed convention)
  *     timestamp,loadStatus,uname,engine,filename,schemaVersion,parseTimeMs,
- *     geometryTimeMs,totalTimeMs,geometryMemoryMb,rssMb,peakRssMb,heapUsedMb,
- *     heapTotalMb,externalMb,arrayBuffersMb,preprocessorVersion,
- *     originatingSystem
+ *     geometryTimeMs,totalTimeMs,geometryMemoryMb,peakWasmHeapMb,rssMb,
+ *     peakRssMb,heapUsedMb,heapTotalMb,externalMb,arrayBuffersMb,
+ *     preprocessorVersion,originatingSystem
  *
  * The three columns perf.csv does not carry (schemaVersion,
  * preprocessorVersion, originatingSystem) are written as N/A rather than
- * omitted, so the file keeps the 18-column shape every existing consumer and
+ * omitted, so the file keeps the 19-column shape every existing consumer and
  * GitHub's CSV viewer expect. None of the three reaches the delta:
  * preprocessorVersion/originatingSystem are not in its column set, and
  * schemaVersion is carried through as a label.
@@ -39,11 +40,15 @@
  * high-water mark; `rssMb`/`heapUsedMb`/`heapTotalMb`/`externalMb`/
  * `arrayBuffersMb` are single samples taken at the end of the load with no GC
  * first. They are not interchangeable, `arrayBuffersMb` is a subset of
- * `externalMb`, and no JS-side sum of them sees the wasm heap — see the
- * column-by-column note on writePerfCsvIfRequested in
+ * `externalMb`, and no JS-side sum of them sees the wasm heap. `peakWasmHeapMb`
+ * is the column that does: emscripten's linear memory is grow-only, so a
+ * single reading of it is already the high-water mark. It is a THIRD quantity,
+ * distinct from `geometryMemoryMb` (the vertex+index payload) by an order of
+ * magnitude — see the column-by-column note on writePerfCsvIfRequested in
  * src/ifc/ifc_regression_main.ts.
  *
- * OLD SNAPSHOTS LACK `peakRssMb`/`externalMb`/`arrayBuffersMb`, and
+ * OLD SNAPSHOTS LACK `peakWasmHeapMb`/`peakRssMb`/`externalMb`/
+ * `arrayBuffersMb`, and
  * `geometryMemoryMb` was N/A on every
  * conway-native snapshot before #552. gen_delta_csv.cjs propagates an absent
  * measurement instead of coercing it to 0, so those deltas read N/A rather
@@ -74,8 +79,8 @@ const { generateDeltaCSV } = require('./gen_delta_csv.cjs');
 const DETAIL_COLUMNS = [
   'timestamp', 'loadStatus', 'uname', 'engine', 'filename', 'schemaVersion',
   'parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb',
-  'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb', 'externalMb',
-  'arrayBuffersMb', 'preprocessorVersion', 'originatingSystem',
+  'peakWasmHeapMb', 'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb',
+  'externalMb', 'arrayBuffersMb', 'preprocessorVersion', 'originatingSystem',
 ];
 
 /** Columns perf.csv does not measure; written as N/A to keep the 15-column shape. */
@@ -154,6 +159,7 @@ function writeDetailCsv(rows, outPath, engine, timestamp) {
       // Absent from every perf.csv written before #552, and from FAIL rows,
       // which is why this reads the column instead of assuming it.
       row.geometryMemoryMb || UNMEASURED,
+      row.peakWasmHeapMb || UNMEASURED,
       row.rssMb || UNMEASURED,
       row.peakRssMb || UNMEASURED,
       row.heapUsedMb || UNMEASURED,
@@ -348,9 +354,16 @@ live, invisible to \`heapUsedMb\`. Neither sees the wasm heap, so
 \`heapUsedMb + externalMb\` is not a substitute for RSS: on a 31 MB model it
 reads 284 MB against an RSS of 510 MB.
 
-Snapshots blessed before conway#552 carry none of \`peakRssMb\`,
-\`externalMb\` or \`arrayBuffersMb\`, nor a measured \`geometryMemoryMb\`, so
-those columns come out \`N/A\` in a delta against them. That is a missing
+\`peakWasmHeapMb\` is the wasm linear memory conway's geometry engine runs in,
+which nothing else here can see. It is grow-only, so one reading is the
+high-water mark. Do not read it as \`geometryMemoryMb\`: that column is the
+vertex+index payload a consumer would copy out, and the heap around it also
+holds allocator overhead, fragmentation and boolean intermediates — 8 MB of
+payload under an 85 MB heap on one model in this corpus.
+
+Snapshots blessed before conway#552 carry none of \`peakWasmHeapMb\`,
+\`peakRssMb\`, \`externalMb\` or \`arrayBuffersMb\`, nor a measured
+\`geometryMemoryMb\`, so those columns come out \`N/A\` in a delta against them. That is a missing
 measurement, not a zero: do not read it as "no change".
 
 ## Regenerating

--- a/scripts/bless_perf_snapshot.cjs
+++ b/scripts/bless_perf_snapshot.cjs
@@ -19,27 +19,34 @@
  * TWO COLUMN SETS ARE IN PLAY, and they are not the same file:
  *
  *   perf.csv (input, written by src/ifc/ifc_regression_main.ts)
- *     file,status,parseTimeMs,geometryTimeMs,totalTimeMs,rssMb,heapUsedMb,
- *     heapTotalMb
+ *     file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,
+ *     rssMb,peakRssMb,heapUsedMb,heapTotalMb
  *
  *   performance-detail.csv (output, the committed convention)
  *     timestamp,loadStatus,uname,engine,filename,schemaVersion,parseTimeMs,
- *     geometryTimeMs,totalTimeMs,geometryMemoryMb,rssMb,heapUsedMb,
+ *     geometryTimeMs,totalTimeMs,geometryMemoryMb,rssMb,peakRssMb,heapUsedMb,
  *     heapTotalMb,preprocessorVersion,originatingSystem
  *
- * The four columns perf.csv does not carry (schemaVersion, geometryMemoryMb,
+ * The three columns perf.csv does not carry (schemaVersion,
  * preprocessorVersion, originatingSystem) are written as N/A rather than
- * omitted, so the file keeps the 15-column shape every existing consumer and
- * GitHub's CSV viewer expect.
- *
- * Of those four, only geometryMemoryMb reaches the delta:
+ * omitted, so the file keeps the 16-column shape every existing consumer and
+ * GitHub's CSV viewer expect. None of the three reaches the delta:
  * preprocessorVersion/originatingSystem are not in its column set, and
- * schemaVersion is carried through as a label. `geometryMemoryMbDelta` is
- * therefore N/A on every row of a delta involving this snapshot — which is the
- * honest answer, and it is only true because gen_delta_csv.cjs propagates an
- * absent measurement instead of coercing it to 0. Coercing produced a
- * fabricated `geometryMemoryMbDelta = -185.836` for SKYLARK250 — the entire
- * baseline allocation reported as a memory win.
+ * schemaVersion is carried through as a label.
+ *
+ * PEAK vs INSTANT (conway#552). `peakRssMb` is the child process's kernel
+ * high-water mark; `rssMb`/`heapUsedMb`/`heapTotalMb` are single samples taken
+ * at the end of the load with no GC first. They are not interchangeable — see
+ * the column-by-column note on writePerfCsvIfRequested in
+ * src/ifc/ifc_regression_main.ts.
+ *
+ * OLD SNAPSHOTS LACK `peakRssMb`, and `geometryMemoryMb` was N/A on every
+ * conway-native snapshot before #552. gen_delta_csv.cjs propagates an absent
+ * measurement instead of coercing it to 0, so those deltas read N/A rather
+ * than a number. That guard is why baselines do not need re-blessing here.
+ * Coercion is not a hypothetical: it produced a fabricated
+ * `geometryMemoryMbDelta = -185.836` for SKYLARK250 — the entire baseline
+ * allocation reported as a memory win (#548).
  *
  * HARNESS BOUNDARY. The committed `conway<version>-ci_*` snapshots to date
  * were produced by scripts/benchmark.cjs driving headless-three, i.e. conway
@@ -47,9 +54,10 @@
  * parse/geometry/total are conway's own stage timings in both cases and are
  * broadly comparable on the same runner class, but the memory columns are
  * not: `rssMb` here excludes a GL context and a three.js scene graph, and
- * `geometryMemoryMb` is not measured at all. The README written alongside the
- * snapshot records which harness produced it so nobody differences across the
- * boundary without seeing it.
+ * `geometryMemoryMb`, while measured on both sides now, counts only conway's
+ * own vertex+index payload — the three.js host's copy of the same geometry is
+ * not in it. The README written alongside the snapshot records which harness
+ * produced it so nobody differences across the boundary without seeing it.
  */
 
 const fs = require('fs');
@@ -62,7 +70,7 @@ const { generateDeltaCSV } = require('./gen_delta_csv.cjs');
 const DETAIL_COLUMNS = [
   'timestamp', 'loadStatus', 'uname', 'engine', 'filename', 'schemaVersion',
   'parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb',
-  'rssMb', 'heapUsedMb', 'heapTotalMb', 'preprocessorVersion',
+  'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb', 'preprocessorVersion',
   'originatingSystem',
 ];
 
@@ -139,8 +147,11 @@ function writeDetailCsv(rows, outPath, engine, timestamp) {
       row.parseTimeMs || UNMEASURED,
       row.geometryTimeMs || UNMEASURED,
       row.totalTimeMs || UNMEASURED,
-      UNMEASURED,
+      // Absent from every perf.csv written before #552, and from FAIL rows,
+      // which is why this reads the column instead of assuming it.
+      row.geometryMemoryMb || UNMEASURED,
       row.rssMb || UNMEASURED,
+      row.peakRssMb || UNMEASURED,
       row.heapUsedMb || UNMEASURED,
       row.heapTotalMb || UNMEASURED,
       UNMEASURED,
@@ -314,13 +325,20 @@ headless-three, i.e. conway inside a three.js host.
 \`parseTimeMs\` / \`geometryTimeMs\` / \`totalTimeMs\` are conway's own stage
 timings in both harnesses and are broadly comparable on the same runner class.
 The memory columns are not: \`rssMb\` here excludes a GL context and a three.js
-scene graph. \`schemaVersion\`, \`geometryMemoryMb\`, \`preprocessorVersion\` and
-\`originatingSystem\` are \`N/A\` — the conway-native perf writer does not
-capture them.
+scene graph, and \`geometryMemoryMb\` counts only conway's own vertex+index
+payload, without the host's copy of the same geometry. \`schemaVersion\`,
+\`preprocessorVersion\` and \`originatingSystem\` are \`N/A\` — the conway-native
+perf writer does not capture them.
 
-Because \`geometryMemoryMb\` is absent here, \`geometryMemoryMbDelta\` is \`N/A\`
-on every row of a delta against this snapshot. That is a missing measurement,
-not a zero: do not read it as "no change in geometry memory".
+\`peakRssMb\` is the load's high-water mark (the kernel's, via
+\`resourceUsage().maxRSS\`); \`rssMb\`, \`heapUsedMb\` and \`heapTotalMb\` are
+single samples taken at the end of the load with no GC first. Do not read the
+instants as peaks, or \`heapUsedMb\` as a live set — it includes garbage GC has
+not collected.
+
+Snapshots blessed before conway#552 carry neither \`peakRssMb\` nor a measured
+\`geometryMemoryMb\`, so those columns come out \`N/A\` in a delta against them.
+That is a missing measurement, not a zero: do not read it as "no change".
 
 ## Regenerating
 

--- a/scripts/bless_perf_snapshot.cjs
+++ b/scripts/bless_perf_snapshot.cjs
@@ -20,27 +20,31 @@
  *
  *   perf.csv (input, written by src/ifc/ifc_regression_main.ts)
  *     file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,
- *     rssMb,peakRssMb,heapUsedMb,heapTotalMb
+ *     rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,arrayBuffersMb
  *
  *   performance-detail.csv (output, the committed convention)
  *     timestamp,loadStatus,uname,engine,filename,schemaVersion,parseTimeMs,
  *     geometryTimeMs,totalTimeMs,geometryMemoryMb,rssMb,peakRssMb,heapUsedMb,
- *     heapTotalMb,preprocessorVersion,originatingSystem
+ *     heapTotalMb,externalMb,arrayBuffersMb,preprocessorVersion,
+ *     originatingSystem
  *
  * The three columns perf.csv does not carry (schemaVersion,
  * preprocessorVersion, originatingSystem) are written as N/A rather than
- * omitted, so the file keeps the 16-column shape every existing consumer and
+ * omitted, so the file keeps the 18-column shape every existing consumer and
  * GitHub's CSV viewer expect. None of the three reaches the delta:
  * preprocessorVersion/originatingSystem are not in its column set, and
  * schemaVersion is carried through as a label.
  *
  * PEAK vs INSTANT (conway#552). `peakRssMb` is the child process's kernel
- * high-water mark; `rssMb`/`heapUsedMb`/`heapTotalMb` are single samples taken
- * at the end of the load with no GC first. They are not interchangeable — see
- * the column-by-column note on writePerfCsvIfRequested in
+ * high-water mark; `rssMb`/`heapUsedMb`/`heapTotalMb`/`externalMb`/
+ * `arrayBuffersMb` are single samples taken at the end of the load with no GC
+ * first. They are not interchangeable, `arrayBuffersMb` is a subset of
+ * `externalMb`, and no JS-side sum of them sees the wasm heap — see the
+ * column-by-column note on writePerfCsvIfRequested in
  * src/ifc/ifc_regression_main.ts.
  *
- * OLD SNAPSHOTS LACK `peakRssMb`, and `geometryMemoryMb` was N/A on every
+ * OLD SNAPSHOTS LACK `peakRssMb`/`externalMb`/`arrayBuffersMb`, and
+ * `geometryMemoryMb` was N/A on every
  * conway-native snapshot before #552. gen_delta_csv.cjs propagates an absent
  * measurement instead of coercing it to 0, so those deltas read N/A rather
  * than a number. That guard is why baselines do not need re-blessing here.
@@ -70,8 +74,8 @@ const { generateDeltaCSV } = require('./gen_delta_csv.cjs');
 const DETAIL_COLUMNS = [
   'timestamp', 'loadStatus', 'uname', 'engine', 'filename', 'schemaVersion',
   'parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb',
-  'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb', 'preprocessorVersion',
-  'originatingSystem',
+  'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb', 'externalMb',
+  'arrayBuffersMb', 'preprocessorVersion', 'originatingSystem',
 ];
 
 /** Columns perf.csv does not measure; written as N/A to keep the 15-column shape. */
@@ -154,6 +158,8 @@ function writeDetailCsv(rows, outPath, engine, timestamp) {
       row.peakRssMb || UNMEASURED,
       row.heapUsedMb || UNMEASURED,
       row.heapTotalMb || UNMEASURED,
+      row.externalMb || UNMEASURED,
+      row.arrayBuffersMb || UNMEASURED,
       UNMEASURED,
       UNMEASURED,
     ]));
@@ -331,14 +337,21 @@ payload, without the host's copy of the same geometry. \`schemaVersion\`,
 perf writer does not capture them.
 
 \`peakRssMb\` is the load's high-water mark (the kernel's, via
-\`resourceUsage().maxRSS\`); \`rssMb\`, \`heapUsedMb\` and \`heapTotalMb\` are
-single samples taken at the end of the load with no GC first. Do not read the
-instants as peaks, or \`heapUsedMb\` as a live set — it includes garbage GC has
-not collected.
+\`resourceUsage().maxRSS\`); \`rssMb\`, \`heapUsedMb\`, \`heapTotalMb\`,
+\`externalMb\` and \`arrayBuffersMb\` are single samples taken at the end of the
+load with no GC first. Do not read the instants as peaks, or \`heapUsedMb\` as a
+live set — it includes garbage GC has not collected.
 
-Snapshots blessed before conway#552 carry neither \`peakRssMb\` nor a measured
-\`geometryMemoryMb\`, so those columns come out \`N/A\` in a delta against them.
-That is a missing measurement, not a zero: do not read it as "no change".
+\`externalMb\` is off-heap memory V8 knows about and \`arrayBuffersMb\` is its
+ArrayBuffer subset — that is where the source buffer and the parse structures
+live, invisible to \`heapUsedMb\`. Neither sees the wasm heap, so
+\`heapUsedMb + externalMb\` is not a substitute for RSS: on a 31 MB model it
+reads 284 MB against an RSS of 510 MB.
+
+Snapshots blessed before conway#552 carry none of \`peakRssMb\`,
+\`externalMb\` or \`arrayBuffersMb\`, nor a measured \`geometryMemoryMb\`, so
+those columns come out \`N/A\` in a delta against them. That is a missing
+measurement, not a zero: do not read it as "no change".
 
 ## Regenerating
 

--- a/scripts/gen_delta_csv.cjs
+++ b/scripts/gen_delta_csv.cjs
@@ -68,6 +68,7 @@ function writeDataToCsv(data, csvFilename, isWebIfc = false) {
         'totalTimeMsPercentageChange',
         'geometryMemoryMbDelta',
         'rssMbDelta',
+        'peakRssMbDelta',
         'heapUsedMbDelta',
         'heapTotalMbDelta',
       ]
@@ -88,6 +89,7 @@ function writeDataToCsv(data, csvFilename, isWebIfc = false) {
         'totalTimeMsPercentageChange',
         'geometryMemoryMbDelta',
         'rssMbDelta',
+        'peakRssMbDelta',
         'heapUsedMbDelta',
         'heapTotalMbDelta',
       ];
@@ -237,6 +239,9 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           ),
           geometryMemoryMbDelta: computeDelta('geometryMemoryMb', entry2, entry1),
           rssMbDelta: computeDelta('rssMb', entry2, entry1),
+          // Absent from every snapshot committed before #552; computeDelta
+          // reports that as N/A rather than differencing against zero.
+          peakRssMbDelta: computeDelta('peakRssMb', entry2, entry1),
           heapUsedMbDelta: computeDelta('heapUsedMb', entry2, entry1),
           heapTotalMbDelta: computeDelta('heapTotalMb', entry2, entry1),
         });
@@ -255,6 +260,7 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           totalTimeMsPercentageChange: 'N/A',
           geometryMemoryMbDelta: 'N/A',
           rssMbDelta: 'N/A',
+          peakRssMbDelta: 'N/A',
           heapUsedMbDelta: 'N/A',
           heapTotalMbDelta: 'N/A',
         });
@@ -278,6 +284,7 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           totalTimeMsPercentageChange: 'N/A',
           geometryMemoryMbDelta: 'N/A',
           rssMbDelta: 'N/A',
+          peakRssMbDelta: 'N/A',
           heapUsedMbDelta: 'N/A',
           heapTotalMbDelta: 'N/A',
         });
@@ -313,6 +320,9 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           totalTimeMsPercentageChange: totalTimePercentageChange,
           geometryMemoryMbDelta: computeDelta('geometryMemoryMb', entry2, entry1),
           rssMbDelta: computeDelta('rssMb', entry2, entry1),
+          // Absent from every snapshot committed before #552; computeDelta
+          // reports that as N/A rather than differencing against zero.
+          peakRssMbDelta: computeDelta('peakRssMb', entry2, entry1),
           heapUsedMbDelta: computeDelta('heapUsedMb', entry2, entry1),
           heapTotalMbDelta: computeDelta('heapTotalMb', entry2, entry1),
         });
@@ -334,6 +344,7 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           totalTimeMsPercentageChange: 'N/A',
           geometryMemoryMbDelta: 'N/A',
           rssMbDelta: 'N/A',
+          peakRssMbDelta: 'N/A',
           heapUsedMbDelta: 'N/A',
           heapTotalMbDelta: 'N/A',
         });
@@ -360,6 +371,7 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           totalTimeMsPercentageChange: 'N/A',
           geometryMemoryMbDelta: 'N/A',
           rssMbDelta: 'N/A',
+          peakRssMbDelta: 'N/A',
           heapUsedMbDelta: 'N/A',
           heapTotalMbDelta: 'N/A',
         });

--- a/scripts/gen_delta_csv.cjs
+++ b/scripts/gen_delta_csv.cjs
@@ -67,6 +67,7 @@ function writeDataToCsv(data, csvFilename, isWebIfc = false) {
         'totalTimeMsDelta',
         'totalTimeMsPercentageChange',
         'geometryMemoryMbDelta',
+        'peakWasmHeapMbDelta',
         'rssMbDelta',
         'peakRssMbDelta',
         'heapUsedMbDelta',
@@ -90,6 +91,7 @@ function writeDataToCsv(data, csvFilename, isWebIfc = false) {
         'totalTimeMsDelta',
         'totalTimeMsPercentageChange',
         'geometryMemoryMbDelta',
+        'peakWasmHeapMbDelta',
         'rssMbDelta',
         'peakRssMbDelta',
         'heapUsedMbDelta',
@@ -242,6 +244,10 @@ function computeDeltas(data1, data2, isWebIfc = false) {
             entry2.totalTimeMs
           ),
           geometryMemoryMbDelta: computeDelta('geometryMemoryMb', entry2, entry1),
+          // A different quantity from geometryMemoryMb, not a rescaling of it:
+          // the wasm heap holds allocator overhead and boolean intermediates
+          // the payload figure excludes. Also absent before #552.
+          peakWasmHeapMbDelta: computeDelta('peakWasmHeapMb', entry2, entry1),
           rssMbDelta: computeDelta('rssMb', entry2, entry1),
           // Absent from every snapshot committed before #552; computeDelta
           // reports that as N/A rather than differencing against zero.
@@ -267,6 +273,7 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           totalTimeMsDelta: 'N/A',
           totalTimeMsPercentageChange: 'N/A',
           geometryMemoryMbDelta: 'N/A',
+          peakWasmHeapMbDelta: 'N/A',
           rssMbDelta: 'N/A',
           peakRssMbDelta: 'N/A',
           heapUsedMbDelta: 'N/A',
@@ -293,6 +300,7 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           totalTimeMsDelta: 'N/A',
           totalTimeMsPercentageChange: 'N/A',
           geometryMemoryMbDelta: 'N/A',
+          peakWasmHeapMbDelta: 'N/A',
           rssMbDelta: 'N/A',
           peakRssMbDelta: 'N/A',
           heapUsedMbDelta: 'N/A',
@@ -331,6 +339,10 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           totalTimeMsDelta: totalTimeDelta,
           totalTimeMsPercentageChange: totalTimePercentageChange,
           geometryMemoryMbDelta: computeDelta('geometryMemoryMb', entry2, entry1),
+          // A different quantity from geometryMemoryMb, not a rescaling of it:
+          // the wasm heap holds allocator overhead and boolean intermediates
+          // the payload figure excludes. Also absent before #552.
+          peakWasmHeapMbDelta: computeDelta('peakWasmHeapMb', entry2, entry1),
           rssMbDelta: computeDelta('rssMb', entry2, entry1),
           // Absent from every snapshot committed before #552; computeDelta
           // reports that as N/A rather than differencing against zero.
@@ -359,6 +371,7 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           totalTimeMsDelta: 'N/A',
           totalTimeMsPercentageChange: 'N/A',
           geometryMemoryMbDelta: 'N/A',
+          peakWasmHeapMbDelta: 'N/A',
           rssMbDelta: 'N/A',
           peakRssMbDelta: 'N/A',
           heapUsedMbDelta: 'N/A',
@@ -388,6 +401,7 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           totalTimeMsDelta: 'N/A',
           totalTimeMsPercentageChange: 'N/A',
           geometryMemoryMbDelta: 'N/A',
+          peakWasmHeapMbDelta: 'N/A',
           rssMbDelta: 'N/A',
           peakRssMbDelta: 'N/A',
           heapUsedMbDelta: 'N/A',

--- a/scripts/gen_delta_csv.cjs
+++ b/scripts/gen_delta_csv.cjs
@@ -71,6 +71,8 @@ function writeDataToCsv(data, csvFilename, isWebIfc = false) {
         'peakRssMbDelta',
         'heapUsedMbDelta',
         'heapTotalMbDelta',
+        'externalMbDelta',
+        'arrayBuffersMbDelta',
       ]
     : [
         'timestamp',
@@ -92,6 +94,8 @@ function writeDataToCsv(data, csvFilename, isWebIfc = false) {
         'peakRssMbDelta',
         'heapUsedMbDelta',
         'heapTotalMbDelta',
+        'externalMbDelta',
+        'arrayBuffersMbDelta',
       ];
 
   const lines = [];
@@ -244,6 +248,10 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           peakRssMbDelta: computeDelta('peakRssMb', entry2, entry1),
           heapUsedMbDelta: computeDelta('heapUsedMb', entry2, entry1),
           heapTotalMbDelta: computeDelta('heapTotalMb', entry2, entry1),
+          // Also absent before #552. arrayBuffersMb is a subset of externalMb,
+          // so the two deltas are not independent — read them together.
+          externalMbDelta: computeDelta('externalMb', entry2, entry1),
+          arrayBuffersMbDelta: computeDelta('arrayBuffersMb', entry2, entry1),
         });
       } else {
         // Present in data1, missing in data2
@@ -263,6 +271,8 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           peakRssMbDelta: 'N/A',
           heapUsedMbDelta: 'N/A',
           heapTotalMbDelta: 'N/A',
+          externalMbDelta: 'N/A',
+          arrayBuffersMbDelta: 'N/A',
         });
       }
     }
@@ -287,6 +297,8 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           peakRssMbDelta: 'N/A',
           heapUsedMbDelta: 'N/A',
           heapTotalMbDelta: 'N/A',
+          externalMbDelta: 'N/A',
+          arrayBuffersMbDelta: 'N/A',
         });
       }
     }
@@ -325,6 +337,10 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           peakRssMbDelta: computeDelta('peakRssMb', entry2, entry1),
           heapUsedMbDelta: computeDelta('heapUsedMb', entry2, entry1),
           heapTotalMbDelta: computeDelta('heapTotalMb', entry2, entry1),
+          // Also absent before #552. arrayBuffersMb is a subset of externalMb,
+          // so the two deltas are not independent — read them together.
+          externalMbDelta: computeDelta('externalMb', entry2, entry1),
+          arrayBuffersMbDelta: computeDelta('arrayBuffersMb', entry2, entry1),
         });
       } else {
         deltas.push({
@@ -347,6 +363,8 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           peakRssMbDelta: 'N/A',
           heapUsedMbDelta: 'N/A',
           heapTotalMbDelta: 'N/A',
+          externalMbDelta: 'N/A',
+          arrayBuffersMbDelta: 'N/A',
         });
       }
     }
@@ -374,6 +392,8 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           peakRssMbDelta: 'N/A',
           heapUsedMbDelta: 'N/A',
           heapTotalMbDelta: 'N/A',
+          externalMbDelta: 'N/A',
+          arrayBuffersMbDelta: 'N/A',
         });
       }
     }

--- a/src/AP214E3_2010/ap214_command_line_main.ts
+++ b/src/AP214E3_2010/ap214_command_line_main.ts
@@ -555,15 +555,16 @@ function geometryExtraction(
   const ONE_KB = 1024
   const ONE_MB = ONE_KB * ONE_KB
 
+  // Recorded on the statistics rather than logged on its own line, so the one
+  // spelling of this number reaches the benchmark's `peakWasmHeapMb` column
+  // through the same load-status line as every other measurement (#552).
   // Measured through wasmHeapByteLength rather than HEAPU8.length: the
   // module's cached view can be a growth step behind the real heap (#485), and
   // a high-water figure that under-reports is worse than none.
   const wasmModule = conwaywasm.wasmModule
 
   if (wasmModule !== void 0) {
-    Logger.info(
-        `WASM heap high-water: ${
-          (wasmHeapByteLength(wasmModule) / ONE_MB).toFixed(1)} MB`)
+    statistics?.setWasmHeapPeak(wasmHeapByteLength(wasmModule) / ONE_MB)
   }
 
   statistics?.setGeometryMemory(conwayModel.model.geometry.calculateGeometrySize() / (ONE_MB))

--- a/src/AP214E3_2010/ap214_regression_main.ts
+++ b/src/AP214E3_2010/ap214_regression_main.ts
@@ -61,12 +61,14 @@ const UNMEASURED = 'N/A'
  * column layout of the IFC regression child so the batch aggregator can
  * merge STEP and IFC rows into one perf CSV. No-op when perfPath is empty.
  *
- * `peakRssMb` is the process high-water mark; `rssMb`, `heapUsedMb` and
- * `heapTotalMb` are single instants sampled at write time, and
- * `geometryMemoryMb` is conway's own vertex+index payload rather than a
- * process metric. See the fuller column-by-column note on the IFC child's
- * copy of this function (`src/ifc/ifc_regression_main.ts`), which is the
- * writer these columns have to stay identical to.
+ * `peakRssMb` is the process high-water mark; `rssMb`, `heapUsedMb`,
+ * `heapTotalMb`, `externalMb` and `arrayBuffersMb` are single instants
+ * sampled at write time, and `geometryMemoryMb` is conway's own vertex+index
+ * payload rather than a process metric. `arrayBuffersMb` is a subset of
+ * `externalMb`, and neither sees the wasm heap. See the fuller
+ * column-by-column note on the IFC child's copy of this function
+ * (`src/ifc/ifc_regression_main.ts`), which is the writer these columns have
+ * to stay identical to.
  *
  * @param perfPath Path to write the CSV to. Empty string disables.
  * @param stepFile Source STEP file path (basename used as the row key).
@@ -95,6 +97,9 @@ async function writePerfCsvIfRequested(
   const rssMb = ( mem.rss / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   const heapUsedMb = ( mem.heapUsed / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   const heapTotalMb = ( mem.heapTotal / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
+  const externalMb = ( mem.external / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
+  const arrayBuffersMb =
+    ( mem.arrayBuffers / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   // maxRSS is reported in kilobytes, unlike memoryUsage() which is in bytes.
   const peakRssMb =
     ( process.resourceUsage().maxRSS / KB_PER_MB ).toFixed( PERF_MB_PRECISION )
@@ -106,10 +111,11 @@ async function writePerfCsvIfRequested(
 
   const header =
     'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,' +
-    'rssMb,peakRssMb,heapUsedMb,heapTotalMb\n'
+    'rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,arrayBuffersMb\n'
   const row =
     `${fileName},${status},${parseTimeMs},${geometryTimeMs},${totalTimeMs},` +
-    `${geometryMemoryMb},${rssMb},${peakRssMb},${heapUsedMb},${heapTotalMb}\n`
+    `${geometryMemoryMb},${rssMb},${peakRssMb},${heapUsedMb},${heapTotalMb},` +
+    `${externalMb},${arrayBuffersMb}\n`
 
   try {
     await fsPromises.writeFile( perfPath, header + row )

--- a/src/AP214E3_2010/ap214_regression_main.ts
+++ b/src/AP214E3_2010/ap214_regression_main.ts
@@ -45,14 +45,28 @@ function csvSafeString( from: string ): string {
 // eslint-disable-next-line no-magic-numbers
 const BYTES_PER_MB = 1024 * 1024
 
+// Kilobytes per megabyte, for resourceUsage().maxRSS which reports kB.
+// eslint-disable-next-line no-magic-numbers
+const KB_PER_MB = 1024
+
 // Fixed-point precision for perf MB values.
 // eslint-disable-next-line no-magic-numbers
 const PERF_MB_PRECISION = 2
+
+/** Placeholder for a column this row has no measurement for. */
+const UNMEASURED = 'N/A'
 
 /**
  * Write a single-row per-file perf CSV at the given path, matching the
  * column layout of the IFC regression child so the batch aggregator can
  * merge STEP and IFC rows into one perf CSV. No-op when perfPath is empty.
+ *
+ * `peakRssMb` is the process high-water mark; `rssMb`, `heapUsedMb` and
+ * `heapTotalMb` are single instants sampled at write time, and
+ * `geometryMemoryMb` is conway's own vertex+index payload rather than a
+ * process metric. See the fuller column-by-column note on the IFC child's
+ * copy of this function (`src/ifc/ifc_regression_main.ts`), which is the
+ * writer these columns have to stay identical to.
  *
  * @param perfPath Path to write the CSV to. Empty string disables.
  * @param stepFile Source STEP file path (basename used as the row key).
@@ -60,6 +74,8 @@ const PERF_MB_PRECISION = 2
  * @param parseTimeMs Parse stage duration in ms.
  * @param geometryTimeMs Geometry extraction duration in ms.
  * @param totalTimeMs Sum of parse + geometry in ms.
+ * @param geometryMemoryBytes Geometry payload conway allocated, in bytes, or
+ * undefined where no geometry was extracted (written as N/A).
  */
 async function writePerfCsvIfRequested(
     perfPath: string,
@@ -68,6 +84,7 @@ async function writePerfCsvIfRequested(
     parseTimeMs: number,
     geometryTimeMs: number,
     totalTimeMs: number,
+    geometryMemoryBytes?: number,
 ): Promise<void> {
 
   if ( perfPath.length === 0 ) {
@@ -78,14 +95,21 @@ async function writePerfCsvIfRequested(
   const rssMb = ( mem.rss / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   const heapUsedMb = ( mem.heapUsed / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   const heapTotalMb = ( mem.heapTotal / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
+  // maxRSS is reported in kilobytes, unlike memoryUsage() which is in bytes.
+  const peakRssMb =
+    ( process.resourceUsage().maxRSS / KB_PER_MB ).toFixed( PERF_MB_PRECISION )
+  const geometryMemoryMb = geometryMemoryBytes !== void 0 ?
+    ( geometryMemoryBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
+    UNMEASURED
 
   const fileName = csvSafeString( path.basename( stepFile ) )
 
   const header =
-    'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,rssMb,heapUsedMb,heapTotalMb\n'
+    'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,' +
+    'rssMb,peakRssMb,heapUsedMb,heapTotalMb\n'
   const row =
     `${fileName},${status},${parseTimeMs},${geometryTimeMs},${totalTimeMs},` +
-    `${rssMb},${heapUsedMb},${heapTotalMb}\n`
+    `${geometryMemoryMb},${rssMb},${peakRssMb},${heapUsedMb},${heapTotalMb}\n`
 
   try {
     await fsPromises.writeFile( perfPath, header + row )
@@ -288,8 +312,14 @@ function doWork() {
         const totalTimeMs = geomEndMs - parseStartMs
 
         const perfStatus = extraction === void 0 ? 'FAIL' : 'OK'
+        // Sized before anything downstream can release meshes, and only on
+        // the OK path: a failed extraction leaves a partial cache whose size
+        // is not this model's geometry footprint.
+        const geometryMemoryBytes = extraction !== void 0 ?
+          model.geometry.calculateGeometrySize() : void 0
         await writePerfCsvIfRequested(
-            perfPath, stepFile, perfStatus, parseTimeMs, geometryTimeMs, totalTimeMs)
+            perfPath, stepFile, perfStatus, parseTimeMs, geometryTimeMs, totalTimeMs,
+            geometryMemoryBytes)
 
         // AFTP sizing pass: no-op unless the wasm module was built with
         // CONWAY_ALLOC_TELEMETRY (see conway-geom structures/alloc_telemetry.h).

--- a/src/AP214E3_2010/ap214_regression_main.ts
+++ b/src/AP214E3_2010/ap214_regression_main.ts
@@ -10,6 +10,7 @@ import fsPromises from 'fs/promises'
 import path from 'path'
 import crypto from 'crypto'
 import { ConwayGeometry } from '../../dependencies/conway-geom'
+import { wasmHeapByteLength } from '../core/wasm_heap'
 import Logger from '../logging/logger'
 import Environment from '../utilities/environment'
 import { ExtractResult } from '../core/shared_constants'
@@ -78,6 +79,8 @@ const UNMEASURED = 'N/A'
  * @param totalTimeMs Sum of parse + geometry in ms.
  * @param geometryMemoryBytes Geometry payload conway allocated, in bytes, or
  * undefined where no geometry was extracted (written as N/A).
+ * @param wasmHeapBytes Wasm linear-memory high-water in bytes, or undefined
+ * where the module was never brought up (written as N/A).
  */
 async function writePerfCsvIfRequested(
     perfPath: string,
@@ -87,6 +90,7 @@ async function writePerfCsvIfRequested(
     geometryTimeMs: number,
     totalTimeMs: number,
     geometryMemoryBytes?: number,
+    wasmHeapBytes?: number,
 ): Promise<void> {
 
   if ( perfPath.length === 0 ) {
@@ -106,16 +110,20 @@ async function writePerfCsvIfRequested(
   const geometryMemoryMb = geometryMemoryBytes !== void 0 ?
     ( geometryMemoryBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
     UNMEASURED
+  const peakWasmHeapMb = wasmHeapBytes !== void 0 ?
+    ( wasmHeapBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
+    UNMEASURED
 
   const fileName = csvSafeString( path.basename( stepFile ) )
 
   const header =
     'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,' +
-    'rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,arrayBuffersMb\n'
+    'peakWasmHeapMb,rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,' +
+    'arrayBuffersMb\n'
   const row =
     `${fileName},${status},${parseTimeMs},${geometryTimeMs},${totalTimeMs},` +
-    `${geometryMemoryMb},${rssMb},${peakRssMb},${heapUsedMb},${heapTotalMb},` +
-    `${externalMb},${arrayBuffersMb}\n`
+    `${geometryMemoryMb},${peakWasmHeapMb},${rssMb},${peakRssMb},` +
+    `${heapUsedMb},${heapTotalMb},${externalMb},${arrayBuffersMb}\n`
 
   try {
     await fsPromises.writeFile( perfPath, header + row )
@@ -323,9 +331,15 @@ function doWork() {
         // is not this model's geometry footprint.
         const geometryMemoryBytes = extraction !== void 0 ?
           model.geometry.calculateGeometrySize() : void 0
+        // The heap is grow-only, so this is the run's high-water mark even
+        // though it is read once, after the fact. conwayGeom is the engine
+        // every extraction in this process runs against.
+        const wasmModule = conwayGeom.wasmModule
+        const wasmHeapBytes = wasmModule !== void 0 ?
+          wasmHeapByteLength( wasmModule ) : void 0
         await writePerfCsvIfRequested(
             perfPath, stepFile, perfStatus, parseTimeMs, geometryTimeMs, totalTimeMs,
-            geometryMemoryBytes)
+            geometryMemoryBytes, wasmHeapBytes)
 
         // AFTP sizing pass: no-op unless the wasm module was built with
         // CONWAY_ALLOC_TELEMETRY (see conway-geom structures/alloc_telemetry.h).

--- a/src/core/wasm_heap.ts
+++ b/src/core/wasm_heap.ts
@@ -352,10 +352,11 @@ export function wasmHeapView< TArray >(
  * trade. Do not put it in a loop.
  *
  * That the refresh cannot throw (see refreshHeapViews) matters more here than
- * at the other call site: this figure's only consumer is the AP214 CLI's
- * high-water log line, so an embind failure escaping would abort an otherwise
- * complete extraction from a log statement. A lagging number is the right
- * answer there.
+ * at the other call site: every consumer of this figure is reporting — the
+ * loaders' and CLIs' high-water statistic, and the regression children's
+ * `peakWasmHeapMb` perf column (#552) — so an embind failure escaping would
+ * abort an otherwise complete extraction from a measurement. A lagging number
+ * is the right answer there.
  *
  * @param wasmModule The module to measure.
  * @return {number} The heap's size in bytes, or 0 if it has no heap yet.

--- a/src/ifc/ifc_command_line_main.ts
+++ b/src/ifc/ifc_command_line_main.ts
@@ -13,6 +13,7 @@ import { ConwayGeometry }
   from '../../dependencies/conway-geom'
 import { IfcSceneBuilder } from './ifc_scene_builder'
 import GeometryConvertor from '../core/geometry_convertor'
+import { wasmHeapByteLength } from '../core/wasm_heap'
 import GeometryAggregator from '../core/geometry_aggregator'
 import Logger, { LogLevel } from '../logging/logger'
 import { CountProgressCallback, ProgressTracker } from '../core/progress'
@@ -743,6 +744,19 @@ function geometryExtraction(
   const ONE_MB = ONE_KB * ONE_KB
    
   statistics?.setGeometryMemory(conwayModel.model.geometry.calculateGeometrySize() / (ONE_MB))
+
+  // The wasm heap, which nothing else here can see: geometryMemory above is
+  // the vertex+index payload only, and the JS-side heap/external figures do
+  // not include emscripten's linear memory at all. Grow-only, so one reading
+  // is the high-water mark. Measured through wasmHeapByteLength rather than
+  // HEAPU8.length: the module's cached view can be a growth step behind the
+  // real heap (#485), and a high-water figure that under-reports is worse
+  // than none.
+  const wasmModule = conwaywasm.wasmModule
+
+  if (wasmModule !== void 0) {
+    statistics?.setWasmHeapPeak(wasmHeapByteLength(wasmModule) / ONE_MB)
+  }
 
   const ifcProjectName = conwayModel.getIfcProjectName()
 

--- a/src/ifc/ifc_regression_main.ts
+++ b/src/ifc/ifc_regression_main.ts
@@ -51,20 +51,55 @@ function csvSafeString( from: string ): string {
 // eslint-disable-next-line no-magic-numbers
 const BYTES_PER_MB = 1024 * 1024
 
+// Kilobytes per megabyte, for resourceUsage().maxRSS which reports kB.
+// eslint-disable-next-line no-magic-numbers
+const KB_PER_MB = 1024
+
 // Fixed-point precision for perf MB values.
 // eslint-disable-next-line no-magic-numbers
 const PERF_MB_PRECISION = 2
+
+/** Placeholder for a column this row has no measurement for. */
+const UNMEASURED = 'N/A'
 
 /**
  * Write a single-row per-file perf CSV at the given path. Memory snapshot is
  * taken at call time; for the OK path this is right after geometry extraction
  * — close to peak. No-op when perfPath is empty.
  *
- * Memory semantics: `rssMb` includes the conway-geom WASM heap (mmap'd into
- * the process) and is the load-bearing memory metric for geometry work.
+ * WHICH COLUMNS ARE PEAK AND WHICH ARE INSTANTS — they are not comparable and
+ * the difference is large (conway#552):
+ *
+ *   peakRssMb        PEAK. The kernel's high-water mark for this process
+ *                    (`resourceUsage().maxRSS`, kB), i.e. the number that
+ *                    decides whether a browser tab or a runner survives the
+ *                    load. Free to read and perturbs nothing.
+ *   rssMb            INSTANT. One `memoryUsage()` sample at write time. A run
+ *                    that transiently hit 5 GB and settled to 1 GB reports
+ *                    1 GB here and 5 GB in peakRssMb.
+ *   heapUsedMb       INSTANT, and *not* live set: it is live data plus
+ *                    whatever garbage GC has not collected yet, so it moves
+ *                    with GC timing. Measuring SKYLARK250 this way gives
+ *                    2547 MB where the same run's live heap after two forced
+ *                    full GCs is 981 MB. A live-heap column would need forced
+ *                    GC, which wrecks the timing columns, so it is not here.
+ *   heapTotalMb      INSTANT. V8's reserved heap.
+ *   geometryMemoryMb Not a process metric at all: the vertex+index payload
+ *                    conway itself allocated for this model, summed by
+ *                    `calculateGeometrySize()`. Unlike rss/heap it excludes
+ *                    everything the harness happens to be holding.
+ *
+ * `rssMb` and `peakRssMb` include the conway-geom WASM heap (mmap'd into the
+ * process) and are the load-bearing memory metrics for geometry work.
  * `heapUsedMb` / `heapTotalMb` are V8-only — useful for tracking JS-side
  * allocation pressure but they exclude WASM-side buffers. Expect a large
  * gap between rss and heap on geometry-heavy models.
+ *
+ * The column list here is shared with the AP214 regression child
+ * (`ap214_regression_main.ts`): `aggregatePerfCsvs` in
+ * `ifc_regression_batch_main.ts` keeps the header of whichever per-file CSV it
+ * reads first and concatenates the rest as rows, so a mixed IFC/STEP corpus
+ * mislabels every column if the two writers drift apart.
  *
  * @param perfPath Path to write the CSV to. Empty string disables.
  * @param ifcFile Source IFC file path (basename used as the row key).
@@ -72,6 +107,8 @@ const PERF_MB_PRECISION = 2
  * @param parseTimeMs Parse stage duration in ms.
  * @param geometryTimeMs Geometry extraction duration in ms.
  * @param totalTimeMs Sum of parse + geometry in ms.
+ * @param geometryMemoryBytes Geometry payload conway allocated, in bytes, or
+ * undefined where no geometry was extracted (written as N/A).
  */
 async function writePerfCsvIfRequested(
     perfPath: string,
@@ -80,6 +117,7 @@ async function writePerfCsvIfRequested(
     parseTimeMs: number,
     geometryTimeMs: number,
     totalTimeMs: number,
+    geometryMemoryBytes?: number,
 ): Promise<void> {
 
   if ( perfPath.length === 0 ) {
@@ -90,14 +128,21 @@ async function writePerfCsvIfRequested(
   const rssMb = ( mem.rss / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   const heapUsedMb = ( mem.heapUsed / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   const heapTotalMb = ( mem.heapTotal / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
+  // maxRSS is reported in kilobytes, unlike memoryUsage() which is in bytes.
+  const peakRssMb =
+    ( process.resourceUsage().maxRSS / KB_PER_MB ).toFixed( PERF_MB_PRECISION )
+  const geometryMemoryMb = geometryMemoryBytes !== void 0 ?
+    ( geometryMemoryBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
+    UNMEASURED
 
   const fileName = csvSafeString( path.basename( ifcFile ) )
 
   const header =
-    'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,rssMb,heapUsedMb,heapTotalMb\n'
+    'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,' +
+    'rssMb,peakRssMb,heapUsedMb,heapTotalMb\n'
   const row =
     `${fileName},${status},${parseTimeMs},${geometryTimeMs},${totalTimeMs},` +
-    `${rssMb},${heapUsedMb},${heapTotalMb}\n`
+    `${geometryMemoryMb},${rssMb},${peakRssMb},${heapUsedMb},${heapTotalMb}\n`
 
   try {
     await fsPromises.writeFile( perfPath, header + row )
@@ -307,8 +352,14 @@ function doWork() {
           const totalTimeMs = geomEndMs - parseStartMs
 
           const perfStatus = result === void 0 ? 'FAIL' : 'OK'
+          // Sized before anything downstream can release meshes, and only on
+          // the OK path: a failed extraction leaves a partial cache whose size
+          // is not this model's geometry footprint.
+          const geometryMemoryBytes = result !== void 0 ?
+            model.geometry.calculateGeometrySize() : void 0
           await writePerfCsvIfRequested(
-              perfPath, ifcFile, perfStatus, parseTimeMs, geometryTimeMs, totalTimeMs)
+              perfPath, ifcFile, perfStatus, parseTimeMs, geometryTimeMs, totalTimeMs,
+              geometryMemoryBytes)
 
           // AFTP sizing pass: no-op unless the wasm module was built with
           // CONWAY_ALLOC_TELEMETRY (see conway-geom structures/alloc_telemetry.h).

--- a/src/ifc/ifc_regression_main.ts
+++ b/src/ifc/ifc_regression_main.ts
@@ -84,10 +84,25 @@ const UNMEASURED = 'N/A'
  *                    full GCs is 981 MB. A live-heap column would need forced
  *                    GC, which wrecks the timing columns, so it is not here.
  *   heapTotalMb      INSTANT. V8's reserved heap.
+ *   externalMb       INSTANT. Off-heap bytes V8 knows about, which heapUsed
+ *                    does not include and which are a real part of the
+ *                    footprint: on MB-Khaya (31 MB IFC) `readFileSync` alone
+ *                    moves this 1.7 -> 33.1 MB while heapUsed does not move.
+ *   arrayBuffersMb   INSTANT, and a SUBSET of externalMb — the ArrayBuffer
+ *                    share of it, which is where the source buffer and the
+ *                    parse structures land (31.5 of that 33.1 MB).
  *   geometryMemoryMb Not a process metric at all: the vertex+index payload
  *                    conway itself allocated for this model, summed by
  *                    `calculateGeometrySize()`. Unlike rss/heap it excludes
  *                    everything the harness happens to be holding.
+ *
+ * There is deliberately no `heapUsed + external` total. It looks like a
+ * portable stand-in for RSS and is not one: on that same model it reads
+ * 284 MB against an RSS of 510 MB after geometry, and wasm init alone adds
+ * ~65 MB of RSS while moving `external` by under 2 MB. Emscripten's heap is
+ * structurally invisible to JS-side accounting, so such a total would be
+ * blind to exactly the memory this bench exists to track. peakRssMb is the
+ * headline.
  *
  * `rssMb` and `peakRssMb` include the conway-geom WASM heap (mmap'd into the
  * process) and are the load-bearing memory metrics for geometry work.
@@ -128,6 +143,9 @@ async function writePerfCsvIfRequested(
   const rssMb = ( mem.rss / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   const heapUsedMb = ( mem.heapUsed / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   const heapTotalMb = ( mem.heapTotal / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
+  const externalMb = ( mem.external / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
+  const arrayBuffersMb =
+    ( mem.arrayBuffers / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   // maxRSS is reported in kilobytes, unlike memoryUsage() which is in bytes.
   const peakRssMb =
     ( process.resourceUsage().maxRSS / KB_PER_MB ).toFixed( PERF_MB_PRECISION )
@@ -139,10 +157,11 @@ async function writePerfCsvIfRequested(
 
   const header =
     'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,' +
-    'rssMb,peakRssMb,heapUsedMb,heapTotalMb\n'
+    'rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,arrayBuffersMb\n'
   const row =
     `${fileName},${status},${parseTimeMs},${geometryTimeMs},${totalTimeMs},` +
-    `${geometryMemoryMb},${rssMb},${peakRssMb},${heapUsedMb},${heapTotalMb}\n`
+    `${geometryMemoryMb},${rssMb},${peakRssMb},${heapUsedMb},${heapTotalMb},` +
+    `${externalMb},${arrayBuffersMb}\n`
 
   try {
     await fsPromises.writeFile( perfPath, header + row )

--- a/src/ifc/ifc_regression_main.ts
+++ b/src/ifc/ifc_regression_main.ts
@@ -17,6 +17,7 @@ import fsPromises from 'fs/promises'
 import EntityTypesIfc from './ifc4_gen/entity_types_ifc.gen'
 import { IfcBooleanResult } from './ifc4_gen'
 import { MemoizationCapture, RegressionCaptureState } from '../core/regression_capture_state'
+import { wasmHeapByteLength } from '../core/wasm_heap'
 import { materialHashes } from './ifc_material_cache_node'
 import { dumpGeometryOBJs, geometryHashes } from './ifc_model_geometry_node'
 import { curveHashes, dumpCurveOBJs } from './ifc_model_curves_node'
@@ -91,10 +92,23 @@ const UNMEASURED = 'N/A'
  *   arrayBuffersMb   INSTANT, and a SUBSET of externalMb — the ArrayBuffer
  *                    share of it, which is where the source buffer and the
  *                    parse structures land (31.5 of that 33.1 MB).
- *   geometryMemoryMb Not a process metric at all: the vertex+index payload
+ *   geometryMemoryMb Not a process metric at all: the vertex+index PAYLOAD
  *                    conway itself allocated for this model, summed by
- *                    `calculateGeometrySize()`. Unlike rss/heap it excludes
- *                    everything the harness happens to be holding.
+ *                    `calculateGeometrySize()` — what a consumer would copy
+ *                    out. Unlike rss/heap it excludes everything the harness
+ *                    happens to be holding, and unlike peakWasmHeapMb it
+ *                    excludes everything the allocator is holding.
+ *   peakWasmHeapMb   PEAK, and the only column that sees conway's native
+ *                    memory. Emscripten's linear memory grows and never
+ *                    shrinks, so one reading of `wasmHeapByteLength` IS the
+ *                    high-water mark — nothing to sample, nothing perturbed.
+ *                    Read through that helper rather than `HEAPU8.length`,
+ *                    whose cached view can be a growth step behind the real
+ *                    heap (#485); a high-water figure that under-reports is
+ *                    worse than none. This is NOT geometryMemoryMb: it
+ *                    includes allocator overhead, fragmentation and the
+ *                    intermediate buffers a boolean leaves behind, which on
+ *                    MB-Khaya is an 85 MB heap over an 8 MB live payload.
  *
  * There is deliberately no `heapUsed + external` total. It looks like a
  * portable stand-in for RSS and is not one: on that same model it reads
@@ -124,6 +138,8 @@ const UNMEASURED = 'N/A'
  * @param totalTimeMs Sum of parse + geometry in ms.
  * @param geometryMemoryBytes Geometry payload conway allocated, in bytes, or
  * undefined where no geometry was extracted (written as N/A).
+ * @param wasmHeapBytes Wasm linear-memory high-water in bytes, or undefined
+ * where the module was never brought up (written as N/A).
  */
 async function writePerfCsvIfRequested(
     perfPath: string,
@@ -133,6 +149,7 @@ async function writePerfCsvIfRequested(
     geometryTimeMs: number,
     totalTimeMs: number,
     geometryMemoryBytes?: number,
+    wasmHeapBytes?: number,
 ): Promise<void> {
 
   if ( perfPath.length === 0 ) {
@@ -152,16 +169,20 @@ async function writePerfCsvIfRequested(
   const geometryMemoryMb = geometryMemoryBytes !== void 0 ?
     ( geometryMemoryBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
     UNMEASURED
+  const peakWasmHeapMb = wasmHeapBytes !== void 0 ?
+    ( wasmHeapBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
+    UNMEASURED
 
   const fileName = csvSafeString( path.basename( ifcFile ) )
 
   const header =
     'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,' +
-    'rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,arrayBuffersMb\n'
+    'peakWasmHeapMb,rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,' +
+    'arrayBuffersMb\n'
   const row =
     `${fileName},${status},${parseTimeMs},${geometryTimeMs},${totalTimeMs},` +
-    `${geometryMemoryMb},${rssMb},${peakRssMb},${heapUsedMb},${heapTotalMb},` +
-    `${externalMb},${arrayBuffersMb}\n`
+    `${geometryMemoryMb},${peakWasmHeapMb},${rssMb},${peakRssMb},` +
+    `${heapUsedMb},${heapTotalMb},${externalMb},${arrayBuffersMb}\n`
 
   try {
     await fsPromises.writeFile( perfPath, header + row )
@@ -376,9 +397,16 @@ function doWork() {
           // is not this model's geometry footprint.
           const geometryMemoryBytes = result !== void 0 ?
             model.geometry.calculateGeometrySize() : void 0
+          // The heap is grow-only, so this is the run's high-water mark even
+          // though it is read once, after the fact. geometryExtraction hands
+          // back the engine it brought up; there is no heap to measure when
+          // it failed before that.
+          const wasmModule = result?.[ 1 ].wasmModule
+          const wasmHeapBytes = wasmModule !== void 0 ?
+            wasmHeapByteLength( wasmModule ) : void 0
           await writePerfCsvIfRequested(
               perfPath, ifcFile, perfStatus, parseTimeMs, geometryTimeMs, totalTimeMs,
-              geometryMemoryBytes)
+              geometryMemoryBytes, wasmHeapBytes)
 
           // AFTP sizing pass: no-op unless the wasm module was built with
           // CONWAY_ALLOC_TELEMETRY (see conway-geom structures/alloc_telemetry.h).

--- a/src/loaders/conway_model_loader.ts
+++ b/src/loaders/conway_model_loader.ts
@@ -15,9 +15,38 @@ import Memory from '../memory/memory'
 import ParsingBuffer from '../parsing/parsing_buffer'
 import { ParseResult } from '../step/parsing/step_parser'
 import { extractModelInfo, parseFileHeader } from './loading_utilities'
+import { wasmHeapByteLength } from '../core/wasm_heap'
+import { Statistics } from '../statistics/statistics'
 
 const ONE_KB = 1024
 const ONE_MB = ONE_KB * ONE_KB
+
+/**
+ * Record the wasm heap's high-water mark on the run's statistics.
+ *
+ * The wasm heap only grows, so one reading of it is already the peak — there
+ * is nothing to sample and nothing to perturb. This is the only column that
+ * sees conway's native memory at all: `heapUsed`/`external` cannot (wasm init
+ * alone moves RSS by ~65 MB while moving `external` by under 2 MB), and
+ * `geometryMemory` is the vertex+index payload only, which on MB-Khaya is
+ * 8 MB live under an 85 MB wasm heap.
+ *
+ * Measured through wasmHeapByteLength rather than HEAPU8.length: the module's
+ * cached view can be a growth step behind the real heap (#485), and a
+ * high-water figure that under-reports is worse than none.
+ *
+ * @param statistics The run's statistics.
+ * @param conwayWasm The geometry engine whose heap to measure.
+ */
+function recordWasmHeapPeak(
+    statistics: Statistics, conwayWasm: ConwayGeometry ): void {
+
+  const wasmModule = conwayWasm.wasmModule
+
+  if ( wasmModule !== void 0 ) {
+    statistics.setWasmHeapPeak( wasmHeapByteLength( wasmModule ) / ONE_MB )
+  }
+}
 
 /**
  * Options threading the progress/yield contract (issue #301) through a load.
@@ -235,6 +264,8 @@ export class ConwayModelLoader {
                
               conwayModel.model.geometry.calculateGeometrySize() / (ONE_MB))
 
+          recordWasmHeapPeak(statistics, conwayWasm)
+
           statistics.setGeometryTypeCounts(conwayModel.geometryTypeCounts)
 
           model.invalidate(true)
@@ -444,6 +475,8 @@ export class ConwayModelLoader {
           statistics.setGeometryMemory(
                
               conwayModel.model.geometry.calculateGeometrySize() / (ONE_MB))
+
+          recordWasmHeapPeak(statistics, conwayWasm)
 
           const ifcProjectName = conwayModel.getIfcProjectName()
 

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -87,10 +87,18 @@ export default class Memory {
     const rss = (memoryUsage.rss / 1024 / 1024).toFixed(3)
     const heapTotal = (memoryUsage.heapTotal / 1024 / 1024).toFixed(3)
     const heapUsed = (memoryUsage.heapUsed / 1024 / 1024).toFixed(3)
+    // The kernel's high-water mark for this process, which the three
+    // instants above cannot show: a load that transiently hit 5 GB and
+    // settled to 1 GB reports 1 GB in `RSS` and 5 GB here (conway#552).
+    // maxRSS is in kilobytes, unlike memoryUsage() which is in bytes.
+    const peakRss = (process.resourceUsage().maxRSS / 1024).toFixed(3)
     /* eslint-enable no-magic-numbers */
 
+    // `Peak RSS:` keeps its colon so that scripts/benchmark.cjs's existing
+    // `/RSS ([\d.]+) MB/` scrape cannot bind to it instead of the instant.
     return `Node Memory Usage: RSS ${rss} MB, ` +
            `Heap Total: ${heapTotal} MB, ` +
-           `Heap Used: ${heapUsed} MB`
+           `Heap Used: ${heapUsed} MB, ` +
+           `Peak RSS: ${peakRss} MB`
   }
 }

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -87,18 +87,34 @@ export default class Memory {
     const rss = (memoryUsage.rss / 1024 / 1024).toFixed(3)
     const heapTotal = (memoryUsage.heapTotal / 1024 / 1024).toFixed(3)
     const heapUsed = (memoryUsage.heapUsed / 1024 / 1024).toFixed(3)
-    // The kernel's high-water mark for this process, which the three
-    // instants above cannot show: a load that transiently hit 5 GB and
-    // settled to 1 GB reports 1 GB in `RSS` and 5 GB here (conway#552).
+    // Off-heap bytes V8 knows about, and the ArrayBuffer subset of them.
+    // Neither is visible in heapUsed, and between them they hold the source
+    // Buffer and the parse structures: on MB-Khaya (31 MB IFC) readFileSync
+    // alone moves arrayBuffers 0.1 -> 31.5 MB while heapUsed does not budge,
+    // and by the geometry stage it is 56 MB the other columns cannot see
+    // (conway#552). They do NOT see the wasm heap — heapUsed + external
+    // reads 284 MB against an RSS of 510 MB on that model — which is why
+    // peakRss stays the headline rather than a JS-side total.
+    const external = (memoryUsage.external / 1024 / 1024).toFixed(3)
+    const arrayBuffers = (memoryUsage.arrayBuffers / 1024 / 1024).toFixed(3)
+    // The kernel's high-water mark for this process, which the instants
+    // above cannot show: a load that transiently hit 5 GB and settled to
+    // 1 GB reports 1 GB in `RSS` and 5 GB here (conway#552).
     // maxRSS is in kilobytes, unlike memoryUsage() which is in bytes.
     const peakRss = (process.resourceUsage().maxRSS / 1024).toFixed(3)
     /* eslint-enable no-magic-numbers */
 
-    // `Peak RSS:` keeps its colon so that scripts/benchmark.cjs's existing
-    // `/RSS ([\d.]+) MB/` scrape cannot bind to it instead of the instant.
+    // Every field scripts/benchmark.cjs scrapes out of this line is named
+    // with a colon before its number, EXCEPT the historical `RSS <n> MB`.
+    // That one is matched non-globally as `/RSS ([\d.]+) MB/`, so it takes
+    // the first hit in the whole server log: any new field spelled without
+    // the colon would bind there and overwrite the instant with a different
+    // measurement.
     return `Node Memory Usage: RSS ${rss} MB, ` +
            `Heap Total: ${heapTotal} MB, ` +
            `Heap Used: ${heapUsed} MB, ` +
-           `Peak RSS: ${peakRss} MB`
+           `Peak RSS: ${peakRss} MB, ` +
+           `External: ${external} MB, ` +
+           `ArrayBuffers: ${arrayBuffers} MB`
   }
 }

--- a/src/memory/memory_stats.test.ts
+++ b/src/memory/memory_stats.test.ts
@@ -6,15 +6,35 @@ import Environment, { EnvironmentType } from '../utilities/environment'
 /**
  * The node memory line `Memory.checkMemoryUsage()` returns is not just a log
  * string: scripts/benchmark.cjs regex-scrapes it into the `rssMb` /
- * `peakRssMb` / `heapUsedMb` / `heapTotalMb` columns of every
- * `performance-detail.csv` snapshot committed to the model repos. The format
- * is therefore a contract with a consumer in another repo's file, which is why
- * it is pinned here rather than left to the writer.
+ * `peakRssMb` / `heapUsedMb` / `heapTotalMb` / `externalMb` /
+ * `arrayBuffersMb` columns of every `performance-detail.csv` snapshot
+ * committed to the model repos. The format is therefore a contract with a
+ * consumer in another repo's file, which is why it is pinned here rather than
+ * left to the writer.
  *
  * The scrapes below are copied verbatim from scripts/benchmark.cjs.
  */
 const INSTANT_RSS_SCRAPE = /RSS ([\d.]+) MB/
 const PEAK_RSS_SCRAPE = /Peak RSS: ([\d.]+) MB/
+const HEAP_USED_SCRAPE = /Heap Used: ([\d.]+) MB/
+const EXTERNAL_SCRAPE = /External: ([\d.]+) MB/
+const ARRAY_BUFFERS_SCRAPE = /ArrayBuffers: ([\d.]+) MB/
+
+/* eslint-disable no-magic-numbers */
+const BYTES_PER_MB = 1024 * 1024
+
+/** Big enough to bypass Node's Buffer pool and get its own ArrayBuffer. */
+const BIG_BUFFER_BYTES = 32 * BYTES_PER_MB
+
+/**
+ * Slack on the growth assertions. The allocation is held across both samples,
+ * so arrayBuffers must show nearly all of it; heapUsed must show almost none,
+ * and is bounded well below rather than at zero because the two samples are
+ * separated by real work that allocates a little on the JS heap.
+ */
+const MOSTLY = 0.9
+const BARELY = 0.5
+/* eslint-enable no-magic-numbers */
 
 let line: string
 
@@ -54,6 +74,51 @@ describe('Memory.checkMemoryUsage in node', () => {
     // memoryUsage() in bytes, so a unit slip here shows up as a factor of
     // ~1000 rather than as a plausible-looking number.
     expect(Number(peak![1])).toBeGreaterThanOrEqual(Number(instant![1]))
+  })
+
+  test('reports external and its arrayBuffers subset', () => {
+    // conway#552's amendment: both come free from the memoryUsage() call the
+    // line already makes, and they are where a real part of the footprint
+    // lives. Node documents arrayBuffers as included in external, so the
+    // subset relation is a contract, not an observation — a writer that
+    // swapped the two would still produce plausible-looking numbers.
+    const external = EXTERNAL_SCRAPE.exec(line)
+    const arrayBuffers = ARRAY_BUFFERS_SCRAPE.exec(line)
+
+    expect(external).not.toBeNull()
+    expect(arrayBuffers).not.toBeNull()
+    expect(Number(arrayBuffers![1])).toBeLessThanOrEqual(Number(external![1]))
+  })
+
+  test('a large Buffer moves arrayBuffers, and not heapUsed', () => {
+    // The reason these columns are worth a CSV column each. On MB-Khaya the
+    // 31 MB readFileSync moves arrayBuffers 0.1 -> 31.5 MB while heapUsed
+    // does not move at all, so a bench recording only heapUsed cannot see the
+    // source buffer or the parse structures. Reproduced here in miniature.
+    const before = Memory.checkMemoryUsage()
+    const held = Buffer.allocUnsafeSlow(BIG_BUFFER_BYTES)
+    const after = Memory.checkMemoryUsage()
+
+    /**
+     * Read one MB figure out of a memory line.
+     *
+     * @param scrape The field's regex.
+     * @param from The line to read.
+     * @return The value in MB.
+     */
+    const mb = (scrape: RegExp, from: string) => Number(scrape.exec(from)![1])
+
+    const arrayBuffersGrowth =
+      mb(ARRAY_BUFFERS_SCRAPE, after) - mb(ARRAY_BUFFERS_SCRAPE, before)
+    const heapUsedGrowth =
+      mb(HEAP_USED_SCRAPE, after) - mb(HEAP_USED_SCRAPE, before)
+    const expectedMb = BIG_BUFFER_BYTES / BYTES_PER_MB
+
+    // Held across both samples so the allocation cannot be collected between
+    // them; the read also stops the buffer being optimised away.
+    expect(held.length).toBe(BIG_BUFFER_BYTES)
+    expect(arrayBuffersGrowth).toBeGreaterThan(expectedMb * MOSTLY)
+    expect(heapUsedGrowth).toBeLessThan(expectedMb * BARELY)
   })
 
   test('the instant scrape does not bind to the peak instead', () => {

--- a/src/memory/memory_stats.test.ts
+++ b/src/memory/memory_stats.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test, beforeAll } from '@jest/globals'
+import Memory from './memory'
+import Environment, { EnvironmentType } from '../utilities/environment'
+
+
+/**
+ * The node memory line `Memory.checkMemoryUsage()` returns is not just a log
+ * string: scripts/benchmark.cjs regex-scrapes it into the `rssMb` /
+ * `peakRssMb` / `heapUsedMb` / `heapTotalMb` columns of every
+ * `performance-detail.csv` snapshot committed to the model repos. The format
+ * is therefore a contract with a consumer in another repo's file, which is why
+ * it is pinned here rather than left to the writer.
+ *
+ * The scrapes below are copied verbatim from scripts/benchmark.cjs.
+ */
+const INSTANT_RSS_SCRAPE = /RSS ([\d.]+) MB/
+const PEAK_RSS_SCRAPE = /Peak RSS: ([\d.]+) MB/
+
+let line: string
+
+beforeAll(() => {
+  Environment.checkEnvironment()
+  line = Memory.checkMemoryUsage()
+})
+
+describe('Memory.checkMemoryUsage in node', () => {
+
+  test('runs as a node environment under jest', () => {
+    // The rest of this suite is about the node branch; if the detector puts us
+    // somewhere else the assertions below would be vacuous.
+    expect([EnvironmentType.NODE, EnvironmentType.BOTH_FEATURES])
+        .toContain(Environment.environmentType)
+  })
+
+  test('reports the process peak alongside the instantaneous sample', () => {
+    // conway#552: every memory number in every blessed snapshot was one
+    // un-GC'd `process.memoryUsage()` sample, so the high-water mark — the
+    // number that decides whether a tab or a runner survives a model — was
+    // never recorded anywhere.
+    const peak = PEAK_RSS_SCRAPE.exec(line)
+
+    expect(peak).not.toBeNull()
+    expect(Number(peak![1])).toBeGreaterThan(0)
+  })
+
+  test('the peak is at least the instant, since it is a high-water mark', () => {
+    const instant = INSTANT_RSS_SCRAPE.exec(line)
+    const peak = PEAK_RSS_SCRAPE.exec(line)
+
+    expect(instant).not.toBeNull()
+    expect(peak).not.toBeNull()
+    // Not an equality: they coincide when the sample is taken at the peak, and
+    // diverge by whatever the process has released since. maxRSS is in kB and
+    // memoryUsage() in bytes, so a unit slip here shows up as a factor of
+    // ~1000 rather than as a plausible-looking number.
+    expect(Number(peak![1])).toBeGreaterThanOrEqual(Number(instant![1]))
+  })
+
+  test('the instant scrape does not bind to the peak instead', () => {
+    // benchmark.cjs matches non-globally, so `/RSS ([\d.]+) MB/` takes the
+    // FIRST occurrence in the whole server log. `Peak RSS:` keeps its colon
+    // precisely so it cannot satisfy that pattern — otherwise adding the peak
+    // would silently overwrite the historical `rssMb` column with a different
+    // measurement, and every cross-version delta over it would compare two
+    // different quantities.
+    expect(INSTANT_RSS_SCRAPE.exec('Peak RSS: 4096.000 MB')).toBeNull()
+
+    const instant = INSTANT_RSS_SCRAPE.exec(line)
+    expect(instant).not.toBeNull()
+    expect(line.indexOf(instant![0]))
+        .toBeLessThan(line.indexOf('Peak RSS:'))
+  })
+})

--- a/src/scripts/bless_perf_snapshot.test.ts
+++ b/src/scripts/bless_perf_snapshot.test.ts
@@ -8,8 +8,8 @@ import { createRequire } from 'module'
  * The rc-regression bless path's perf snapshot (scripts/bless_perf_snapshot.cjs).
  *
  * The `rebless` job measures the full corpus with
- * `ifc_regression_batch_main --perf`, whose 10-column perf.csv is a different
- * file from the 16-column `performance-detail.csv` the committed benchmark
+ * `ifc_regression_batch_main --perf`, whose 12-column perf.csv is a different
+ * file from the 18-column `performance-detail.csv` the committed benchmark
  * snapshots use. This pins the mapping between them — the shape a delta and
  * GitHub's CSV viewer both depend on — and the choice of predecessor to diff
  * against.
@@ -51,7 +51,7 @@ afterEach(() => {
 
 describe('writeDetailCsv', () => {
 
-  test('maps perf.csv onto the 16-column convention, N/A for unmeasured', () => {
+  test('maps perf.csv onto the 18-column convention, N/A for unmeasured', () => {
     const out = path.join(workDir, 'performance-detail.csv')
 
     writeDetailCsv(
@@ -66,6 +66,8 @@ describe('writeDetailCsv', () => {
         peakRssMb: '905.75',
         heapUsedMb: '410.25',
         heapTotalMb: '450.00',
+        externalMb: '96.40',
+        arrayBuffersMb: '94.10',
       }],
       out, 'conway1.543.1513-ci', '20260821221710')
 
@@ -92,13 +94,16 @@ describe('writeDetailCsv', () => {
     expect(cell('totalTimeMs')).toBe('6600')
     expect(cell('rssMb')).toBe('812.50')
 
-    // The two columns #552 added to the conway-native writer. geometryMemoryMb
-    // is what regressed: the writer stopped emitting it, and this mapping
+    // The columns #552 added to the conway-native writer. geometryMemoryMb is
+    // what regressed: the writer stopped emitting it, and this mapping
     // hardcoded N/A over it, so it read 0/107 on the 1.549 snapshot against
     // 98/100 on 1.451. peakRssMb is the load's high-water mark, next to the
-    // end-of-load instant in rssMb.
+    // end-of-load instant in rssMb; externalMb and its arrayBuffersMb subset
+    // are the off-heap bytes heapUsedMb cannot see.
     expect(cell('geometryMemoryMb')).toBe('185.84')
     expect(cell('peakRssMb')).toBe('905.75')
+    expect(cell('externalMb')).toBe('96.40')
+    expect(cell('arrayBuffersMb')).toBe('94.10')
 
     // The committed snapshots URL-encode the filename and the delta joins on
     // it, so an unencoded name would simply fail to match the baseline row.
@@ -114,9 +119,10 @@ describe('writeDetailCsv', () => {
   })
 
   test('writes N/A for a perf.csv that predates the memory columns', () => {
-    // A perf.csv artifact written before #552 has neither geometryMemoryMb nor
-    // peakRssMb. The mapping must degrade to N/A rather than emitting
-    // 'undefined' into a column a delta then reads as a measurement.
+    // A perf.csv artifact written before #552 has none of geometryMemoryMb,
+    // peakRssMb, externalMb or arrayBuffersMb. The mapping must degrade to
+    // N/A rather than emitting 'undefined' into a column a delta then reads
+    // as a measurement.
     const out = path.join(workDir, 'legacy.csv')
 
     writeDetailCsv(
@@ -131,6 +137,8 @@ describe('writeDetailCsv', () => {
     expect(row).toHaveLength(DETAIL_COLUMNS.length)
     expect(row[DETAIL_COLUMNS.indexOf('geometryMemoryMb')]).toBe('N/A')
     expect(row[DETAIL_COLUMNS.indexOf('peakRssMb')]).toBe('N/A')
+    expect(row[DETAIL_COLUMNS.indexOf('externalMb')]).toBe('N/A')
+    expect(row[DETAIL_COLUMNS.indexOf('arrayBuffersMb')]).toBe('N/A')
     // The columns it does carry are unaffected.
     expect(row[DETAIL_COLUMNS.indexOf('rssMb')]).toBe('812.50')
   })

--- a/src/scripts/bless_perf_snapshot.test.ts
+++ b/src/scripts/bless_perf_snapshot.test.ts
@@ -8,8 +8,8 @@ import { createRequire } from 'module'
  * The rc-regression bless path's perf snapshot (scripts/bless_perf_snapshot.cjs).
  *
  * The `rebless` job measures the full corpus with
- * `ifc_regression_batch_main --perf`, whose 12-column perf.csv is a different
- * file from the 18-column `performance-detail.csv` the committed benchmark
+ * `ifc_regression_batch_main --perf`, whose 13-column perf.csv is a different
+ * file from the 19-column `performance-detail.csv` the committed benchmark
  * snapshots use. This pins the mapping between them — the shape a delta and
  * GitHub's CSV viewer both depend on — and the choice of predecessor to diff
  * against.
@@ -51,7 +51,7 @@ afterEach(() => {
 
 describe('writeDetailCsv', () => {
 
-  test('maps perf.csv onto the 18-column convention, N/A for unmeasured', () => {
+  test('maps perf.csv onto the 19-column convention, N/A for unmeasured', () => {
     const out = path.join(workDir, 'performance-detail.csv')
 
     writeDetailCsv(
@@ -62,6 +62,7 @@ describe('writeDetailCsv', () => {
         geometryTimeMs: '5400',
         totalTimeMs: '6600',
         geometryMemoryMb: '185.84',
+        peakWasmHeapMb: '1283.00',
         rssMb: '812.50',
         peakRssMb: '905.75',
         heapUsedMb: '410.25',
@@ -99,8 +100,11 @@ describe('writeDetailCsv', () => {
     // hardcoded N/A over it, so it read 0/107 on the 1.549 snapshot against
     // 98/100 on 1.451. peakRssMb is the load's high-water mark, next to the
     // end-of-load instant in rssMb; externalMb and its arrayBuffersMb subset
-    // are the off-heap bytes heapUsedMb cannot see.
+    // are the off-heap bytes heapUsedMb cannot see; peakWasmHeapMb is the
+    // wasm linear memory, which none of the JS-side columns can see and which
+    // is a far larger number than the geometryMemoryMb payload beside it.
     expect(cell('geometryMemoryMb')).toBe('185.84')
+    expect(cell('peakWasmHeapMb')).toBe('1283.00')
     expect(cell('peakRssMb')).toBe('905.75')
     expect(cell('externalMb')).toBe('96.40')
     expect(cell('arrayBuffersMb')).toBe('94.10')
@@ -120,7 +124,7 @@ describe('writeDetailCsv', () => {
 
   test('writes N/A for a perf.csv that predates the memory columns', () => {
     // A perf.csv artifact written before #552 has none of geometryMemoryMb,
-    // peakRssMb, externalMb or arrayBuffersMb. The mapping must degrade to
+    // peakWasmHeapMb, peakRssMb, externalMb or arrayBuffersMb. The mapping must degrade to
     // N/A rather than emitting 'undefined' into a column a delta then reads
     // as a measurement.
     const out = path.join(workDir, 'legacy.csv')
@@ -136,6 +140,7 @@ describe('writeDetailCsv', () => {
     const row = parseCsv(fs.readFileSync(out, 'utf8'))[1]
     expect(row).toHaveLength(DETAIL_COLUMNS.length)
     expect(row[DETAIL_COLUMNS.indexOf('geometryMemoryMb')]).toBe('N/A')
+    expect(row[DETAIL_COLUMNS.indexOf('peakWasmHeapMb')]).toBe('N/A')
     expect(row[DETAIL_COLUMNS.indexOf('peakRssMb')]).toBe('N/A')
     expect(row[DETAIL_COLUMNS.indexOf('externalMb')]).toBe('N/A')
     expect(row[DETAIL_COLUMNS.indexOf('arrayBuffersMb')]).toBe('N/A')

--- a/src/scripts/bless_perf_snapshot.test.ts
+++ b/src/scripts/bless_perf_snapshot.test.ts
@@ -8,8 +8,8 @@ import { createRequire } from 'module'
  * The rc-regression bless path's perf snapshot (scripts/bless_perf_snapshot.cjs).
  *
  * The `rebless` job measures the full corpus with
- * `ifc_regression_batch_main --perf`, whose 8-column perf.csv is a different
- * file from the 15-column `performance-detail.csv` the committed benchmark
+ * `ifc_regression_batch_main --perf`, whose 10-column perf.csv is a different
+ * file from the 16-column `performance-detail.csv` the committed benchmark
  * snapshots use. This pins the mapping between them — the shape a delta and
  * GitHub's CSV viewer both depend on — and the choice of predecessor to diff
  * against.
@@ -51,7 +51,7 @@ afterEach(() => {
 
 describe('writeDetailCsv', () => {
 
-  test('maps perf.csv onto the 15-column convention, N/A for unmeasured', () => {
+  test('maps perf.csv onto the 16-column convention, N/A for unmeasured', () => {
     const out = path.join(workDir, 'performance-detail.csv')
 
     writeDetailCsv(
@@ -61,7 +61,9 @@ describe('writeDetailCsv', () => {
         parseTimeMs: '1200',
         geometryTimeMs: '5400',
         totalTimeMs: '6600',
+        geometryMemoryMb: '185.84',
         rssMb: '812.50',
+        peakRssMb: '905.75',
         heapUsedMb: '410.25',
         heapTotalMb: '450.00',
       }],
@@ -90,18 +92,47 @@ describe('writeDetailCsv', () => {
     expect(cell('totalTimeMs')).toBe('6600')
     expect(cell('rssMb')).toBe('812.50')
 
+    // The two columns #552 added to the conway-native writer. geometryMemoryMb
+    // is what regressed: the writer stopped emitting it, and this mapping
+    // hardcoded N/A over it, so it read 0/107 on the 1.549 snapshot against
+    // 98/100 on 1.451. peakRssMb is the load's high-water mark, next to the
+    // end-of-load instant in rssMb.
+    expect(cell('geometryMemoryMb')).toBe('185.84')
+    expect(cell('peakRssMb')).toBe('905.75')
+
     // The committed snapshots URL-encode the filename and the delta joins on
     // it, so an unencoded name would simply fail to match the baseline row.
     expect(cell('filename'))
         .toBe('Snowdon%20Towers%20Sample%20Architectural_IFC4.ifc')
 
     // perf.csv does not carry these; they stay as placeholders rather than
-    // being dropped, so the row keeps its 15-column shape.
+    // being dropped, so the row keeps its 16-column shape.
     for (const column of
-      ['schemaVersion', 'geometryMemoryMb', 'preprocessorVersion',
-        'originatingSystem']) {
+      ['schemaVersion', 'preprocessorVersion', 'originatingSystem']) {
       expect(cell(column)).toBe('N/A')
     }
+  })
+
+  test('writes N/A for a perf.csv that predates the memory columns', () => {
+    // A perf.csv artifact written before #552 has neither geometryMemoryMb nor
+    // peakRssMb. The mapping must degrade to N/A rather than emitting
+    // 'undefined' into a column a delta then reads as a measurement.
+    const out = path.join(workDir, 'legacy.csv')
+
+    writeDetailCsv(
+      [{
+        file: 'old.ifc', status: 'OK', parseTimeMs: '1200',
+        geometryTimeMs: '5400', totalTimeMs: '6600', rssMb: '812.50',
+        heapUsedMb: '410.25', heapTotalMb: '450.00',
+      }],
+      out, 'conway1.543.1513-ci', '20260821221710')
+
+    const row = parseCsv(fs.readFileSync(out, 'utf8'))[1]
+    expect(row).toHaveLength(DETAIL_COLUMNS.length)
+    expect(row[DETAIL_COLUMNS.indexOf('geometryMemoryMb')]).toBe('N/A')
+    expect(row[DETAIL_COLUMNS.indexOf('peakRssMb')]).toBe('N/A')
+    // The columns it does carry are unaffected.
+    expect(row[DETAIL_COLUMNS.indexOf('rssMb')]).toBe('812.50')
   })
 
   test('carries a FAIL row through instead of dropping it', () => {

--- a/src/scripts/perf_csv_quoting.test.ts
+++ b/src/scripts/perf_csv_quoting.test.ts
@@ -11,7 +11,7 @@ import { createRequire } from 'module'
  * `preprocessorVersion` and `originatingSystem` are free text lifted straight
  * out of an IFC/STEP FILE_NAME header. Emitted unquoted, a value like
  * `Trimble Nova (Build = 16.2.0.15, Compile = Sep 23 2021)` splits the record
- * into 17 columns against a 16-column header — which is exactly what five
+ * into 19 columns against an 18-column header — which is exactly what five
  * committed rows in test-models / test-models-private did, and why GitHub's
  * CSV viewer refused to render them.
  *
@@ -45,22 +45,25 @@ const NASTY_PREPROCESSOR =
   'Trimble Nova (Build = 16.2.0.15, Compile = "Sep 23 2021")'
 
 /** Columns in the delta CSV, per the committed `*_delta.csv` convention. */
-const DELTA_COLUMN_COUNT = 19
+const DELTA_COLUMN_COUNT = 21
 
 const DETAIL_HEADER = [
   'timestamp', 'loadStatus', 'uname', 'engine', 'filename', 'schemaVersion',
   'parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb',
-  'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb', 'preprocessorVersion',
-  'originatingSystem',
+  'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb', 'externalMb',
+  'arrayBuffersMb', 'preprocessorVersion', 'originatingSystem',
 ]
 
+/** The three memory columns #552 added, absent from every older snapshot. */
+const COLUMNS_ADDED_IN_552 = ['peakRssMb', 'externalMb', 'arrayBuffersMb']
+
 /**
- * The header every snapshot committed before #552 carries: no `peakRssMb`.
- * Those files are the baselines a release delta is computed against, so the
- * 15-column shape has to keep working as an input forever.
+ * The header every snapshot committed before #552 carries. Those files are
+ * the baselines a release delta is computed against, so the 15-column shape
+ * has to keep working as an input forever.
  */
 const LEGACY_DETAIL_HEADER =
-  DETAIL_HEADER.filter((column) => column !== 'peakRssMb')
+  DETAIL_HEADER.filter((column) => !COLUMNS_ADDED_IN_552.includes(column))
 
 /**
  * Build a performance-detail.csv row the way scripts/benchmark.cjs does —
@@ -74,7 +77,7 @@ function detailRow(filename: string, totalTimeMs: string): string {
   return csvRow([
     '20260811153721', 'OK', 'x64', 'conway1.451.1357', filename, 'IFC2X3',
     '71', '245', totalTimeMs, '0.776', '300.859', '412.320', '137.000',
-    '157.582', NASTY_PREPROCESSOR, 'N/A',
+    '157.582', '38.100', '36.400', NASTY_PREPROCESSOR, 'N/A',
   ])
 }
 
@@ -122,7 +125,7 @@ describe('performance-detail.csv rows', () => {
     const records = parseCsv(text)
 
     expect(records).toHaveLength(2)
-    // The whole point: 16 columns, not 17.
+    // The whole point: 18 columns, not 19.
     expect(records[0]).toHaveLength(DETAIL_HEADER.length)
     expect(records[1]).toHaveLength(DETAIL_HEADER.length)
 
@@ -162,7 +165,7 @@ describe('gen_delta_csv.cjs', () => {
     return filePath
   }
 
-  test('joins on filename across quoted fields and emits 19 columns', () => {
+  test('joins on filename across quoted fields and emits 21 columns', () => {
     const older = writeDetail('older.csv', [
       detailRow('mep.ifc', '400'),
       detailRow('only-in-older.ifc', '100'),
@@ -227,7 +230,7 @@ describe('gen_delta_csv.cjs', () => {
   const SKYLARK_1_451 = csvRow([
     '20260811154725', 'OK', 'x64', 'conway1.451.1357', 'skylark.ifc', 'IFC4',
     '5729', '42572', '48303', '185.836', '5495.645', '5601.500', '3865.072',
-    '3952.602', NASTY_PREPROCESSOR, 'N/A',
+    '3952.602', '432.500', '430.250', NASTY_PREPROCESSOR, 'N/A',
   ])
 
   test('reports an absent measurement as N/A, not as a delta against zero', () => {
@@ -243,7 +246,7 @@ describe('gen_delta_csv.cjs', () => {
     const withoutMemory = csvRow([
       '20260821154725', 'OK', 'x64', 'conway1.543.1513-ci', 'skylark.ifc',
       'N/A', '8035', '72371', '80406', 'N/A', '5379.12', '5488.40', '3793.69',
-      '3877.96', 'N/A', 'N/A',
+      '3877.96', '428.30', '426.10', 'N/A', 'N/A',
     ])
 
     const older = writeDetail('mem-older.csv', [SKYLARK_1_451])
@@ -270,7 +273,7 @@ describe('gen_delta_csv.cjs', () => {
     const newerMemory = csvRow([
       '20260821154725', 'OK', 'x64', 'conway1.550.1516-ci', 'skylark.ifc',
       'N/A', '8035', '72371', '80406', '190.836', '5379.12', '5488.50',
-      '3793.69', '3877.96', 'N/A', 'N/A',
+      '3793.69', '3877.96', '433.500', '431.250', 'N/A', 'N/A',
     ])
 
     const older = writeDetail('gmem-older.csv', [SKYLARK_1_451])
@@ -287,11 +290,40 @@ describe('gen_delta_csv.cjs', () => {
     expect(row[header.indexOf('peakRssMbDelta')]).toBe('-113')
   })
 
-  test('reports peakRssMb as N/A against a snapshot whose header lacks it', () => {
+  test('differences the off-heap columns when both sides measured them', () => {
+    // externalMb / arrayBuffersMb hold what heapUsedMb structurally cannot
+    // see — the source buffer and the parse structures. On MB-Khaya a 31 MB
+    // readFileSync moves arrayBuffers 0.1 -> 31.5 MB without moving heapUsed
+    // at all, so a release that changed how the source is held would show up
+    // in these two columns and nowhere else in this file.
+    const newerOffHeap = csvRow([
+      '20260821154725', 'OK', 'x64', 'conway1.550.1516-ci', 'skylark.ifc',
+      'N/A', '8035', '72371', '80406', '185.836', '5495.645', '5601.500',
+      '3865.072', '3952.602', '433.500', '431.250', 'N/A', 'N/A',
+    ])
+
+    const older = writeDetail('ext-older.csv', [SKYLARK_1_451])
+    const newer = writeDetail('ext-newer.csv', [newerOffHeap])
+    const out = path.join(workDir, 'ext-delta.csv')
+
+    generateDeltaCSV(older, newer, out)
+
+    const records = parseCsv(fs.readFileSync(out, 'utf8'))
+    const header = records[0]
+    const row = records[1]
+
+    expect(row[header.indexOf('externalMbDelta')]).toBe('1')
+    expect(row[header.indexOf('arrayBuffersMbDelta')]).toBe('1')
+    // Both are real measurements here, so neither may fall back to N/A.
+    expect(row[header.indexOf('heapUsedMbDelta')]).toBe('0')
+  })
+
+  test('reports the #552 columns as N/A against a header that lacks them', () => {
     // Every snapshot committed before #552 has a 15-column header with no
-    // peakRssMb at all — not an N/A cell, no cell. That absence must read as
-    // "no measurement", exactly like #548's N/A: coercing it to 0 would report
-    // the new run's entire peak as a regression against nothing.
+    // peakRssMb / externalMb / arrayBuffersMb at all — not N/A cells, no
+    // cells. That absence must read as "no measurement", exactly like #548's
+    // N/A: coercing it to 0 would report the new run's entire peak, and its
+    // whole off-heap footprint, as regressions against nothing.
     const legacyRow = csvRow([
       '20260811153651', 'OK', 'x64', 'conway1.451.1357', 'skylark.ifc', 'IFC4',
       '5729', '42572', '48303', '185.836', '5495.645', '3865.072', '3952.602',
@@ -310,6 +342,8 @@ describe('gen_delta_csv.cjs', () => {
     const row = records[1]
 
     expect(row[header.indexOf('peakRssMbDelta')]).toBe('N/A')
+    expect(row[header.indexOf('externalMbDelta')]).toBe('N/A')
+    expect(row[header.indexOf('arrayBuffersMbDelta')]).toBe('N/A')
     // Every column both files DO carry still computes; the join is unaffected
     // by the differing column counts because it reads by name.
     expect(row[header.indexOf('totalTimeMsDelta')]).toBe('0')
@@ -325,7 +359,7 @@ describe('gen_delta_csv.cjs', () => {
     const failRow = csvRow([
       '20260821153721', 'FAIL', 'x64', 'conway1.543.1513', 'flipper.ifc',
       'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
-      'N/A',
+      'N/A', 'N/A', 'N/A',
     ])
 
     const older = writeDetail('fail-older.csv', [okRow])
@@ -351,7 +385,8 @@ describe('gen_delta_csv.cjs', () => {
     // distinguishable.
     const zeroed = (engine: string, total: string) => csvRow([
       '20260811154725', 'OK', 'x64', engine, 'z.ifc', 'IFC4',
-      '0', '0', total, '1.5', '100', '120', '50', '60', 'N/A', 'N/A',
+      '0', '0', total, '1.5', '100', '120', '50', '60', '12', '10', 'N/A',
+      'N/A',
     ])
 
     const older = writeDetail('zero-older.csv', [zeroed('webifc0.0.67', '100')])
@@ -378,7 +413,7 @@ describe('gen_delta_csv.cjs', () => {
     const rawFail = csvRow([
       '20260811154725', 'FAIL', 'x64', 'conway1.451.1357',
       'S_Office_Integrated Design Archi.ifc', 'N/A', 'N/A', 'N/A', 'N/A',
-      'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
+      'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
     ])
     const encodedOk =
       detailRow('S_Office_Integrated%20Design%20Archi.ifc', '4647')
@@ -426,8 +461,8 @@ describe('gen_delta_csv.cjs', () => {
     const okRow = detailRow('flipper.ifc', '500')
     const failRow = csvRow([
       '20260821153721', 'FAIL', 'x64', 'conway1.543.1513', 'flipper.ifc',
-      'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
-      NASTY_PREPROCESSOR, 'N/A',
+      'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
+      'N/A', NASTY_PREPROCESSOR, 'N/A',
     ])
 
     const older = writeDetail('status-older.csv', [okRow])

--- a/src/scripts/perf_csv_quoting.test.ts
+++ b/src/scripts/perf_csv_quoting.test.ts
@@ -11,7 +11,7 @@ import { createRequire } from 'module'
  * `preprocessorVersion` and `originatingSystem` are free text lifted straight
  * out of an IFC/STEP FILE_NAME header. Emitted unquoted, a value like
  * `Trimble Nova (Build = 16.2.0.15, Compile = Sep 23 2021)` splits the record
- * into 16 columns against a 15-column header — which is exactly what five
+ * into 17 columns against a 16-column header — which is exactly what five
  * committed rows in test-models / test-models-private did, and why GitHub's
  * CSV viewer refused to render them.
  *
@@ -45,14 +45,22 @@ const NASTY_PREPROCESSOR =
   'Trimble Nova (Build = 16.2.0.15, Compile = "Sep 23 2021")'
 
 /** Columns in the delta CSV, per the committed `*_delta.csv` convention. */
-const DELTA_COLUMN_COUNT = 18
+const DELTA_COLUMN_COUNT = 19
 
 const DETAIL_HEADER = [
   'timestamp', 'loadStatus', 'uname', 'engine', 'filename', 'schemaVersion',
   'parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb',
-  'rssMb', 'heapUsedMb', 'heapTotalMb', 'preprocessorVersion',
+  'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb', 'preprocessorVersion',
   'originatingSystem',
 ]
+
+/**
+ * The header every snapshot committed before #552 carries: no `peakRssMb`.
+ * Those files are the baselines a release delta is computed against, so the
+ * 15-column shape has to keep working as an input forever.
+ */
+const LEGACY_DETAIL_HEADER =
+  DETAIL_HEADER.filter((column) => column !== 'peakRssMb')
 
 /**
  * Build a performance-detail.csv row the way scripts/benchmark.cjs does —
@@ -65,8 +73,8 @@ const DETAIL_HEADER = [
 function detailRow(filename: string, totalTimeMs: string): string {
   return csvRow([
     '20260811153721', 'OK', 'x64', 'conway1.451.1357', filename, 'IFC2X3',
-    '71', '245', totalTimeMs, '0.776', '300.859', '137.000', '157.582',
-    NASTY_PREPROCESSOR, 'N/A',
+    '71', '245', totalTimeMs, '0.776', '300.859', '412.320', '137.000',
+    '157.582', NASTY_PREPROCESSOR, 'N/A',
   ])
 }
 
@@ -114,7 +122,7 @@ describe('performance-detail.csv rows', () => {
     const records = parseCsv(text)
 
     expect(records).toHaveLength(2)
-    // The whole point: 15 columns, not 16.
+    // The whole point: 16 columns, not 17.
     expect(records[0]).toHaveLength(DETAIL_HEADER.length)
     expect(records[1]).toHaveLength(DETAIL_HEADER.length)
 
@@ -144,15 +152,17 @@ describe('gen_delta_csv.cjs', () => {
    *
    * @param name File basename to write.
    * @param rows Encoded records.
+   * @param header Column header to write, for the old-vs-new column-set cases.
    * @return The absolute path written.
    */
-  function writeDetail(name: string, rows: string[]): string {
+  function writeDetail(
+      name: string, rows: string[], header: string[] = DETAIL_HEADER): string {
     const filePath = path.join(workDir, name)
-    fs.writeFileSync(filePath, `${csvRow(DETAIL_HEADER)}\n${rows.join('\n')}\n`)
+    fs.writeFileSync(filePath, `${csvRow(header)}\n${rows.join('\n')}\n`)
     return filePath
   }
 
-  test('joins on filename across quoted fields and emits 18 columns', () => {
+  test('joins on filename across quoted fields and emits 19 columns', () => {
     const older = writeDetail('older.csv', [
       detailRow('mep.ifc', '400'),
       detailRow('only-in-older.ifc', '100'),
@@ -213,25 +223,30 @@ describe('gen_delta_csv.cjs', () => {
     expect(records[1][header.indexOf('loadStatus1')]).toBe('OK')
   })
 
+  /** SKYLARK250 as a 1.451 headless-three snapshot row: every column measured. */
+  const SKYLARK_1_451 = csvRow([
+    '20260811154725', 'OK', 'x64', 'conway1.451.1357', 'skylark.ifc', 'IFC4',
+    '5729', '42572', '48303', '185.836', '5495.645', '5601.500', '3865.072',
+    '3952.602', NASTY_PREPROCESSOR, 'N/A',
+  ])
+
   test('reports an absent measurement as N/A, not as a delta against zero', () => {
     // The bug this pins: parseValue used to coerce 'N/A' to 0, so a matched row
     // whose newer side has no geometryMemoryMb came out as
     // geometryMemoryMbDelta = -(the whole baseline allocation) — a fabricated
     // 100% memory win. It reported -185.836 for SKYLARK250, which is exactly
     // the model someone reads this delta for.
-    const withMemory = csvRow([
-      '20260811154725', 'OK', 'x64', 'conway1.451.1357', 'skylark.ifc', 'IFC4',
-      '5729', '42572', '48303', '185.836', '5495.645', '3865.072', '3952.602',
-      NASTY_PREPROCESSOR, 'N/A',
-    ])
-    // The conway-native perf writer does not measure geometryMemoryMb.
+    //
+    // The conway-native writer measures geometryMemoryMb again since #552, but
+    // every snapshot blessed between #548 and #552 wrote N/A into that column,
+    // and those files stay in the corpus as baselines forever.
     const withoutMemory = csvRow([
       '20260821154725', 'OK', 'x64', 'conway1.543.1513-ci', 'skylark.ifc',
-      'N/A', '8035', '72371', '80406', 'N/A', '5379.12', '3793.69', '3877.96',
-      'N/A', 'N/A',
+      'N/A', '8035', '72371', '80406', 'N/A', '5379.12', '5488.40', '3793.69',
+      '3877.96', 'N/A', 'N/A',
     ])
 
-    const older = writeDetail('mem-older.csv', [withMemory])
+    const older = writeDetail('mem-older.csv', [SKYLARK_1_451])
     const newer = writeDetail('mem-newer.csv', [withoutMemory])
     const out = path.join(workDir, 'mem-delta.csv')
 
@@ -247,6 +262,61 @@ describe('gen_delta_csv.cjs', () => {
     expect(row[header.indexOf('rssMbDelta')]).not.toBe('N/A')
   })
 
+  test('differences geometryMemoryMb when both sides measured it', () => {
+    // The other half of the #548 asymmetry, and what #552 restored: with the
+    // conway-native writer emitting the column again, a delta between two
+    // measured runs must report the number rather than the N/A that stood in
+    // for "this harness cannot measure it".
+    const newerMemory = csvRow([
+      '20260821154725', 'OK', 'x64', 'conway1.550.1516-ci', 'skylark.ifc',
+      'N/A', '8035', '72371', '80406', '190.836', '5379.12', '5488.50',
+      '3793.69', '3877.96', 'N/A', 'N/A',
+    ])
+
+    const older = writeDetail('gmem-older.csv', [SKYLARK_1_451])
+    const newer = writeDetail('gmem-newer.csv', [newerMemory])
+    const out = path.join(workDir, 'gmem-delta.csv')
+
+    generateDeltaCSV(older, newer, out)
+
+    const records = parseCsv(fs.readFileSync(out, 'utf8'))
+    const header = records[0]
+    const row = records[1]
+
+    expect(row[header.indexOf('geometryMemoryMbDelta')]).toBe('5')
+    expect(row[header.indexOf('peakRssMbDelta')]).toBe('-113')
+  })
+
+  test('reports peakRssMb as N/A against a snapshot whose header lacks it', () => {
+    // Every snapshot committed before #552 has a 15-column header with no
+    // peakRssMb at all — not an N/A cell, no cell. That absence must read as
+    // "no measurement", exactly like #548's N/A: coercing it to 0 would report
+    // the new run's entire peak as a regression against nothing.
+    const legacyRow = csvRow([
+      '20260811153651', 'OK', 'x64', 'conway1.451.1357', 'skylark.ifc', 'IFC4',
+      '5729', '42572', '48303', '185.836', '5495.645', '3865.072', '3952.602',
+      NASTY_PREPROCESSOR, 'N/A',
+    ])
+
+    const older =
+      writeDetail('legacy-older.csv', [legacyRow], LEGACY_DETAIL_HEADER)
+    const newer = writeDetail('legacy-newer.csv', [SKYLARK_1_451])
+    const out = path.join(workDir, 'legacy-delta.csv')
+
+    generateDeltaCSV(older, newer, out)
+
+    const records = parseCsv(fs.readFileSync(out, 'utf8'))
+    const header = records[0]
+    const row = records[1]
+
+    expect(row[header.indexOf('peakRssMbDelta')]).toBe('N/A')
+    // Every column both files DO carry still computes; the join is unaffected
+    // by the differing column counts because it reads by name.
+    expect(row[header.indexOf('totalTimeMsDelta')]).toBe('0')
+    expect(row[header.indexOf('geometryMemoryMbDelta')]).toBe('0')
+    expect(row[header.indexOf('rssMbDelta')]).toBe('0')
+  })
+
   test('reports a FAIL row as N/A rather than a 100% improvement', () => {
     // Same coercion, and this is where it did the most damage: a model that
     // regressed OK -> FAIL used to read as totalTimeMsDelta = -(its old total)
@@ -255,6 +325,7 @@ describe('gen_delta_csv.cjs', () => {
     const failRow = csvRow([
       '20260821153721', 'FAIL', 'x64', 'conway1.543.1513', 'flipper.ifc',
       'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
+      'N/A',
     ])
 
     const older = writeDetail('fail-older.csv', [okRow])
@@ -280,7 +351,7 @@ describe('gen_delta_csv.cjs', () => {
     // distinguishable.
     const zeroed = (engine: string, total: string) => csvRow([
       '20260811154725', 'OK', 'x64', engine, 'z.ifc', 'IFC4',
-      '0', '0', total, '1.5', '100', '50', '60', 'N/A', 'N/A',
+      '0', '0', total, '1.5', '100', '120', '50', '60', 'N/A', 'N/A',
     ])
 
     const older = writeDetail('zero-older.csv', [zeroed('webifc0.0.67', '100')])
@@ -307,7 +378,7 @@ describe('gen_delta_csv.cjs', () => {
     const rawFail = csvRow([
       '20260811154725', 'FAIL', 'x64', 'conway1.451.1357',
       'S_Office_Integrated Design Archi.ifc', 'N/A', 'N/A', 'N/A', 'N/A',
-      'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
+      'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
     ])
     const encodedOk =
       detailRow('S_Office_Integrated%20Design%20Archi.ifc', '4647')
@@ -355,7 +426,7 @@ describe('gen_delta_csv.cjs', () => {
     const okRow = detailRow('flipper.ifc', '500')
     const failRow = csvRow([
       '20260821153721', 'FAIL', 'x64', 'conway1.543.1513', 'flipper.ifc',
-      'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
+      'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
       NASTY_PREPROCESSOR, 'N/A',
     ])
 

--- a/src/scripts/perf_csv_quoting.test.ts
+++ b/src/scripts/perf_csv_quoting.test.ts
@@ -11,7 +11,7 @@ import { createRequire } from 'module'
  * `preprocessorVersion` and `originatingSystem` are free text lifted straight
  * out of an IFC/STEP FILE_NAME header. Emitted unquoted, a value like
  * `Trimble Nova (Build = 16.2.0.15, Compile = Sep 23 2021)` splits the record
- * into 19 columns against an 18-column header — which is exactly what five
+ * into 20 columns against a 19-column header — which is exactly what five
  * committed rows in test-models / test-models-private did, and why GitHub's
  * CSV viewer refused to render them.
  *
@@ -45,17 +45,18 @@ const NASTY_PREPROCESSOR =
   'Trimble Nova (Build = 16.2.0.15, Compile = "Sep 23 2021")'
 
 /** Columns in the delta CSV, per the committed `*_delta.csv` convention. */
-const DELTA_COLUMN_COUNT = 21
+const DELTA_COLUMN_COUNT = 22
 
 const DETAIL_HEADER = [
   'timestamp', 'loadStatus', 'uname', 'engine', 'filename', 'schemaVersion',
   'parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb',
-  'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb', 'externalMb',
-  'arrayBuffersMb', 'preprocessorVersion', 'originatingSystem',
+  'peakWasmHeapMb', 'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb',
+  'externalMb', 'arrayBuffersMb', 'preprocessorVersion', 'originatingSystem',
 ]
 
-/** The three memory columns #552 added, absent from every older snapshot. */
-const COLUMNS_ADDED_IN_552 = ['peakRssMb', 'externalMb', 'arrayBuffersMb']
+/** The four memory columns #552 added, absent from every older snapshot. */
+const COLUMNS_ADDED_IN_552 =
+  ['peakWasmHeapMb', 'peakRssMb', 'externalMb', 'arrayBuffersMb']
 
 /**
  * The header every snapshot committed before #552 carries. Those files are
@@ -76,8 +77,8 @@ const LEGACY_DETAIL_HEADER =
 function detailRow(filename: string, totalTimeMs: string): string {
   return csvRow([
     '20260811153721', 'OK', 'x64', 'conway1.451.1357', filename, 'IFC2X3',
-    '71', '245', totalTimeMs, '0.776', '300.859', '412.320', '137.000',
-    '157.582', '38.100', '36.400', NASTY_PREPROCESSOR, 'N/A',
+    '71', '245', totalTimeMs, '0.776', '46.500', '300.859', '412.320',
+    '137.000', '157.582', '38.100', '36.400', NASTY_PREPROCESSOR, 'N/A',
   ])
 }
 
@@ -125,7 +126,7 @@ describe('performance-detail.csv rows', () => {
     const records = parseCsv(text)
 
     expect(records).toHaveLength(2)
-    // The whole point: 18 columns, not 19.
+    // The whole point: 19 columns, not 20.
     expect(records[0]).toHaveLength(DETAIL_HEADER.length)
     expect(records[1]).toHaveLength(DETAIL_HEADER.length)
 
@@ -165,7 +166,7 @@ describe('gen_delta_csv.cjs', () => {
     return filePath
   }
 
-  test('joins on filename across quoted fields and emits 21 columns', () => {
+  test('joins on filename across quoted fields and emits 22 columns', () => {
     const older = writeDetail('older.csv', [
       detailRow('mep.ifc', '400'),
       detailRow('only-in-older.ifc', '100'),
@@ -229,8 +230,8 @@ describe('gen_delta_csv.cjs', () => {
   /** SKYLARK250 as a 1.451 headless-three snapshot row: every column measured. */
   const SKYLARK_1_451 = csvRow([
     '20260811154725', 'OK', 'x64', 'conway1.451.1357', 'skylark.ifc', 'IFC4',
-    '5729', '42572', '48303', '185.836', '5495.645', '5601.500', '3865.072',
-    '3952.602', '432.500', '430.250', NASTY_PREPROCESSOR, 'N/A',
+    '5729', '42572', '48303', '185.836', '1283.000', '5495.645', '5601.500',
+    '3865.072', '3952.602', '432.500', '430.250', NASTY_PREPROCESSOR, 'N/A',
   ])
 
   test('reports an absent measurement as N/A, not as a delta against zero', () => {
@@ -245,8 +246,8 @@ describe('gen_delta_csv.cjs', () => {
     // and those files stay in the corpus as baselines forever.
     const withoutMemory = csvRow([
       '20260821154725', 'OK', 'x64', 'conway1.543.1513-ci', 'skylark.ifc',
-      'N/A', '8035', '72371', '80406', 'N/A', '5379.12', '5488.40', '3793.69',
-      '3877.96', '428.30', '426.10', 'N/A', 'N/A',
+      'N/A', '8035', '72371', '80406', 'N/A', 'N/A', '5379.12', '5488.40',
+      '3793.69', '3877.96', '428.30', '426.10', 'N/A', 'N/A',
     ])
 
     const older = writeDetail('mem-older.csv', [SKYLARK_1_451])
@@ -272,8 +273,8 @@ describe('gen_delta_csv.cjs', () => {
     // for "this harness cannot measure it".
     const newerMemory = csvRow([
       '20260821154725', 'OK', 'x64', 'conway1.550.1516-ci', 'skylark.ifc',
-      'N/A', '8035', '72371', '80406', '190.836', '5379.12', '5488.50',
-      '3793.69', '3877.96', '433.500', '431.250', 'N/A', 'N/A',
+      'N/A', '8035', '72371', '80406', '190.836', '1281.000', '5379.12',
+      '5488.50', '3793.69', '3877.96', '433.500', '431.250', 'N/A', 'N/A',
     ])
 
     const older = writeDetail('gmem-older.csv', [SKYLARK_1_451])
@@ -288,6 +289,10 @@ describe('gen_delta_csv.cjs', () => {
 
     expect(row[header.indexOf('geometryMemoryMbDelta')]).toBe('5')
     expect(row[header.indexOf('peakRssMbDelta')]).toBe('-113')
+    // A separate quantity, moving separately: the payload grew by 5 MB while
+    // the heap around it shrank by 2. Reporting one for the other, or scaling
+    // one into the other, would invert the reading of this row.
+    expect(row[header.indexOf('peakWasmHeapMbDelta')]).toBe('-2')
   })
 
   test('differences the off-heap columns when both sides measured them', () => {
@@ -298,8 +303,8 @@ describe('gen_delta_csv.cjs', () => {
     // in these two columns and nowhere else in this file.
     const newerOffHeap = csvRow([
       '20260821154725', 'OK', 'x64', 'conway1.550.1516-ci', 'skylark.ifc',
-      'N/A', '8035', '72371', '80406', '185.836', '5495.645', '5601.500',
-      '3865.072', '3952.602', '433.500', '431.250', 'N/A', 'N/A',
+      'N/A', '8035', '72371', '80406', '185.836', '1283.000', '5495.645',
+      '5601.500', '3865.072', '3952.602', '433.500', '431.250', 'N/A', 'N/A',
     ])
 
     const older = writeDetail('ext-older.csv', [SKYLARK_1_451])
@@ -320,8 +325,8 @@ describe('gen_delta_csv.cjs', () => {
 
   test('reports the #552 columns as N/A against a header that lacks them', () => {
     // Every snapshot committed before #552 has a 15-column header with no
-    // peakRssMb / externalMb / arrayBuffersMb at all — not N/A cells, no
-    // cells. That absence must read as "no measurement", exactly like #548's
+    // peakWasmHeapMb / peakRssMb / externalMb / arrayBuffersMb at all — not
+    // N/A cells, no cells. That absence must read as "no measurement", exactly like #548's
     // N/A: coercing it to 0 would report the new run's entire peak, and its
     // whole off-heap footprint, as regressions against nothing.
     const legacyRow = csvRow([
@@ -341,6 +346,7 @@ describe('gen_delta_csv.cjs', () => {
     const header = records[0]
     const row = records[1]
 
+    expect(row[header.indexOf('peakWasmHeapMbDelta')]).toBe('N/A')
     expect(row[header.indexOf('peakRssMbDelta')]).toBe('N/A')
     expect(row[header.indexOf('externalMbDelta')]).toBe('N/A')
     expect(row[header.indexOf('arrayBuffersMbDelta')]).toBe('N/A')
@@ -359,7 +365,7 @@ describe('gen_delta_csv.cjs', () => {
     const failRow = csvRow([
       '20260821153721', 'FAIL', 'x64', 'conway1.543.1513', 'flipper.ifc',
       'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
-      'N/A', 'N/A', 'N/A',
+      'N/A', 'N/A', 'N/A', 'N/A',
     ])
 
     const older = writeDetail('fail-older.csv', [okRow])
@@ -385,8 +391,8 @@ describe('gen_delta_csv.cjs', () => {
     // distinguishable.
     const zeroed = (engine: string, total: string) => csvRow([
       '20260811154725', 'OK', 'x64', engine, 'z.ifc', 'IFC4',
-      '0', '0', total, '1.5', '100', '120', '50', '60', '12', '10', 'N/A',
-      'N/A',
+      '0', '0', total, '1.5', '80', '100', '120', '50', '60', '12', '10',
+      'N/A', 'N/A',
     ])
 
     const older = writeDetail('zero-older.csv', [zeroed('webifc0.0.67', '100')])
@@ -462,7 +468,7 @@ describe('gen_delta_csv.cjs', () => {
     const failRow = csvRow([
       '20260821153721', 'FAIL', 'x64', 'conway1.543.1513', 'flipper.ifc',
       'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
-      'N/A', NASTY_PREPROCESSOR, 'N/A',
+      'N/A', 'N/A', NASTY_PREPROCESSOR, 'N/A',
     ])
 
     const older = writeDetail('status-older.csv', [okRow])

--- a/src/statistics/statistics.ts
+++ b/src/statistics/statistics.ts
@@ -12,6 +12,7 @@ export class Statistics {
   private geometryTime: number | undefined
   private totalTime: number | undefined
   private geometryMemory: number | undefined
+  private wasmHeapPeak: number | undefined
   private preprocessorVersion: string | undefined
   private originatingSystem: string | undefined
   private memoryStatistics: string | undefined
@@ -130,6 +131,29 @@ export class Statistics {
    */
   setGeometryMemory(value: number) {
     this.geometryMemory = value
+  }
+
+  /**
+   * Wasm linear-memory high-water mark in MB, from wasmHeapByteLength.
+   *
+   * @return {number | undefined} - wasm heap high-water, or undefined
+   */
+  getWasmHeapPeak(): number | undefined {
+    return this.wasmHeapPeak
+  }
+
+  /**
+   * The wasm heap only ever grows, so a single reading of it IS the peak —
+   * no sampling loop and no forced GC. It is a different quantity from
+   * geometryMemory, and by a wide margin: on MB-Khaya an 8 MB live geometry
+   * payload sits under an 85 MB wasm heap, the gap being allocator overhead,
+   * fragmentation and the intermediate buffers a boolean leaves behind (see
+   * src/ifc/geometry_residency.ts). Neither substitutes for the other.
+   *
+   * @param value - wasm heap high-water in MB
+   */
+  setWasmHeapPeak(value: number) {
+    this.wasmHeapPeak = value
   }
 
   /**
@@ -296,6 +320,7 @@ export class Statistics {
             `Parse Time: ${this.parseTime} ms, Geometry Time: ${this.geometryTime} ms, ` +
             `Total Time: ${this.totalTime} ms, ` +
             `Geometry Memory: ${this.geometryMemory?.toFixed(3)} MB, ` +
+            `WASM Heap High-Water: ${this.wasmHeapPeak?.toFixed(3)} MB, ` +
             products +
             `Memory Statistics: ${this.memoryStatistics}, ` +
             `Preprocessor Version: ${this.preprocessorVersion}, ` +

--- a/src/statistics/statistics_wasm_heap.test.ts
+++ b/src/statistics/statistics_wasm_heap.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from '@jest/globals'
+import { Statistics } from './statistics'
+
+
+/**
+ * The load-summary line's wasm high-water field.
+ *
+ * Like the memory line (see src/memory/memory_stats.test.ts), this string is
+ * a contract rather than decoration: scripts/benchmark.cjs scrapes
+ * `WASM Heap High-Water:` out of the render server's log into the
+ * `peakWasmHeapMb` column of every `performance-detail.csv` it writes. It is
+ * also the ONLY column in that file that sees conway's native memory —
+ * heapUsed/external do not include emscripten's linear memory, and
+ * `Geometry Memory` beside it is the vertex+index payload only (conway#552).
+ *
+ * The scrapes are copied verbatim from scripts/benchmark.cjs.
+ */
+const WASM_HEAP_SCRAPE = /WASM Heap High-Water: ([\d.]+) MB/
+const GEOMETRY_MEMORY_SCRAPE = /Geometry Memory: ([\d.]+) MB/
+
+/** An 85 MB wasm heap over an 8 MB payload, as measured on MB-Khaya. */
+const WASM_HEAP_MB = 85.25
+const GEOMETRY_PAYLOAD_MB = 8.5
+
+describe('the load-summary line', () => {
+
+  /**
+   * A statistics object with both native figures set.
+   *
+   * @return The formatted load-summary line.
+   */
+  function lineWithBothNativeFigures(): string {
+    const statistics = new Statistics()
+
+    statistics.setLoadStatus('OK')
+    statistics.setGeometryMemory(GEOMETRY_PAYLOAD_MB)
+    statistics.setWasmHeapPeak(WASM_HEAP_MB)
+
+    return statistics.format()
+  }
+
+  test('carries the wasm high-water as its own field', () => {
+    const scraped = WASM_HEAP_SCRAPE.exec(lineWithBothNativeFigures())
+
+    expect(scraped).not.toBeNull()
+    expect(Number(scraped![1])).toBeCloseTo(WASM_HEAP_MB, 2)
+  })
+
+  test('keeps the wasm heap and the geometry payload distinct', () => {
+    // The failure this pins is conflation, not absence: the two differ by an
+    // order of magnitude — the heap also holds allocator overhead,
+    // fragmentation and the intermediate buffers a boolean leaves behind — so
+    // a writer that reported one under the other's name would still emit a
+    // plausible-looking number into a released benchmark.
+    const line = lineWithBothNativeFigures()
+
+    const wasmHeap = Number(WASM_HEAP_SCRAPE.exec(line)![1])
+    const payload = Number(GEOMETRY_MEMORY_SCRAPE.exec(line)![1])
+
+    expect(payload).toBeCloseTo(GEOMETRY_PAYLOAD_MB, 2)
+    expect(wasmHeap).not.toBeCloseTo(payload, 2)
+  })
+
+  test('reports no number at all when the heap was never measured', () => {
+    // A load that failed before the module came up has no high-water to
+    // report. The scrape must find nothing — benchmark.cjs then leaves the
+    // column N/A, which the delta propagates rather than differencing
+    // against zero (#548).
+    const statistics = new Statistics()
+
+    statistics.setLoadStatus('FAIL')
+
+    expect(WASM_HEAP_SCRAPE.exec(statistics.format())).toBeNull()
+  })
+})


### PR DESCRIPTION
Tier 1 of #552, including the amendment in [this comment](https://github.com/bldrs-ai/conway/issues/552#issuecomment-5380685171). Tier 2 (`peakLiveHeapMb` behind forced GC), and the before/after retention delta, are **not** here. **No closing keyword on purpose** — #552 should stay open for Tier 2 and be narrowed by comment when this lands.

## Five columns, four of them new

| column | source | what it is |
|---|---|---|
| `geometryMemoryMb` | `calculateGeometrySize()` | **restored.** The vertex+index **payload** a consumer would copy out |
| `peakWasmHeapMb` | `wasmHeapByteLength()` | **new.** Wasm linear-memory high-water — allocator overhead, fragmentation, boolean intermediates included |
| `peakRssMb` | `resourceUsage().maxRSS` | **new.** Kernel high-water for the whole process |
| `externalMb` | `memoryUsage().external` | **new.** Off-heap bytes V8 knows about |
| `arrayBuffersMb` | `memoryUsage().arrayBuffers` | **new.** The ArrayBuffer subset of `external` |

`rssMb` / `heapUsedMb` / `heapTotalMb` are unchanged and stay for continuity with historical snapshots. Every column is **added**, never replaced.

**The four native/off-heap quantities are deliberately not collapsed.** One real load, MB-Khaya (31 MB IFC), through the IFC CLI on this branch:

```
Geometry Memory: 16.817 MB    <- payload
WASM Heap High-Water: 101.563 MB  <- linear memory around it
External: 58.187 MB / ArrayBuffers: 56.288 MB   <- source buffer + parse structures
RSS 515.680 MB / Heap Used: 230.156 MB          <- process
```

They differ by up to 30×, and they move independently: on `box.ifc` the payload is `0.00` under a `16.00` MB wasm heap (the allocator's initial arena), so no ratio converts one into the other.

**No `heapUsed + external` total, and it is not a substitute for RSS.** The issue's own measurement refutes it: 284 MB against an RSS of 510 MB after geometry, and wasm init alone adds ~65 MB of RSS while moving `external` by under 2 MB. `peakRssMb` stays the headline; `peakWasmHeapMb` is what makes conway's own native memory visible at all.

## Where each writer was wired

- **`geometryMemoryMb`** was never dead at the source — `calculateGeometrySize()` is still called on the loader paths and the CLIs. It was `ifc_regression_main.ts` (and its AP214 sibling) that never put it in perf.csv, and `bless_perf_snapshot.cjs` that hardcoded `N/A` over it. Populated 98/100 at `conway1.451.1357-ci`, **0/107** at `conway1.549.1515-ci`.
- **`peakWasmHeapMb` coverage was backwards**: the AP214 CLI logged it, the IFC CLI did not, neither regression main did, and the **loader** — the path the benchmark's render server actually drives — did not either, so it reached no CSV. It is now a `Statistics` field (`WASM Heap High-Water:` in the load-summary line) set at the loader's IFC and AP214 arms and both CLIs, and a perf.csv column from both regression children. The AP214 CLI's standalone `Logger.info` line is replaced by that field rather than kept beside it: one number, one spelling, one emission — and it is the spelling `benchmark.cjs` scrapes. Its `wasmHeapByteLength`-not-`HEAPU8.length` reasoning (#485: the cached view can be a growth step behind, and a high-water figure that under-reports is worse than none) travels with it; `wasm_heap.ts`'s own comment claiming the AP214 CLI is its "only consumer" is updated, since that is no longer true.
- **Both regression children are edited together on purpose.** `aggregatePerfCsvs` keeps the header of whichever per-file CSV it reads first and concatenates the rest as rows, so a mixed IFC/STEP corpus mislabels every column if they drift apart. Verified by running both children and diffing their headers — identical.
- **Colon discipline in the log line.** `benchmark.cjs` matches the historical `RSS ([\d.]+) MB` **non-globally**, so it takes the first hit in the whole server log. Every new field (`Peak RSS:`, `External:`, `ArrayBuffers:`, `WASM Heap High-Water:`) carries a colon before its number so none of them can bind there and silently overwrite `rssMb` with a different measurement. A test pins it.

`gen_delta_csv.cjs` gains the four matching `*Delta` columns; the perf tables in `build.yml` and `perf-baseline-oneoff.yml` display them (all read by column name, none position-sensitive).

## Blast radius: old snapshots

Every committed historical snapshot lacks all four columns. `parseValue` returns `null` for a column that is **absent entirely**, exactly as for `N/A`, so `computeDelta` reports `N/A` rather than differencing against zero. This is the #548 bug — coercion to `0.0` reported `geometryMemoryMbDelta = -185.836` for SKYLARK250, a phantom 100% memory win on the one model people read that delta for — and it is not reintroduced in any new column. **No re-blessing; the next rc picks the columns up.**

Verified end to end against the real committed baseline `benchmarks/conway1.451.1357-ci_test-models/performance-detail.csv` in bldrs-ai/test-models (15-column header), blessed against a fresh `ifc_regression_batch_main --perf` run over 11 real models:

```
filename                       Δ total ms   Δ geomMem   Δ wasmHeap   Δ RSS      Δ peakRSS   Δ external
171210AISC_Sculpture_param       51.000      0.012        N/A        -40.393      N/A         N/A
House%20Aarburg%20IFC%20(1)      -7.000      0.028        N/A        -59.724      N/A         N/A
KIT-Simple-Road-Test-...RC2       N/A        N/A          N/A          N/A        N/A         N/A
MB-Khaya                       -357.000      5.435        N/A        -44.604      N/A         N/A
Remigen_Mo                        6.000     -0.008        N/A        -30.425      N/A         N/A
Schependomlaan                 -101.000      0.096        N/A       -167.284      N/A         N/A
b                                45.000     -0.062        N/A        -42.637      N/A         N/A
bath-csg-solid                   65.000      0.011        N/A        -44.742      N/A         N/A
box                              83.000     -0.001        N/A        -23.751      N/A         N/A
haus                            -49.000      0.002        N/A        -41.922      N/A         N/A
index                            94.000      0.001        N/A        -34.901      N/A         N/A
```

All four new columns are `N/A` on **all 47** delta rows — never a number. Ten of the eleven joined rows compute every column both sides carry; the eleventh (`KIT-Simple-Road-Test`) is `FAIL` with all-`N/A` in the 1.451 baseline, so `N/A` there is the #548 behaviour working, not a gap.

## Measured, not asserted

`ifc_regression_batch_main --perf` on this branch (`main` emits none of these columns at all):

| model | geometryMemoryMb | peakWasmHeapMb | peakRssMb | externalMb |
|---|---|---|---|---|
| box.ifc | 0.00 | 16.00 | 244.53 | 7.75 |
| index.ifc | 0.01 | 16.00 | 236.88 | 5.86 |
| Remigen_Mo.ifc | 1.80 | 19.25 | 253.79 | 7.25 |
| haus.ifc | 1.69 | 35.13 | 285.18 | 9.97 |
| House Aarburg IFC (1).ifc | 0.25 | 29.19 | **264.70** (rss 260.44) | 6.47 |
| Schependomlaan.ifc | 13.69 | 73.69 | 471.54 | 77.99 |
| MB-Khaya.ifc | 22.26 | 101.56 | 573.65 | 59.93 |

SKYLARK250 through the single-file child: `geometryMemoryMb 185.22`, against the `185.836` recorded at 1.451. The AP214 child on a real 110 MB STEP model (`DSA2.step`): payload `4.27`, wasm heap `48.00`, external `194.50`, RSS `884.06` — four quantities, four answers.

`externalMb`/`arrayBuffersMb` reproduce the issue amendment's numbers independently: it measured `58.1`/`56.3` post-GC after geometry on MB-Khaya; the writer records `58.187`/`56.288` with no GC at all.

## On `peakRssMb` vs `rssMb`

Earlier in this branch every model measured showed them equal, because the conway-native writer takes the row at the load's peak by construction. The wider corpus produced a counter-example — `House Aarburg IFC (1).ifc`, peak **264.70** against an end-of-load **260.44** — so the column is not redundant even on that path. It matters most on the loader path, where `model.invalidate(true)` runs before `setMemoryStatistics` (`conway_model_loader.ts`), i.e. the sample is taken *after* a release. That path needs headless-three and was not exercised locally; the scrape contract for it was verified against real conway logs instead.

## Verification

- `yarn lint`: 0 errors (682 warnings, unchanged from `main`).
- `yarn test`: **99 suites, 654 tests, all passing** (`main`: 97 / 641).
- Mutation-checked in three passes, each reverting only that pass's source: **9/10**, **7/7** and **8/9** new-or-amended tests fail without the change. The three that survive are `memory_stats › runs as a node environment under jest` (a precondition guard for its siblings) and `statistics_wasm_heap › reports no number at all when the heap was never measured` (a negative assertion, vacuously true when the field does not exist) — both stated rather than counted as evidence.
- The `gc(); await setImmediate(); gc();` settle has **no site in this change**: nothing here forces GC, by design — that is Tier 2. The three existing `globalThis.gc?.()` sample sites (`m2_consumer_spike.mjs`, `m3_pump_spike.mjs`, `profile_store_extract.mjs`) are synchronous helpers called from many places, so per the amendment they are left alone rather than restructured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RHVKvZN2erpMD7svDWALU