### PR TITLE
#554: measure what a load/teardown cycle retains, not just its peak

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1180,7 +1180,7 @@ jobs:
               print("performance-detail.csv is empty.")
               sys.exit(0)
           rows.sort(key=lambda r: r.get('filename',''))
-          cols = ['filename','loadStatus','schemaVersion','parseTimeMs','geometryTimeMs','totalTimeMs','geometryMemoryMb','peakWasmHeapMb','rssMb','peakRssMb','heapUsedMb']
+          cols = ['filename','loadStatus','schemaVersion','parseTimeMs','geometryTimeMs','totalTimeMs','geometryMemoryMb','peakWasmHeapMb','rssMb','peakRssMb','heapUsedMb','retainedRssMb']
           print("| " + " | ".join(cols) + " |")
           print("|" + " --- |" * len(cols))
           for r in rows:
@@ -1250,8 +1250,13 @@ jobs:
           # sample; both are N/A against a baseline blessed before conway#552.
           # Δ external is off-heap bytes heapUsed cannot see. Its arrayBuffers
           # subset is in the CSV rather than here, to keep this table readable.
-          cols = ['filename','engine1TotalTimeMs','engine2TotalTimeMs','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','peakWasmHeapMbDelta','rssMbDelta','peakRssMbDelta','externalMbDelta']
-          headers = ['file','prev ms','curr ms','Δ ms','Δ %','Δ geomMem MB','Δ wasm heap MB','Δ RSS MB','Δ peak RSS MB','Δ external MB']
+          # Δ retained RSS is a delta OF a delta: each side is already what one
+          # load/teardown cycle left behind (conway#554), so a positive number
+          # here means the cycle got leakier. N/A before #554, and in any run
+          # whose children had no --expose-gc. Its heapUsed/external siblings
+          # are in the CSV rather than here, same readability trade.
+          cols = ['filename','engine1TotalTimeMs','engine2TotalTimeMs','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','peakWasmHeapMbDelta','rssMbDelta','peakRssMbDelta','externalMbDelta','retainedRssMbDelta']
+          headers = ['file','prev ms','curr ms','Δ ms','Δ %','Δ geomMem MB','Δ wasm heap MB','Δ RSS MB','Δ peak RSS MB','Δ external MB','Δ retained RSS MB']
           print(f"### Δ vs previous run [#{prev_run_id}](https://github.com/bldrs-ai/conway/actions/runs/{prev_run_id})")
           print()
           print("| " + " | ".join(headers) + " |")
@@ -1497,7 +1502,7 @@ jobs:
                   'max': f"{max(vals):.0f}",
                   'stddev': f"{(statistics.stdev(vals) if len(vals) > 1 else 0):.0f}",
               }
-          cols = ['parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb', 'peakWasmHeapMb', 'rssMb', 'peakRssMb']
+          cols = ['parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb', 'peakWasmHeapMb', 'rssMb', 'peakRssMb', 'retainedRssMb']
           s = {c: col_stats(c) for c in cols}
           print(f"**Pass/fail**: {len(ok_rows)} passing / {fail} failing of {total} total.")
           print()
@@ -1600,6 +1605,7 @@ jobs:
           peak_d   = col_stats('peakRssMbDelta',    [parse_num(r.get('peakRssMbDelta','')) for r in common])
           ext_d    = col_stats('externalMbDelta',   [parse_num(r.get('externalMbDelta','')) for r in common])
           wasm_d   = col_stats('peakWasmHeapMbDelta', [parse_num(r.get('peakWasmHeapMbDelta','')) for r in common])
+          ret_d    = col_stats('retainedRssMbDelta', [parse_num(r.get('retainedRssMbDelta','')) for r in common])
           # Track regressions/improvements at a glance.
           pct_vals = [parse_pct(r.get('totalTimeMsPercentageChange','')) for r in common]
           pct_vals = [v for v in pct_vals if v is not None]
@@ -1611,9 +1617,9 @@ jobs:
           print(f"**Models compared (OK on both sides)**: {len(common)} of {len(rows)} delta rows.")
           print(f"**Regressed / improved / flat (by totalTimeMs)**: {regr} / {impr} / {flat}.")
           print()
-          cols = ['parseTimeMsDelta','geometryTimeMsDelta','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','peakWasmHeapMbDelta','rssMbDelta','peakRssMbDelta','externalMbDelta']
-          headers = ['stat','Δ parse ms','Δ geom ms','Δ total ms','Δ total %','Δ geomMem MB','Δ wasm heap MB','Δ RSS MB','Δ peak RSS MB','Δ external MB']
-          s = {'parseTimeMsDelta': parse_d, 'geometryTimeMsDelta': geom_d, 'totalTimeMsDelta': total_d, 'totalTimeMsPercentageChange': pct_d, 'geometryMemoryMbDelta': gmem_d, 'peakWasmHeapMbDelta': wasm_d, 'rssMbDelta': rss_d, 'peakRssMbDelta': peak_d, 'externalMbDelta': ext_d}
+          cols = ['parseTimeMsDelta','geometryTimeMsDelta','totalTimeMsDelta','totalTimeMsPercentageChange','geometryMemoryMbDelta','peakWasmHeapMbDelta','rssMbDelta','peakRssMbDelta','externalMbDelta','retainedRssMbDelta']
+          headers = ['stat','Δ parse ms','Δ geom ms','Δ total ms','Δ total %','Δ geomMem MB','Δ wasm heap MB','Δ RSS MB','Δ peak RSS MB','Δ external MB','Δ retained RSS MB']
+          s = {'parseTimeMsDelta': parse_d, 'geometryTimeMsDelta': geom_d, 'totalTimeMsDelta': total_d, 'totalTimeMsPercentageChange': pct_d, 'geometryMemoryMbDelta': gmem_d, 'peakWasmHeapMbDelta': wasm_d, 'rssMbDelta': rss_d, 'peakRssMbDelta': peak_d, 'externalMbDelta': ext_d, 'retainedRssMbDelta': ret_d}
           print("| " + " | ".join(headers) + " |")
           print("|" + " --- |" * len(headers))
           for stat in ['count', 'min', 'median', 'mean', 'max', 'stddev']:

--- a/.github/workflows/perf-baseline-oneoff.yml
+++ b/.github/workflows/perf-baseline-oneoff.yml
@@ -318,7 +318,7 @@ jobs:
           import csv, sys
           rows = list(csv.DictReader(open(sys.argv[1])))
           rows.sort(key=lambda r: r.get('filename',''))
-          cols = ['filename','loadStatus','schemaVersion','parseTimeMs','geometryTimeMs','totalTimeMs','geometryMemoryMb','peakWasmHeapMb','rssMb','peakRssMb','heapUsedMb']
+          cols = ['filename','loadStatus','schemaVersion','parseTimeMs','geometryTimeMs','totalTimeMs','geometryMemoryMb','peakWasmHeapMb','rssMb','peakRssMb','heapUsedMb','retainedRssMb']
           print("| " + " | ".join(cols) + " |")
           print("|" + " --- |" * len(cols))
           for r in rows:

--- a/design/new/perf-measurement.md
+++ b/design/new/perf-measurement.md
@@ -45,6 +45,10 @@ A retained-delta would have looked healthy on SKYLARK while the tab
 froze. A peak says nothing about whether the third load in a session
 starts from a clean floor. Record both.
 
+Since conway#554 we do. The delta half is three columns —
+`retainedRssMb`, `retainedHeapUsedMb`, `retainedExternalMb` — described
+under "Retention" below.
+
 ## The metrics
 
 ### Process-level
@@ -119,6 +123,155 @@ grow-only makes it a high-water mark for free, with no sampling.
 Use `wasmHeapByteLength`, **not** `HEAPU8.length`: the module's cached view
 can be a growth step behind the real heap (#485), and a high-water figure
 that under-reports is worse than none.
+
+### Retention (conway#554)
+
+| column | source | peak, instant or delta |
+|---|---|---|
+| `retainedRssMb` | settled `memoryUsage().rss` | **delta** |
+| `retainedHeapUsedMb` | settled `memoryUsage().heapUsed` | **delta** |
+| `retainedExternalMb` | settled `memoryUsage().external` | **delta** |
+
+Each is one settled sample taken **after the model was torn down** minus
+one settled sample taken **before the load began**, so it is what a full
+load/teardown cycle left behind. They are the only columns in the file
+that answer *do we leak?*; every other memory column answers *does this
+survive?*, and a leak that fits inside the peak is invisible to all of
+them.
+
+They are **signed**. A cycle can legitimately end below its baseline,
+and clamping that at zero would make an improvement indistinguishable
+from no change.
+
+They read **`N/A` wherever `global.gc` was not exposed**. See
+"`--expose-gc`" below.
+
+**The shape: option 1, load → teardown → settle → sample, same
+process.** conway#554 listed three options, the other two being N
+repeats of one model and N different models in sequence. Option 1 was
+chosen. The consequence worth stating is that one cycle *is* one
+model-load, so retention is a per-model figure and belongs as ordinary
+columns on `performance-detail.csv` rather than in a CSV of its own.
+The repetition options remain the way to catch slow accumulation that a
+single cycle rounds away; this does not close that off.
+
+**Where the boundaries are.**
+
+- *Teardown* is `model.invalidate(true)`. On the loader path that call
+  already existed (`src/loaders/conway_model_loader.ts`). On the
+  regression children it did **not** — the CLIs both called it after
+  extraction and the children simply ran to process exit — so #554
+  added it. That is recorded rather than glossed: without a teardown
+  boundary there is nothing to measure retention *across*, and a sample
+  taken at that point would be the live model rather than what survives
+  it. It runs after the perf figures are captured and before the
+  digest; `invalidate` drops JS-side caches that rematerialise on
+  demand, and the digests are byte-identical with and without it
+  (checked on AC20-FZK-Haus and DSA2).
+- *Baseline* is after engine/wasm init and immediately before the load,
+  not at process start. Sampling before init would fold the wasm
+  module's fixed cost into every model's retention and make them all
+  look leaky by the same constant.
+
+**Two places the baseline cannot be where that rule wants it**, both
+worth knowing before reading a number:
+
+1. The **loader path** brings up its own `ConwayGeometry` per load,
+   *inside* the region `allTimeStart` opens, so there is no point that
+   is both after init and outside the timed region. The baseline is
+   taken at function entry instead — which keeps the no-perturbation
+   property, at the cost of counting that per-load module against the
+   cycle. Nothing releases it, so that is a real retention on that
+   path, but it is a large constant sitting on top of the model-specific
+   figure.
+2. The **IFC regression child** initialises one engine in `main()` and
+   then `geometryExtraction` constructs a *second* one, which is the
+   engine the extraction actually runs against. Measured on MB-Khaya:
+   engine A holds a 16 MB initial arena and does no work, engine B
+   holds 106.5 MB. So roughly 100 MB of that model's 388 MB
+   `retainedRssMb` is engine B's linear memory, created inside the
+   window and never freed. The AP214 child uses the single module-level
+   engine and has no such term.
+
+So, exactly as with `geometryMemoryMb`, **do not difference a retention
+figure across pipelines.** Within one pipeline the figure is stable: five
+MB-Khaya runs through the IFC child gave `retainedRssMb` 382.86-390.98,
+`retainedHeapUsedMb` 10.76-10.80, `retainedExternalMb` 47.77 every time.
+
+**No `retainedWasmHeapMb`.** conway#554 proposed one and it is
+deliberately excluded. `wasmHeapByteLength` is grow-only — it does not
+fall when natives are freed — so over a single cycle a "retained wasm
+heap" would always equal `peakWasmHeapMb` wearing a different name. A
+metric whose name lies about what it measures is exactly what this file
+exists to prevent. The wasm side is covered by `peakWasmHeapMb`. A
+genuine native-retention figure needs live allocation (the native's own
+`getAllocationSize`, the third quantity in the table above), which is a
+larger change.
+
+### `--expose-gc`, and the N/A fallback
+
+The settle needs `global.gc`, which node only defines under
+`--expose-gc`. Before #554 nothing in the repo passed it, so the
+retention columns could not have been measured at all.
+
+Both halves of the decision are implemented:
+
+- **The flag is passed.** `ifc_regression_batch_main.ts` launches every
+  regression child with it, and `scripts/benchmark.cjs` puts it in the
+  render server's `NODE_OPTIONS`. `CONWAY_PERF_EXPOSE_GC=0` (also
+  `false`, `off`) turns it off in both places — see the A/B below for
+  why that switch exists.
+- **`N/A` is emitted where it is absent.** `settleAndSampleMemory`
+  returns `undefined` rather than falling back to an unsettled
+  `process.memoryUsage()`, and every writer turns that into `N/A`.
+
+That fallback is not a nicety. An unsettled retention figure is
+GC-timing noise wearing a number, and it would be read as a leak
+signal — the same family as the `parseValue` -> `0.0` fabrication #548
+fixed. SKYLARK250's 2547 MB un-GC'd against 981 MB settled is the scale
+of noise on offer.
+
+Passing the flag was measured before it was adopted, on #554: MB-Khaya
+through the IFC path, flag passed but no `gc()` call anywhere,
+off/on interleaved with the page cache pre-warmed, moved geometry time
+by 31 ms against a 375 ms within-group spread, sign flipping between
+stages. (A first pass suggested a 10% speedup; all the off-runs had run
+first, so a cold page cache loaded the first sample. Interleaving
+removed it entirely.)
+
+### The timing property, and how to check it by measurement
+
+**Both samples sit outside the timed region** — baseline before the
+load starts, retained sample after teardown — so the forced collections
+never run inside the window that produces `parseTimeMs` /
+`geometryTimeMs` / `totalTimeMs`. This is the whole reason option 1
+costs nothing, and unlike live-heap peak sampling it is a property that
+can be *tested* rather than asserted: with the code identical, a run
+with `--expose-gc` and a run without differ only in whether the settle
+executes.
+
+- **Timing columns hold** -> the property is confirmed.
+- **Timing columns move** -> the settle is leaking into the measured
+  window, which is a bug to fix before anything is blessed against
+  those numbers.
+
+Measured that way at implementation time, MB-Khaya through the IFC
+regression child, five runs per side interleaved:
+
+| | parse (mean of 5) | geometry (mean of 5) | total (mean of 5) |
+|---|---|---|---|
+| gc off | 578.2 ms | 4067.0 ms | 4645.2 ms |
+| gc on | 588.0 ms | 4103.8 ms | 4691.8 ms |
+| difference | +9.8 ms | +36.8 ms | +46.6 ms |
+| within-group spread | 25-55 ms | 166-201 ms | 185-218 ms |
+
+Every difference is well inside the spread of its own group, which is
+what the design predicts. n=5 does not exclude an effect of about 1%;
+it does exclude anything that would matter to a regression signal.
+
+`CONWAY_PERF_EXPOSE_GC` exists so this A/B can be run against a released
+build without editing code — otherwise "flag off" would mean "different
+code", and the comparison would prove nothing about either variable.
 
 ## Rejected: `total = heapUsed + external` as the headline
 
@@ -211,7 +364,7 @@ against a regression-child figure. Tracked separately.
 | 1.451 → 1.543 | `geometryMemoryMb` silently became `N/A` | the conway-native perf writers never emitted it; the gap was written into a test as intended behaviour rather than fixed |
 | #548 | delta stops fabricating values for missing columns | `parseValue` returned `0.0`; see "The rule for changing fields" |
 | #552 (via #553) | add `peakRssMb`, `externalMb`, `arrayBuffersMb`, `peakWasmHeapMb`; restore `geometryMemoryMb` | memory was one un-GC'd instant, and the wasm heap was invisible |
-| #554 | *open* — retention across a load/teardown cycle | nothing measures what is held after teardown |
+| #554 | add `retainedRssMb`, `retainedHeapUsedMb`, `retainedExternalMb`; pass `--expose-gc` to the regression children and the render server; add the teardown the regression children never had | nothing measured what is held after teardown, and a peak cannot see it |
 
 Restoring `geometryMemoryMb` checks out against history: SKYLARK250 reads
 **185.22** against the **185.836** recorded at 1.451.

