### PR TITLE
#554: run the gc-settle A/B as two passes inside one rc job

### DIFF
--- a/.github/workflows/rc-regression.yml
+++ b/.github/workflows/rc-regression.yml
@@ -104,13 +104,16 @@ jobs:
     # engine over ~100 models with --parallel and reserves multi-GB shared.
     runs-on: ubuntu-24.04-4vcpu-8gb-150gbssd
     # Outer backstop against a wedged run (down from an old 90). A healthy run
-    # is build-from-warm-cache + LFS checkout + the serial (--concurrency 1)
-    # regen, comfortably under ~30 min; the regen step has its own tighter
-    # 20-min cap, the batch self-exits, and per-model work is timeout-bounded,
-    # so this rarely fires. 45 leaves headroom for a cold WASM-cache rebuild
-    # while still cancelling a hang far sooner than the old ceiling. Bump it if
-    # a legitimate cold rebuild is ever cancelled here.
-    timeout-minutes: 45
+    # is build-from-warm-cache + LFS checkout + TWO serial (--concurrency 1)
+    # passes over the corpus — the blessed one and the gc-off control (see
+    # "Control perf pass" below) — each with its own tighter 20-min cap, the
+    # batch self-exits, and per-model work is timeout-bounded, so this rarely
+    # fires. Raised from 45 to 70 when the control pass was added: 45 had
+    # ~15 min of headroom over a single-pass run, which a second full pass
+    # would have eaten. 70 still leaves room for a cold WASM-cache rebuild
+    # while cancelling a hang far sooner than the old 90 ceiling. Bump it if a
+    # legitimate cold rebuild is ever cancelled here.
+    timeout-minutes: 70
     steps:
       # --- Build conway from source (identical to run-ifc-regression) ---
       - name: Checkout conway
@@ -250,8 +253,20 @@ jobs:
       # — actions/hashFiles only matches paths under GITHUB_WORKSPACE, so the
       # upload step below can gate on it. No separate perf pass needed. This is
       # conway-native load timing, distinct from the perf-three-* render jobs.
+      #
+      # THIS IS THE BLESSED PASS. It runs the shipped configuration and its
+      # perf.csv is the only one that reaches bless_perf_snapshot.cjs and the
+      # re-bless PR. `CONWAY_PERF_EXPOSE_GC: '1'` is that default written down
+      # rather than changed: `exposeGcRequested()` in
+      # ifc_regression_batch_main.ts returns true when the variable is unset,
+      # so this pins the condition being blessed against the control pass
+      # below, which sets it to '0'. Do NOT make the control pass the blessed
+      # one — that would put a release's numbers under a configuration nobody
+      # ships.
       - name: Regenerate baseline digests
         timeout-minutes: 20
+        env:
+          CONWAY_PERF_EXPOSE_GC: '1'
         run: |
           node --experimental-specifier-resolution=node \
             ./compiled/src/ifc/ifc_regression_batch_main.js \
@@ -370,6 +385,78 @@ jobs:
           print("\nNo new failures. Pre-existing known-failers do not block the rc.")
           EOF
 
+      # --- The gc-off control pass (conway#554) ---
+      #
+      # The second half of an A/B whose only variable is whether the retention
+      # settle runs. conway#554 defines the retention columns so that both of
+      # their samples sit outside the timed region — baseline before the load,
+      # retained sample after teardown — which makes "the settle costs no
+      # timing" a property that can be MEASURED rather than asserted: identical
+      # code, run once with `--expose-gc` reaching the children and once
+      # without, must produce the same parse/geometry/total columns.
+      #
+      # WHY IT IS HERE AND NOT A SECOND rc RUN. The original plan was to tag,
+      # run, flip the switch and run again. That does not work. Two
+      # `run-ifc-regression` jobs an hour apart on near-identical code came out
+      # with EVERY model faster in the later run, median 1.55x, and MB-Khaya's
+      # totalTimeMs across three such runs read 8039 / 4745 / 7621 ms
+      # (conway#554, comment 5381287618). The effect under test is ~1%, so a
+      # between-run comparison measures which runner the job landed on and
+      # nothing else. Both conditions therefore run in ONE job, sharing a
+      # runner, a machine and a moment, so that scale factor cancels.
+      #
+      # WHAT THIS PASS MUST NOT TOUCH:
+      #   - it writes its digests to `perf-control-out` in the workspace, NOT
+      #     to models/regression/test_models, so the blessed baseline the
+      #     previous steps produced is not overwritten by numbers taken under
+      #     a configuration we do not ship;
+      #   - its perf CSV is `perf-nogc.csv`, and only `perf.csv` is passed to
+      #     bless_perf_snapshot.cjs below;
+      #   - the failure gate and the zero-geometry gate above are NOT repeated
+      #     — a second identical digest run yields no extra signal, and the
+      #     re-bless PR carries the first pass's output only.
+      #
+      # THE OUTPUT PATH MUST STAY RELATIVE. The batch's runDiff ends every run
+      # with `git diff -- <output_folder>` from inside the model checkout, and
+      # nothing catches its rejection. A relative `perf-control-out` resolves
+      # (to a path that does not exist) inside that repo and diffs to nothing,
+      # exactly as the blessed pass's `models/regression/test_models` already
+      # does from that cwd. An ABSOLUTE path makes git exit 128 with "is
+      # outside repository", which fails this step. Verified both ways
+      # locally.
+      #
+      # No new checkout: the corpus is already materialized in `models`, so
+      # this doubles the perf compute and costs zero extra LFS bandwidth.
+      #
+      # Default step condition (success()) on purpose: when the failure gate
+      # above reddened the rc, the release is already bad and a methodology
+      # control is not worth another ~20 minutes of large-runner time. It gets
+      # its chance on the re-run.
+      #
+      # continue-on-error for the mirror-image reason. Every step after this
+      # one that carries no `if:` — dropping changes.csv, the churn summary,
+      # and the re-bless PR that IS the release's regression report — runs on
+      # the implicit success(), so without this a control pass that timed out
+      # or crashed would silently withhold the rc's entire deliverable. The
+      # control is the least important thing in this job and must never be
+      # able to block the most important.
+      - name: Control perf pass (CONWAY_PERF_EXPOSE_GC=0)
+        timeout-minutes: 20
+        continue-on-error: true
+        env:
+          CONWAY_PERF_EXPOSE_GC: '0'
+        run: |
+          node --experimental-specifier-resolution=node \
+            ./compiled/src/ifc/ifc_regression_batch_main.js \
+            -e "sp-.*\.ifc|cg4.*-cylinder\.stp" \
+            --concurrency 1 \
+            --timeout 300000 \
+            --perf "${GITHUB_WORKSPACE}/perf-nogc.csv" \
+            models \
+            perf-control-out \
+            --parallel --mem-utilization 90
+          rm -rf "${GITHUB_WORKSPACE}/perf-control-out"
+
       # Summarize + upload the steady per-model perf the regen captured (one
       # model at a time, full cores). Runs even when the gate failed — a new
       # failure elsewhere shouldn't cost us the timing data — hence
@@ -400,12 +487,49 @@ jobs:
                     f"{r.get('rssMb','')} |")
           EOF
 