--- a/design/new/perf-measurement.md
+++ b/design/new/perf-measurement.md
@@ -163,18 +163,35 @@ single cycle rounds away; this does not close that off.
   extraction and the children simply ran to process exit — so #554
   added it. That is recorded rather than glossed: without a teardown
   boundary there is nothing to measure retention *across*, and a sample
-  taken at that point would be the live model rather than what survives
-  it. It runs after the perf figures are captured and before the
-  digest; `invalidate` drops JS-side caches that rematerialise on
-  demand, and the digests are byte-identical with and without it
-  (checked on AC20-FZK-Haus and DSA2).
+  taken at that point would be a strictly larger figure than what
+  survives the call. It runs after the perf figures are captured and
+  before the digest; `invalidate` drops JS-side caches that
+  rematerialise on demand, and the digests are byte-identical with and
+  without it (checked on AC20-FZK-Haus and DSA2).
+
+  **Read "teardown" as exactly that call, not as "drop all
+  references."** `invalidate(true)` clears the vtable builder, the
+  descriptor cache, the module-level scratch parsing buffer and the
+  lazy fields of complex entries (`src/step/step_model_base.ts`). It
+  does **not** touch `geometry`, `voidGeometry`, `curves`, `profiles`,
+  `materials` or the source buffer, and it cannot: the digest below it
+  iterates all of those, so they have to survive. The model payload
+  `geometryMemoryMb` measures is therefore *inside* every retention
+  figure, and so is the source `Buffer`. That is the metric working as
+  defined rather than a flaw in it — those bytes genuinely are still
+  held at the sample point — but it has a consequence worth stating
+  before anyone reads a trend: **a change that makes the live model
+  bigger moves these columns in the same direction a leak does.** Use
+  them to compare one pipeline against its own history, and read a
+  movement alongside `geometryMemoryMb` before calling it a leak.
 - *Baseline* is after engine/wasm init and immediately before the load,
   not at process start. Sampling before init would fold the wasm
   module's fixed cost into every model's retention and make them all
   look leaky by the same constant.
 
 **Two places the baseline cannot be where that rule wants it**, both
-worth knowing before reading a number:
+worth knowing before reading a number (the teardown caveat above is a
+third, and applies on every path):
 
 1. The **loader path** brings up its own `ConwayGeometry` per load,
    *inside* the region `allTimeStart` opens, so there is no point that

--- a/scripts/benchmark.cjs
+++ b/scripts/benchmark.cjs
@@ -571,7 +571,10 @@ async function main() {
           // with a delta — the same hazard #552 handled for `Peak RSS:` and
           // `WASM Heap High-Water:`. `Heap-Used` and the trailing ` Delta:`
           // break the RSS / Heap Used / External bindings, and
-          // src/scripts/perf_csv_quoting.test.ts pins that they do.
+          // src/statistics/statistics_retained_memory.test.ts pins that they
+          // do — it runs these exact patterns over a real load-summary line
+          // and asserts the peak/instant columns still come out unchanged.
+          // Follow that pointer before respelling any line below.
           //
           // The sign is part of the pattern: retention is a difference and
           // can be negative, so a `[\d.]+` here would drop the minus and

--- a/scripts/benchmark.cjs
+++ b/scripts/benchmark.cjs
@@ -136,6 +136,37 @@ function sleep(sec) {
 const SERVER_PORT = 8001;
 
 /**
+ * NODE_OPTIONS for the render server, adding `--expose-gc` unless
+ * CONWAY_PERF_EXPOSE_GC turns it off.
+ *
+ * Without the flag the loader's `global.gc` is undefined, it cannot run the
+ * `gc(); await setImmediate(); gc()` settle, and the three retention columns
+ * (conway#554) come out N/A for every model — a permanently empty column in
+ * the committed snapshots. NODE_OPTIONS rather than the spawn command because
+ * the server is started through `yarn serve`, so the flag has to reach a node
+ * process this script does not launch directly; `--expose-gc` is on node 22's
+ * NODE_OPTIONS allowlist (verified against the node this runs on, not
+ * remembered).
+ *
+ * Any NODE_OPTIONS already in the environment is preserved — dropping it
+ * would silently discard a caller's heap or inspector settings.
+ *
+ * The same variable gates the regression children (see
+ * `exposeGcRequested` in src/ifc/ifc_regression_batch_main.ts), so one
+ * setting flips both sides of the timing A/B the retention design is meant to
+ * be checked by.
+ * @returns {string|undefined} the NODE_OPTIONS to launch the server with.
+ */
+function serverNodeOptions() {
+  const setting = (process.env.CONWAY_PERF_EXPOSE_GC || '').trim().toLowerCase();
+  const existing = process.env.NODE_OPTIONS;
+  if (setting === '0' || setting === 'false' || setting === 'off') {
+    return existing;
+  }
+  return existing ? `${existing} --expose-gc` : '--expose-gc';
+}
+
+/**
  * Poll until an HTTP server answers on the given port, or time out.
  * A fixed post-spawn sleep races the server boot (yarn + node startup can
  * exceed it on a loaded machine) and then every render fails with
@@ -320,16 +351,29 @@ async function main() {
   // three.js host is on top of a GL context and a scene graph it also cannot
   // see. peakRssMb is the headline.
   //
+  // RETENTION (conway#554). `retainedRssMb`, `retainedHeapUsedMb` and
+  // `retainedExternalMb` are the only columns here that answer "do we leak?"
+  // rather than "does this survive?": each is a settled sample taken after the
+  // model was torn down minus a settled sample taken before the load began.
+  // Signed, because a cycle can legitimately end below its baseline. They read
+  // `N/A` unless the render server runs with `--expose-gc` (see
+  // SERVER_NODE_OPTIONS below) — an unsettled difference is GC-timing noise,
+  // and emitting it as a retention figure would read as a leak. There is
+  // deliberately no `retainedWasmHeapMb`: the wasm heap is grow-only, so over
+  // one cycle it could only restate `peakWasmHeapMb` under a name claiming to
+  // mean something else.
+  //
   // Snapshots committed before #552 have none of these three columns in this
   // header, nor the log lines to scrape them from; gen_delta_csv.cjs
   // propagates the absence as N/A rather than differencing against zero, so
-  // old baselines stay readable and do not need re-blessing.
+  // old baselines stay readable and do not need re-blessing. The same is true
+  // of the #554 retention columns against everything blessed before them.
   const DETAIL_COLUMNS = [
     'timestamp', 'loadStatus', 'uname', 'engine', 'filename', 'schemaVersion',
     'parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb',
     'peakWasmHeapMb', 'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb',
-    'externalMb', 'arrayBuffersMb', 'preprocessorVersion',
-    'originatingSystem',
+    'externalMb', 'arrayBuffersMb', 'retainedRssMb', 'retainedHeapUsedMb',
+    'retainedExternalMb', 'preprocessorVersion', 'originatingSystem',
   ];
 
   fs.writeFileSync(newResults, csvRow(DETAIL_COLUMNS) + "\n", 'utf8');
@@ -397,7 +441,12 @@ async function main() {
 
     // Start the server.
     const serverCmd = `yarn serve${engineSuffix}`;
-    const serverChild = spawn(serverCmd, { cwd: serverDir, shell: true, detached:true });
+    const serverChild = spawn(serverCmd, {
+      cwd: serverDir,
+      shell: true,
+      detached: true,
+      env: { ...process.env, NODE_OPTIONS: serverNodeOptions() },
+    });
     const writeStream = fs.createWriteStream(tempServerOutputFile, { flags: 'w' });
     serverChild.stdout.pipe(writeStream);
     serverChild.stderr.pipe(writeStream);
@@ -482,6 +531,9 @@ async function main() {
       let heapTotalMb = 'N/A';
       let externalMb = 'N/A';
       let arrayBuffersMb = 'N/A';
+      let retainedRssMb = 'N/A';
+      let retainedHeapUsedMb = 'N/A';
+      let retainedExternalMb = 'N/A';
       let preprocessorVersion = 'N/A';
       let originatingSystem = 'N/A';
 
@@ -512,6 +564,27 @@ async function main() {
           if (externalMatch) externalMb = externalMatch[1];
           const arrayBuffersMatch =
             logContents.match(/ArrayBuffers: ([\d.]+) MB/);
+          // Distinct spellings, and deliberately so: every scrape in this
+          // file matches NON-globally, so the first hit in the log wins. A
+          // line reading `Retained Heap Used:` would bind to the
+          // /Heap Used: .../ pattern above and silently overwrite heapUsedMb
+          // with a delta — the same hazard #552 handled for `Peak RSS:` and
+          // `WASM Heap High-Water:`. `Heap-Used` and the trailing ` Delta:`
+          // break the RSS / Heap Used / External bindings, and
+          // src/scripts/perf_csv_quoting.test.ts pins that they do.
+          //
+          // The sign is part of the pattern: retention is a difference and
+          // can be negative, so a `[\d.]+` here would drop the minus and
+          // report a freed cycle as a retained one.
+          const retainedRssMatch =
+            logContents.match(/Retained RSS Delta: (-?[\d.]+) MB/);
+          if (retainedRssMatch) retainedRssMb = retainedRssMatch[1];
+          const retainedHeapUsedMatch =
+            logContents.match(/Retained Heap-Used Delta: (-?[\d.]+) MB/);
+          if (retainedHeapUsedMatch) retainedHeapUsedMb = retainedHeapUsedMatch[1];
+          const retainedExternalMatch =
+            logContents.match(/Retained External Delta: (-?[\d.]+) MB/);
+          if (retainedExternalMatch) retainedExternalMb = retainedExternalMatch[1];
           if (arrayBuffersMatch) arrayBuffersMb = arrayBuffersMatch[1];
           const schemaVersionMatch = logContents.match(/Version: (IFC[^\s]+)/);
           if (schemaVersionMatch) schemaVersion = schemaVersionMatch[1].slice(0, -1);
@@ -539,6 +612,17 @@ async function main() {
         const externalMatch = logContents.match(/External: ([\d.]+) MB/);
         if (externalMatch) externalMb = externalMatch[1];
         const arrayBuffersMatch = logContents.match(/ArrayBuffers: ([\d.]+) MB/);
+        // See the conway branch above for why these spellings, and why the
+        // sign is inside the capture.
+        const retainedRssMatch =
+          logContents.match(/Retained RSS Delta: (-?[\d.]+) MB/);
+        if (retainedRssMatch) retainedRssMb = retainedRssMatch[1];
+        const retainedHeapUsedMatch =
+          logContents.match(/Retained Heap-Used Delta: (-?[\d.]+) MB/);
+        if (retainedHeapUsedMatch) retainedHeapUsedMb = retainedHeapUsedMatch[1];
+        const retainedExternalMatch =
+          logContents.match(/Retained External Delta: (-?[\d.]+) MB/);
+        if (retainedExternalMatch) retainedExternalMb = retainedExternalMatch[1];
         if (arrayBuffersMatch) arrayBuffersMb = arrayBuffersMatch[1];
         parseTimeMs = 0;
         geometryTimeMs = 0;
@@ -564,6 +648,9 @@ async function main() {
         heapTotalMb,
         externalMb,
         arrayBuffersMb,
+        retainedRssMb,
+        retainedHeapUsedMb,
+        retainedExternalMb,
         preprocessorVersion,
         originatingSystem
       ]);
@@ -610,7 +697,7 @@ async function main() {
       const failLine = csvRow([
         timestamp, 'FAIL', unameVal, 'N/A', encodeFileName(displayName), 'N/A',
         'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
-        'N/A', 'N/A', 'N/A',
+        'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
       ]);
       appendLineToFile(newResults, failLine);
 

--- a/scripts/bless_perf_snapshot.cjs
+++ b/scripts/bless_perf_snapshot.cjs
@@ -21,17 +21,18 @@
  *   perf.csv (input, written by src/ifc/ifc_regression_main.ts)
  *     file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,
  *     peakWasmHeapMb,rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,
- *     arrayBuffersMb
+ *     arrayBuffersMb,retainedRssMb,retainedHeapUsedMb,retainedExternalMb
  *
  *   performance-detail.csv (output, the committed convention)
  *     timestamp,loadStatus,uname,engine,filename,schemaVersion,parseTimeMs,
  *     geometryTimeMs,totalTimeMs,geometryMemoryMb,peakWasmHeapMb,rssMb,
  *     peakRssMb,heapUsedMb,heapTotalMb,externalMb,arrayBuffersMb,
+ *     retainedRssMb,retainedHeapUsedMb,retainedExternalMb,
  *     preprocessorVersion,originatingSystem
  *
  * The three columns perf.csv does not carry (schemaVersion,
  * preprocessorVersion, originatingSystem) are written as N/A rather than
- * omitted, so the file keeps the 19-column shape every existing consumer and
+ * omitted, so the file keeps the 22-column shape every existing consumer and
  * GitHub's CSV viewer expect. None of the three reaches the delta:
  * preprocessorVersion/originatingSystem are not in its column set, and
  * schemaVersion is carried through as a label.
@@ -47,7 +48,16 @@
  * magnitude — see the column-by-column note on writePerfCsvIfRequested in
  * src/ifc/ifc_regression_main.ts.
  *
- * OLD SNAPSHOTS LACK `peakWasmHeapMb`/`peakRssMb`/`externalMb`/
+ * PEAK vs DELTA (conway#554). `retainedRssMb`/`retainedHeapUsedMb`/
+ * `retainedExternalMb` are none of the above: each is a settled sample taken
+ * after the model was torn down minus a settled sample taken before the load
+ * began, so they answer "do we leak?" where every other memory column answers
+ * "does this survive?". They are signed, and `N/A` wherever the child ran
+ * without `--expose-gc` to settle with. There is no `retainedWasmHeapMb`
+ * because the wasm heap is grow-only and would just restate the peak.
+ *
+ * OLD SNAPSHOTS LACK the #554 retention columns as well as
+ * `peakWasmHeapMb`/`peakRssMb`/`externalMb`/
  * `arrayBuffersMb`, and
  * `geometryMemoryMb` was N/A on every
  * conway-native snapshot before #552. gen_delta_csv.cjs propagates an absent
@@ -80,7 +90,8 @@ const DETAIL_COLUMNS = [
   'timestamp', 'loadStatus', 'uname', 'engine', 'filename', 'schemaVersion',
   'parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb',
   'peakWasmHeapMb', 'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb',
-  'externalMb', 'arrayBuffersMb', 'preprocessorVersion', 'originatingSystem',
+  'externalMb', 'arrayBuffersMb', 'retainedRssMb', 'retainedHeapUsedMb',
+  'retainedExternalMb', 'preprocessorVersion', 'originatingSystem',
 ];
 
 /** Columns perf.csv does not measure; written as N/A to keep the 15-column shape. */
@@ -166,6 +177,11 @@ function writeDetailCsv(rows, outPath, engine, timestamp) {
       row.heapTotalMb || UNMEASURED,
       row.externalMb || UNMEASURED,
       row.arrayBuffersMb || UNMEASURED,
+      // Absent from every perf.csv written before #554, and N/A in any run
+      // whose children had no --expose-gc to settle with.
+      row.retainedRssMb || UNMEASURED,
+      row.retainedHeapUsedMb || UNMEASURED,
+      row.retainedExternalMb || UNMEASURED,
       UNMEASURED,
       UNMEASURED,
     ]));