-      - name: Upload steady perf CSV
+      # Difference the two passes and put the answer in the job summary, where
+      # "did the settle move the timing columns, and by how much against the
+      # scatter between models" is readable without downloading anything.
+      #
+      # continue-on-error, and the script itself never exits non-zero on a
+      # finding: this runs BEFORE the steps that bless the snapshot and open
+      # the re-bless PR, both of which are gated on the steps before them
+      # succeeding. A methodology check must not be able to withhold the
+      # release's regression report. An A/B that came out invalid (the control
+      # pass measured retention, i.e. the env switch never reached the
+      # children) is reported as a ::warning:: and said plainly in the table
+      # header instead.
+      - name: Compare the two perf passes
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: |
+          PERF="${GITHUB_WORKSPACE}/perf.csv"
+          CONTROL="${GITHUB_WORKSPACE}/perf-nogc.csv"
+          if [ ! -f "$PERF" ] || [ ! -f "$CONTROL" ]; then
+            echo "### GC-settle A/B (${{ matrix.target.repo }})" >> "$GITHUB_STEP_SUMMARY"
+            echo "_Not run: the control pass produced no perf-nogc.csv (skipped, or the rc failed its gate)._" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          node scripts/perf_ab_compare.cjs \
+            "$PERF" "$CONTROL" \
+            "${GITHUB_WORKSPACE}/perf-gc-ab.md" \
+            "${GITHUB_WORKSPACE}/perf-gc-ab.csv" \
+            --label "${{ matrix.target.repo }}"
+          cat "${GITHUB_WORKSPACE}/perf-gc-ab.md" >> "$GITHUB_STEP_SUMMARY"
+
+      # Both passes' CSVs plus the joined per-model comparison. Missing paths
+      # only warn in upload-artifact@v4 as long as one matches, so a skipped
+      # control pass still uploads the blessed perf.csv.
+      - name: Upload steady perf CSVs
         if: ${{ !cancelled() && hashFiles('perf.csv') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: perf-serial-${{ matrix.target.name }}-${{ github.run_id }}
-          path: perf.csv
+          path: |
+            perf.csv
+            perf-nogc.csv
+            perf-gc-ab.csv
+            perf-gc-ab.md
 
       # Bless the run's perf numbers alongside the digests, and diff them
       # against the previous blessed snapshot.
@@ -418,6 +542,12 @@ jobs:
       # and reuses scripts/gen_delta_csv.cjs for the delta; see the header of
       # bless_perf_snapshot.cjs for the column mapping and the
       # conway-native-vs-headless-three harness boundary.
+      #
+      # ONLY THE BLESSED PASS REACHES HERE. `$PERF` is the workspace's
+      # perf.csv, written by the digest regen under the shipped configuration.
+      # The control pass's numbers live in perf-nogc.csv and are never passed
+      # to this script, so a release's record cannot end up carrying timings
+      # taken with the settle disabled.
       #
       # rc-* tags only. The blessed benchmark directory is named for a release
       # and is part of a release's record; an ad-hoc workflow_dispatch re-run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ Check `scripts/` before building tooling — see
 | STEP support: schemas, coverage, known gaps | [design/new/step-support.md](design/new/step-support.md) |
 | STEP product structure and metadata (the AP242 wrinkle, NIST) | [design/new/step-metadata-nist.md](design/new/step-metadata-nist.md) |
 | Native GLB export from the CLI | [design/new/glb-native-export.md](design/new/glb-native-export.md) |
-| What the perf bench measures and why: peak vs retention, the three distinct native quantities, why `heapUsed + external` is not a stand-in for RSS, GC settling, and the rule for changing recorded fields | [design/new/perf-measurement.md](design/new/perf-measurement.md) |
+| What the perf bench measures and why: peak vs retention, the three distinct native quantities, why `heapUsed + external` is not a stand-in for RSS, GC settling, the two-pass gc A/B the rc job runs and why a between-run comparison is invalid, and the rule for changing recorded fields | [design/new/perf-measurement.md](design/new/perf-measurement.md) |
 | Memory residency, streaming and federated loading | [design/new/memory-residency.md](design/new/memory-residency.md), [design/new/streaming-federated-loader.md](design/new/streaming-federated-loader.md) |
 | emsdk version, wasm build environment | [design/new/web-build-environment.md](design/new/web-build-environment.md), [design/new/emsdk-upgrade-scalable-allocator.md](design/new/emsdk-upgrade-scalable-allocator.md) |
 | Where a model lands in world space: `COORDINATE_TO_ORIGIN`, why the recentre snaps to a grid, why two exports of one object used to land 76m apart, what a frame change costs in re-blessing and saved cameras | [design/new/coordination-frame.md](design/new/coordination-frame.md) |

--- a/design/new/perf-measurement.md
+++ b/design/new/perf-measurement.md
@@ -237,7 +237,8 @@ Both halves of the decision are implemented:
   regression child with it, and `scripts/benchmark.cjs` puts it in the
   render server's `NODE_OPTIONS`. `CONWAY_PERF_EXPOSE_GC=0` (also
   `false`, `off`) turns it off in both places — see the A/B below for
-  why that switch exists.
+  why that switch exists, and "The A/B runs as two passes inside one rc
+  job" for the one caller that sets it.
 - **`N/A` is emitted where it is absent.** `settleAndSampleMemory`
   returns `undefined` rather than falling back to an unsettled
   `process.memoryUsage()`, and every writer turns that into `N/A`.
@@ -268,9 +269,19 @@ with `--expose-gc` and a run without differ only in whether the settle
 executes.
 
 - **Timing columns hold** -> the property is confirmed.
-- **Timing columns move** -> the settle is leaking into the measured
-  window, which is a bug to fix before anything is blessed against
-  those numbers.
+- **Timing columns move, gc on SLOWER** -> the settle is leaking into
+  the measured window, which is a bug to fix before anything is blessed
+  against those numbers.
+- **Timing columns move, gc on FASTER** -> the opposite, and not a
+  defect in the shipped configuration: the *control* pass is carrying
+  pre-load garbage into the window the blessed pass entered clean. See
+  "The settle also cleans the window" below, which is what the first
+  measurement of this found.
+
+The middle case is the one #554 wrote the switch for. The third was not
+anticipated, and the rule above is stated with a sign because reading a
+movement without one would have called a 13% parse difference a leak in
+the measurement.
 
 Measured that way at implementation time, MB-Khaya through the IFC
 regression child, five runs per side interleaved:
@@ -289,6 +300,96 @@ it does exclude anything that would matter to a regression signal.
 `CONWAY_PERF_EXPOSE_GC` exists so this A/B can be run against a released
 build without editing code — otherwise "flag off" would mean "different
 code", and the comparison would prove nothing about either variable.
+
+### The A/B runs as two passes inside one rc job
+
+`.github/workflows/rc-regression.yml` runs the corpus **twice in one
+`rebless` job**: the blessed pass in the shipped configuration, then a
+control pass with `CONWAY_PERF_EXPOSE_GC=0`. `scripts/perf_ab_compare.cjs`
+differences them into the job summary and the run's `perf-serial-*`
+artifact.
+
+**Two separate rc runs cannot answer this, and that was the original
+plan.** Two `run-ifc-regression` jobs an hour apart, on near-identical
+code, came out with *every* model faster in the later run — median
+**1.55x**, MB-Khaya 8039 -> 4745 ms, AC20-FZK-Haus 1524 -> 978 ms. A
+third sample since read 7621 ms for MB-Khaya, so that one model's
+`totalTimeMs` spans **8039 / 4745 / 7621** across three runs of
+near-identical code, a 1.7x spread. The effect under test is about 1%.
+A between-run comparison measures which runner the job landed on and
+nothing else (#554, comment 5381287618).
+
+Two passes in one job share a runner, a machine and a moment, so the
+scale factor applies to both halves and cancels. The same confound is
+why a **cross-version `*_delta.csv` timing column is a lead, not a
+measurement**: a model that "got 30% faster between releases" may have
+changed by nothing at all.
+
+**The blessed pass is the default one, not the control.** The flag-on
+pass is what ships, and its `perf.csv` is the only file passed to
+`bless_perf_snapshot.cjs` or committed by the re-bless PR. The control
+pass writes `perf-nogc.csv` and sends its digests to a scratch folder
+outside the models checkout; blessing it would put a release's numbers
+under a configuration nobody runs. Neither the failure gate nor the
+zero-geometry gate is repeated — a second identical digest run yields
+no extra signal — and the control pass reuses the same LFS checkout, so
+the perf compute roughly doubles and the bandwidth does not.
+
+**What the pass order can and cannot confound.** Pass 2 runs on a
+warmer machine than pass 1. Model file I/O is outside all three timing
+columns — `parseStartMs` is taken after `readFileSync` in
+`ifc_regression_main.ts` — so a warmer page cache cannot reach them
+directly; what pass 2 does get is warmer node/wasm module loads and
+whatever drift there is in runner contention. Read a small
+control-is-faster result with that in mind, and reach for option 2 from
+#554 (interleave the two conditions per model) if it ever needs to be
+excluded properly.
+
+### The settle also cleans the window
+
+Measured while wiring the CI A/B up: 12 interleaved pairs on a dev
+machine, four models through the IFC regression child, one batch run
+per side per pair.
+
+| model | parse, gc on | parse, gc off |
+|---|---|---|
+| AC20-FZK-Haus.ifc (2.5 MB) | 58.75 ms (57-63) | 67.42 ms (58-76) |
+| ISSUE_005_haus.ifc (2.5 MB) | 58.58 ms (57-62) | 70.08 ms (58-93) |
+| IfcOpenHouse_IFC4.ifc (113 kB) | 13.00 ms | 13.42 ms |
+| Sample_entities.ifc (29 kB) | 8.08 ms | 9.25 ms |
+
+`geometryTimeMs` showed no consistent direction over the same 12 pairs
+(398.5 vs 395.2, 390.8 vs 387.6, 158.6 vs 173.3, 102.4 vs 103.9), which
+is the property holding. `parseTimeMs` did: **13-16% lower with the
+flag on** on the two mid-size models, with the ranges barely
+overlapping.
+
+The mechanism is the pre-load settle, not the flag. `--expose-gc` alone
+measured neutral in two separate experiments (#554). What moves parse
+is that the settle's two collections run immediately before
+`parseStartMs`, so the blessed pass enters the timed region with
+engine-init garbage already collected while the control pass carries it
+in and pays for it inside the window. Same reason the instant memory
+columns move: `heapUsedMb` ran 5-11 MB *lower* with the flag on in
+every one of the 12 pairs, and `rssMb` 6-9 MB lower. Those columns are
+sampled at end of load, downstream of the baseline settle.
+
+Two consequences worth stating before anyone reads a trend:
+
+1. **`parseTimeMs` is not comparable across the #554 boundary.** Older
+   blessed snapshots were taken with no pre-load settle, so their parse
+   figures carry a collection this one does not. A delta across that
+   boundary shows a parse improvement that is a change of methodology,
+   not of the parser. Same for `heapUsedMb` and `rssMb`, in the other
+   direction.
+2. **The control pass's memory columns are not a defect report.** Only
+   the timing columns carry the question the A/B is asking; the memory
+   rows in the comparison output are there so their (expected)
+   movement is not read as one.
+
+This is n=12 on one machine over four models. The corpus-wide figures
+land in the first rc run that carries both passes, and that summary is
+what should settle it.
 
 ## Rejected: `total = heapUsed + external` as the headline
 
@@ -382,6 +483,7 @@ against a regression-child figure. Tracked separately.
 | #548 | delta stops fabricating values for missing columns | `parseValue` returned `0.0`; see "The rule for changing fields" |
 | #552 (via #553) | add `peakRssMb`, `externalMb`, `arrayBuffersMb`, `peakWasmHeapMb`; restore `geometryMemoryMb` | memory was one un-GC'd instant, and the wasm heap was invisible |
 | #554 | add `retainedRssMb`, `retainedHeapUsedMb`, `retainedExternalMb`; pass `--expose-gc` to the regression children and the render server; add the teardown the regression children never had | nothing measured what is held after teardown, and a peak cannot see it |
+| #554 (via the two-pass rc A/B) | `parseTimeMs` drops 13-16%, `heapUsedMb` 5-11 MB and `rssMb` 6-9 MB against the same code without the settle | the pre-load settle collects engine-init garbage *outside* the timed region that used to be collected inside it, and the end-of-load memory instants sample from that collected floor. Not a new column, but a redefinition of three existing ones by methodology: do not difference parse/heapUsed/rss across this boundary |
 
 Restoring `geometryMemoryMb` checks out against history: SKYLARK250 reads
 **185.22** against the **185.836** recorded at 1.451.
@@ -392,3 +494,8 @@ Restoring `geometryMemoryMb` checks out against history: SKYLARK250 reads
   native allocation rather than heap high-water is the unit for a ceiling
 - `design/new/ci-regression-cost.md` — CI tiering, the rc / re-bless / LFS runbook
 - `regression/README.md` — corpus, digest CSVs, smoke subset vs rc pass
+- `.github/workflows/rc-regression.yml` — the `rebless` job that runs both
+  passes, and `scripts/perf_ab_compare.cjs`, which differences them
+- `scripts/bless_perf_snapshot.cjs` — writes the blessed snapshot and the
+  README that ships beside it; that README carries the reader-facing half
+  of the column definitions above

--- a/design/new/perf-measurement.md
+++ b/design/new/perf-measurement.md
@@ -373,7 +373,11 @@ excluded properly.
 
 Measured while wiring the CI A/B up: 12 interleaved pairs on a dev
 machine, four models through the IFC regression child, one batch run
-per side per pair.
+per side per pair. Taken against pre-#557 code, so the absolute
+`geometryTimeMs` figures below no longer reproduce — #557 removed a
+second `initialize()` from inside that window (IfcOpenHouse_IFC4 156 ->
+70 ms). It cannot touch the parse column: the second engine was
+constructed in `geometryExtraction`, after `parseEndMs`.
 
 | model | parse, gc on | parse, gc off |
 |---|---|---|
@@ -388,6 +392,19 @@ is the property holding. `parseTimeMs` did: **13-16% lower with the
 flag on** on the two mid-size models, with the ranges barely
 overlapping.
 
+**It is an absolute cost, and it does not generalise up the corpus.**
+The gap is 8.7 and 11.5 ms on the two 2.5 MB models and 0.4 and 1.2 ms
+on the two small ones; the fraction reads 13-16% only because those two
+parses take about 60 ms. The MB-Khaya table further up is the same
+effect at the other end of the range and is *not* a contradiction of
+this one: 578.2 ms gc-off against 588.0 ms gc-on, n=5 — the opposite
+sign, and well inside a 25-55 ms within-group spread, which is what a
+~10 ms shift looks like when it is 1.7% of the figure it is shifting.
+So expect the corpus-wide median `parseTimeMs` ratio the rc job reports
+to sit far nearer 1.00 than 0.85, weighted as it is by models that
+parse in hundreds of ms, and read a per-model ratio against that
+model's own parse time rather than against the percentage.
+
 The mechanism is the pre-load settle, not the flag. `--expose-gc` alone
 measured neutral in two separate experiments (#554). What moves parse
 is that the settle's two collections run immediately before
@@ -400,12 +417,15 @@ sampled at end of load, downstream of the baseline settle.
 
 Two consequences worth stating before anyone reads a trend:
 
-1. **`parseTimeMs` is not comparable across the #554 boundary.** Older
-   blessed snapshots were taken with no pre-load settle, so their parse
-   figures carry a collection this one does not. A delta across that
-   boundary shows a parse improvement that is a change of methodology,
-   not of the parser. Same for `heapUsedMb` and `rssMb`, in the other
-   direction.
+1. **`parseTimeMs` is not comparable across the #554 boundary** for
+   anything that parses quickly. Older blessed snapshots were taken
+   with no pre-load settle, so their parse figures carry a collection
+   this one does not. A delta across that boundary shows a parse
+   improvement that is a change of methodology, not of the parser —
+   about 10 ms of it, so material on a 60 ms parse and lost in the
+   noise on a 600 ms one. Same for `heapUsedMb` and `rssMb`, in the
+   other direction. Distinct from the #557 boundary, which moves
+   `geometryTimeMs` and the memory columns on IFC rows only.
 2. **The control pass's memory columns are not a defect report.** Only
    the timing columns carry the question the A/B is asking; the memory
    rows in the comparison output are there so their (expected)

--- a/scripts/bless_perf_snapshot.cjs
+++ b/scripts/bless_perf_snapshot.cjs
@@ -327,6 +327,10 @@ function removeStaleDeltas(outDir, version) {
  * @param {string} info.engine Engine label.
  * @param {string} info.repoName Model repo directory name.
  * @param {number} info.modelCount Models measured.
+ * @param {number} info.retentionCount Rows carrying a measured retention
+ *   figure, i.e. rows whose child had `--expose-gc` to settle with. Reported
+ *   on the snapshot's own face so a directory full of `N/A` retention says
+ *   why without anyone having to find this script.
  * @param {string} info.deltaName Delta filename, or '' when none was produced.
  * @param {string} info.previousName Previous snapshot directory, or ''.
  * @return {string} README body.
@@ -335,6 +339,28 @@ function renderReadme(info) {
   const deltaLine = info.deltaName !== '' ?
     `\`${info.deltaName}\` diffs this run against \`../${info.previousName}/\`.` :
     'No previous snapshot was committed in this repo, so no delta was produced.';
+
+  // Which condition of the rc job's two-pass A/B produced this directory.
+  // Always the settle-on pass — the control pass is never blessed — but a
+  // snapshot whose retention columns are all N/A needs to say so itself,
+  // rather than leaving a reader to guess between "no leak" and "not
+  // measured".
+  const retentionLine = info.retentionCount > 0 ?
+    [
+      `Retention is measured on ${info.retentionCount} of ${info.modelCount}`,
+      'rows here, so the settle ran. conway\'s `rc-regression` job runs the',
+      'corpus **twice** in one job — this blessed pass in the shipped',
+      'configuration, then a control pass with `CONWAY_PERF_EXPOSE_GC=0` whose',
+      'only purpose is to check that the settle does not perturb the timing',
+      'columns. The control pass is never blessed and none of its numbers are',
+      'in this directory; its comparison is in that run\'s job summary and',
+      '`perf-serial-*` artifact.',
+    ].join('\n') :
+    [
+      'Retention is `N/A` on every row here: this run\'s children had no',
+      '`--expose-gc`, so the settle could not run. Read that as *not',
+      'measured*, not as *nothing retained*.',
+    ].join('\n');
 
   return `# ${info.engine} — ${info.repoName}, rc-regression baseline
 
@@ -356,7 +382,24 @@ The memory columns are not: \`rssMb\` here excludes a GL context and a three.js
 scene graph, and \`geometryMemoryMb\` counts only conway's own vertex+index
 payload, without the host's copy of the same geometry. \`schemaVersion\`,
 \`preprocessorVersion\` and \`originatingSystem\` are \`N/A\` — the conway-native
-perf writer does not capture them.
+perf writer does not capture them. Every other column is measured — with the
+exception of a row whose \`loadStatus\` is not \`OK\`, which carries \`N/A\` for
+the stages the load never reached.
+
+**"Comparable on the same runner class" is doing real work in that sentence.**
+Two conway CI regression jobs an hour apart, on near-identical code, came out
+with every model faster in the later run by a median 1.55x (conway#554). A
+timing delta between two releases carries that factor as well as any change in
+conway, so treat a cross-version timing move as a lead rather than a
+measurement unless it is far larger than 1.5x.
+
+\`parseTimeMs\` additionally is **not** comparable across the conway#554
+boundary. From #554 on, a forced collection settles the heap immediately
+before the parse clock starts, so the parse runs from a collected floor
+instead of collecting engine-init garbage inside the timed window. Measured
+locally over 12 interleaved pairs on two 2.5 MB models, that is worth 13-16%
+of \`parseTimeMs\`, in the direction of the newer snapshot looking faster with
+nothing in the parser having changed.
 
 \`peakRssMb\` is the load's high-water mark (the kernel's, via
 \`resourceUsage().maxRSS\`); \`rssMb\`, \`heapUsedMb\`, \`heapTotalMb\`,
@@ -378,12 +421,43 @@ behind. They are signed — a cycle can end below its baseline — and they read
 \`N/A\` wherever the run had no \`--expose-gc\` to settle with, because an
 unsettled difference is GC timing rather than retention.
 
+**They are not a pure leak metric**, and this is the column most likely to be
+misread. Teardown is exactly \`model.invalidate(true)\`: it drops the vtable
+builder, the descriptor cache, the scratch parsing buffer and lazy entity
+fields, and it does **not** drop \`geometry\`, \`voidGeometry\`, \`curves\`,
+\`profiles\`, \`materials\` or the source buffer — the digest iterates all of
+those after it runs, so it cannot. A retention figure is therefore *the
+still-live model plus anything genuinely leaked*, and a change that makes the
+live model bigger moves it in the same direction a leak does. Read a movement
+alongside \`geometryMemoryMb\`, against this corpus's own history. It is a good
+regression signal for a fixed model; it is not a number to quote on its own.
+
+${retentionLine}
+
 \`peakWasmHeapMb\` is the wasm linear memory conway's geometry engine runs in,
 which nothing else here can see. It is grow-only, so one reading is the
 high-water mark. Do not read it as \`geometryMemoryMb\`: that column is the
 vertex+index payload a consumer would copy out, and the heap around it also
 holds allocator overhead, fragmentation and boolean intermediates — 8 MB of
-payload under an 85 MB heap on one model in this corpus.
+payload under an 85 MB heap on one model in this corpus. A **third** native
+quantity exists and is deliberately not a column here: the native's own live
+allocation (\`getAllocationSize\`), which is what a residency budget governs.
+The three differ by an order of magnitude and none of them converts into
+another.
+
+**Two columns are comparable only within one pipeline, and this file mixes
+two.** IFC models are measured by the IFC regression child and STEP models by
+the AP214 one. \`geometryMemoryMb\` is sampled at different points under
+different CSG options in the two — 16.8 vs 22.3 MB for the same model through
+two conway pipelines
+([conway#555](https://github.com/bldrs-ai/conway/issues/555)). The retention
+columns carry their own split: the IFC child brings up a *second* wasm engine
+inside the measured window and never frees it, so roughly 100 MB of an IFC
+model's \`retainedRssMb\` is that engine rather than the model, while the
+AP214 child has no such term
+([conway#557](https://github.com/bldrs-ai/conway/issues/557)). Difference
+these two columns against the same pipeline's own history — never an IFC row
+against a STEP row, and never a CLI figure against one from here.
 
 Snapshots blessed before conway#552 carry none of \`peakWasmHeapMb\`,
 \`peakRssMb\`, \`externalMb\` or \`arrayBuffersMb\`, nor a measured
@@ -491,6 +565,11 @@ function main() {
       engine,
       repoName,
       modelCount,
+      // Counted from the input rows rather than assumed from the workflow:
+      // the same script blesses a run whose children had no --expose-gc, and
+      // that snapshot's README must say so on its own face.
+      retentionCount: rows.filter(
+        (row) => (row.retainedRssMb || UNMEASURED) !== UNMEASURED).length,
       deltaName,
       previousName: previous !== null ? previous.name : '',
     }),
@@ -507,6 +586,7 @@ module.exports = {
   isChronologicalDelta,
   removeStaleDeltas,
   readPerfCsv,
+  renderReadme,
   versionCompare,
   writeDetailCsv,
 };

--- a/scripts/bless_perf_snapshot.cjs
+++ b/scripts/bless_perf_snapshot.cjs
@@ -465,13 +465,13 @@ has not been measured to disagree.
 ([conway#557](https://github.com/bldrs-ai/conway/issues/557)).** The IFC
 regression child used to build a *second* \`ConwayGeometry\` inside
 \`geometryExtraction\`, so that engine's linear memory was allocated inside
-the retention window and never released — against the 16 MB idle arena of the
-engine \`main()\` had initialised, worth a ~55-60 MB constant on every IFC row
+the retention window and never released while the engine \`main()\` had
+initialised sat idle. It measured as a ~55-60 MB constant on every IFC row
 regardless of model size, plus its \`initialize()\` inside \`geometryTimeMs\`.
 From #557 on both regression children extract on the single engine they
-initialised before the baseline, so the two are the same shape and this file's
-IFC and STEP rows no longer differ by construction. What does NOT survive that
-boundary is a comparison with an older snapshot: IFC \`retainedRssMb\`,
+initialised before the baseline, so their retention columns are the same shape
+and an IFC row here no longer carries a term a STEP row cannot. What does NOT
+survive that boundary is a comparison with an older snapshot: IFC \`retainedRssMb\`,
 \`peakRssMb\` and \`geometryTimeMs\` all step down once at #557 on unchanged
 geometry — MB-Khaya's \`retainedRssMb\` 379-389 to 326-333, \`index.ifc\` 58.96
 to 2.38, \`IfcOpenHouse_IFC4\`'s \`geometryTimeMs\` 156 to 70 ms, with digests

--- a/scripts/bless_perf_snapshot.cjs
+++ b/scripts/bless_perf_snapshot.cjs
@@ -382,9 +382,11 @@ The memory columns are not: \`rssMb\` here excludes a GL context and a three.js
 scene graph, and \`geometryMemoryMb\` counts only conway's own vertex+index
 payload, without the host's copy of the same geometry. \`schemaVersion\`,
 \`preprocessorVersion\` and \`originatingSystem\` are \`N/A\` — the conway-native
-perf writer does not capture them. Every other column is measured — with the
-exception of a row whose \`loadStatus\` is not \`OK\`, which carries \`N/A\` for
-the stages the load never reached.
+perf writer does not capture them. Every other column is measured, with two
+exceptions. A row whose \`loadStatus\` is not \`OK\` carries \`N/A\` for the
+stages the load never reached. And the three retention columns carry \`N/A\`
+whenever the run had no \`--expose-gc\` to settle with, on an \`OK\` row as
+much as a failed one — see below.
 
 **"Comparable on the same runner class" is doing real work in that sentence.**
 Two conway CI regression jobs an hour apart, on near-identical code, came out
@@ -396,10 +398,13 @@ measurement unless it is far larger than 1.5x.
 \`parseTimeMs\` additionally is **not** comparable across the conway#554
 boundary. From #554 on, a forced collection settles the heap immediately
 before the parse clock starts, so the parse runs from a collected floor
-instead of collecting engine-init garbage inside the timed window. Measured
-locally over 12 interleaved pairs on two 2.5 MB models, that is worth 13-16%
-of \`parseTimeMs\`, in the direction of the newer snapshot looking faster with
-nothing in the parser having changed.
+instead of collecting engine-init garbage inside the timed window. **That is
+an absolute cost, not a percentage.** Measured locally over 12 interleaved
+pairs it was 9-12 ms per load on two 2.5 MB models — 13-16% only because
+their parse takes about 60 ms — and it is not resolvable at all against
+MB-Khaya's 578 ms parse. So it tilts a fast model's parse in the direction of
+the newer snapshot looking faster with nothing in the parser having changed,
+and leaves a slow model's alone.
 
 \`peakRssMb\` is the load's high-water mark (the kernel's, via
 \`resourceUsage().maxRSS\`); \`rssMb\`, \`heapUsedMb\`, \`heapTotalMb\`,
@@ -445,25 +450,42 @@ allocation (\`getAllocationSize\`), which is what a residency budget governs.
 The three differ by an order of magnitude and none of them converts into
 another.
 
-**Two columns are comparable only within one pipeline, and this file mixes
-two.** IFC models are measured by the IFC regression child and STEP models by
-the AP214 one. \`geometryMemoryMb\` is sampled at different points under
-different CSG options in the two — 16.8 vs 22.3 MB for the same model through
-two conway pipelines
-([conway#555](https://github.com/bldrs-ai/conway/issues/555)). The retention
-columns carry their own split: the IFC child brings up a *second* wasm engine
-inside the measured window and never frees it, so roughly 100 MB of an IFC
-model's \`retainedRssMb\` is that engine rather than the model, while the
-AP214 child has no such term
-([conway#557](https://github.com/bldrs-ai/conway/issues/557)). Difference
-these two columns against the same pipeline's own history — never an IFC row
-against a STEP row, and never a CLI figure against one from here.
+**\`geometryMemoryMb\` is comparable only within one writer, and the writers
+that disagree are not the two in this file.** The IFC **CLI** and the IFC
+regression child read 16.8 vs 22.3 MB for the same model: the same
+\`calculateGeometrySize()\`, sampled at different points in two pipelines
+running different CSG options
+([conway#555](https://github.com/bldrs-ai/conway/issues/555)). Every row here
+comes from a regression child, so the hazard is differencing one of these
+figures against a CLI-produced one — which a delta will do without saying so.
+IFC rows against STEP rows within this file is a different pair, and that pair
+has not been measured to disagree.
+
+**The retention columns carried a second, unrelated split until conway#557
+([conway#557](https://github.com/bldrs-ai/conway/issues/557)).** The IFC
+regression child used to build a *second* \`ConwayGeometry\` inside
+\`geometryExtraction\`, so that engine's linear memory was allocated inside
+the retention window and never released — against the 16 MB idle arena of the
+engine \`main()\` had initialised, worth a ~55-60 MB constant on every IFC row
+regardless of model size, plus its \`initialize()\` inside \`geometryTimeMs\`.
+From #557 on both regression children extract on the single engine they
+initialised before the baseline, so the two are the same shape and this file's
+IFC and STEP rows no longer differ by construction. What does NOT survive that
+boundary is a comparison with an older snapshot: IFC \`retainedRssMb\`,
+\`peakRssMb\` and \`geometryTimeMs\` all step down once at #557 on unchanged
+geometry — MB-Khaya's \`retainedRssMb\` 379-389 to 326-333, \`index.ifc\` 58.96
+to 2.38, \`IfcOpenHouse_IFC4\`'s \`geometryTimeMs\` 156 to 70 ms, with digests
+byte-identical throughout. The one cross-pipeline split left is the loader
+path, which brings up a \`ConwayGeometry\` per load inside its own timed
+region; nothing in this file comes from there.
 
 Snapshots blessed before conway#552 carry none of \`peakWasmHeapMb\`,
 \`peakRssMb\`, \`externalMb\` or \`arrayBuffersMb\`, nor a measured
 \`geometryMemoryMb\`, and nothing blessed before conway#554 carries the three
 retention columns, so those columns come out \`N/A\` in a delta against them. That is a missing
-measurement, not a zero: do not read it as "no change".
+measurement, not a zero: do not read it as "no change". A snapshot blessed
+before conway#557 carries those columns but populated differently on its IFC
+rows; see the #557 note above before differencing one.
 
 ## Regenerating
 

--- a/scripts/perf_ab_compare.cjs
+++ b/scripts/perf_ab_compare.cjs
@@ -1,0 +1,570 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/**
+ * Difference the two perf passes an rc-regression job runs against each other:
+ * the blessed pass (the shipped configuration, `--expose-gc` reaching every
+ * regression child) and the control pass (`CONWAY_PERF_EXPOSE_GC=0`, so
+ * `global.gc` is undefined, the settle cannot run and the retention columns
+ * read `N/A`).
+ *
+ * WHAT QUESTION THIS ANSWERS. conway#554's retention columns are defined so
+ * that both of their samples sit OUTSIDE the timed region — the baseline
+ * before the load begins, the retained sample after `model.invalidate(true)`.
+ * If that holds, the forced collections cannot touch `parseTimeMs` /
+ * `geometryTimeMs` / `totalTimeMs`, and two passes of identical code differing
+ * only in whether the settle executes must produce the same timing columns.
+ *
+ * The sign of any movement is what distinguishes the two ways that can fail,
+ * so the report leads with it: gc-on SLOWER is the settle leaking into the
+ * measured window, which is a bug; gc-on FASTER is the control pass carrying
+ * pre-load garbage into the window the blessed pass entered clean, which is
+ * not a defect in the blessed configuration but does break comparability with
+ * pre-#554 snapshots.
+ *
+ * WHY BOTH PASSES LIVE IN ONE JOB. The obvious alternative — tag an rc, run,
+ * flip the switch, run again — cannot answer it. Two `run-ifc-regression` jobs
+ * an hour apart on near-identical code showed every model faster in the later
+ * run by a median 1.55x (conway#554, comment 5381287618), and MB-Khaya's
+ * `totalTimeMs` across three such runs read 8039 / 4745 / 7621 ms. The effect
+ * under test is about 1%. A between-run comparison measures which runner the
+ * job landed on and nothing else, so the two passes have to share a runner, a
+ * machine and a moment for that scale factor to cancel.
+ *
+ * WHAT THE STATISTIC IS. One sample per model per pass, so there is no
+ * within-pass spread to compare a difference against on a single model.
+ * Across the corpus there is: run-to-run noise scatters the per-model
+ * on-over-off ratios around 1.0 with no preferred direction, while a settle
+ * that genuinely cost time inside the window would shift essentially every
+ * model the same way. Hence the median ratio, the p10/p90 band around it, and
+ * the count of models that came out slower with the flag on — a sign test the
+ * scale factor cannot fake, because it applies to both passes equally.
+ *
+ * SMALL MODELS ARE EXCLUDED FROM THE RATIOS. The stage timings come from
+ * `Date.now()`, so a model whose parse takes 3 ms carries a +/-1 ms
+ * quantisation floor — a 33% "ratio" that is pure rounding. Rows under
+ * RATIO_FLOOR_MS on either side are counted and reported, not silently
+ * dropped.
+ *
+ * THE MEMORY COLUMNS ARE EXPECTED TO MOVE, and their movement is not a
+ * finding. The flag-on pass settles the heap immediately before the load, so
+ * its end-of-load `heapUsedMb` / `rssMb` sample starts from a collected floor
+ * that the flag-off pass never gets. Measured locally over four interleaved
+ * pairs on four models, `heapUsedMb` ran 5-11 MB lower with the flag on, every
+ * time. They are reported for information and explicitly not read as a defect;
+ * only the timing columns carry the question.
+ *
+ * Usage:
+ *   node scripts/perf_ab_compare.cjs <blessed.csv> <control.csv> \
+ *       <out.md> [<out.csv>] [--label <text>]
+ *
+ * Analysis findings NEVER exit non-zero. This runs inside the rc job ahead of
+ * the steps that open the re-bless PR, and a methodology check must not be
+ * able to withhold the release's regression report. A control pass that came
+ * back with populated retention columns (i.e. the env switch did not take)
+ * is reported as a `::warning::` and marks the comparison invalid in the
+ * output.
+ */
+
+const fs = require('fs');
+const { csvRow, parseCsv } = require('./csv_rfc4180.cjs');
+
+/** Timing columns the A/B is actually about. */
+const TIMING_COLUMNS = ['parseTimeMs', 'geometryTimeMs', 'totalTimeMs'];
+
+/**
+ * Memory columns reported alongside, purely so nobody reads their (expected)
+ * movement as a defect. See the header note.
+ */
+const MEMORY_COLUMNS = ['heapUsedMb', 'rssMb', 'peakRssMb'];
+
+/** The retention columns, present only when the settle could run. */
+const RETENTION_COLUMNS =
+  ['retainedRssMb', 'retainedHeapUsedMb', 'retainedExternalMb'];
+
+/**
+ * Below this, `Date.now()` quantisation dominates the ratio. 10 ms keeps a
+ * +/-1 ms tick under 10% of the figure it is quantising.
+ */
+const RATIO_FLOOR_MS = 10;
+
+/** How many per-model rows the markdown table shows, slowest first. */
+const TOP_MODELS = 10;
+
+/** The unmeasured marker every perf writer in the repo emits. */
+const UNMEASURED = 'N/A';
+
+/**
+ * Read a perf CSV into rows keyed by column name.
+ *
+ * @param {string} file Path to a perf.csv written by ifc_regression_batch_main.
+ * @return {Array<Record<string, string>>} One record per data row, in file order.
+ */
+function readPerfCsv(file) {
+  const records = parseCsv(fs.readFileSync(file, 'utf8'));
+
+  if (records.length === 0) {
+    return [];
+  }
+
+  const header = records[0];
+
+  return records.slice(1).map((fields) => {
+    const row = {};
+
+    header.forEach((name, index) => {
+      row[name] = fields[index] === undefined ? '' : fields[index];
+    });
+
+    return row;
+  });
+}
+
+/**
+ * Parse a perf CSV cell as a number, treating `N/A` and blanks as absent.
+ *
+ * Deliberately does NOT coerce a missing value to 0 — that is the #548
+ * fabrication this repo's perf tooling exists to avoid.
+ *
+ * @param {string|undefined} value Raw cell.
+ * @return {number|null} The number, or null when the cell carries no measurement.
+ */
+function numeric(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const text = String(value).trim();
+
+  if (text === '' || text === UNMEASURED) {
+    return null;
+  }
+
+  const parsed = Number(text);
+
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Linear-interpolated percentile of a numeric sample.
+ *
+ * @param {Array<number>} values Sample; not required to be sorted.
+ * @param {number} fraction Percentile in [0, 1].
+ * @return {number|null} The percentile, or null for an empty sample.
+ */
+function percentile(values, fraction) {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const position = (sorted.length - 1) * fraction;
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+
+  if (lower === upper) {
+    return sorted[lower];
+  }
+
+  return sorted[lower] + ((sorted[upper] - sorted[lower]) * (position - lower));
+}
+
+/**
+ * Median of a numeric sample.
+ *
+ * @param {Array<number>} values Sample.
+ * @return {number|null} The median, or null for an empty sample.
+ */
+function median(values) {
+  return percentile(values, 0.5);
+}
+
+/**
+ * Whether the two passes' retention columns look the way the switch says they
+ * should: measured on the blessed side, `N/A` on the control side.
+ *
+ * A control pass carrying numbers means `CONWAY_PERF_EXPOSE_GC` did not reach
+ * the children, so the two passes differ in nothing and every timing
+ * comparison below is between two identical configurations.
+ *
+ * @param {Array<Record<string, string>>} blessed Rows from the blessed pass.
+ * @param {Array<Record<string, string>>} control Rows from the control pass.
+ * @return {{blessedMeasured: number, blessedTotal: number,
+ *           controlMeasured: number, controlTotal: number, valid: boolean}}
+ *   Counts of rows carrying a measured `retainedRssMb` on each side, and
+ *   whether the pair is a usable A/B.
+ */
+function checkSwitch(blessed, control) {
+  const measured = (rows) =>
+    rows.filter((row) => numeric(row.retainedRssMb) !== null).length;
+
+  const blessedMeasured = measured(blessed);
+  const controlMeasured = measured(control);
+
+  return {
+    blessedMeasured,
+    blessedTotal: blessed.length,
+    controlMeasured,
+    controlTotal: control.length,
+    // The blessed side must have measured something (else the flag never
+    // reached the children there either, and there is no "on" condition), and
+    // the control side must have measured nothing.
+    valid: blessedMeasured > 0 && controlMeasured === 0,
+  };
+}
+
+/**
+ * Per-column statistics over the models both passes measured.
+ *
+ * @param {Array<{file: string, blessed: Record<string, string>,
+ *                control: Record<string, string>}>} pairs Joined rows.
+ * @param {string} column Column to summarise.
+ * @param {boolean} applyFloor Whether to drop rows under RATIO_FLOOR_MS.
+ * @return {{column: string, n: number, floored: number, medianRatio: number|null,
+ *           p10: number|null, p90: number|null, slower: number,
+ *           medianDelta: number|null}} Summary for one column.
+ */
+function summariseColumn(pairs, column, applyFloor) {
+  const ratios = [];
+  const deltas = [];
+  let floored = 0;
+  let slower = 0;
+
+  for (const pair of pairs) {
+    const on = numeric(pair.blessed[column]);
+    const off = numeric(pair.control[column]);
+
+    if (on === null || off === null || off === 0) {
+      continue;
+    }
+
+    if (applyFloor && (on < RATIO_FLOOR_MS || off < RATIO_FLOOR_MS)) {
+      ++floored;
+      continue;
+    }
+
+    const ratio = on / off;
+
+    ratios.push(ratio);
+    deltas.push(on - off);
+
+    if (ratio > 1) {
+      ++slower;
+    }
+  }
+
+  return {
+    column,
+    n: ratios.length,
+    floored,
+    medianRatio: median(ratios),
+    p10: percentile(ratios, 0.1),
+    p90: percentile(ratios, 0.9),
+    slower,
+    medianDelta: median(deltas),
+  };
+}
+
+/**
+ * Join the two passes on `file` and summarise every column of interest.
+ *
+ * Only rows with `status` OK on both sides are joined: a model that failed in
+ * one pass has a timing that measures how far it got, not how long it takes.
+ *
+ * @param {Array<Record<string, string>>} blessedRows Blessed-pass rows.
+ * @param {Array<Record<string, string>>} controlRows Control-pass rows.
+ * @return {{pairs: Array<object>, timing: Array<object>, memory: Array<object>,
+ *           switchCheck: object, blessedOnly: Array<string>,
+ *           controlOnly: Array<string>}} The comparison.
+ */
+function compareRuns(blessedRows, controlRows) {
+  const controlByFile = new Map(controlRows.map((row) => [row.file, row]));
+  const blessedByFile = new Map(blessedRows.map((row) => [row.file, row]));
+  const pairs = [];
+  const blessedOnly = [];
+
+  for (const blessed of blessedRows) {
+    const control = controlByFile.get(blessed.file);
+
+    if (control === undefined) {
+      blessedOnly.push(blessed.file);
+      continue;
+    }
+
+    if (blessed.status !== 'OK' || control.status !== 'OK') {
+      continue;
+    }
+
+    pairs.push({ file: blessed.file, blessed, control });
+  }
+
+  const controlOnly = controlRows
+      .filter((row) => !blessedByFile.has(row.file))
+      .map((row) => row.file);
+
+  return {
+    pairs,
+    timing: TIMING_COLUMNS.map((column) => summariseColumn(pairs, column, true)),
+    memory: MEMORY_COLUMNS.map((column) => summariseColumn(pairs, column, false)),
+    switchCheck: checkSwitch(blessedRows, controlRows),
+    blessedOnly,
+    controlOnly,
+  };
+}
+
+/**
+ * Format a number for the markdown tables, or an em dash when absent.
+ *
+ * @param {number|null} value The value.
+ * @param {number} places Decimal places.
+ * @param {string} [sign] '+' to force a leading sign on positives.
+ * @return {string} Display text.
+ */
+function show(value, places, sign) {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+
+  const text = value.toFixed(places);
+
+  return (sign === '+' && value > 0) ? `+${text}` : text;
+}
+
+/**
+ * Render the comparison as a GitHub-flavoured markdown section.
+ *
+ * @param {object} comparison Result of compareRuns.
+ * @param {string} label Corpus/run label for the heading.
+ * @return {string} Markdown, newline terminated.
+ */
+function renderMarkdown(comparison, label) {
+  const { switchCheck, pairs, timing, memory } = comparison;
+  const out = [];
+
+  out.push(`### GC-settle A/B — two passes, one job (${label})`);
+  out.push('');
+  out.push(
+      'Pass 1 is the blessed pass (shipped configuration, the settle runs and ' +
+      'the retention columns are measured). Pass 2 is the control ' +
+      '(`CONWAY_PERF_EXPOSE_GC=0`, no `global.gc`, retention `N/A`). Same ' +
+      'runner, same checkout, same corpus, minutes apart — which is the only ' +
+      'way this comparison is valid: between two separate CI runs the timing ' +
+      'columns carry a ~1.5x runner scale factor, two orders of magnitude ' +
+      'larger than the ~1% effect under test (conway#554).');
+  out.push('');
+
+  if (switchCheck.valid) {
+    out.push(
+        `**Switch check: OK.** Retention measured on ` +
+        `${switchCheck.blessedMeasured}/${switchCheck.blessedTotal} blessed ` +
+        `rows, on 0/${switchCheck.controlTotal} control rows.`);
+  } else {
+    out.push(
+        `**Switch check: INVALID — the two passes were not in different ` +
+        `configurations.** Retention measured on ` +
+        `${switchCheck.blessedMeasured}/${switchCheck.blessedTotal} blessed ` +
+        `rows and ${switchCheck.controlMeasured}/${switchCheck.controlTotal} ` +
+        `control rows; the control pass should measure none. Everything ` +
+        `below is a comparison of two identical configurations and answers ` +
+        `nothing about the settle.`);
+  }
+
+  out.push('');
+  out.push(`${pairs.length} model(s) measured OK in both passes.`);
+  out.push('');
+  out.push('| timing column | n | median on÷off | p10 | p90 | slower with gc on | median Δ ms | under 10 ms floor |');
+  out.push('| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
+
+  for (const stat of timing) {
+    out.push(
+        `| \`${stat.column}\` | ${stat.n} | ${show(stat.medianRatio, 3)} | ` +
+        `${show(stat.p10, 3)} | ${show(stat.p90, 3)} | ` +
+        `${stat.slower}/${stat.n} | ${show(stat.medianDelta, 1, '+')} | ` +
+        `${stat.floored} |`);
+  }
+
+  out.push('');
+  out.push(
+      '**How to read it — the sign matters.** A median ratio near 1.00 with ' +
+      'the slower-count near half the models, and a p10/p90 band that ' +
+      'straddles 1.00, is the design holding: both retention samples sit ' +
+      'outside the timed region, so the settle cannot reach ' +
+      '`parseTimeMs`/`geometryTimeMs`/`totalTimeMs`.');
+  out.push('');
+  out.push(
+      'Above 1.00 across nearly every model (gc on SLOWER) is the settle ' +
+      'leaking INTO the measured window — a bug to fix before anything is ' +
+      'blessed against these numbers, not a tolerance to widen.');
+  out.push('');
+  out.push(
+      'Below 1.00 across nearly every model (gc on FASTER) is the opposite ' +
+      'and is not a defect in the blessed pass: the settle collects ' +
+      'immediately before `parseStartMs`, so the blessed pass enters the ' +
+      'timed region with the init garbage already paid for while the control ' +
+      'pass carries it in and collects it inside the window. Measured ' +
+      'locally over 12 interleaved pairs, `parseTimeMs` ran 13-16% LOWER ' +
+      'with the flag on; see design/new/perf-measurement.md. What it does ' +
+      'mean is that a `parseTimeMs` from a post-conway#554 blessed snapshot ' +
+      'is not comparable with one from before it.');
+  out.push('');
+  out.push(
+      'Model file I/O is outside all three columns (`parseStartMs` is taken ' +
+      'after `readFileSync`), so pass order buys the second pass only warmer ' +
+      'node/wasm module loads, not a warmer model read.');
+  out.push('');
+  out.push('| memory column (expected to move) | n | median on÷off | median Δ MB |');
+  out.push('| --- | ---: | ---: | ---: |');
+
+  for (const stat of memory) {
+    out.push(
+        `| \`${stat.column}\` | ${stat.n} | ${show(stat.medianRatio, 3)} | ` +
+        `${show(stat.medianDelta, 2, '+')} |`);
+  }
+
+  out.push('');
+  out.push(
+      'The memory rows are information, not a finding: the blessed pass ' +
+      'settles the heap immediately before the load, so its end-of-load ' +
+      'sample starts from a collected floor the control pass never gets. ' +
+      'Lower with the flag on is the expected direction.');
+  out.push('');
+
+  const slowest = [...pairs].sort((a, b) =>
+    (numeric(b.blessed.totalTimeMs) ?? 0) - (numeric(a.blessed.totalTimeMs) ?? 0));
+
+  out.push(`Slowest ${Math.min(TOP_MODELS, slowest.length)} model(s) by blessed total time:`);
+  out.push('');
+  out.push('| model | total on | total off | on÷off | parse on | parse off | geometry on | geometry off |');
+  out.push('| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
+
+  for (const pair of slowest.slice(0, TOP_MODELS)) {
+    const on = numeric(pair.blessed.totalTimeMs);
+    const off = numeric(pair.control.totalTimeMs);
+    const ratio = (on !== null && off !== null && off !== 0) ? on / off : null;
+
+    out.push(
+        `| ${pair.file} | ${pair.blessed.totalTimeMs} | ` +
+        `${pair.control.totalTimeMs} | ${show(ratio, 3)} | ` +
+        `${pair.blessed.parseTimeMs} | ${pair.control.parseTimeMs} | ` +
+        `${pair.blessed.geometryTimeMs} | ${pair.control.geometryTimeMs} |`);
+  }
+
+  if (comparison.blessedOnly.length > 0 || comparison.controlOnly.length > 0) {
+    out.push('');
+    out.push(
+        `Unpaired rows — blessed only: ${comparison.blessedOnly.length}, ` +
+        `control only: ${comparison.controlOnly.length}.`);
+  }
+
+  out.push('');
+
+  return `${out.join('\n')}\n`;
+}
+
+/**
+ * Render the joined per-model comparison as a CSV, so the run's artifact
+ * carries the numbers the markdown table summarises.
+ *
+ * @param {object} comparison Result of compareRuns.
+ * @return {string} CSV text, newline terminated.
+ */
+function renderCsv(comparison) {
+  const columns = [...TIMING_COLUMNS, ...MEMORY_COLUMNS];
+  const header = ['file'];
+
+  for (const column of columns) {
+    header.push(`${column}_gcOn`, `${column}_gcOff`, `${column}_ratio`);
+  }
+
+  for (const column of RETENTION_COLUMNS) {
+    header.push(`${column}_gcOn`);
+  }
+
+  const lines = [csvRow(header)];
+
+  for (const pair of comparison.pairs) {
+    const fields = [pair.file];
+
+    for (const column of columns) {
+      const on = numeric(pair.blessed[column]);
+      const off = numeric(pair.control[column]);
+
+      fields.push(
+          on === null ? UNMEASURED : String(on),
+          off === null ? UNMEASURED : String(off),
+          (on === null || off === null || off === 0) ?
+            UNMEASURED : (on / off).toFixed(4));
+    }
+
+    for (const column of RETENTION_COLUMNS) {
+      fields.push(pair.blessed[column] ?? UNMEASURED);
+    }
+
+    lines.push(csvRow(fields));
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * CLI entry point.
+ *
+ * @return {void}
+ */
+function main() {
+  const args = process.argv.slice(2);
+  const labelIndex = args.indexOf('--label');
+  let label = 'rc';
+
+  if (labelIndex >= 0) {
+    label = args[labelIndex + 1] ?? label;
+    args.splice(labelIndex, 2);
+  }
+
+  const [blessedPath, controlPath, markdownPath, csvPath] = args;
+
+  if (!blessedPath || !controlPath || !markdownPath) {
+    console.error(
+        'usage: perf_ab_compare.cjs <blessed.csv> <control.csv> <out.md> ' +
+        '[<out.csv>] [--label <text>]');
+    process.exit(2);
+  }
+
+  const comparison =
+    compareRuns(readPerfCsv(blessedPath), readPerfCsv(controlPath));
+
+  fs.writeFileSync(markdownPath, renderMarkdown(comparison, label));
+
+  if (csvPath) {
+    fs.writeFileSync(csvPath, renderCsv(comparison));
+  }
+
+  if (!comparison.switchCheck.valid) {
+    console.log(
+        '::warning::CONWAY_PERF_EXPOSE_GC A/B is invalid: the control pass ' +
+        `measured retention on ${comparison.switchCheck.controlMeasured} row(s) ` +
+        '(expected 0), so both passes ran in the same configuration.');
+  }
+
+  console.log(
+      `Compared ${comparison.pairs.length} model(s); wrote ${markdownPath}` +
+      `${csvPath ? ` and ${csvPath}` : ''}.`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  RATIO_FLOOR_MS,
+  checkSwitch,
+  compareRuns,
+  median,
+  numeric,
+  percentile,
+  readPerfCsv,
+  renderCsv,
+  renderMarkdown,
+  summariseColumn,
+};

--- a/scripts/perf_ab_compare.cjs
+++ b/scripts/perf_ab_compare.cjs
@@ -50,7 +50,7 @@
  * THE MEMORY COLUMNS ARE EXPECTED TO MOVE, and their movement is not a
  * finding. The flag-on pass settles the heap immediately before the load, so
  * its end-of-load `heapUsedMb` / `rssMb` sample starts from a collected floor
- * that the flag-off pass never gets. Measured locally over four interleaved
+ * that the flag-off pass never gets. Measured locally over 12 interleaved
  * pairs on four models, `heapUsedMb` ran 5-11 MB lower with the flag on, every
  * time. They are reported for information and explicitly not read as a defect;
  * only the timing columns carry the question.
@@ -235,12 +235,23 @@ function summariseColumn(pairs, column, applyFloor) {
     const on = numeric(pair.blessed[column]);
     const off = numeric(pair.control[column]);
 
-    if (on === null || off === null || off === 0) {
+    if (on === null || off === null) {
       continue;
     }
 
+    // Floor BEFORE the divide-by-zero guard. A 0 ms stage is below the floor
+    // by definition, so testing `off === 0` first dropped such a row out of
+    // both `n` and `floored` and left the report's counts unable to account
+    // for every pair — which is exactly what the header promises they can.
+    // Not hypothetical: box.ifc parses in 1 ms in the committed snapshots,
+    // one `Date.now()` tick away from 0, and a zero-geometry model's
+    // `geometryTimeMs` is the same story.
     if (applyFloor && (on < RATIO_FLOOR_MS || off < RATIO_FLOOR_MS)) {
       ++floored;
+      continue;
+    }
+
+    if (off === 0) {
       continue;
     }
 
@@ -402,11 +413,18 @@ function renderMarkdown(comparison, label) {
       'and is not a defect in the blessed pass: the settle collects ' +
       'immediately before `parseStartMs`, so the blessed pass enters the ' +
       'timed region with the init garbage already paid for while the control ' +
-      'pass carries it in and collects it inside the window. Measured ' +
-      'locally over 12 interleaved pairs, `parseTimeMs` ran 13-16% LOWER ' +
-      'with the flag on; see design/new/perf-measurement.md. What it does ' +
-      'mean is that a `parseTimeMs` from a post-conway#554 blessed snapshot ' +
-      'is not comparable with one from before it.');
+      'pass carries it in and collects it inside the window. **That is an ' +
+      'absolute cost, not a percentage.** Measured locally over 12 ' +
+      'interleaved pairs it was 9-12 ms of `parseTimeMs` on two 2.5 MB ' +
+      'models — 13-16% only because their parse takes about 60 ms — while ' +
+      'MB-Khaya\'s 578 ms parse showed no resolvable effect at n=5, in the ' +
+      'other direction and well inside its own spread. Expect this median to ' +
+      'sit far nearer 1.00 than 0.85 for that reason, and read a per-model ' +
+      'ratio against that model\'s own parse time rather than against the ' +
+      'percentage; see design/new/perf-measurement.md. What it does mean is ' +
+      'that a `parseTimeMs` from a post-conway#554 blessed snapshot is not ' +
+      'comparable with one from before it — materially so on a fast parse, ' +
+      'unresolvably on a slow one.');
   out.push('');
   out.push(
       'Model file I/O is outside all three columns (`parseStartMs` is taken ' +

--- a/src/core/retained_memory.ts
+++ b/src/core/retained_memory.ts
@@ -115,8 +115,14 @@ export function canSettleMemory(): boolean {
  * produces `parseTimeMs` / `geometryTimeMs` / `totalTimeMs` — baseline before
  * the load starts, retained sample after teardown. That property is what
  * makes the retention columns free, and it is checkable by measurement: a run
- * with `--expose-gc` and a run without share identical code, so if the timing
- * columns move between them, the settle is leaking into the measured window.
+ * with `--expose-gc` and a run without share identical code, so any movement
+ * in the timing columns between them is down to the settle. The SIGN says
+ * which way: gc-on slower is the settle leaking into the measured window,
+ * which is a bug; gc-on faster is the pre-load settle taking engine-init
+ * garbage OUT of that window, which is why `parseTimeMs` measures 13-16%
+ * lower with the flag on. `rc-regression.yml` runs both conditions in one
+ * job; see design/new/perf-measurement.md §"The settle also cleans the
+ * window".
  *
  * @return {Promise<SettledMemorySample | undefined>} The settled sample, or
  * undefined where no collector is exposed — in which case the caller emits

--- a/src/core/retained_memory.ts
+++ b/src/core/retained_memory.ts
@@ -119,10 +119,12 @@ export function canSettleMemory(): boolean {
  * in the timing columns between them is down to the settle. The SIGN says
  * which way: gc-on slower is the settle leaking into the measured window,
  * which is a bug; gc-on faster is the pre-load settle taking engine-init
- * garbage OUT of that window, which is why `parseTimeMs` measures 13-16%
- * lower with the flag on. `rc-regression.yml` runs both conditions in one
- * job; see design/new/perf-measurement.md §"The settle also cleans the
- * window".
+ * garbage OUT of that window. That is an absolute cost of about 10 ms per
+ * load, measured as 13-16% of `parseTimeMs` on models that parse in ~60 ms
+ * and unresolvable against one that parses in 578 ms, so read a ratio
+ * against the model's own parse time. `rc-regression.yml` runs both
+ * conditions in one job; see design/new/perf-measurement.md §"The settle
+ * also cleans the window".
  *
  * @return {Promise<SettledMemorySample | undefined>} The settled sample, or
  * undefined where no collector is exposed — in which case the caller emits

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -42,8 +42,9 @@ const CHILD_NODE_FLAGS = '--experimental-specifier-resolution=node'
  * Read any movement with its sign. Gc-on SLOWER means the settle is reaching
  * the measured window, which is a bug rather than a tolerance. Gc-on FASTER
  * means the opposite — the pre-load settle collects engine-init garbage that
- * the flag-off run collects inside the timed region instead, worth 13-16% of
- * `parseTimeMs` when measured.
+ * the flag-off run collects inside the timed region instead. That is about
+ * 10 ms per load: 13-16% of `parseTimeMs` on a model that parses in ~60 ms,
+ * and lost in the noise on one that parses in 578 ms.
  *
  * @return {boolean} True unless CONWAY_PERF_EXPOSE_GC disables it.
  */

--- a/src/ifc/ifc_regression_batch_main.ts
+++ b/src/ifc/ifc_regression_batch_main.ts
@@ -33,9 +33,17 @@ const CHILD_NODE_FLAGS = '--experimental-specifier-resolution=node'
  * both samples sit outside the timed region — baseline before the load,
  * retained sample after teardown — so a run with the flag and a run without
  * should produce the same timing columns from identical code. Set the
- * variable to `0`, `false` or `off` for the without side of that A/B. If the
- * timing columns move between the two, the settle is reaching the measured
- * window, and that is a bug rather than a tolerance.
+ * variable to `0`, `false` or `off` for the without side of that A/B; the
+ * `rebless` job of `.github/workflows/rc-regression.yml` does exactly that
+ * for its second, control pass, because the two conditions have to share a
+ * runner for the comparison to mean anything (between two CI runs the timing
+ * columns carry a ~1.5x runner scale factor against a ~1% effect).
+ *
+ * Read any movement with its sign. Gc-on SLOWER means the settle is reaching
+ * the measured window, which is a bug rather than a tolerance. Gc-on FASTER
+ * means the opposite — the pre-load settle collects engine-init garbage that
+ * the flag-off run collects inside the timed region instead, worth 13-16% of
+ * `parseTimeMs` when measured.
  *
  * @return {boolean} True unless CONWAY_PERF_EXPOSE_GC disables it.
  */

--- a/src/scripts/bless_perf_snapshot.test.ts
+++ b/src/scripts/bless_perf_snapshot.test.ts
@@ -20,11 +20,19 @@ const require_ = createRequire(import.meta.url)
 // scripts/ is not part of the tsc build. Jest's rootDir is the repo root.
 const {
   DETAIL_COLUMNS, findPreviousSnapshot, isChronologicalDelta, removeStaleDeltas,
-  writeDetailCsv, versionCompare,
+  renderReadme, writeDetailCsv, versionCompare,
 } =
   require_(path.resolve(process.cwd(), 'scripts/bless_perf_snapshot.cjs')) as {
     DETAIL_COLUMNS: string[],
     isChronologicalDelta: (name: string, version: string) => boolean,
+    renderReadme: (info: {
+      engine: string,
+      repoName: string,
+      modelCount: number,
+      retentionCount: number,
+      deltaName: string,
+      previousName: string,
+    }) => string,
     removeStaleDeltas: (outDir: string, version: string) => string[],
     findPreviousSnapshot: (dir: string, self: string, version: string) =>
       { name: string, version: string, engine: string } | null,
@@ -435,5 +443,71 @@ describe('isChronologicalDelta', () => {
       'README.md', 'index.html', '00-command.log.txt']) {
       expect(isChronologicalDelta(name, '0.23.940')).toBe(false)
     }
+  })
+})
+
+describe('renderReadme', () => {
+
+  const info = {
+    engine: 'conway1.560.1600-ci',
+    repoName: 'test-models',
+    modelCount: 97,
+    retentionCount: 97,
+    deltaName: 'conway1.451.1357-ci_1.560.1600_delta.csv',
+    previousName: 'conway1.451.1357-ci_test-models',
+  }
+
+  test('does not repeat the pre-#553 claim that geometryMemoryMb is N/A', () => {
+    // #553 restored geometryMemoryMb on the conway-native writer (SKYLARK250
+    // reads 185.22 against the 185.836 recorded at 1.451). The README shipped
+    // beside the 1.549 snapshot still says it is unmeasured, which is now the
+    // opposite of the truth for a column carrying real data; that text was
+    // removed from this template, and this keeps it out.
+    const text = renderReadme(info)
+
+    expect(text).not.toContain('`geometryMemoryMb` is absent here')
+    expect(text).toContain(
+      '`schemaVersion`,\n`preprocessorVersion` and `originatingSystem` are `N/A`')
+    // The N/A-is-not-a-zero framing is the point of #548 and must survive for
+    // the columns genuinely absent from an older snapshot.
+    expect(text).toContain('That is a missing\nmeasurement, not a zero')
+  })
+
+  test('says on its own face whether the settle ran', () => {
+    // A directory of N/A retention must explain itself without anyone having
+    // to find the workflow that produced it.
+    expect(renderReadme(info)).toContain('Retention is measured on 97 of 97')
+    expect(renderReadme({ ...info, retentionCount: 0 }))
+      .toContain('Retention is `N/A` on every row here')
+  })
+
+  test('names the blessed pass as the one this snapshot came from', () => {
+    const text = renderReadme(info)
+
+    expect(text).toContain('CONWAY_PERF_EXPOSE_GC=0')
+    expect(text).toContain('The control pass is never blessed')
+  })
+
+  test('warns off the misreadings the columns invite', () => {
+    const text = renderReadme(info)
+
+    // Retention is live model + leak, not leak.
+    expect(text).toContain('still-live model plus anything genuinely leaked')
+    // The two columns that are pipeline-scoped, with their issues.
+    expect(text).toContain('conway/issues/555')
+    expect(text).toContain('conway/issues/557')
+    // The third native quantity, and the arrayBuffers/external subset rule.
+    expect(text).toContain('getAllocationSize')
+    expect(text).toContain('ArrayBuffer subset')
+    // Cross-run timing carries the runner scale factor.
+    expect(text).toContain('median 1.55x')
+  })
+
+  test('names the delta and its predecessor, or says there is none', () => {
+    expect(renderReadme(info)).toContain(
+      '`conway1.451.1357-ci_1.560.1600_delta.csv` diffs this run against ' +
+      '`../conway1.451.1357-ci_test-models/`.')
+    expect(renderReadme({ ...info, deltaName: '', previousName: '' }))
+      .toContain('no delta was produced')
   })
 })

--- a/src/scripts/bless_perf_snapshot.test.ts
+++ b/src/scripts/bless_perf_snapshot.test.ts
@@ -488,6 +488,45 @@ describe('renderReadme', () => {
     expect(text).toContain('The control pass is never blessed')
   })
 
+  test('the N/A inventory covers the retention columns, not just FAIL rows', () => {
+    // A settle-less snapshot used to assert both 'Every other column is
+    // measured - with the exception of a row whose loadStatus is not OK' and
+    // 'Retention is `N/A` on every row here', four paragraphs apart in one
+    // file. The retention columns read N/A on an OK row whenever the run had
+    // no --expose-gc, which is exactly the run this branch describes.
+    const text = renderReadme({ ...info, retentionCount: 0 })
+
+    expect(text).toContain('Retention is `N/A` on every row here')
+    expect(text).not.toContain('Every other column is measured — with the')
+    expect(text).toContain('the three retention columns carry `N/A`')
+    expect(text).toContain('on an `OK` row as\nmuch as a failed one')
+  })
+
+  test('attributes the geometryMemoryMb split to the writers #555 measured', () => {
+    // #555 measured 16.8 vs 22.3 MB between `ifc_command_line_main` and the
+    // IFC regression child - two IFC pipelines. MB-Khaya never reaches the
+    // AP214 child, so pinning that figure to the IFC-row-vs-STEP-row split
+    // this file mixes would cite evidence for a claim it does not support.
+    const text = renderReadme(info)
+
+    expect(text).toContain('The IFC **CLI** and the IFC\nregression child read 16.8 vs 22.3 MB')
+    expect(text).toContain('has not been measured to disagree')
+  })
+
+  test('describes the second-engine term as closed by #557, not as current', () => {
+    // conway#557 landed: both regression children now extract on the engine
+    // main() initialised. A README still saying an IFC row carries ~100 MB of
+    // second engine would be describing a world that no longer exists - and
+    // the boundary that DOES matter now is that pre-#557 snapshots carry the
+    // constant and this one does not.
+    const text = renderReadme(info)
+
+    expect(text).toContain('carried a second, unrelated split until conway#557')
+    expect(text).toContain('~55-60 MB constant on every IFC row')
+    expect(text).not.toContain('roughly 100 MB')
+    expect(text).toContain('A snapshot blessed\nbefore conway#557')
+  })
+
   test('warns off the misreadings the columns invite', () => {
     const text = renderReadme(info)
 

--- a/src/scripts/perf_ab_compare.test.ts
+++ b/src/scripts/perf_ab_compare.test.ts
@@ -1,0 +1,339 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
+import { createRequire } from 'module'
+
+/**
+ * The rc-regression GC-settle A/B comparator (scripts/perf_ab_compare.cjs).
+ *
+ * The rc job runs the corpus twice in one job — the blessed pass in the
+ * shipped configuration, then a control pass with `CONWAY_PERF_EXPOSE_GC=0` —
+ * and differences them there, because between two separate CI runs the timing
+ * columns carry a ~1.5x runner scale factor two orders of magnitude larger
+ * than the ~1% effect under test (conway#554). This pins the three things
+ * that make the resulting number readable: that a control pass which measured
+ * retention is called out as an invalid A/B rather than reported as a result,
+ * that `N/A` propagates instead of being coerced to 0 (#548), and that
+ * `Date.now()`-quantised rows are excluded from the ratio statistics rather
+ * than allowed to dominate them.
+ */
+/* eslint-disable no-magic-numbers -- the literals here are the fixture
+   timings and percentile fractions the cases are about; naming a 0.1 or a
+   110 ms parse would hide the shape each case exists to express. */
+
+const require_ = createRequire(import.meta.url)
+
+// Resolved from the repo root: the test runs from compiled/src/scripts, and
+// scripts/ is not part of the tsc build. Jest's rootDir is the repo root.
+type PerfRow = Record<string, string>
+type ColumnSummary = {
+  column: string,
+  n: number,
+  floored: number,
+  medianRatio: number | null,
+  p10: number | null,
+  p90: number | null,
+  slower: number,
+  medianDelta: number | null,
+}
+type Comparison = {
+  pairs: { file: string, blessed: PerfRow, control: PerfRow }[],
+  timing: ColumnSummary[],
+  memory: ColumnSummary[],
+  switchCheck: {
+    blessedMeasured: number,
+    blessedTotal: number,
+    controlMeasured: number,
+    controlTotal: number,
+    valid: boolean,
+  },
+  blessedOnly: string[],
+  controlOnly: string[],
+}
+
+const {
+  RATIO_FLOOR_MS, checkSwitch, compareRuns, numeric, percentile, readPerfCsv,
+  renderCsv, renderMarkdown, summariseColumn,
+} =
+  require_(path.resolve(process.cwd(), 'scripts/perf_ab_compare.cjs')) as {
+    RATIO_FLOOR_MS: number,
+    readPerfCsv: (file: string) => PerfRow[],
+    checkSwitch: (blessed: PerfRow[], control: PerfRow[]) =>
+      Comparison['switchCheck'],
+    compareRuns: (blessed: PerfRow[], control: PerfRow[]) => Comparison,
+    numeric: (value: string | undefined) => number | null,
+    percentile: (values: number[], fraction: number) => number | null,
+    renderCsv: (comparison: Comparison) => string,
+    renderMarkdown: (comparison: Comparison, label: string) => string,
+    summariseColumn: (
+      pairs: Comparison['pairs'], column: string, applyFloor: boolean) =>
+      ColumnSummary,
+  }
+
+/**
+ * A perf.csv row with the columns this comparator reads, overridable per test.
+ *
+ * @param overrides Column values to set.
+ * @return {PerfRow} The row.
+ */
+function row(overrides: Partial<PerfRow> & { file: string }): PerfRow {
+  return {
+    status: 'OK',
+    parseTimeMs: '100',
+    geometryTimeMs: '1000',
+    totalTimeMs: '1100',
+    heapUsedMb: '50.00',
+    rssMb: '300.00',
+    peakRssMb: '310.00',
+    retainedRssMb: 'N/A',
+    retainedHeapUsedMb: 'N/A',
+    retainedExternalMb: 'N/A',
+    ...overrides,
+  }
+}
+
+/**
+ * A blessed-pass row: the settle ran, so retention is measured.
+ *
+ * @param overrides Column values to set.
+ * @return {PerfRow} The row.
+ */
+function blessedRow(overrides: Partial<PerfRow> & { file: string }): PerfRow {
+  return row({
+    retainedRssMb: '380.00',
+    retainedHeapUsedMb: '10.00',
+    retainedExternalMb: '47.00',
+    ...overrides,
+  })
+}
+
+describe('readPerfCsv', () => {
+
+  let workDir: string
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-ab-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true })
+  })
+
+  test('reads the 16-column perf.csv both passes write', () => {
+    // The exact header ifc_regression_main.ts emits, with a control-pass row:
+    // the file this comparator is pointed at in CI, not a reduced stand-in.
+    const file = path.join(workDir, 'perf-nogc.csv')
+
+    fs.writeFileSync(file,
+      'file,status,parseTimeMs,geometryTimeMs,totalTimeMs,geometryMemoryMb,' +
+      'peakWasmHeapMb,rssMb,peakRssMb,heapUsedMb,heapTotalMb,externalMb,' +
+      'arrayBuffersMb,retainedRssMb,retainedHeapUsedMb,retainedExternalMb\n' +
+      'AC20-FZK-Haus.ifc,OK,76,436,512,1.69,35.13,289.39,289.52,54.40,84.34,' +
+      '9.98,7.93,N/A,N/A,N/A\n')
+
+    const rows = readPerfCsv(file)
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].file).toBe('AC20-FZK-Haus.ifc')
+    expect(rows[0].totalTimeMs).toBe('512')
+    expect(rows[0].retainedRssMb).toBe('N/A')
+  })
+
+  test('an empty file is no rows, not a throw', () => {
+    const file = path.join(workDir, 'empty.csv')
+
+    fs.writeFileSync(file, '')
+
+    expect(readPerfCsv(file)).toEqual([])
+  })
+})
+
+describe('numeric', () => {
+
+  test('treats N/A and blank as absent rather than zero', () => {
+    // #548: parseValue returning 0.0 for a missing column produced a phantom
+    // -185.836 MB "win" for SKYLARK250. Nothing in this file may repeat it.
+    expect(numeric('N/A')).toBeNull()
+    expect(numeric('')).toBeNull()
+    expect(numeric(undefined)).toBeNull()
+    expect(numeric('0')).toBe(0)
+    expect(numeric('12.5')).toBe(12.5)
+  })
+})
+
+describe('percentile', () => {
+
+  test('interpolates between samples and handles the empty case', () => {
+    expect(percentile([1, 2, 3, 4], 0.5)).toBeCloseTo(2.5)
+    expect(percentile([1, 2, 3, 4, 5], 0.1)).toBeCloseTo(1.4)
+    expect(percentile([], 0.5)).toBeNull()
+  })
+})
+
+describe('checkSwitch', () => {
+
+  test('a control pass with no retention against a blessed pass with it is valid', () => {
+    const check = checkSwitch(
+      [blessedRow({ file: 'a.ifc' }), blessedRow({ file: 'b.ifc' })],
+      [row({ file: 'a.ifc' }), row({ file: 'b.ifc' })])
+
+    expect(check.valid).toBe(true)
+    expect(check.blessedMeasured).toBe(2)
+    expect(check.controlMeasured).toBe(0)
+  })
+
+  test('a control pass that measured retention is not an A/B at all', () => {
+    // The env switch never reached the children, so both passes ran the same
+    // configuration and every timing ratio below is noise against noise.
+    const check = checkSwitch(
+      [blessedRow({ file: 'a.ifc' })], [blessedRow({ file: 'a.ifc' })])
+
+    expect(check.valid).toBe(false)
+    expect(check.controlMeasured).toBe(1)
+  })
+
+  test('a blessed pass with no retention is equally not an A/B', () => {
+    const check =
+      checkSwitch([row({ file: 'a.ifc' })], [row({ file: 'a.ifc' })])
+
+    expect(check.valid).toBe(false)
+  })
+})
+
+describe('summariseColumn', () => {
+
+  const pairs = (
+    blessed: Partial<PerfRow>[], control: Partial<PerfRow>[]) =>
+    blessed.map((value, index) => ({
+      file: `m${index}.ifc`,
+      blessed: row({ file: `m${index}.ifc`, ...value }),
+      control: row({ file: `m${index}.ifc`, ...control[index] }),
+    }))
+
+  test('ratio, sign count and median delta', () => {
+    const stat = summariseColumn(
+      pairs(
+        [{ totalTimeMs: '110' }, { totalTimeMs: '90' }, { totalTimeMs: '100' }],
+        [{ totalTimeMs: '100' }, { totalTimeMs: '100' }, { totalTimeMs: '100' }]),
+      'totalTimeMs', true)
+
+    expect(stat.n).toBe(3)
+    expect(stat.medianRatio).toBeCloseTo(1.0)
+    expect(stat.slower).toBe(1)
+    expect(stat.medianDelta).toBe(0)
+  })
+
+  test('rows under the quantisation floor are counted out, not counted in', () => {
+    // A 3 ms parse carries a +/-1 ms Date.now() tick — a 33% "ratio" that is
+    // pure rounding, and there are enough tiny models in the corpus to swamp
+    // the median with them.
+    const stat = summariseColumn(
+      pairs(
+        [{ parseTimeMs: '3' }, { parseTimeMs: '4' }, { parseTimeMs: '200' }],
+        [{ parseTimeMs: '1' }, { parseTimeMs: '2' }, { parseTimeMs: '100' }]),
+      'parseTimeMs', true)
+
+    expect(RATIO_FLOOR_MS).toBe(10)
+    expect(stat.floored).toBe(2)
+    expect(stat.n).toBe(1)
+    expect(stat.medianRatio).toBeCloseTo(2.0)
+  })
+
+  test('the floor is not applied to the memory columns', () => {
+    const stat = summariseColumn(
+      pairs([{ heapUsedMb: '5.0' }], [{ heapUsedMb: '8.0' }]),
+      'heapUsedMb', false)
+
+    expect(stat.floored).toBe(0)
+    expect(stat.n).toBe(1)
+  })
+
+  test('an unmeasured cell on either side drops the pair, it does not read zero', () => {
+    const stat = summariseColumn(
+      pairs([{ totalTimeMs: 'N/A' }, { totalTimeMs: '200' }],
+        [{ totalTimeMs: '100' }, { totalTimeMs: 'N/A' }]),
+      'totalTimeMs', true)
+
+    expect(stat.n).toBe(0)
+    expect(stat.medianRatio).toBeNull()
+  })
+})
+
+describe('compareRuns', () => {
+
+  test('joins on file, and reports rows only one pass produced', () => {
+    const comparison = compareRuns(
+      [blessedRow({ file: 'a.ifc' }), blessedRow({ file: 'only-blessed.ifc' })],
+      [row({ file: 'a.ifc' }), row({ file: 'only-control.ifc' })])
+
+    expect(comparison.pairs.map((pair) => pair.file)).toEqual(['a.ifc'])
+    expect(comparison.blessedOnly).toEqual(['only-blessed.ifc'])
+    expect(comparison.controlOnly).toEqual(['only-control.ifc'])
+  })
+
+  test('a model that failed in either pass is not timed against one that did not', () => {
+    const comparison = compareRuns(
+      [blessedRow({ file: 'a.ifc', status: 'FAIL' })],
+      [row({ file: 'a.ifc' })])
+
+    expect(comparison.pairs).toHaveLength(0)
+  })
+
+  test('summarises the three timing columns and the memory columns', () => {
+    const comparison =
+      compareRuns([blessedRow({ file: 'a.ifc' })], [row({ file: 'a.ifc' })])
+
+    expect(comparison.timing.map((stat) => stat.column))
+      .toEqual(['parseTimeMs', 'geometryTimeMs', 'totalTimeMs'])
+    expect(comparison.memory.map((stat) => stat.column))
+      .toEqual(['heapUsedMb', 'rssMb', 'peakRssMb'])
+  })
+})
+
+describe('renderMarkdown', () => {
+
+  test('a valid A/B says so, and reports the sign rule in both directions', () => {
+    const text = renderMarkdown(
+      compareRuns([blessedRow({ file: 'a.ifc' })], [row({ file: 'a.ifc' })]),
+      'bldrs-ai/test-models')
+
+    expect(text).toContain('**Switch check: OK.**')
+    expect(text).toContain('gc on SLOWER')
+    expect(text).toContain('gc on FASTER')
+  })
+
+  test('an invalid A/B is labelled INVALID rather than presented as a result', () => {
+    const text = renderMarkdown(
+      compareRuns(
+        [blessedRow({ file: 'a.ifc' })], [blessedRow({ file: 'a.ifc' })]),
+      'bldrs-ai/test-models')
+
+    expect(text).toContain('INVALID')
+    expect(text).toContain('answers nothing about the settle')
+  })
+})
+
+describe('renderCsv', () => {
+
+  test('carries both passes, the ratio, and the blessed retention columns', () => {
+    const text = renderCsv(compareRuns(
+      [blessedRow({ file: 'a.ifc', totalTimeMs: '110' })],
+      [row({ file: 'a.ifc', totalTimeMs: '100' })]))
+    const [header, dataRow] = text.trim().split('\n')
+
+    expect(header).toContain('totalTimeMs_gcOn,totalTimeMs_gcOff,totalTimeMs_ratio')
+    expect(header).toContain('retainedRssMb_gcOn')
+    expect(dataRow).toContain('110,100,1.1000')
+    expect(dataRow).toContain('380.00')
+  })
+
+  test('an unmeasured input yields N/A, never a fabricated ratio', () => {
+    const text = renderCsv(compareRuns(
+      [blessedRow({ file: 'a.ifc', totalTimeMs: 'N/A' })],
+      [row({ file: 'a.ifc', totalTimeMs: '100' })]))
+    const dataRow = text.trim().split('\n')[1]
+
+    expect(dataRow).toContain('N/A,100,N/A')
+  })
+})

--- a/src/scripts/perf_ab_compare.test.ts
+++ b/src/scripts/perf_ab_compare.test.ts
@@ -240,6 +240,23 @@ describe('summariseColumn', () => {
     expect(stat.medianRatio).toBeCloseTo(2.0)
   })
 
+  test('a zero on the control side is floored, not dropped uncounted', () => {
+    // 0 ms is BELOW the 10 ms floor, so it belongs in `floored`. Testing
+    // `off === 0` ahead of the floor dropped such a row out of both counts,
+    // leaving n + floored unable to account for every pair - which the
+    // module header promises they can. Reachable: box.ifc parses in 1 ms in
+    // the committed snapshots, one Date.now() tick from 0, and a
+    // zero-geometry model's geometryTimeMs is the same story.
+    const stat = summariseColumn(
+      pairs([{ geometryTimeMs: '0' }, { geometryTimeMs: '200' }],
+        [{ geometryTimeMs: '0' }, { geometryTimeMs: '100' }]),
+      'geometryTimeMs', true)
+
+    expect(stat.floored).toBe(1)
+    expect(stat.n).toBe(1)
+    expect(stat.floored + stat.n).toBe(2)
+  })
+
   test('the floor is not applied to the memory columns', () => {
     const stat = summariseColumn(
       pairs([{ heapUsedMb: '5.0' }], [{ heapUsedMb: '8.0' }]),


### PR DESCRIPTION
Closes the gap left by #556: `CONWAY_PERF_EXPOSE_GC` was built and nothing called it. `rc-regression.yml` had zero references to it, so tagging an rc ran one pass with the flag defaulting on — retention populated, no A/B.

Refs #554.

## Why two passes in one job, not two rc runs

The original plan was to tag an rc, run, flip the switch, run again. [#554 comment 5381287618](https://github.com/bldrs-ai/conway/issues/554#issuecomment-5381287618) shows that cannot work: two `run-ifc-regression` jobs an hour apart on near-identical code came out with **every** model faster in the later run, median **1.55×**. A third sample since makes MB-Khaya's `totalTimeMs` read **8039 → 4745 → 7621 ms** across three runs of near-identical code. The effect under test is ~1%, so a between-run comparison measures which runner the job landed on.

Both conditions now run in one `rebless` job, sharing a runner, a machine and a moment, so the scale factor cancels. This is option 1 from that comment.

## What the workflow does now

| step | condition | notes |
|---|---|---|
| Regenerate baseline digests | unchanged | **blessed pass**, now with `CONWAY_PERF_EXPOSE_GC: '1'` written down rather than left implicit → `perf.csv` |
| Fail on NEW regression failures | unchanged | runs **once** |
| **Control perf pass** | `success()` + `continue-on-error` | `CONWAY_PERF_EXPOSE_GC: '0'` → `perf-nogc.csv`, digests to a scratch folder that is deleted |
| Summarize steady perf | unchanged | pass 1 only |
| **Compare the two passes** | `!cancelled()` + `continue-on-error` | job summary table + `perf-gc-ab.{md,csv}` |
| Upload perf CSVs | unchanged gate | now carries both CSVs and the comparison |
| Bless perf snapshot | unchanged | only ever sees `perf.csv` |

Job `timeout-minutes` 45 → 70, because 45 had only ~15 min of headroom over a single-pass run.

Design points, each with the reason it is that way in a comment beside it:

- **The blessed pass is the default one.** The control's numbers never reach `bless_perf_snapshot.cjs` (it is handed `$PERF` = `perf.csv`, and `perf-nogc.csv` appears nowhere else) or the re-bless PR (`add-paths` is scoped to `regression/test_models` and `benchmarks` **inside** `models`; the control writes outside that checkout). Blessing the control would put a release's record under a configuration nobody ships.
- **No extra LFS bandwidth.** The control pass reuses the corpus already materialised in `models`. Perf compute roughly doubles; that is the accepted cost.
- **Neither gate runs twice.** The failure gate and the zero-geometry gate stay on pass 1; a second identical digest run yields no extra signal.
- **The `rc-*` ref gate is untouched** — `case "$REF_NAME"` still guards the blessed snapshot, so an ad-hoc `workflow_dispatch` still cannot mint one.
- **The control pass can never block the rc's deliverable.** Every step after it that carries no `if:` — including the re-bless PR that *is* the regression report — runs on the implicit `success()`, so it is `continue-on-error`. Same reason the comparison step is, and why the comparison script never exits non-zero on a finding.
- **The control output path must stay relative.** The batch ends every run with `git diff -- <output_folder>` from inside the model checkout, unguarded. A relative `perf-control-out` resolves inside that repo and diffs to nothing (exactly as `models/regression/test_models` already does from that cwd); an absolute path makes git exit 128 with `is outside repository` and fails the step. Verified both ways locally.

## `scripts/perf_ab_compare.cjs`

Emits a job-summary table and a joined CSV. One sample per model per pass means there is no within-pass spread on a single model, so the statistic is across the corpus: per-column **median on÷off ratio**, a **p10/p90 band**, and the **count of models slower with the flag on** — a sign test the runner scale factor cannot fake, since it applies to both passes equally. Rows under a 10 ms `Date.now()` quantisation floor are counted out and reported, not silently dropped. It also checks the switch actually took (retention measured on the blessed side, `N/A` on the control side) and prints **INVALID** rather than a result if it did not.

19 tests in `src/scripts/perf_ab_compare.test.ts`.

## A finding that changes how to read the result

Wiring this up produced the first measurement of the settle itself (as opposed to the flag, which #554 already measured neutral). 12 interleaved pairs, four models through the IFC regression child:

| model | parse, gc on | parse, gc off |
|---|---|---|
| AC20-FZK-Haus.ifc (2.5 MB) | 58.75 ms (57-63) | 67.42 ms (58-76) |
| ISSUE_005_haus.ifc (2.5 MB) | 58.58 ms (57-62) | 70.08 ms (58-93) |
| IfcOpenHouse_IFC4.ifc (113 kB) | 13.00 ms | 13.42 ms |
| Sample_entities.ifc (29 kB) | 8.08 ms | 9.25 ms |

`geometryTimeMs` shows no consistent direction over the same pairs — the property holding. `parseTimeMs` does move, and **it is an absolute cost of about 10 ms per load, not a percentage**: 8.7 and 11.5 ms on the two 2.5 MB models, 0.4 and 1.2 ms on the two small ones. It reads as 13-16% only because those two parses take about 60 ms. The mechanism is the pre-load settle: its collections run immediately before `parseStartMs`, so the blessed pass enters the timed region with engine-init garbage already collected while the control pass carries it in and pays for it inside the window. `heapUsedMb` runs 5-11 MB lower with the flag on for the same reason.

**This does not contradict the MB-Khaya A/B already in the doc** (578.2 ms gc-off vs 588.0 ms gc-on, n=5 — the opposite sign, inside a 25-55 ms spread). A ~10 ms shift is 1.7% of a 578 ms parse and simply not resolvable there. So expect the corpus-wide median `parseTimeMs` ratio from the rc job to sit far nearer 1.00 than 0.85, and read a per-model ratio against that model's own parse time rather than against the percentage.

So the doc's conclusion rule needed a **sign**, and it now has one:

- gc-on **slower** → the settle is leaking into the measured window. A bug.
- gc-on **faster** → the control is carrying garbage in. Not a defect in the shipped configuration, but it means `parseTimeMs`, `heapUsedMb` and `rssMb` are **not comparable across the #554 boundary** — materially so on a fast parse, unresolvably on a slow one.

n=12 on one dev machine over four models, and taken against pre-#557 code, so the absolute `geometryTimeMs` figures no longer reproduce (#557 removed a second `initialize()` from inside that window). It cannot touch the parse column: the second engine was constructed in `geometryExtraction`, after `parseEndMs`. The corpus-wide figures land in the first rc that carries both passes.

## Also: the snapshot README now defines its own columns

Per Pablo's call on retention naming — "just so it's defined and discoverable". `bless_perf_snapshot.cjs`'s README generator gained the parts a reader can be misled by: that retention is the **still-live model plus anything leaked** (`invalidate(true)` cannot release `geometry`/`curves`/`profiles`/`materials` or the source buffer — the digest iterates them after teardown); the `geometryMemoryMb` writer split (#555, IFC **CLI** vs IFC regression child — every row in this file comes from a regression child, so the hazard is a CLI figure differenced against one from here); the retention split #557 closed, and the fact that a pre-#557 snapshot's IFC `retainedRssMb`/`peakRssMb`/`geometryTimeMs` therefore are not comparable with this one; the third native quantity; the cross-run timing scale factor; and whether the settle ran, counted from the rows so a snapshot of `N/A` retention says why on its own face.

The stale "`geometryMemoryMb` is absent here" paragraph the 1.549 snapshot still carries **was already removed from this template by #553** (`9c12be5d`); that committed README predates it and regenerates correctly at the next rc. A test now pins it out.

## Review round (post-#559)

`origin/main` moved under this branch: #559 landed the #557 single-engine fix. Merged in (one conflict, both changelog rows kept). The review that followed found and fixed five claim-level defects, each with a test:

1. The README attributed #555's 16.8 vs 22.3 MB `geometryMemoryMb` divergence to the IFC-child-vs-AP214-child split this file mixes. #555 measured it between `ifc_command_line_main` and the IFC regression child — MB-Khaya never reaches the AP214 child, and no CLI row is ever in this file.
2. The same paragraph described the second `ConwayGeometry` as current and generalised #557's single-model figure to "roughly 100 MB of an IFC model's `retainedRssMb`". Rewritten as the closed boundary it is, with #559's measured ~55-60 MB step-down.
3. "Every other column is measured — with the exception of a row whose `loadStatus` is not `OK`" contradicted, four paragraphs later, "Retention is `N/A` on every row here".
4. The 13-16% parse figure was stated without its size dependence, and the adjacent MB-Khaya n=5 table (opposite sign) was left unreconciled. Fixed in the doc, the generated README, the rc job summary and both source comments.
5. `summariseColumn` tested `off === 0` before the 10 ms floor, so a 0 ms stage landed in neither `n` nor `floored` — contra the module header's promise. Floor first, then the divide-by-zero guard.

## Verification — and its limits

**Verified by execution:**
- The switch differentiates. Two batch runs over a 4-model set, identical CLI, one with `CONWAY_PERF_EXPOSE_GC` unset and one `=0`. Headers identical; the only columns differing in measured/unmeasured status are `retainedRssMb`, `retainedHeapUsedMb`, `retainedExternalMb`. `geometryMemoryMb` and `peakWasmHeapMb` come out byte-identical.
- Both new step bodies, run verbatim against a git-backed mirror of the CI layout: exit 0, `perf-control-out` created and cleaned up, blessed digests in `models/regression/test_models` untouched.
- The absolute-vs-relative `git diff` pathspec behaviour, both ways (relative non-matching pathspec → exit 0 and no output; absolute → exit 128 `is outside repository`).
- The comparison script against real two-pass CSVs, both the valid and the missing-control branches.
- **Post-merge:** `yarn lint` 0 errors / 681 warnings; full suite **102 suites, 696 tests, 0 failures**. Each of the five review fixes mutation-checked by reverting it and showing its test fail.

**Verified by reading only:** that the control pass cannot reach the blessing path (traced through `bless_perf_snapshot.cjs`'s single `$PERF` argument, the batch's `outputPath`/`changes` derivation, and the PR step's `add-paths`), and how `continue-on-error` behaves on a real runner.

**Not verified at all:** the workflow end to end. It needs `REBLESS_TOKEN`, both corpora and LFS. No claim is made that a real rc run works; the first `rc-*` tag after this merges is the test.

---
_Generated by [Claude Code](https://claude.ai/code/session_013RHVKvZN2erpMD7svDWALU)_