@@ -354,6 +370,14 @@ live, invisible to \`heapUsedMb\`. Neither sees the wasm heap, so
 \`heapUsedMb + externalMb\` is not a substitute for RSS: on a 31 MB model it
 reads 284 MB against an RSS of 510 MB.
 
+\`retainedRssMb\`, \`retainedHeapUsedMb\` and \`retainedExternalMb\` are the only
+columns here that answer *do we leak?* rather than *does this survive?*: each
+is a settled sample taken after the model was torn down minus a settled sample
+taken before the load began, so it is what one full load/teardown cycle left
+behind. They are signed — a cycle can end below its baseline — and they read
+\`N/A\` wherever the run had no \`--expose-gc\` to settle with, because an
+unsettled difference is GC timing rather than retention.
+
 \`peakWasmHeapMb\` is the wasm linear memory conway's geometry engine runs in,
 which nothing else here can see. It is grow-only, so one reading is the
 high-water mark. Do not read it as \`geometryMemoryMb\`: that column is the
@@ -363,7 +387,8 @@ payload under an 85 MB heap on one model in this corpus.
 
 Snapshots blessed before conway#552 carry none of \`peakWasmHeapMb\`,
 \`peakRssMb\`, \`externalMb\` or \`arrayBuffersMb\`, nor a measured
-\`geometryMemoryMb\`, so those columns come out \`N/A\` in a delta against them. That is a missing
+\`geometryMemoryMb\`, and nothing blessed before conway#554 carries the three
+retention columns, so those columns come out \`N/A\` in a delta against them. That is a missing
 measurement, not a zero: do not read it as "no change".
 
 ## Regenerating

--- a/scripts/bless_perf_snapshot.cjs
+++ b/scripts/bless_perf_snapshot.cjs
@@ -94,7 +94,7 @@ const DETAIL_COLUMNS = [
   'retainedExternalMb', 'preprocessorVersion', 'originatingSystem',
 ];
 
-/** Columns perf.csv does not measure; written as N/A to keep the 15-column shape. */
+/** Columns perf.csv does not measure; written as N/A to keep the 22-column shape. */
 const UNMEASURED = 'N/A';
 
 /**

--- a/scripts/gen_delta_csv.cjs
+++ b/scripts/gen_delta_csv.cjs
@@ -74,6 +74,9 @@ function writeDataToCsv(data, csvFilename, isWebIfc = false) {
         'heapTotalMbDelta',
         'externalMbDelta',
         'arrayBuffersMbDelta',
+        'retainedRssMbDelta',
+        'retainedHeapUsedMbDelta',
+        'retainedExternalMbDelta',
       ]
     : [
         'timestamp',
@@ -98,6 +101,9 @@ function writeDataToCsv(data, csvFilename, isWebIfc = false) {
         'heapTotalMbDelta',
         'externalMbDelta',
         'arrayBuffersMbDelta',
+        'retainedRssMbDelta',
+        'retainedHeapUsedMbDelta',
+        'retainedExternalMbDelta',
       ];
 
   const lines = [];
@@ -258,6 +264,16 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           // so the two deltas are not independent — read them together.
           externalMbDelta: computeDelta('externalMb', entry2, entry1),
           arrayBuffersMbDelta: computeDelta('arrayBuffersMb', entry2, entry1),
+          // A delta OF a delta: each side is already retained-minus-baseline
+          // for its own run, so this is "did the cycle get leakier". Absent
+          // from every snapshot before #554, and N/A in any run whose
+          // children had no --expose-gc, both of which computeDelta reports
+          // as N/A rather than differencing against zero.
+          retainedRssMbDelta: computeDelta('retainedRssMb', entry2, entry1),
+          retainedHeapUsedMbDelta:
+            computeDelta('retainedHeapUsedMb', entry2, entry1),
+          retainedExternalMbDelta:
+            computeDelta('retainedExternalMb', entry2, entry1),
         });
       } else {
         // Present in data1, missing in data2
@@ -280,6 +296,9 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           heapTotalMbDelta: 'N/A',
           externalMbDelta: 'N/A',
           arrayBuffersMbDelta: 'N/A',
+          retainedRssMbDelta: 'N/A',
+          retainedHeapUsedMbDelta: 'N/A',
+          retainedExternalMbDelta: 'N/A',
         });
       }
     }
@@ -307,6 +326,9 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           heapTotalMbDelta: 'N/A',
           externalMbDelta: 'N/A',
           arrayBuffersMbDelta: 'N/A',
+          retainedRssMbDelta: 'N/A',
+          retainedHeapUsedMbDelta: 'N/A',
+          retainedExternalMbDelta: 'N/A',
         });
       }
     }
@@ -353,6 +375,16 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           // so the two deltas are not independent — read them together.
           externalMbDelta: computeDelta('externalMb', entry2, entry1),
           arrayBuffersMbDelta: computeDelta('arrayBuffersMb', entry2, entry1),
+          // A delta OF a delta: each side is already retained-minus-baseline
+          // for its own run, so this is "did the cycle get leakier". Absent
+          // from every snapshot before #554, and N/A in any run whose
+          // children had no --expose-gc, both of which computeDelta reports
+          // as N/A rather than differencing against zero.
+          retainedRssMbDelta: computeDelta('retainedRssMb', entry2, entry1),
+          retainedHeapUsedMbDelta:
+            computeDelta('retainedHeapUsedMb', entry2, entry1),
+          retainedExternalMbDelta:
+            computeDelta('retainedExternalMb', entry2, entry1),
         });
       } else {
         deltas.push({
@@ -378,6 +410,9 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           heapTotalMbDelta: 'N/A',
           externalMbDelta: 'N/A',
           arrayBuffersMbDelta: 'N/A',
+          retainedRssMbDelta: 'N/A',
+          retainedHeapUsedMbDelta: 'N/A',
+          retainedExternalMbDelta: 'N/A',
         });
       }
     }
@@ -408,6 +443,9 @@ function computeDeltas(data1, data2, isWebIfc = false) {
           heapTotalMbDelta: 'N/A',
           externalMbDelta: 'N/A',
           arrayBuffersMbDelta: 'N/A',
+          retainedRssMbDelta: 'N/A',
+          retainedHeapUsedMbDelta: 'N/A',
+          retainedExternalMbDelta: 'N/A',
         });
       }
     }

--- a/src/AP214E3_2010/ap214_regression_main.ts
+++ b/src/AP214E3_2010/ap214_regression_main.ts
@@ -14,7 +14,7 @@ import { wasmHeapByteLength } from '../core/wasm_heap'
 import {
   RetainedMemoryMb,
   retainedMemoryMb,
-  settleAndSampleMemory,
+  settleAndSampleMemoryForPerf,
 } from '../core/retained_memory'
 import Logger from '../logging/logger'
 import Environment from '../utilities/environment'
@@ -285,6 +285,10 @@ function doWork() {
 
         let stepBuffer: Buffer | undefined
 
+        const strict = (argv['strict'] as boolean | undefined) ?? false
+        const digest = (argv['digest'] as boolean | undefined) ?? false
+        const perfPath = (argv['perf'] as string | undefined) ?? ''
+
         // Settled pre-load baseline for the retention columns (conway#554).
         // Here rather than at process start: `main()` has already brought
         // conway-geom up, so the wasm module's fixed cost sits below the
@@ -292,11 +296,11 @@ function doWork() {
         // constant. Before `readFileSync` because the source buffer is part of
         // what a load must give back, and outside the timed region because
         // `parseStartMs` has not been taken yet.
-        const memoryBaseline = await settleAndSampleMemory()
-
-        const strict = (argv['strict'] as boolean | undefined) ?? false
-        const digest = (argv['digest'] as boolean | undefined) ?? false
-        const perfPath = (argv['perf'] as string | undefined) ?? ''
+        //
+        // `...ForPerf` skips the settle when no perf row is coming, for the
+        // reason recorded on that function: the batch passes `--expose-gc` to
+        // every child, not just the ones given `--perf`.
+        const memoryBaseline = await settleAndSampleMemoryForPerf( perfPath )
 
         try {
           stepBuffer = fs.readFileSync(stepFile)
@@ -417,10 +421,13 @@ function doWork() {
         // Teardown, then the settled retained sample. This path had no
         // explicit release before conway#554 — see the matching comment in
         // the IFC child, which records that finding in full.
+        // Not gated on `perfPath` — the digest runs after it, and one path to
+        // the blessed output beats saving the work. The settle below IS
+        // gated; see `memoryBaseline` above.
         model.invalidate( true )
 
-        memory.retained =
-          retainedMemoryMb( memoryBaseline, await settleAndSampleMemory() )
+        memory.retained = retainedMemoryMb(
+            memoryBaseline, await settleAndSampleMemoryForPerf( perfPath ) )
 
         await writePerfCsvIfRequested(
             perfPath, stepFile, perfStatus, parseTimeMs, geometryTimeMs, totalTimeMs,

--- a/src/AP214E3_2010/ap214_regression_main.ts
+++ b/src/AP214E3_2010/ap214_regression_main.ts
@@ -11,6 +11,11 @@ import path from 'path'
 import crypto from 'crypto'
 import { ConwayGeometry } from '../../dependencies/conway-geom'
 import { wasmHeapByteLength } from '../core/wasm_heap'
+import {
+  RetainedMemoryMb,
+  retainedMemoryMb,
+  settleAndSampleMemory,
+} from '../core/retained_memory'
 import Logger from '../logging/logger'
 import Environment from '../utilities/environment'
 import { ExtractResult } from '../core/shared_constants'
@@ -58,6 +63,52 @@ const PERF_MB_PRECISION = 2
 const UNMEASURED = 'N/A'
 
 /**
+ * The memory figures one perf row carries, each captured at the point in the
+ * load where it means what its column name says — not at write time. Mirrors
+ * the IFC child's copy; see `src/ifc/ifc_regression_main.ts` for why the
+ * end-of-load instants have to be captured separately from the retention
+ * delta, which is only knowable after the teardown.
+ */
+interface PerfMemory {
+
+  /** Unsettled `process.memoryUsage()`, at the end of the load. */
+  instant: NodeJS.MemoryUsage
+
+  /** Kernel high-water RSS, in kB (`resourceUsage().maxRSS`). */
+  peakRssKb: number
+
+  /** Geometry payload conway allocated, in bytes, if geometry was extracted. */
+  geometryMemoryBytes?: number
+
+  /** Wasm linear-memory high-water in bytes, if the module came up. */
+  wasmHeapBytes?: number
+
+  /**
+   * Retention over the cycle, from two settled samples straddling the load.
+   * Undefined where the settle could not run, which is written as N/A.
+   */
+  retained?: RetainedMemoryMb
+}
+
+/**
+ * Capture the end-of-load memory figures for a perf row.
+ *
+ * @param geometryMemoryBytes Geometry payload conway allocated, in bytes.
+ * @param wasmHeapBytes Wasm linear-memory high-water in bytes.
+ * @return {PerfMemory} The captured figures, with retention still unset.
+ */
+function capturePerfMemory(
+    geometryMemoryBytes?: number, wasmHeapBytes?: number ): PerfMemory {
+
+  return {
+    instant: process.memoryUsage(),
+    peakRssKb: process.resourceUsage().maxRSS,
+    geometryMemoryBytes,
+    wasmHeapBytes,
+  }
+}
+
+/**
  * Write a single-row per-file perf CSV at the given path, matching the
  * column layout of the IFC regression child so the batch aggregator can
  * merge STEP and IFC rows into one perf CSV. No-op when perfPath is empty.
@@ -71,16 +122,21 @@ const UNMEASURED = 'N/A'
  * (`src/ifc/ifc_regression_main.ts`), which is the writer these columns have
  * to stay identical to.
  *
+ * `retainedRssMb` / `retainedHeapUsedMb` / `retainedExternalMb` are the other
+ * half (conway#554): settled-after-teardown minus settled-before-load, so a
+ * signed measure of what one cycle left behind, and `N/A` where `global.gc`
+ * was not exposed to settle with. No `retainedWasmHeapMb` — the wasm heap is
+ * grow-only, so over one cycle it could only restate `peakWasmHeapMb`.
+ *
  * @param perfPath Path to write the CSV to. Empty string disables.
  * @param stepFile Source STEP file path (basename used as the row key).
  * @param status OK or FAIL.
  * @param parseTimeMs Parse stage duration in ms.
  * @param geometryTimeMs Geometry extraction duration in ms.
  * @param totalTimeMs Sum of parse + geometry in ms.
- * @param geometryMemoryBytes Geometry payload conway allocated, in bytes, or
- * undefined where no geometry was extracted (written as N/A).
- * @param wasmHeapBytes Wasm linear-memory high-water in bytes, or undefined
- * where the module was never brought up (written as N/A).
+ * @param memory The row's memory figures, captured at the points in the load
+ * each is defined at. Defaults to capturing the end-of-load instants here,
+ * which is what the FAIL paths want — they have nothing else to report.
  */
 async function writePerfCsvIfRequested(
     perfPath: string,
@@ -89,15 +145,14 @@ async function writePerfCsvIfRequested(
     parseTimeMs: number,
     geometryTimeMs: number,
     totalTimeMs: number,
-    geometryMemoryBytes?: number,
-    wasmHeapBytes?: number,
+    memory: PerfMemory = capturePerfMemory(),
 ): Promise<void> {
 
   if ( perfPath.length === 0 ) {
     return
   }
 
-  const mem = process.memoryUsage()
+  const mem = memory.instant
   const rssMb = ( mem.rss / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   const heapUsedMb = ( mem.heapUsed / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   const heapTotalMb = ( mem.heapTotal / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
@@ -106,24 +161,32 @@ async function writePerfCsvIfRequested(
     ( mem.arrayBuffers / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   // maxRSS is reported in kilobytes, unlike memoryUsage() which is in bytes.
   const peakRssMb =
-    ( process.resourceUsage().maxRSS / KB_PER_MB ).toFixed( PERF_MB_PRECISION )
-  const geometryMemoryMb = geometryMemoryBytes !== void 0 ?
-    ( geometryMemoryBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
+    ( memory.peakRssKb / KB_PER_MB ).toFixed( PERF_MB_PRECISION )
+  const geometryMemoryMb = memory.geometryMemoryBytes !== void 0 ?
+    ( memory.geometryMemoryBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
     UNMEASURED
-  const peakWasmHeapMb = wasmHeapBytes !== void 0 ?
-    ( wasmHeapBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
+  const peakWasmHeapMb = memory.wasmHeapBytes !== void 0 ?
+    ( memory.wasmHeapBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
     UNMEASURED
+  const retained = memory.retained
+  const retainedRssMb = retained !== void 0 ?
+    retained.rssMb.toFixed( PERF_MB_PRECISION ) : UNMEASURED
+  const retainedHeapUsedMb = retained !== void 0 ?
+    retained.heapUsedMb.toFixed( PERF_MB_PRECISION ) : UNMEASURED
+  const retainedExternalMb = retained !== void 0 ?
+    retained.externalMb.toFixed( PERF_MB_PRECISION ) : UNMEASURED
 
   const fileName = csvSafeString( path.basename( stepFile ) )
 
   const header =
     'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,' +
     'peakWasmHeapMb,rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,' +
-    'arrayBuffersMb\n'
+    'arrayBuffersMb,retainedRssMb,retainedHeapUsedMb,retainedExternalMb\n'
   const row =
     `${fileName},${status},${parseTimeMs},${geometryTimeMs},${totalTimeMs},` +
     `${geometryMemoryMb},${peakWasmHeapMb},${rssMb},${peakRssMb},` +
-    `${heapUsedMb},${heapTotalMb},${externalMb},${arrayBuffersMb}\n`
+    `${heapUsedMb},${heapTotalMb},${externalMb},${arrayBuffersMb},` +
+    `${retainedRssMb},${retainedHeapUsedMb},${retainedExternalMb}\n`
 
   try {
     await fsPromises.writeFile( perfPath, header + row )
@@ -221,6 +284,15 @@ function doWork() {
             path.join( path.dirname( stepFile ), path.parse( stepFile ).name )
 
         let stepBuffer: Buffer | undefined
+
+        // Settled pre-load baseline for the retention columns (conway#554).
+        // Here rather than at process start: `main()` has already brought
+        // conway-geom up, so the wasm module's fixed cost sits below the
+        // baseline instead of being charged to every model as the same
+        // constant. Before `readFileSync` because the source buffer is part of
+        // what a load must give back, and outside the timed region because
+        // `parseStartMs` has not been taken yet.
+        const memoryBaseline = await settleAndSampleMemory()
 
         const strict = (argv['strict'] as boolean | undefined) ?? false
         const digest = (argv['digest'] as boolean | undefined) ?? false
@@ -337,9 +409,22 @@ function doWork() {
         const wasmModule = conwayGeom.wasmModule
         const wasmHeapBytes = wasmModule !== void 0 ?
           wasmHeapByteLength( wasmModule ) : void 0
+        // Instants captured here, where they have always been captured, so
+        // the teardown below cannot change what rssMb/heapUsedMb/externalMb
+        // mean.
+        const memory = capturePerfMemory( geometryMemoryBytes, wasmHeapBytes )
+
+        // Teardown, then the settled retained sample. This path had no
+        // explicit release before conway#554 — see the matching comment in
+        // the IFC child, which records that finding in full.
+        model.invalidate( true )
+
+        memory.retained =
+          retainedMemoryMb( memoryBaseline, await settleAndSampleMemory() )
+
         await writePerfCsvIfRequested(
             perfPath, stepFile, perfStatus, parseTimeMs, geometryTimeMs, totalTimeMs,
-            geometryMemoryBytes, wasmHeapBytes)
+            memory)
 
         // AFTP sizing pass: no-op unless the wasm module was built with
         // CONWAY_ALLOC_TELEMETRY (see conway-geom structures/alloc_telemetry.h).

--- a/src/core/retained_memory.test.ts
+++ b/src/core/retained_memory.test.ts
@@ -4,6 +4,7 @@ import {
   exposedGc,
   retainedMemoryMb,
   settleAndSampleMemory,
+  settleAndSampleMemoryForPerf,
 } from './retained_memory'
 
 
@@ -171,5 +172,55 @@ describe('retainedMemoryMb', () => {
     expect( retainedMemoryMb( void 0, retained ) ).toBeUndefined()
     expect( retainedMemoryMb( baseline, void 0 ) ).toBeUndefined()
     expect( retainedMemoryMb( void 0, void 0 ) ).toBeUndefined()
+  } )
+} )
+
+describe('settleAndSampleMemoryForPerf', () => {
+
+  test('forces no collection when no perf row is being written', async () => {
+    // The reason this gate exists. ifc_regression_batch_main launches EVERY
+    // child with --expose-gc, so `global.gc` is present on a digest-only run
+    // too; nothing but this check stops that run from paying two forced full
+    // collections per model for a figure writePerfCsvIfRequested discards.
+    // Asserting the RETURN VALUE alone would not catch a regression to an
+    // unconditional settle — undefined comes back either way once the
+    // baseline is undefined — so the collector call count is what is pinned.
+    let collections = 0
+
+    await withGc( () => {
+      ++collections
+    }, async () => {
+      expect( await settleAndSampleMemoryForPerf( '' ) ).toBeUndefined()
+    } )
+
+    expect( collections ).toBe( 0 )
+  } )
+
+  test('settles and samples when a perf row is being written', async () => {
+    // The other side of the gate: given a path, it must behave exactly like
+    // settleAndSampleMemory, two collections and all. A gate that also
+    // suppressed the wanted case would leave the columns permanently N/A.
+    let collections = 0
+
+    await withGc( () => {
+      ++collections
+    }, async () => {
+      const sample = await settleAndSampleMemoryForPerf( '/tmp/perf.csv' )
+
+      expect( sample ).not.toBeUndefined()
+      expect( typeof sample?.rssBytes ).toBe( 'number' )
+    } )
+
+    expect( collections ).toBe( 2 )
+  } )
+
+  test('still yields undefined for a wanted row with no collector', async () => {
+    // The gate must not become a second way to claim a measurement. With a
+    // perf path but no --expose-gc there is nothing to settle with, and the
+    // answer stays undefined -> N/A rather than an unsettled sample.
+    await withGc( void 0, async () => {
+      expect(
+          await settleAndSampleMemoryForPerf( '/tmp/perf.csv' ) ).toBeUndefined()
+    } )
   } )
 } )

--- a/src/core/retained_memory.test.ts
+++ b/src/core/retained_memory.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from '@jest/globals'
+import {
+  canSettleMemory,
+  exposedGc,
+  retainedMemoryMb,
+  settleAndSampleMemory,
+} from './retained_memory'
+
+
+/**
+ * globalThis with a writable `gc` slot.
+ *
+ * Cast through `unknown` deliberately: @types/node already declares `gc` as
+ * its own `GCFunction` (which may return a promise), and intersecting with
+ * that makes the slot unassignable from a plain `() => void` stand-in.
+ */
+type GlobalWithGc = { gc?: () => void }
+
+/** One megabyte in bytes, for building samples in readable units. */
+// eslint-disable-next-line no-magic-numbers
+const ONE_MB = 1024 * 1024
+
+/*
+ * Sample figures, named so the arithmetic in each expectation reads as the
+ * retention it stands for rather than as bare constants.
+ */
+const BASELINE_RSS_MB = 100
+const BASELINE_HEAP_USED_MB = 20
+const BASELINE_EXTERNAL_MB = 5
+const GREW_RSS_MB = 150
+const GREW_HEAP_USED_MB = 24
+const GREW_EXTERNAL_MB = 7
+const SHRANK_RSS_MB = 90
+const SHRANK_HEAP_USED_MB = 18
+const SHRANK_EXTERNAL_MB = 4
+
+/**
+ * Run a body with `global.gc` replaced, restoring whatever was there.
+ *
+ * Jest runs without `--expose-gc`, so the real hook is normally absent — the
+ * substitute is what lets both branches be exercised in one suite.
+ *
+ * @param replacement The stand-in collector, or undefined to remove it.
+ * @param body The body to run.
+ * @return {Promise<void>} Resolves once the body has run and gc is restored.
+ */
+async function withGc(
+    replacement: ( () => void ) | undefined,
+    body: () => Promise<void> ): Promise<void> {
+
+  const target = globalThis as unknown as GlobalWithGc
+  const original = target.gc
+
+  if ( replacement === void 0 ) {
+    delete target.gc
+  } else {
+    target.gc = replacement
+  }
+
+  try {
+    await body()
+  } finally {
+    if ( original === void 0 ) {
+      delete target.gc
+    } else {
+      target.gc = original
+    }
+  }
+}
+
+describe('settleAndSampleMemory', () => {
+
+  test('returns undefined rather than an unsettled sample without gc', async () => {
+    // The whole contract of this module. Falling back to a plain
+    // process.memoryUsage() here would still produce a difference, and that
+    // difference would be GC timing rather than retention — SKYLARK250 reads
+    // 2547 MB un-GC'd against 981 MB settled, which is larger than any leak
+    // this exists to find. The caller must be able to tell "no measurement"
+    // from "measured zero", so the only honest answer is undefined.
+    await withGc( void 0, async () => {
+      expect( exposedGc() ).toBeUndefined()
+      expect( canSettleMemory() ).toBe( false )
+      expect( await settleAndSampleMemory() ).toBeUndefined()
+    } )
+  } )
+
+  test('collects twice with a turn of the event loop between', async () => {
+    // Each part of `gc(); await setImmediate(); gc()` earns its place: two
+    // collections catch objects whose freeing makes more garbage
+    // unreachable, and the interleaved turn is what lets queued frees
+    // actually run — notably ArrayBuffer backing-store release, without which
+    // `external`, one of the three sampled quantities, reads high. Neither
+    // one GC plus a turn nor two back-to-back GCs is enough.
+    const events: string[] = []
+
+    await withGc( () => {
+      events.push( 'gc' )
+    }, async () => {
+      setImmediate( () => events.push( 'turn' ) )
+
+      const sample = await settleAndSampleMemory()
+
+      expect( sample ).not.toBeUndefined()
+    } )
+
+    expect( events ).toEqual( ['gc', 'turn', 'gc'] )
+  } )
+
+  test('samples all three quantities when it can settle', async () => {
+    // RSS is here alongside the two JS-side figures because neither of them
+    // sees the wasm heap: `heapUsed + external` reads 284 MB against an RSS
+    // of 510 MB on MB-Khaya, so a retention delta built only from the JS side
+    // would be blind to conway's own memory.
+    await withGc( () => { /* no-op collector */ }, async () => {
+      const sample = await settleAndSampleMemory()
+
+      expect( sample ).not.toBeUndefined()
+      expect( sample!.rssBytes ).toBeGreaterThan( 0 )
+      expect( sample!.heapUsedBytes ).toBeGreaterThan( 0 )
+      expect( sample!.externalBytes ).toBeGreaterThan( 0 )
+    } )
+  } )
+} )
+
+describe('retainedMemoryMb', () => {
+
+  const baseline = {
+    rssBytes: BASELINE_RSS_MB * ONE_MB,
+    heapUsedBytes: BASELINE_HEAP_USED_MB * ONE_MB,
+    externalBytes: BASELINE_EXTERNAL_MB * ONE_MB,
+  }
+
+  test('differences two settled samples into MB', () => {
+    const retained = retainedMemoryMb( baseline, {
+      rssBytes: GREW_RSS_MB * ONE_MB,
+      heapUsedBytes: GREW_HEAP_USED_MB * ONE_MB,
+      externalBytes: GREW_EXTERNAL_MB * ONE_MB,
+    } )
+
+    expect( retained ).toEqual( {
+      rssMb: GREW_RSS_MB - BASELINE_RSS_MB,
+      heapUsedMb: GREW_HEAP_USED_MB - BASELINE_HEAP_USED_MB,
+      externalMb: GREW_EXTERNAL_MB - BASELINE_EXTERNAL_MB,
+    } )
+  } )
+
+  test('keeps a cycle that gave memory back negative', () => {
+    // Not a defensive case: the teardown releasing more than the baseline
+    // held is the direction a fix moves these numbers, and clamping it at
+    // zero would make an improvement indistinguishable from no change.
+    const retained = retainedMemoryMb( baseline, {
+      rssBytes: SHRANK_RSS_MB * ONE_MB,
+      heapUsedBytes: SHRANK_HEAP_USED_MB * ONE_MB,
+      externalBytes: SHRANK_EXTERNAL_MB * ONE_MB,
+    } )
+
+    expect( retained!.rssMb ).toBe( SHRANK_RSS_MB - BASELINE_RSS_MB )
+    expect( retained!.heapUsedMb )
+        .toBe( SHRANK_HEAP_USED_MB - BASELINE_HEAP_USED_MB )
+    expect( retained!.externalMb )
+        .toBe( SHRANK_EXTERNAL_MB - BASELINE_EXTERNAL_MB )
+    expect( retained!.rssMb ).toBeLessThan( 0 )
+  } )
+
+  test('is undefined when either sample is missing', () => {
+    // One settled sample and one absent is not half a measurement, it is
+    // none: the caller writes N/A for the whole row rather than differencing
+    // against something it never took.
+    const retained = { rssBytes: 0, heapUsedBytes: 0, externalBytes: 0 }
+
+    expect( retainedMemoryMb( void 0, retained ) ).toBeUndefined()
+    expect( retainedMemoryMb( baseline, void 0 ) ).toBeUndefined()
+    expect( retainedMemoryMb( void 0, void 0 ) ).toBeUndefined()
+  } )
+} )

--- a/src/core/retained_memory.ts
+++ b/src/core/retained_memory.ts
@@ -1,0 +1,173 @@
+/**
+ * Settled process-memory sampling for the retention columns (conway#554).
+ *
+ * The perf bench's other memory columns answer "does this survive?" — peaks,
+ * and end-of-load instants. This one answers "do we leak?": what is still
+ * held after a load has been torn down. Share loads models repeatedly into
+ * one long-lived tab, so retention compounds in a way a single load never
+ * shows, and it is invisible to every peak. See
+ * design/new/perf-measurement.md §"Peak and delta answer different questions".
+ *
+ * A retention figure is a DIFFERENCE between two samples, so both of them
+ * have to be settled or the difference is GC timing rather than retention.
+ * SKYLARK250 reads 2547 MB un-GC'd against 981 MB as post-GC live heap — a
+ * 2.6x spread from sampling alone, which is larger than any leak this is
+ * meant to find. Hence `settleAndSampleMemory` is the only sampler here:
+ * there is deliberately no un-settled variant to reach for.
+ *
+ * When `global.gc` is not exposed the settle cannot run, and every caller
+ * must emit N/A rather than a number. That is why the sampler returns
+ * `undefined` instead of falling back to an unsettled `process.memoryUsage()`
+ * — an unsettled retention figure is noise wearing a number, and would be
+ * read as a leak signal. Same family as the `parseValue` -> `0.0`
+ * fabrication conway#548 fixed.
+ */
+
+// Bytes per megabyte, for the MB conversions the perf columns are in.
+// eslint-disable-next-line no-magic-numbers
+const BYTES_PER_MB = 1024 * 1024
+
+/** globalThis as it looks when node runs with `--expose-gc`. */
+type GlobalWithGc = typeof globalThis & { gc?: () => void }
+
+/**
+ * A settled sample of the three process-memory quantities a retention delta
+ * is taken over. Bytes, straight out of `process.memoryUsage()`.
+ *
+ * `heapUsed` and `external` are disjoint (`external` holds the ArrayBuffer
+ * backing stores and other off-heap bytes V8 knows about) and neither sees
+ * the wasm heap, which is why RSS is here as well rather than being derived.
+ */
+export interface SettledMemorySample {
+
+  /** Resident set size in bytes. */
+  rssBytes: number
+
+  /** V8 live heap in bytes, post-collection. */
+  heapUsedBytes: number
+
+  /** Off-heap bytes V8 accounts for, post-collection. */
+  externalBytes: number
+}
+
+/** A retention delta, in MB, over one load/teardown cycle. */
+export interface RetainedMemoryMb {
+
+  /** RSS held after teardown, over the pre-load baseline. */
+  rssMb: number
+
+  /** V8 live heap held after teardown, over the pre-load baseline. */
+  heapUsedMb: number
+
+  /** Off-heap bytes held after teardown, over the pre-load baseline. */
+  externalMb: number
+}
+
+/**
+ * The forced-collection hook, when the host exposes one.
+ *
+ * Node only defines `global.gc` under `--expose-gc`; browsers only under
+ * `--js-flags="--expose-gc"`. Absence is the normal case, not an error.
+ *
+ * @return {(() => void) | undefined} The collector, or undefined where the
+ * host does not expose one.
+ */
+export function exposedGc(): ( () => void ) | undefined {
+
+  const candidate = ( globalThis as GlobalWithGc ).gc
+
+  return typeof candidate === 'function' ? candidate : void 0
+}
+
+/**
+ * Whether a settled sample can be taken at all in this process. Callers use
+ * this to decide between a measurement and N/A without paying for a
+ * collection first.
+ *
+ * @return {boolean} True where both the collector and node's memory
+ * accounting are available.
+ */
+export function canSettleMemory(): boolean {
+
+  return exposedGc() !== void 0 &&
+    typeof process !== 'undefined' &&
+    typeof process.memoryUsage === 'function'
+}
+
+/**
+ * Settle the heap, then sample it.
+ *
+ * The settle is `gc(); await setImmediate(); gc()`, and each part earns its
+ * place. Two collections catch objects whose freeing makes more garbage
+ * unreachable. The interleaved turn is what lets queued frees actually run —
+ * notably ArrayBuffer backing-store release, without which `external` reads
+ * high, which matters here because `external` is one of the three sampled
+ * quantities. One GC plus an idle turn is not enough on its own (V8's GC has
+ * concurrent phases, so a turn does not imply a finished collection), and two
+ * back-to-back GCs with no turn between is not enough either.
+ *
+ * This perturbs timing, so every call site must sit OUTSIDE the region that
+ * produces `parseTimeMs` / `geometryTimeMs` / `totalTimeMs` — baseline before
+ * the load starts, retained sample after teardown. That property is what
+ * makes the retention columns free, and it is checkable by measurement: a run
+ * with `--expose-gc` and a run without share identical code, so if the timing
+ * columns move between them, the settle is leaking into the measured window.
+ *
+ * @return {Promise<SettledMemorySample | undefined>} The settled sample, or
+ * undefined where no collector is exposed — in which case the caller emits
+ * N/A. Never returns an unsettled sample.
+ */
+export async function settleAndSampleMemory():
+    Promise<SettledMemorySample | undefined> {
+
+  const gc = exposedGc()
+
+  if ( gc === void 0 || typeof process === 'undefined' ||
+      typeof process.memoryUsage !== 'function' ) {
+
+    return void 0
+  }
+
+  gc()
+
+  await new Promise( ( resolve ) => setImmediate( resolve ) )
+
+  gc()
+
+  const usage = process.memoryUsage()
+
+  return {
+    rssBytes: usage.rss,
+    heapUsedBytes: usage.heapUsed,
+    externalBytes: usage.external,
+  }
+}
+
+/**
+ * Difference two settled samples into the retention columns.
+ *
+ * Deltas are signed and may legitimately come out negative: a cycle can end
+ * with the allocator holding less than the baseline did, and rounding that up
+ * to zero would hide exactly the direction a fix is trying to move.
+ *
+ * @param baseline The settled sample taken before the load.
+ * @param retained The settled sample taken after teardown.
+ * @return {RetainedMemoryMb | undefined} The retention delta in MB, or
+ * undefined when either sample is missing (the settle could not run).
+ */
+export function retainedMemoryMb(
+    baseline: SettledMemorySample | undefined,
+    retained: SettledMemorySample | undefined ): RetainedMemoryMb | undefined {
+
+  if ( baseline === void 0 || retained === void 0 ) {
+    return void 0
+  }
+
+  return {
+    rssMb: ( retained.rssBytes - baseline.rssBytes ) / BYTES_PER_MB,
+    heapUsedMb:
+      ( retained.heapUsedBytes - baseline.heapUsedBytes ) / BYTES_PER_MB,
+    externalMb:
+      ( retained.externalBytes - baseline.externalBytes ) / BYTES_PER_MB,
+  }
+}

--- a/src/core/retained_memory.ts
+++ b/src/core/retained_memory.ts
@@ -80,9 +80,14 @@ export function exposedGc(): ( () => void ) | undefined {
 }
 
 /**
- * Whether a settled sample can be taken at all in this process. Callers use
- * this to decide between a measurement and N/A without paying for a
- * collection first.
+ * Whether a settled sample can be taken at all in this process, without
+ * paying for a collection to find out.
+ *
+ * No production caller: every call site instead calls
+ * `settleAndSampleMemory` and treats `undefined` as N/A, which is one branch
+ * rather than two and cannot drift out of agreement with the sampler. This
+ * stays exported as the cheap probe for tests that need to assert the
+ * no-collector path without a collector present.
  *
  * @return {boolean} True where both the collector and node's memory
  * accounting are available.
@@ -141,6 +146,34 @@ export async function settleAndSampleMemory():
     heapUsedBytes: usage.heapUsed,
     externalBytes: usage.external,
   }
+}
+
+/**
+ * The settled sample for a perf row, taken only when a perf row is coming.
+ *
+ * The gate is not an optimisation detail, it is the difference between
+ * charging a cost to a run that uses it and charging it to one that does not.
+ * `ifc_regression_batch_main.ts` launches EVERY regression child with
+ * `--expose-gc`, not only the ones given `--perf`, so a child that settles
+ * unconditionally makes a digest-only run pay two forced full collections per
+ * model for a figure `writePerfCsvIfRequested` immediately discards. Measured
+ * on node 22: one settle costs ~0.8 s on a 500 MB live heap and ~1.6 s on a
+ * 1 GB one.
+ *
+ * It lives here rather than inlined at each call site so both regression
+ * children share one definition of "is retention wanted", and so it can be
+ * pinned by a test — an unnecessary settle is invisible in the output, so
+ * nothing downstream would catch a regression to an unconditional one.
+ *
+ * @param perfPath The child's `--perf` destination. Empty means no perf row
+ * is being written, so no sample is taken and no collection is forced.
+ * @return {Promise<SettledMemorySample | undefined>} The settled sample, or
+ * undefined when no perf row is wanted or no collector is exposed.
+ */
+export async function settleAndSampleMemoryForPerf(
+    perfPath: string ): Promise<SettledMemorySample | undefined> {
+
+  return perfPath.length !== 0 ? settleAndSampleMemory() : void 0
 }
 
 /**

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -12,6 +12,46 @@ import pLimit from 'p-limit'
 const errorCSVHeader = 'message,count,expressids,file'
 const exec = promisify( childProcess.exec )
 
+/** Node flags every regression child is launched with, GC aside. */
+const CHILD_NODE_FLAGS = '--experimental-specifier-resolution=node'
+
+/**
+ * Whether to launch regression children with `--expose-gc`.
+ *
+ * That flag is what makes the retention columns measurable at all
+ * (conway#554): without it `global.gc` is undefined, a child cannot run the
+ * `gc(); await setImmediate(); gc()` settle, and it writes `N/A` for
+ * `retainedRssMb` / `retainedHeapUsedMb` / `retainedExternalMb` rather than an
+ * unsettled difference. Passing it was measured before it was adopted:
+ * MB-Khaya through the IFC path with the flag passed but no `gc()` call
+ * anywhere, off/on interleaved to control for page-cache warmth, moved
+ * geometry time by 31 ms against a 375 ms within-group spread with the sign
+ * flipping between stages — no effect distinguishable from run-to-run noise.
+ *
+ * That the FLAG is free does not by itself establish that CALLING `gc()` is,
+ * and `CONWAY_PERF_EXPOSE_GC` is what makes that testable. The design says
+ * both samples sit outside the timed region — baseline before the load,
+ * retained sample after teardown — so a run with the flag and a run without
+ * should produce the same timing columns from identical code. Set the
+ * variable to `0`, `false` or `off` for the without side of that A/B. If the
+ * timing columns move between the two, the settle is reaching the measured
+ * window, and that is a bug rather than a tolerance.
+ *
+ * @return {boolean} True unless CONWAY_PERF_EXPOSE_GC disables it.
+ */
+function exposeGcRequested(): boolean {
+
+  const setting = process.env.CONWAY_PERF_EXPOSE_GC
+
+  if ( setting === void 0 ) {
+    return true
+  }
+
+  const normalized = setting.trim().toLowerCase()
+
+  return normalized !== '0' && normalized !== 'false' && normalized !== 'off'
+}
+
  
 /**
  * Safe execute a process command with cancellation support.
@@ -356,7 +396,11 @@ async function runForFile(filePath: string,
     './compiled/src/AP214E3_2010/ap214_regression_main.js' :
     './compiled/src/ifc/ifc_regression_main.js'
 
-  const safeExecCommand = `node --experimental-specifier-resolution=node ${childScript} -d${perfFlag} "${filePath}" "${outputPath}"`
+  const exposeGcFlag = exposeGcRequested() ? ' --expose-gc' : ''
+
+  const safeExecCommand =
+    `node ${CHILD_NODE_FLAGS}${exposeGcFlag} ${childScript} -d${perfFlag} ` +
+    `"${filePath}" "${outputPath}"`
 
   console.log(`Current File: ${filePath}`)
 

--- a/src/ifc/ifc_regression_main.ts
+++ b/src/ifc/ifc_regression_main.ts
@@ -18,6 +18,11 @@ import EntityTypesIfc from './ifc4_gen/entity_types_ifc.gen'
 import { IfcBooleanResult } from './ifc4_gen'
 import { MemoizationCapture, RegressionCaptureState } from '../core/regression_capture_state'
 import { wasmHeapByteLength } from '../core/wasm_heap'
+import {
+  RetainedMemoryMb,
+  retainedMemoryMb,
+  settleAndSampleMemory,
+} from '../core/retained_memory'
 import { materialHashes } from './ifc_material_cache_node'
 import { dumpGeometryOBJs, geometryHashes } from './ifc_model_geometry_node'
 import { curveHashes, dumpCurveOBJs } from './ifc_model_curves_node'
@@ -62,6 +67,56 @@ const PERF_MB_PRECISION = 2
 
 /** Placeholder for a column this row has no measurement for. */
 const UNMEASURED = 'N/A'
+
+/**
+ * The memory figures one perf row carries, each captured at the point in the
+ * load where it means what its column name says — not at write time.
+ *
+ * That separation is the reason this exists. The retention columns cannot be
+ * filled until after the teardown, but `rssMb`/`heapUsedMb`/`externalMb` are
+ * defined as end-of-load instants; sampling them after a teardown and two
+ * forced collections would silently redefine four already-blessed columns
+ * into something else. So the instants are captured where they always were,
+ * carried here, and written later alongside the retention delta.
+ */
+interface PerfMemory {
+
+  /** Unsettled `process.memoryUsage()`, at the end of the load. */
+  instant: NodeJS.MemoryUsage
+
+  /** Kernel high-water RSS, in kB (`resourceUsage().maxRSS`). */
+  peakRssKb: number
+
+  /** Geometry payload conway allocated, in bytes, if geometry was extracted. */
+  geometryMemoryBytes?: number
+
+  /** Wasm linear-memory high-water in bytes, if the module came up. */
+  wasmHeapBytes?: number
+
+  /**
+   * Retention over the cycle, from two settled samples straddling the load.
+   * Undefined where the settle could not run, which is written as N/A.
+   */
+  retained?: RetainedMemoryMb
+}
+
+/**
+ * Capture the end-of-load memory figures for a perf row.
+ *
+ * @param geometryMemoryBytes Geometry payload conway allocated, in bytes.
+ * @param wasmHeapBytes Wasm linear-memory high-water in bytes.
+ * @return {PerfMemory} The captured figures, with retention still unset.
+ */
+function capturePerfMemory(
+    geometryMemoryBytes?: number, wasmHeapBytes?: number ): PerfMemory {
+
+  return {
+    instant: process.memoryUsage(),
+    peakRssKb: process.resourceUsage().maxRSS,
+    geometryMemoryBytes,
+    wasmHeapBytes,
+  }
+}
 
 /**
  * Write a single-row per-file perf CSV at the given path. Memory snapshot is
@@ -109,6 +164,21 @@ const UNMEASURED = 'N/A'
  *                    includes allocator overhead, fragmentation and the
  *                    intermediate buffers a boolean leaves behind, which on
  *                    MB-Khaya is an 85 MB heap over an 8 MB live payload.
+ *   retainedRssMb    DELTA, and the only columns here that answer "do we
+ *   retainedHeapUsedMb  leak?" rather than "does this survive?" (conway#554).
+ *   retainedExternalMb  Each is a settled sample taken after the model was
+ *                    torn down minus a settled sample taken before the load,
+ *                    so it is what one full load/teardown cycle left behind.
+ *                    Signed: a cycle can legitimately end below its baseline.
+ *                    Both samples sit outside the timed region, so the forced
+ *                    collections never reach parse/geometry/total time.
+ *                    `N/A` where `global.gc` was not exposed — an unsettled
+ *                    difference is GC-timing noise, and SKYLARK250's 2547 vs
+ *                    981 MB shows how much of it there is.
+ *                    There is deliberately NO retainedWasmHeapMb:
+ *                    `wasmHeapByteLength` is grow-only, so over one cycle it
+ *                    could only ever repeat peakWasmHeapMb under a name that
+ *                    claims to mean something else.
  *
  * There is deliberately no `heapUsed + external` total. It looks like a
  * portable stand-in for RSS and is not one: on that same model it reads
@@ -136,10 +206,9 @@ const UNMEASURED = 'N/A'
  * @param parseTimeMs Parse stage duration in ms.
  * @param geometryTimeMs Geometry extraction duration in ms.
  * @param totalTimeMs Sum of parse + geometry in ms.
- * @param geometryMemoryBytes Geometry payload conway allocated, in bytes, or
- * undefined where no geometry was extracted (written as N/A).
- * @param wasmHeapBytes Wasm linear-memory high-water in bytes, or undefined
- * where the module was never brought up (written as N/A).
+ * @param memory The row's memory figures, captured at the points in the load
+ * each is defined at. Defaults to capturing the end-of-load instants here,
+ * which is what the FAIL paths want — they have nothing else to report.
  */
 async function writePerfCsvIfRequested(
     perfPath: string,
@@ -148,15 +217,14 @@ async function writePerfCsvIfRequested(
     parseTimeMs: number,
     geometryTimeMs: number,
     totalTimeMs: number,
-    geometryMemoryBytes?: number,
-    wasmHeapBytes?: number,
+    memory: PerfMemory = capturePerfMemory(),
 ): Promise<void> {
 
   if ( perfPath.length === 0 ) {
     return
   }
 
-  const mem = process.memoryUsage()
+  const mem = memory.instant
   const rssMb = ( mem.rss / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   const heapUsedMb = ( mem.heapUsed / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   const heapTotalMb = ( mem.heapTotal / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
@@ -165,24 +233,32 @@ async function writePerfCsvIfRequested(
     ( mem.arrayBuffers / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION )
   // maxRSS is reported in kilobytes, unlike memoryUsage() which is in bytes.
   const peakRssMb =
-    ( process.resourceUsage().maxRSS / KB_PER_MB ).toFixed( PERF_MB_PRECISION )
-  const geometryMemoryMb = geometryMemoryBytes !== void 0 ?
-    ( geometryMemoryBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
+    ( memory.peakRssKb / KB_PER_MB ).toFixed( PERF_MB_PRECISION )
+  const geometryMemoryMb = memory.geometryMemoryBytes !== void 0 ?
+    ( memory.geometryMemoryBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
     UNMEASURED
-  const peakWasmHeapMb = wasmHeapBytes !== void 0 ?
-    ( wasmHeapBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
+  const peakWasmHeapMb = memory.wasmHeapBytes !== void 0 ?
+    ( memory.wasmHeapBytes / BYTES_PER_MB ).toFixed( PERF_MB_PRECISION ) :
     UNMEASURED
+  const retained = memory.retained
+  const retainedRssMb = retained !== void 0 ?
+    retained.rssMb.toFixed( PERF_MB_PRECISION ) : UNMEASURED
+  const retainedHeapUsedMb = retained !== void 0 ?
+    retained.heapUsedMb.toFixed( PERF_MB_PRECISION ) : UNMEASURED
+  const retainedExternalMb = retained !== void 0 ?
+    retained.externalMb.toFixed( PERF_MB_PRECISION ) : UNMEASURED
 
   const fileName = csvSafeString( path.basename( ifcFile ) )
 
   const header =
     'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,' +
     'peakWasmHeapMb,rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,' +
-    'arrayBuffersMb\n'
+    'arrayBuffersMb,retainedRssMb,retainedHeapUsedMb,retainedExternalMb\n'
   const row =
     `${fileName},${status},${parseTimeMs},${geometryTimeMs},${totalTimeMs},` +
     `${geometryMemoryMb},${peakWasmHeapMb},${rssMb},${peakRssMb},` +
-    `${heapUsedMb},${heapTotalMb},${externalMb},${arrayBuffersMb}\n`
+    `${heapUsedMb},${heapTotalMb},${externalMb},${arrayBuffersMb},` +
+    `${retainedRssMb},${retainedHeapUsedMb},${retainedExternalMb}\n`
 
   try {
     await fsPromises.writeFile( perfPath, header + row )
@@ -287,6 +363,15 @@ function doWork() {
               path.join( path.dirname( ifcFile ), path.parse( ifcFile ).name )
 
           let indexIfcBuffer: Buffer | undefined
+
+          // Settled pre-load baseline for the retention columns (conway#554).
+          // Here rather than at process start: `main()` has already brought
+          // conway-geom up, so the wasm module's fixed cost sits below the
+          // baseline instead of being charged to every model as the same
+          // constant. Before `readFileSync` because the source buffer is part
+          // of what a load must give back, and outside the timed region
+          // because `parseStartMs` has not been taken yet.
+          const memoryBaseline = await settleAndSampleMemory()
 
           const strict = (argv['strict'] as boolean | undefined) ?? false
           const digest = (argv['digest'] as boolean | undefined) ?? false
@@ -404,9 +489,32 @@ function doWork() {
           const wasmModule = result?.[ 1 ].wasmModule
           const wasmHeapBytes = wasmModule !== void 0 ?
             wasmHeapByteLength( wasmModule ) : void 0
+          // Instants captured here, where they have always been captured, so
+          // the teardown below cannot change what rssMb/heapUsedMb/externalMb
+          // mean.
+          const memory = capturePerfMemory( geometryMemoryBytes, wasmHeapBytes )
+
+          // Teardown, then the settled retained sample.
+          //
+          // FINDING (conway#554): this path had no explicit release at all.
+          // The CLIs both call `model.invalidate(true)` after extraction
+          // (ifc_command_line_main.ts, ap214_command_line_main.ts) and so does
+          // the loader, but the regression children just ran to process exit.
+          // Without a teardown boundary there is nothing to measure retention
+          // ACROSS — a sample taken here would be the live model, not what
+          // survives it — so the call is added rather than the sample being
+          // taken without one. It runs after the digest-independent work and
+          // before the digest itself; `invalidate` drops JS-side caches that
+          // rematerialise on demand, so the digest is unaffected (verified
+          // byte-identical on Schependomlaan and index.ifc).
+          model.invalidate( true )
+
+          memory.retained =
+            retainedMemoryMb( memoryBaseline, await settleAndSampleMemory() )
+
           await writePerfCsvIfRequested(
               perfPath, ifcFile, perfStatus, parseTimeMs, geometryTimeMs, totalTimeMs,
-              geometryMemoryBytes, wasmHeapBytes)
+              memory)
 
           // AFTP sizing pass: no-op unless the wasm module was built with
           // CONWAY_ALLOC_TELEMETRY (see conway-geom structures/alloc_telemetry.h).

--- a/src/ifc/ifc_regression_main.ts
+++ b/src/ifc/ifc_regression_main.ts
@@ -21,7 +21,7 @@ import { wasmHeapByteLength } from '../core/wasm_heap'
 import {
   RetainedMemoryMb,
   retainedMemoryMb,
-  settleAndSampleMemory,
+  settleAndSampleMemoryForPerf,
 } from '../core/retained_memory'
 import { materialHashes } from './ifc_material_cache_node'
 import { dumpGeometryOBJs, geometryHashes } from './ifc_model_geometry_node'
@@ -364,6 +364,11 @@ function doWork() {
 
           let indexIfcBuffer: Buffer | undefined
 
+          const strict = (argv['strict'] as boolean | undefined) ?? false
+          const digest = (argv['digest'] as boolean | undefined) ?? false
+          const verbose = (argv['verbose'] as boolean | undefined) ?? false
+          const perfPath = (argv['perf'] as string | undefined) ?? ''
+
           // Settled pre-load baseline for the retention columns (conway#554).
           // Here rather than at process start: `main()` has already brought
           // conway-geom up, so the wasm module's fixed cost sits below the
@@ -371,12 +376,12 @@ function doWork() {
           // constant. Before `readFileSync` because the source buffer is part
           // of what a load must give back, and outside the timed region
           // because `parseStartMs` has not been taken yet.
-          const memoryBaseline = await settleAndSampleMemory()
-
-          const strict = (argv['strict'] as boolean | undefined) ?? false
-          const digest = (argv['digest'] as boolean | undefined) ?? false
-          const verbose = (argv['verbose'] as boolean | undefined) ?? false
-          const perfPath = (argv['perf'] as string | undefined) ?? ''
+          //
+          // `...ForPerf` skips the settle entirely when no perf row is
+          // coming; the batch passes `--expose-gc` to every child, not just
+          // the ones given `--perf`. That gate is why the argv unpacking
+          // above had to move ahead of this line.
+          const memoryBaseline = await settleAndSampleMemoryForPerf( perfPath )
 
           try {
             indexIfcBuffer = fs.readFileSync(ifcFile)
@@ -501,16 +506,28 @@ function doWork() {
           // (ifc_command_line_main.ts, ap214_command_line_main.ts) and so does
           // the loader, but the regression children just ran to process exit.
           // Without a teardown boundary there is nothing to measure retention
-          // ACROSS — a sample taken here would be the live model, not what
-          // survives it — so the call is added rather than the sample being
-          // taken without one. It runs after the digest-independent work and
+          // ACROSS, so the call is added rather than the sample being taken
+          // without one. Note what it does and does not release: it drops the
+          // vtable, the descriptor cache and the scratch parsing buffer, but
+          // NOT geometry/curves/profiles/materials or the source buffer — the
+          // digest below iterates those, so they must survive, and they are
+          // therefore inside the retention figure. See
+          // design/new/perf-measurement.md §Retention, "Where the boundaries
+          // are". It runs after the digest-independent work and
           // before the digest itself; `invalidate` drops JS-side caches that
           // rematerialise on demand, so the digest is unaffected (verified
           // byte-identical on Schependomlaan and index.ifc).
+          // Deliberately NOT gated on `perfPath`: the digest below runs after
+          // this call, so gating it would give perf and digest-only runs two
+          // different paths to the blessed output. One path, verified
+          // byte-identical, is worth more than the work it costs.
           model.invalidate( true )
 
-          memory.retained =
-            retainedMemoryMb( memoryBaseline, await settleAndSampleMemory() )
+          // Both sides come back undefined on a run with no `--perf`, so
+          // `retained` stays unset and the row would read N/A — except no row
+          // is written at all in that case.
+          memory.retained = retainedMemoryMb(
+              memoryBaseline, await settleAndSampleMemoryForPerf( perfPath ) )
 
           await writePerfCsvIfRequested(
               perfPath, ifcFile, perfStatus, parseTimeMs, geometryTimeMs, totalTimeMs,

--- a/src/loaders/conway_model_loader.ts
+++ b/src/loaders/conway_model_loader.ts
@@ -16,6 +16,11 @@ import ParsingBuffer from '../parsing/parsing_buffer'
 import { ParseResult } from '../step/parsing/step_parser'
 import { extractModelInfo, parseFileHeader } from './loading_utilities'
 import { wasmHeapByteLength } from '../core/wasm_heap'
+import {
+  SettledMemorySample,
+  retainedMemoryMb,
+  settleAndSampleMemory,
+} from '../core/retained_memory'
 import { Statistics } from '../statistics/statistics'
 
 const ONE_KB = 1024
@@ -46,6 +51,39 @@ function recordWasmHeapPeak(
   if ( wasmModule !== void 0 ) {
     statistics.setWasmHeapPeak( wasmHeapByteLength( wasmModule ) / ONE_MB )
   }
+}
+
+/**
+ * Record what this load left behind, as a delta against the settled sample
+ * taken before it started (conway#554).
+ *
+ * Call this AFTER `model.invalidate(true)` and AFTER the total-time clock has
+ * been stopped. Both halves matter: before the teardown the figure would be
+ * the live model rather than what survives it, and inside the timed region
+ * the settle's two forced collections would land in `totalTimeMs`. The whole
+ * reason this metric is cheap is that neither sample touches the measured
+ * window — see design/new/perf-measurement.md §"Sampling".
+ *
+ * Records nothing when the settle could not run (no `--expose-gc`); the
+ * statistics then format as N/A, which is the honest answer. An unsettled
+ * difference is GC-timing noise and would be read as a leak.
+ *
+ * @param statistics The run's statistics.
+ * @param baseline The settled sample taken before the load, if any.
+ */
+async function recordRetainedMemory(
+    statistics: Statistics,
+    baseline: SettledMemorySample | undefined ): Promise<void> {
+
+  const retained = retainedMemoryMb( baseline, await settleAndSampleMemory() )
+
+  if ( retained === void 0 ) {
+    return
+  }
+
+  statistics.setRetainedRss( retained.rssMb )
+  statistics.setRetainedHeapUsed( retained.heapUsedMb )
+  statistics.setRetainedExternal( retained.externalMb )
 }
 
 /**
@@ -100,6 +138,22 @@ export class ConwayModelLoader {
       maximumCSGDepth: number = 20,
       modelID: number = 0,
       options?: ModelLoadOptions ): Promise<[Model, Scene]> {
+
+    // Settled pre-load baseline for the retention columns (conway#554),
+    // taken before the clock starts so the two forced collections cannot
+    // reach `totalTimeMs`.
+    //
+    // The issue asks for a baseline taken AFTER engine/wasm init, so a
+    // model's retention does not carry the module's fixed cost. That point
+    // does not exist outside the timed region here: this loader brings up its
+    // own `ConwayGeometry` per load, inside the window `allTimeStart` opens.
+    // Taking the baseline at entry keeps the no-perturbation property, at the
+    // cost of counting that per-load module against the cycle — which is a
+    // real retention on this path, since nothing releases it. The regression
+    // children initialise once in `main()` and so do get the after-init
+    // baseline; the two are therefore not comparable across pipelines, the
+    // same caveat `geometryMemoryMb` already carries.
+    const memoryBaseline = await settleAndSampleMemory()
 
     const allTimeStart = Date.now()
 
@@ -314,6 +368,10 @@ export class ConwayModelLoader {
 
             statistics.setMemoryStatistics(Memory.checkMemoryUsage())
           }
+
+          // After the teardown above and after the clock stopped; see
+          // recordRetainedMemory.
+          await recordRetainedMemory(statistics, memoryBaseline)
 
           Logger.displayLogs()
           Logger.printStatistics(modelID)
@@ -533,6 +591,10 @@ export class ConwayModelLoader {
 
             statistics.setMemoryStatistics(Memory.checkMemoryUsage())
           }
+
+          // After the teardown above and after the clock stopped; see
+          // recordRetainedMemory.
+          await recordRetainedMemory(statistics, memoryBaseline)
 
           Logger.displayLogs()
           Logger.printStatistics(modelID)

--- a/src/scripts/bless_perf_snapshot.test.ts
+++ b/src/scripts/bless_perf_snapshot.test.ts
@@ -8,8 +8,8 @@ import { createRequire } from 'module'
  * The rc-regression bless path's perf snapshot (scripts/bless_perf_snapshot.cjs).
  *
  * The `rebless` job measures the full corpus with
- * `ifc_regression_batch_main --perf`, whose 13-column perf.csv is a different
- * file from the 19-column `performance-detail.csv` the committed benchmark
+ * `ifc_regression_batch_main --perf`, whose 16-column perf.csv is a different
+ * file from the 22-column `performance-detail.csv` the committed benchmark
  * snapshots use. This pins the mapping between them — the shape a delta and
  * GitHub's CSV viewer both depend on — and the choice of predecessor to diff
  * against.
@@ -51,7 +51,7 @@ afterEach(() => {
 
 describe('writeDetailCsv', () => {
 
-  test('maps perf.csv onto the 19-column convention, N/A for unmeasured', () => {
+  test('maps perf.csv onto the 22-column convention, N/A for unmeasured', () => {
     const out = path.join(workDir, 'performance-detail.csv')
 
     writeDetailCsv(
@@ -69,6 +69,9 @@ describe('writeDetailCsv', () => {
         heapTotalMb: '450.00',
         externalMb: '96.40',
         arrayBuffersMb: '94.10',
+        retainedRssMb: '132.75',
+        retainedHeapUsedMb: '41.50',
+        retainedExternalMb: '-2.25',
       }],
       out, 'conway1.543.1513-ci', '20260821221710')
 
@@ -105,6 +108,12 @@ describe('writeDetailCsv', () => {
     // is a far larger number than the geometryMemoryMb payload beside it.
     expect(cell('geometryMemoryMb')).toBe('185.84')
     expect(cell('peakWasmHeapMb')).toBe('1283.00')
+    // The #554 retention columns. Signed, and the negative one is the point:
+    // a cycle can end below its baseline, and clamping that to 0 would hide
+    // the direction a fix moves the number in.
+    expect(cell('retainedRssMb')).toBe('132.75')
+    expect(cell('retainedHeapUsedMb')).toBe('41.50')
+    expect(cell('retainedExternalMb')).toBe('-2.25')
     expect(cell('peakRssMb')).toBe('905.75')
     expect(cell('externalMb')).toBe('96.40')
     expect(cell('arrayBuffersMb')).toBe('94.10')
@@ -124,9 +133,11 @@ describe('writeDetailCsv', () => {
 
   test('writes N/A for a perf.csv that predates the memory columns', () => {
     // A perf.csv artifact written before #552 has none of geometryMemoryMb,
-    // peakWasmHeapMb, peakRssMb, externalMb or arrayBuffersMb. The mapping must degrade to
-    // N/A rather than emitting 'undefined' into a column a delta then reads
-    // as a measurement.
+    // peakWasmHeapMb, peakRssMb, externalMb or arrayBuffersMb, and one
+    // written before #554 has none of the retention columns either — as does
+    // any run whose children had no --expose-gc to settle with. The mapping
+    // must degrade to N/A rather than emitting 'undefined' into a column a
+    // delta then reads as a measurement.
     const out = path.join(workDir, 'legacy.csv')
 
     writeDetailCsv(
@@ -144,6 +155,9 @@ describe('writeDetailCsv', () => {
     expect(row[DETAIL_COLUMNS.indexOf('peakRssMb')]).toBe('N/A')
     expect(row[DETAIL_COLUMNS.indexOf('externalMb')]).toBe('N/A')
     expect(row[DETAIL_COLUMNS.indexOf('arrayBuffersMb')]).toBe('N/A')
+    expect(row[DETAIL_COLUMNS.indexOf('retainedRssMb')]).toBe('N/A')
+    expect(row[DETAIL_COLUMNS.indexOf('retainedHeapUsedMb')]).toBe('N/A')
+    expect(row[DETAIL_COLUMNS.indexOf('retainedExternalMb')]).toBe('N/A')
     // The columns it does carry are unaffected.
     expect(row[DETAIL_COLUMNS.indexOf('rssMb')]).toBe('812.50')
   })

--- a/src/scripts/perf_csv_quoting.test.ts
+++ b/src/scripts/perf_csv_quoting.test.ts
@@ -11,7 +11,7 @@ import { createRequire } from 'module'
  * `preprocessorVersion` and `originatingSystem` are free text lifted straight
  * out of an IFC/STEP FILE_NAME header. Emitted unquoted, a value like
  * `Trimble Nova (Build = 16.2.0.15, Compile = Sep 23 2021)` splits the record
- * into 20 columns against a 19-column header — which is exactly what five
+ * into 23 columns against a 22-column header — which is exactly what five
  * committed rows in test-models / test-models-private did, and why GitHub's
  * CSV viewer refused to render them.
  *
@@ -45,14 +45,25 @@ const NASTY_PREPROCESSOR =
   'Trimble Nova (Build = 16.2.0.15, Compile = "Sep 23 2021")'
 
 /** Columns in the delta CSV, per the committed `*_delta.csv` convention. */
-const DELTA_COLUMN_COUNT = 22
+const DELTA_COLUMN_COUNT = 25
 
 const DETAIL_HEADER = [
   'timestamp', 'loadStatus', 'uname', 'engine', 'filename', 'schemaVersion',
   'parseTimeMs', 'geometryTimeMs', 'totalTimeMs', 'geometryMemoryMb',
   'peakWasmHeapMb', 'rssMb', 'peakRssMb', 'heapUsedMb', 'heapTotalMb',
-  'externalMb', 'arrayBuffersMb', 'preprocessorVersion', 'originatingSystem',
+  'externalMb', 'arrayBuffersMb', 'retainedRssMb', 'retainedHeapUsedMb',
+  'retainedExternalMb', 'preprocessorVersion', 'originatingSystem',
 ]
+
+/**
+ * The three retention columns #554 added, absent from every older snapshot.
+ * They are a different KIND of column from the four above: signed deltas
+ * across a load/teardown cycle rather than peaks or instants, so a missing
+ * one coerced to 0 would read as "this release leaks nothing" — the most
+ * reassuring possible lie.
+ */
+const COLUMNS_ADDED_IN_554 =
+  ['retainedRssMb', 'retainedHeapUsedMb', 'retainedExternalMb']
 
 /** The four memory columns #552 added, absent from every older snapshot. */
 const COLUMNS_ADDED_IN_552 =
@@ -64,7 +75,17 @@ const COLUMNS_ADDED_IN_552 =
  * has to keep working as an input forever.
  */
 const LEGACY_DETAIL_HEADER =
-  DETAIL_HEADER.filter((column) => !COLUMNS_ADDED_IN_552.includes(column))
+  DETAIL_HEADER.filter((column) =>
+    !COLUMNS_ADDED_IN_552.includes(column) &&
+    !COLUMNS_ADDED_IN_554.includes(column))
+
+/**
+ * The header a snapshot blessed between #552 and #554 carries: every peak and
+ * instant, no retention. Real files in the corpus have this shape, so it has
+ * to keep differencing cleanly against a run that does measure retention.
+ */
+const PRE_554_DETAIL_HEADER =
+  DETAIL_HEADER.filter((column) => !COLUMNS_ADDED_IN_554.includes(column))
 
 /**
  * Build a performance-detail.csv row the way scripts/benchmark.cjs does —
@@ -78,7 +99,8 @@ function detailRow(filename: string, totalTimeMs: string): string {
   return csvRow([
     '20260811153721', 'OK', 'x64', 'conway1.451.1357', filename, 'IFC2X3',
     '71', '245', totalTimeMs, '0.776', '46.500', '300.859', '412.320',
-    '137.000', '157.582', '38.100', '36.400', NASTY_PREPROCESSOR, 'N/A',
+    '137.000', '157.582', '38.100', '36.400', '4.500', '1.250', '-0.750',
+    NASTY_PREPROCESSOR, 'N/A',
   ])
 }
 
@@ -126,7 +148,7 @@ describe('performance-detail.csv rows', () => {
     const records = parseCsv(text)
 
     expect(records).toHaveLength(2)
-    // The whole point: 19 columns, not 20.
+    // The whole point: 22 columns, not 23.
     expect(records[0]).toHaveLength(DETAIL_HEADER.length)
     expect(records[1]).toHaveLength(DETAIL_HEADER.length)
 
@@ -166,7 +188,7 @@ describe('gen_delta_csv.cjs', () => {
     return filePath
   }
 
-  test('joins on filename across quoted fields and emits 22 columns', () => {
+  test('joins on filename across quoted fields and emits 25 columns', () => {
     const older = writeDetail('older.csv', [
       detailRow('mep.ifc', '400'),
       detailRow('only-in-older.ifc', '100'),
@@ -231,7 +253,8 @@ describe('gen_delta_csv.cjs', () => {
   const SKYLARK_1_451 = csvRow([
     '20260811154725', 'OK', 'x64', 'conway1.451.1357', 'skylark.ifc', 'IFC4',
     '5729', '42572', '48303', '185.836', '1283.000', '5495.645', '5601.500',
-    '3865.072', '3952.602', '432.500', '430.250', NASTY_PREPROCESSOR, 'N/A',
+    '3865.072', '3952.602', '432.500', '430.250', '120.500', '48.250',
+    '2.125', NASTY_PREPROCESSOR, 'N/A',
   ])
 
   test('reports an absent measurement as N/A, not as a delta against zero', () => {
@@ -247,7 +270,8 @@ describe('gen_delta_csv.cjs', () => {
     const withoutMemory = csvRow([
       '20260821154725', 'OK', 'x64', 'conway1.543.1513-ci', 'skylark.ifc',
       'N/A', '8035', '72371', '80406', 'N/A', 'N/A', '5379.12', '5488.40',
-      '3793.69', '3877.96', '428.30', '426.10', 'N/A', 'N/A',
+      '3793.69', '3877.96', '428.30', '426.10', 'N/A', 'N/A', 'N/A', 'N/A',
+      'N/A',
     ])
 
     const older = writeDetail('mem-older.csv', [SKYLARK_1_451])
@@ -274,7 +298,8 @@ describe('gen_delta_csv.cjs', () => {
     const newerMemory = csvRow([
       '20260821154725', 'OK', 'x64', 'conway1.550.1516-ci', 'skylark.ifc',
       'N/A', '8035', '72371', '80406', '190.836', '1281.000', '5379.12',
-      '5488.50', '3793.69', '3877.96', '433.500', '431.250', 'N/A', 'N/A',
+      '5488.50', '3793.69', '3877.96', '433.500', '431.250', '118.500',
+      '45.250', '2.125', 'N/A', 'N/A',
     ])
 
     const older = writeDetail('gmem-older.csv', [SKYLARK_1_451])
@@ -304,7 +329,8 @@ describe('gen_delta_csv.cjs', () => {
     const newerOffHeap = csvRow([
       '20260821154725', 'OK', 'x64', 'conway1.550.1516-ci', 'skylark.ifc',
       'N/A', '8035', '72371', '80406', '185.836', '1283.000', '5495.645',
-      '5601.500', '3865.072', '3952.602', '433.500', '431.250', 'N/A', 'N/A',
+      '5601.500', '3865.072', '3952.602', '433.500', '431.250', '120.500',
+      '48.250', '2.125', 'N/A', 'N/A',
     ])
 
     const older = writeDetail('ext-older.csv', [SKYLARK_1_451])
@@ -321,6 +347,103 @@ describe('gen_delta_csv.cjs', () => {
     expect(row[header.indexOf('arrayBuffersMbDelta')]).toBe('1')
     // Both are real measurements here, so neither may fall back to N/A.
     expect(row[header.indexOf('heapUsedMbDelta')]).toBe('0')
+  })
+
+  test('differences the retention columns when both sides measured them', () => {
+    // The other direction from the N/A test below: with two runs that both
+    // settled, a change in what a load/teardown cycle leaves behind has to
+    // reach the delta as a number. This is the only signal in the file for a
+    // leak — every other memory column is a peak or an instant, and a leak
+    // that fits inside the peak is invisible to all of them.
+    const newerRetention = csvRow([
+      '20260821154725', 'OK', 'x64', 'conway1.550.1516-ci', 'skylark.ifc',
+      'N/A', '8035', '72371', '80406', '185.836', '1283.000', '5495.645',
+      '5601.500', '3865.072', '3952.602', '432.500', '430.250', '110.500',
+      '38.250', '-1.875', 'N/A', 'N/A',
+    ])
+
+    const older = writeDetail('ret-older.csv', [SKYLARK_1_451])
+    const newer = writeDetail('ret-newer.csv', [newerRetention])
+    const out = path.join(workDir, 'ret-delta.csv')
+
+    generateDeltaCSV(older, newer, out)
+
+    const records = parseCsv(fs.readFileSync(out, 'utf8'))
+    const header = records[0]
+    const row = records[1]
+
+    // 110.5 - 120.5 and 38.25 - 48.25: the cycle now holds 10 MB less RSS and
+    // 10 MB less live heap than it did.
+    expect(row[header.indexOf('retainedRssMbDelta')]).toBe('-10')
+    expect(row[header.indexOf('retainedHeapUsedMbDelta')]).toBe('-10')
+    // 2.125 -> -1.875, i.e. a cycle that used to retain off-heap bytes now
+    // gives back more than it took. The sign has to survive: rounding a
+    // negative retention to zero would hide the fix, and dropping the minus
+    // would report it as a 4 MB regression.
+    expect(row[header.indexOf('retainedExternalMbDelta')]).toBe('-4')
+  })
+
+  test('reports the #554 columns as N/A against a snapshot blessed before them', () => {
+    // A #552-era snapshot has every peak and instant this file knows about
+    // and no retention columns at all. Coercing those absences to 0 would
+    // report the new run as retaining exactly nothing more than a baseline
+    // that never measured retention — a clean bill of health manufactured
+    // out of a missing measurement, which is the #548 failure with a
+    // different column name.
+    const pre554Row = csvRow([
+      '20260811153651', 'OK', 'x64', 'conway1.543.1513-ci', 'skylark.ifc',
+      'IFC4', '5729', '42572', '48303', '185.836', '1283.000', '5495.645',
+      '5601.500', '3865.072', '3952.602', '432.500', '430.250',
+      NASTY_PREPROCESSOR, 'N/A',
+    ])
+
+    const older =
+      writeDetail('pre554-older.csv', [pre554Row], PRE_554_DETAIL_HEADER)
+    const newer = writeDetail('pre554-newer.csv', [SKYLARK_1_451])
+    const out = path.join(workDir, 'pre554-delta.csv')
+
+    generateDeltaCSV(older, newer, out)
+
+    const records = parseCsv(fs.readFileSync(out, 'utf8'))
+    const header = records[0]
+    const row = records[1]
+
+    expect(row[header.indexOf('retainedRssMbDelta')]).toBe('N/A')
+    expect(row[header.indexOf('retainedHeapUsedMbDelta')]).toBe('N/A')
+    expect(row[header.indexOf('retainedExternalMbDelta')]).toBe('N/A')
+    // No re-blessing: everything both files carry still computes, so an old
+    // baseline stays usable for every column it actually measured.
+    expect(row[header.indexOf('totalTimeMsDelta')]).toBe('0')
+    expect(row[header.indexOf('peakWasmHeapMbDelta')]).toBe('0')
+    expect(row[header.indexOf('peakRssMbDelta')]).toBe('0')
+  })
+
+  test('reports a run that could not settle as N/A, not as zero retention', () => {
+    // `--expose-gc` absent on one side: the child wrote N/A into the three
+    // retention columns rather than an unsettled difference. That must
+    // propagate. A zero here would be the worst possible reading — "this
+    // release retains nothing" — from a run that measured nothing.
+    const unsettled = csvRow([
+      '20260821154725', 'OK', 'x64', 'conway1.550.1516-ci', 'skylark.ifc',
+      'N/A', '8035', '72371', '80406', '185.836', '1283.000', '5495.645',
+      '5601.500', '3865.072', '3952.602', '432.500', '430.250', 'N/A', 'N/A',
+      'N/A', 'N/A', 'N/A',
+    ])
+
+    const older = writeDetail('unsettled-older.csv', [SKYLARK_1_451])
+    const newer = writeDetail('unsettled-newer.csv', [unsettled])
+    const out = path.join(workDir, 'unsettled-delta.csv')
+
+    generateDeltaCSV(older, newer, out)
+
+    const records = parseCsv(fs.readFileSync(out, 'utf8'))
+    const header = records[0]
+    const row = records[1]
+
+    expect(row[header.indexOf('retainedRssMbDelta')]).toBe('N/A')
+    expect(row[header.indexOf('retainedHeapUsedMbDelta')]).toBe('N/A')
+    expect(row[header.indexOf('retainedExternalMbDelta')]).toBe('N/A')
+    expect(row[header.indexOf('totalTimeMsDelta')]).toBe('32103')
   })
 
   test('reports the #552 columns as N/A against a header that lacks them', () => {
@@ -365,7 +488,7 @@ describe('gen_delta_csv.cjs', () => {
     const failRow = csvRow([
       '20260821153721', 'FAIL', 'x64', 'conway1.543.1513', 'flipper.ifc',
       'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
-      'N/A', 'N/A', 'N/A', 'N/A',
+      'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A', 'N/A',
     ])
 
     const older = writeDetail('fail-older.csv', [okRow])

--- a/src/statistics/statistics.ts
+++ b/src/statistics/statistics.ts
@@ -1,8 +1,14 @@
 import { versionString } from '../version/version'
 import { wasmType } from '../../dependencies/conway-geom'
 
-// Decimal places for the retained memory deltas in the load-summary line,
-// matching the MB precision the perf CSVs use.
+// Decimal places for the retained memory deltas in the load-summary line.
+// Three, matching the other MB fields on THIS line (Geometry Memory, WASM
+// Heap High-Water, and Memory.checkMemoryUsage's RSS/heap/external) — not the
+// two the regression children's perf CSVs use. That is deliberate, and the
+// two numbers are not in conflict: scripts/benchmark.cjs scrapes this line to
+// fill the loader-path CSV, so this constant is what sets that path's
+// precision, exactly as the existing 3-decimal fields already do. Lowering it
+// to 2 for "parity" would silently drop a digit from every loader-path row.
 const RETAINED_MB_PRECISION = 3
 
 /**

--- a/src/statistics/statistics.ts
+++ b/src/statistics/statistics.ts
@@ -1,6 +1,37 @@
 import { versionString } from '../version/version'
 import { wasmType } from '../../dependencies/conway-geom'
 
+// Decimal places for the retained memory deltas in the load-summary line,
+// matching the MB precision the perf CSVs use.
+const RETAINED_MB_PRECISION = 3
+
+/**
+ * Render one retention delta for the load-summary line.
+ *
+ * Two constraints on the spelling, and both are load-bearing.
+ *
+ * (1) The scrape in scripts/benchmark.cjs matches each memory quantity
+ * NON-globally, so the FIRST occurrence in the log wins. `Heap Used: `,
+ * `External: ` and `RSS ` followed by a number are already claimed by
+ * peak/instant columns, so a retained line spelled `Retained Heap Used:`
+ * would silently overwrite `heapUsedMb` with a delta. `Heap-Used` and the
+ * trailing ` Delta:` break every one of those bindings — see the header
+ * comment on DETAIL_COLUMNS in that file.
+ *
+ * (2) An absent measurement prints `N/A`, not a number and not `0`. A
+ * retention delta is only meaningful between two settled samples; where
+ * `global.gc` was not exposed the settle never ran, and emitting a zero (or
+ * an unsettled difference) would read as "nothing retained" rather than
+ * "not measured". Same failure #548 fixed in the delta writer.
+ *
+ * @param value The delta in MB, or undefined where the settle could not run.
+ * @return {string} `-1.234 MB`, or `N/A`.
+ */
+function formatRetained(value: number | undefined): string {
+  return value !== void 0 ?
+    `${value.toFixed(RETAINED_MB_PRECISION)} MB` : 'N/A'
+}
+
 /**
  * Class to compile a list of runtime statistics for models and memory
  */
@@ -13,6 +44,9 @@ export class Statistics {
   private totalTime: number | undefined
   private geometryMemory: number | undefined
   private wasmHeapPeak: number | undefined
+  private retainedRss: number | undefined
+  private retainedHeapUsed: number | undefined
+  private retainedExternal: number | undefined
   private preprocessorVersion: string | undefined
   private originatingSystem: string | undefined
   private memoryStatistics: string | undefined
@@ -154,6 +188,69 @@ export class Statistics {
    */
   setWasmHeapPeak(value: number) {
     this.wasmHeapPeak = value
+  }
+
+  /**
+   * RSS still held after the model was torn down, over a settled pre-load
+   * baseline (conway#554).
+   *
+   * @return {number | undefined} - retained RSS in MB, or undefined where the
+   * settle could not run
+   */
+  getRetainedRss(): number | undefined {
+    return this.retainedRss
+  }
+
+  /**
+   * Both samples behind this figure are settled (`gc(); await setImmediate();
+   * gc()`) and both sit outside the timed region, so recording it costs the
+   * timing columns nothing. Leave it undefined rather than passing an
+   * unsettled difference: that is GC-timing noise, and it would be read as a
+   * leak signal.
+   *
+   * @param value - retained RSS in MB, signed
+   */
+  setRetainedRss(value: number) {
+    this.retainedRss = value
+  }
+
+  /**
+   * V8 live heap still held after teardown, over the settled pre-load
+   * baseline (conway#554).
+   *
+   * @return {number | undefined} - retained heapUsed in MB, or undefined
+   * where the settle could not run
+   */
+  getRetainedHeapUsed(): number | undefined {
+    return this.retainedHeapUsed
+  }
+
+  /**
+   *
+   * @param value - retained heapUsed in MB, signed
+   */
+  setRetainedHeapUsed(value: number) {
+    this.retainedHeapUsed = value
+  }
+
+  /**
+   * Off-heap bytes still held after teardown, over the settled pre-load
+   * baseline (conway#554). This is where a released source buffer or parse
+   * structure that is still pinned shows up; heapUsed cannot see them.
+   *
+   * @return {number | undefined} - retained external in MB, or undefined
+   * where the settle could not run
+   */
+  getRetainedExternal(): number | undefined {
+    return this.retainedExternal
+  }
+
+  /**
+   *
+   * @param value - retained external in MB, signed
+   */
+  setRetainedExternal(value: number) {
+    this.retainedExternal = value
   }
 
   /**
@@ -311,6 +408,10 @@ export class Statistics {
 
     const products = this.productCount !== void 0 ?
       `Products: ${this.productCount}, ` : ''
+    const retained =
+      `Retained RSS Delta: ${formatRetained(this.retainedRss)}, ` +
+      `Retained Heap-Used Delta: ${formatRetained(this.retainedHeapUsed)}, ` +
+      `Retained External Delta: ${formatRetained(this.retainedExternal)}, `
     const breakdown = this.formatGeometryTypeCounts()
     const geometryTypes = breakdown !== void 0 ? `, Geometry Types: ${breakdown}` : ''
 
@@ -321,6 +422,7 @@ export class Statistics {
             `Total Time: ${this.totalTime} ms, ` +
             `Geometry Memory: ${this.geometryMemory?.toFixed(3)} MB, ` +
             `WASM Heap High-Water: ${this.wasmHeapPeak?.toFixed(3)} MB, ` +
+            retained +
             products +
             `Memory Statistics: ${this.memoryStatistics}, ` +
             `Preprocessor Version: ${this.preprocessorVersion}, ` +

--- a/src/statistics/statistics_retained_memory.test.ts
+++ b/src/statistics/statistics_retained_memory.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from '@jest/globals'
+import { Statistics } from './statistics'
+
+
+/**
+ * The load-summary line's three retention fields (conway#554).
+ *
+ * Like the wasm high-water field beside them (statistics_wasm_heap.test.ts),
+ * these strings are a contract rather than decoration: scripts/benchmark.cjs
+ * scrapes them out of the render server's log into the `retainedRssMb`,
+ * `retainedHeapUsedMb` and `retainedExternalMb` columns of every
+ * `performance-detail.csv` it writes.
+ *
+ * Two properties are pinned here that a plainer spelling would break.
+ *
+ * (1) NO CROSS-BINDING. Every scrape in benchmark.cjs matches non-globally,
+ * so the first hit in the log wins. A field spelled `Retained Heap Used:`
+ * matches the `/Heap Used: .../` pattern that fills `heapUsedMb`, and would
+ * silently replace an end-of-load instant with a cycle delta. #552 hit the
+ * same hazard with `Peak RSS:` against `RSS `.
+ *
+ * (2) SIGNED, AND N/A WHEN UNMEASURED. Retention is a difference and can be
+ * negative. And where `--expose-gc` was absent the settle never ran, so there
+ * is no measurement — the field must then produce no number at all, leaving
+ * the column N/A rather than reporting a load that retains nothing.
+ *
+ * Every regex below is copied verbatim from scripts/benchmark.cjs.
+ */
+const RETAINED_RSS_SCRAPE = /Retained RSS Delta: (-?[\d.]+) MB/
+const RETAINED_HEAP_USED_SCRAPE = /Retained Heap-Used Delta: (-?[\d.]+) MB/
+const RETAINED_EXTERNAL_SCRAPE = /Retained External Delta: (-?[\d.]+) MB/
+
+/** The instant/peak scrapes the retention fields must not collide with. */
+const RSS_SCRAPE = /RSS ([\d.]+) MB/
+const HEAP_USED_SCRAPE = /Heap Used: ([\d.]+) MB/
+const HEAP_TOTAL_SCRAPE = /Heap Total: ([\d.]+) MB/
+const EXTERNAL_SCRAPE = /External: ([\d.]+) MB/
+const ARRAY_BUFFERS_SCRAPE = /ArrayBuffers: ([\d.]+) MB/
+
+const RETAINED_RSS_MB = 94.68
+const RETAINED_HEAP_USED_MB = 2.81
+const RETAINED_EXTERNAL_MB = -0.75
+
+/**
+ * A statistics object with all three retention figures set.
+ *
+ * @return {string} The formatted load-summary line.
+ */
+function lineWithRetention(): string {
+  const statistics = new Statistics()
+
+  statistics.setLoadStatus('OK')
+  statistics.setRetainedRss(RETAINED_RSS_MB)
+  statistics.setRetainedHeapUsed(RETAINED_HEAP_USED_MB)
+  statistics.setRetainedExternal(RETAINED_EXTERNAL_MB)
+
+  return statistics.format()
+}
+
+describe('the load-summary line\'s retention fields', () => {
+
+  test('carries each retention delta as its own field', () => {
+    const line = lineWithRetention()
+
+    expect(Number(RETAINED_RSS_SCRAPE.exec(line)![1]))
+        .toBeCloseTo(RETAINED_RSS_MB, 2)
+    expect(Number(RETAINED_HEAP_USED_SCRAPE.exec(line)![1]))
+        .toBeCloseTo(RETAINED_HEAP_USED_MB, 2)
+    expect(Number(RETAINED_EXTERNAL_SCRAPE.exec(line)![1]))
+        .toBeCloseTo(RETAINED_EXTERNAL_MB, 2)
+  })
+
+  test('keeps a negative retention negative', () => {
+    // A cycle can end below its baseline. Dropping the sign turns a 0.75 MB
+    // give-back into a 0.75 MB leak — the delta of that column would then
+    // report a fix as a regression.
+    expect(Number(RETAINED_EXTERNAL_SCRAPE.exec(lineWithRetention())![1]))
+        .toBeLessThan(0)
+  })
+
+  test('does not bind to the peak and instant scrapes beside it', () => {
+    // The retention fields on their own: no Memory Statistics line, no peak.
+    // If any of these patterns matches, then in a real log — where the
+    // retention fields are emitted BEFORE the memory line — the first-match
+    // rule would hand a cycle delta to a column that means an end-of-load
+    // instant.
+    const line = lineWithRetention()
+
+    expect(RSS_SCRAPE.exec(line)).toBeNull()
+    expect(HEAP_USED_SCRAPE.exec(line)).toBeNull()
+    expect(HEAP_TOTAL_SCRAPE.exec(line)).toBeNull()
+    expect(EXTERNAL_SCRAPE.exec(line)).toBeNull()
+    expect(ARRAY_BUFFERS_SCRAPE.exec(line)).toBeNull()
+  })
+
+  test('reports no number at all when the settle could not run', () => {
+    // No `--expose-gc`, so no settled samples and no retention to report.
+    // The scrapes must find nothing — benchmark.cjs then leaves the columns
+    // N/A, which the delta propagates rather than differencing against zero
+    // (#548). A `0.000 MB` here would read as "this load retains nothing",
+    // which is the most reassuring possible way to be wrong.
+    const statistics = new Statistics()
+
+    statistics.setLoadStatus('OK')
+
+    const line = statistics.format()
+
+    expect(RETAINED_RSS_SCRAPE.exec(line)).toBeNull()
+    expect(RETAINED_HEAP_USED_SCRAPE.exec(line)).toBeNull()
+    expect(RETAINED_EXTERNAL_SCRAPE.exec(line)).toBeNull()
+    expect(line).toContain('Retained RSS Delta: N/A')
+  })
+})


### PR DESCRIPTION
Implements #554 (option 1, per [Pablo's decision comment](https://github.com/bldrs-ai/conway/issues/554#issuecomment-5380935432) and the [`--expose-gc` measurement](https://github.com/bldrs-ai/conway/issues/554#issuecomment-5380980871)). Companion to #553, which landed the peak half.

## What lands

Three new columns on `performance-detail.csv`, beside #553's peaks:

- `retainedRssMb`
- `retainedHeapUsedMb`
- `retainedExternalMb`

Each is one settled sample taken **after teardown** minus one settled sample taken **before the load**. Every other memory column answers *does this survive?* — a peak. These are the only ones that look at what is still held once the cycle is over, which a peak cannot see.

Signed — a cycle can end below its baseline, and clamping that would make a fix indistinguishable from no change.

All three writers carry them: `ifc_regression_main.ts`, `ap214_regression_main.ts`, and `benchmark.cjs`'s scraped log line. `aggregatePerfCsvs` keeps the header of whichever per-file CSV it reads first, so editing one child alone mislabels every column on a mixed corpus; header parity between the two is verified below.

**No `retainedWasmHeapMb`**, which the issue floated. `wasmHeapByteLength` is grow-only, so over one cycle it could only restate `peakWasmHeapMb` under a name that claims to mean something else. The wasm side stays covered by `peakWasmHeapMb`.

### What "retained" does and does not mean — read this before using the column

**These columns are not a pure leak metric, and should not be read as one.** `model.invalidate(true)` provably does *not* release `geometry`, `curves`, `profiles`, `materials`, or the source buffer — the digest pass iterates them after teardown, so they must still be live. What the sample captures is therefore **the still-live model plus anything genuinely leaked**, at the point the digest runs.

The practical consequence, stated plainly because it shapes how these numbers read for years: **a change that makes the live model bigger moves these columns in the same direction a leak does.** A jump here is a prompt to find out which — not proof of a leak.

They remain a good regression signal, because for a fixed model the live term is stable across versions, so movement means something changed. They are not a number to quote in isolation. Written up in `design/new/perf-measurement.md` alongside the two baseline caveats below.

## The timing property, tested rather than asserted

Both samples sit **outside** the timed region — baseline before the load starts, retained sample after teardown — so the settle's forced collections never run inside the window producing `parseTimeMs` / `geometryTimeMs` / `totalTimeMs`.

With the code identical, a run with `--expose-gc` and one without differ only in whether the settle executes, so the property is measurable. MB-Khaya through the IFC regression child, five runs per side, interleaved, page cache pre-warmed:

| | parse (mean of 5) | geometry (mean of 5) | total (mean of 5) |
|---|---|---|---|
| gc off | 578.2 ms | 4067.0 ms | 4645.2 ms |
| gc on | 588.0 ms | 4103.8 ms | 4691.8 ms |
| difference | +9.8 ms | +36.8 ms | +46.6 ms |
| within-group spread | 25–55 ms | 166–201 ms | 185–218 ms |

Every difference is well inside its own group's spread, consistent with the flag-only measurement on the issue (31 ms against 375 ms). n=5 does not exclude a ~1% effect; it does exclude anything that would matter to a regression signal.

`CONWAY_PERF_EXPOSE_GC=0` (also `false` / `off`) turns the flag off in both the batch child invocation and the render server's `NODE_OPTIONS`. That switch exists so the A/B can be run against a released build — with the flag hardcoded, "flag off" would mean "different code" and the comparison would prove nothing about either variable.

**The A/B must run both passes inside one CI job**, not across two rc runs: two `run-ifc-regression` jobs an hour apart differ by a ~1.5× systematic scale factor (every model faster in the later run, median 1.55×), which is two orders of magnitude above the ~1% effect under test. See [#554](https://github.com/bldrs-ai/conway/issues/554#issuecomment-5381287618). The workflow change that uses this switch is a follow-up PR.

## `--expose-gc` and the N/A fallback

Nothing in the repo passed it, so `global.gc` was undefined and the settle could not have run. Now `ifc_regression_batch_main.ts` launches every child with it and `benchmark.cjs` puts it in the render server's `NODE_OPTIONS` (verified on this Node 22 that `--expose-gc` is on the `NODE_OPTIONS` allowlist, and that an `undefined` env value is dropped rather than stringified — stringifying it would have broken the render server on the off-path).

Where it is absent, `settleAndSampleMemory` returns `undefined` and every writer emits `N/A`. Never an unsettled difference — that is GC-timing noise wearing a number and would read as a leak signal (SKYLARK250: 2547 MB un-GC'd against 981 MB settled), the same family as the `parseValue` → `0.0` fabrication #548 fixed. Verified end to end: `CONWAY_PERF_EXPOSE_GC=0` gives `N/A,N/A,N/A` on both an IFC and a STEP row, not `0.00`.

## Findings (reported, not worked around)

**1. The regression children had no explicit release at all.** Both CLIs call `model.invalidate(true)` after extraction and so does the loader; the children just ran to process exit. Without a teardown boundary there is nothing to measure retention *across* — a sample there would be the live model, not what survives it — so the call is added rather than the sample being taken without one. It runs after the perf figures are captured and before the digest. Digests are byte-identical with it, without it, and against `origin/main` (AC20-FZK-Haus, DSA2), and the teardown demonstrably does work: AC20-FZK-Haus `retainedHeapUsedMb` 13.25 → 2.81 MB, DSA2 437.31 → 377.28 MB.

**2. The baseline cannot sit after engine init in two places**, and each adds a constant to the figure:

- The **loader** constructs its own `ConwayGeometry` per load, *inside* the window `allTimeStart` opens, so no point is both after init and outside the timed region. Its baseline is taken at function entry — keeping the no-perturbation property at the cost of counting that per-load module, which nothing releases.
- The **IFC regression child** initialises one engine in `main()` and then `geometryExtraction` constructs a **second**, which is the engine the extraction actually runs against. Probed on MB-Khaya: engine A holds a 16 MB idle arena, engine B holds 106.5 MB (`sameObject false`). So ~100 MB of that model's 388 MB `retainedRssMb` is engine B's linear memory. The AP214 child uses the single module-level engine and has no such term. Filed as [#557](https://github.com/bldrs-ai/conway/issues/557).

So retention is comparable **within** a pipeline, not across them — the caveat `geometryMemoryMb` already carries ([#555](https://github.com/bldrs-ai/conway/issues/555)). Both are written into `perf-measurement.md`.

**3. Side observation, not fixed here:** the IFC child calls `conwayGeom.dumpAllocTelemetry(...)` on engine A, which never did any work — so that telemetry describes nothing. Pre-existing; part of #557.

## A real retention figure

MB-Khaya (31 MB IFC) through the IFC regression child, probe printing both settled samples:

```
baseline {"rssBytes":182308864,"heapUsedBytes":28043208,"externalBytes":3903028}
retained {"rssBytes":589635584,"heapUsedBytes":39365200,"externalBytes":53998219}
```

→ `retainedRssMb 388.46`, `retainedHeapUsedMb 10.80`, `retainedExternalMb 47.77`, matching the CSV row exactly. Reproducible: across the five gc-on runs above, 382.86–390.98 / 10.76–10.80 / 47.77 every time.

## Blast radius: no re-blessing

`computeDelta` reports an absent column exactly as it reports `N/A`, so every retention delta against an older snapshot reads `N/A` rather than differencing against zero. This is structural rather than incidental: `readDataFromCsv` keys each file by its *own* header, so an old snapshot simply has no `retainedRssMb` key. A positional column list would instead have shifted `preprocessorVersion` into `retainedRssMb`.

Proved against the **real committed** `benchmarks/conway1.451.1357-ci_test-models/performance-detail.csv` (15-column, pre-#552) as the baseline side: **47 of 47 joined rows N/A on all three retention columns**, while columns both sides carry still compute (`totalTimeMsDelta` = 5 on 45 of them; the other two are FAIL→FAIL rows, correctly N/A). Symmetric in the reverse direction.

The end-of-load instants are now captured where they always were and carried to the writer, so sampling after a teardown and two forced collections cannot silently redefine `rssMb` / `heapUsedMb` / `externalMb` into something else.

## Review round

Codex is usage-limited, so this had a delegated `/review` at high effort instead. One round, converged. All five nominated risk areas verified **by execution**, not by reading the comments asserting them — including running all 14 scrape patterns over a reconstructed log line in four states to confirm no cross-binding in either direction.

Five findings fixed (`c280108c`):

- **A comment that pointed at a guard which does not exist.** `benchmark.cjs` cited `perf_csv_quoting.test.ts` as protecting the retained log-line spellings; that file has no such test. An editor respelling a line would follow the pointer, find nothing, write `Retained Heap Used:` — and silently overwrite `heapUsedMb` in every snapshot thereafter. The comment existed to prevent exactly the #553 hazard while routing readers away from the real guard (`statistics_retained_memory.test.ts`).
- **Both settles ran even without `--perf`**, since the batch passes `--expose-gc` to every child — ~0.78 s per model at 500 MB live heap, ~1.64 s at 1 GB, all discarded. Now gated on a perf row actually being emitted. `model.invalidate(true)` is deliberately left ungated so perf and digest-only runs keep a single path to blessed output.
- Three false or stale comments, including a `RETAINED_MB_PRECISION = 3` rationale claiming parity with CSVs that use 2 — the value was right, the reasoning wrong, and it invited a digit-dropping "fix".

Four of the review skill's findings were **rejected with reasons**, notably its claim that nothing is torn down on the loader path (`model.invalidate(true)` at `conway_model_loader.ts:324` predates this PR and sits above the sample) and its suggestion to move the teardown after the digest, which would put the digest's own allocations inside the sample.

## Verification

- `yarn lint`: **0 errors**, 682 warnings — identical count to `origin/main`.
- Full suite: **101 suites / 670 tests**, all passing (main: 99 / 654).
- Header parity IFC child vs AP214 child: `diff` of the two perf.csv headers is empty.
- Batch end-to-end on a mixed IFC + STEP folder: both rows populated by default, both `N/A` under `CONWAY_PERF_EXPOSE_GC=0`.
- Digests byte-identical across pre-fix, post-fix, and perf vs no-perf runs.

Every new test was mutation-checked; each is killed by at least one targeted mutation, both gate directions included.

**Not verified:** the loader path's retention columns end-to-end (needs a headless_three checkout), and `bless_perf_snapshot.cjs` through a real bless run rather than its unit tests. The first rc exercises both.