### PR TITLE
#557: run the IFC regression extraction on the engine main() initialised

### DIFF
--- a/design/new/perf-measurement.md
+++ b/design/new/perf-measurement.md
@@ -189,31 +189,55 @@ single cycle rounds away; this does not close that off.
   module's fixed cost into every model's retention and make them all
   look leaky by the same constant.
 
-**Two places the baseline cannot be where that rule wants it**, both
-worth knowing before reading a number (the teardown caveat above is a
-third, and applies on every path):
+**One place the baseline cannot be where that rule wants it**, worth
+knowing before reading a number (the teardown caveat above is a second,
+and applies on every path): the **loader path** brings up its own
+`ConwayGeometry` per load, *inside* the region `allTimeStart` opens, so
+there is no point that is both after init and outside the timed region.
+The baseline is taken at function entry instead — which keeps the
+no-perturbation property, at the cost of counting that per-load module
+against the cycle. Nothing releases it, so that is a real retention on
+that path, but it is a large constant sitting on top of the
+model-specific figure.
 
-1. The **loader path** brings up its own `ConwayGeometry` per load,
-   *inside* the region `allTimeStart` opens, so there is no point that
-   is both after init and outside the timed region. The baseline is
-   taken at function entry instead — which keeps the no-perturbation
-   property, at the cost of counting that per-load module against the
-   cycle. Nothing releases it, so that is a real retention on that
-   path, but it is a large constant sitting on top of the model-specific
-   figure.
-2. The **IFC regression child** initialises one engine in `main()` and
-   then `geometryExtraction` constructs a *second* one, which is the
-   engine the extraction actually runs against. Measured on MB-Khaya:
-   engine A holds a 16 MB initial arena and does no work, engine B
-   holds 106.5 MB. So roughly 100 MB of that model's 388 MB
-   `retainedRssMb` is engine B's linear memory, created inside the
-   window and never freed. The AP214 child uses the single module-level
-   engine and has no such term.
+**The IFC regression child used to be a second such place, and conway#557
+fixed it.** It initialised one engine in `main()` and then
+`geometryExtraction` constructed a *second* one, which was the engine the
+extraction actually ran against — so the engine that was initialised
+before the baseline was not the engine that did the work, and the second
+engine's whole footprint landed inside the window. Measured on MB-Khaya
+before the fix: telemetry engine 16,777,216 bytes of untouched initial
+arena, extraction engine 106,496,000 bytes, `sameObject=false`. The
+extraction now runs against the module-level engine, the way the AP214
+child always has, and the constant comes off every IFC row: MB-Khaya
+`retainedRssMb` 379.58/385.60/388.59 over three runs before, against
+326.48/326.94/327.02/329.23/333.11/333.24 over six after; index.ifc
+58.96 -> 2.38, AC20-FZK-Haus 95.77 -> 36.35, duplex 97.73 -> 42.52,
+Schependomlaan 371.75 -> 308.89 — a ~55-60 MB fixed term regardless of
+model size, which
+is what a second engine looks like. Digests were byte-identical on all
+seven models checked. `peakRssMb` drops by the same term, and
+`geometryTimeMs` loses the second `initialize()` that sat inside the
+timed region (IfcOpenHouse_IFC4 156 -> 70 ms), so the **rc baselines for
+those columns move once** with that fix.
 
-So, exactly as with `geometryMemoryMb`, **do not difference a retention
-figure across pipelines.** Within one pipeline the figure is stable: five
-MB-Khaya runs through the IFC child gave `retainedRssMb` 382.86-390.98,
-`retainedHeapUsedMb` 10.76-10.80, `retainedExternalMb` 47.77 every time.
+So, as with `geometryMemoryMb`, **do not difference a retention figure
+between the loader path and a regression child** — the loader's per-load
+module is a constant one side carries and the other does not. The two
+regression children are now the same shape as each other: one engine,
+initialised before the baseline, growing inside the window as the model
+loads. Within one pipeline the figure is stable: six MB-Khaya runs
+through the IFC child after #557 gave `retainedRssMb` 326.48-333.24,
+`retainedHeapUsedMb` 9.72-9.78, `retainedExternalMb` 46.19 every time.
+(Before #557 the recorded five-run check read 382.86-390.98 /
+10.76-10.80 / 47.77 — stable then too, around a centre that included the
+second engine.)
+
+What remains inside the window on both children is the *growth* of the
+one engine's linear memory during the load — MB-Khaya's arena goes from
+16 MB at the baseline to the 101.56 MB `peakWasmHeapMb` reports, and
+emscripten never gives it back. That is a real cost of loading the model,
+not a measurement artefact, and it is symmetric across the two children.
 
 **No `retainedWasmHeapMb`.** conway#554 proposed one and it is
 deliberately excluded. `wasmHeapByteLength` is grow-only — it does not
@@ -382,6 +406,7 @@ against a regression-child figure. Tracked separately.
 | #548 | delta stops fabricating values for missing columns | `parseValue` returned `0.0`; see "The rule for changing fields" |
 | #552 (via #553) | add `peakRssMb`, `externalMb`, `arrayBuffersMb`, `peakWasmHeapMb`; restore `geometryMemoryMb` | memory was one un-GC'd instant, and the wasm heap was invisible |
 | #554 | add `retainedRssMb`, `retainedHeapUsedMb`, `retainedExternalMb`; pass `--expose-gc` to the regression children and the render server; add the teardown the regression children never had | nothing measured what is held after teardown, and a peak cannot see it |
+| #557 | IFC regression child extracts on the engine `main()` initialised, not a second one built in `geometryExtraction` | the alloc telemetry described an idle module, and the second engine put a ~55-60 MB constant in every IFC retention and RSS row plus its init in `geometryTimeMs`; those IFC baselines move once |
 
 Restoring `geometryMemoryMb` checks out against history: SKYLARK250 reads
 **185.22** against the **185.836** recorded at 1.451.

--- a/src/ifc/ifc_regression_main.ts
+++ b/src/ifc/ifc_regression_main.ts
@@ -303,7 +303,12 @@ async function main() {
 
   try {
 
-    await conwayGeom.initialize()
+    const initializationStatus = await conwayGeom.initialize()
+
+    if (!initializationStatus) {
+      console.error('Couldn\'t initialize conway-geom, exiting...')
+      return
+    }
 
     Environment.checkEnvironment()
     Logger.initializeWasmCallbacks()
@@ -476,22 +481,21 @@ function doWork() {
           model.nullOnErrors = !strict
 
           const geomStartMs = Date.now()
-          const result = await geometryExtraction(model)
+          const scene = geometryExtraction(model)
           const geomEndMs = Date.now()
           const geometryTimeMs = geomEndMs - geomStartMs
           const totalTimeMs = geomEndMs - parseStartMs
 
-          const perfStatus = result === void 0 ? 'FAIL' : 'OK'
+          const perfStatus = scene === void 0 ? 'FAIL' : 'OK'
           // Sized before anything downstream can release meshes, and only on
           // the OK path: a failed extraction leaves a partial cache whose size
           // is not this model's geometry footprint.
-          const geometryMemoryBytes = result !== void 0 ?
+          const geometryMemoryBytes = scene !== void 0 ?
             model.geometry.calculateGeometrySize() : void 0
           // The heap is grow-only, so this is the run's high-water mark even
-          // though it is read once, after the fact. geometryExtraction hands
-          // back the engine it brought up; there is no heap to measure when
-          // it failed before that.
-          const wasmModule = result?.[ 1 ].wasmModule
+          // though it is read once, after the fact. conwayGeom is the engine
+          // every extraction in this process runs against.
+          const wasmModule = conwayGeom.wasmModule
           const wasmHeapBytes = wasmModule !== void 0 ?
             wasmHeapByteLength( wasmModule ) : void 0
           // Instants captured here, where they have always been captured, so
@@ -537,7 +541,7 @@ function doWork() {
           // CONWAY_ALLOC_TELEMETRY (see conway-geom structures/alloc_telemetry.h).
           conwayGeom.dumpAllocTelemetry(path.basename(ifcFile))
 
-          if ( result === void 0 ) {
+          if ( scene === void 0 ) {
             Logger.error( 'Couldn\'t extract geometry')
           } else {
 
@@ -658,21 +662,24 @@ function doWork() {
 }
 
 /**
- * Function to extract Geometry from an IfcStepModel
+ * Function to extract Geometry from an IfcStepModel.
+ *
+ * Runs against the module-level `conwayGeom` that `main()` brought up, the
+ * way the AP214 child does. It used to construct and initialise a *second*
+ * `ConwayGeometry` here (conway#557), which made the engine that did the work
+ * a different object from the one `main()` initialised and
+ * `dumpAllocTelemetry` reported on — so the telemetry described an idle
+ * module, and the second engine's linear memory (106.5 MB on MB-Khaya
+ * against engine A's untouched 16 MB arena) was allocated inside the
+ * retention window and never released.
  *
  * @param model
+ * @return {IfcSceneBuilder | undefined} The extracted scene, or undefined on
+ * failure.
  */
-async function geometryExtraction(model: IfcStepModel):
-  Promise<[IfcSceneBuilder, ConwayGeometry] | undefined> {
+function geometryExtraction(model: IfcStepModel): IfcSceneBuilder | undefined {
 
-  const conwaywasm = new ConwayGeometry()
-  const initializationStatus = await conwaywasm.initialize()
-
-  if (!initializationStatus) {
-    return
-  }
-
-  const conwayModel = new IfcGeometryExtraction(conwaywasm, model)
+  const conwayModel = new IfcGeometryExtraction(conwayGeom, model)
 
   RegressionCaptureState.memoization = MemoizationCapture.FULL
 
@@ -685,5 +692,5 @@ async function geometryExtraction(model: IfcStepModel):
     return void 0
   }
 
-  return [scene, conwaywasm]
+  return scene
 }

--- a/src/ifc/ifc_regression_single_engine.test.ts
+++ b/src/ifc/ifc_regression_single_engine.test.ts
@@ -1,0 +1,75 @@
+import fs from 'fs'
+import path from 'path'
+import { describe, expect, test } from '@jest/globals'
+
+
+/**
+ * One wasm engine per regression child, and it is the engine the extraction
+ * runs against (conway#557).
+ *
+ * The IFC child used to initialise a `ConwayGeometry` in `main()` and then
+ * construct a *second* one inside `geometryExtraction`. The extraction ran
+ * against the second; `dumpAllocTelemetry` — and, later, `peakWasmHeapMb` —
+ * reported on the first, which never did any work. Measured on MB-Khaya
+ * before the fix: telemetry engine 16,777,216 bytes of untouched initial
+ * arena, extraction engine 106,496,000 bytes, `sameObject=false`. The second
+ * engine was also created after `settleAndSampleMemoryForPerf` took the
+ * pre-load baseline, so its whole footprint landed inside the retention
+ * window and put a ~55-60 MB constant into every IFC `retainedRssMb`.
+ *
+ * This is asserted against the SOURCE TEXT rather than by running the
+ * children, because both are process entry points: they call `main()` at
+ * module scope and drive `yargs` off `process.argv`, so importing either one
+ * from a test starts a regression run. The property is structural — how many
+ * engines the file builds and which one every consumer names — so the text is
+ * where it can be checked at all. A runtime equivalent would need the child
+ * to expose its engines, which is a larger change to production code than the
+ * defect warrants.
+ */
+describe('regression children use a single wasm engine', () => {
+
+  // Resolved from the repo root rather than relative to this file: the test
+  // runs from compiled/src/ifc, and the TypeScript sources are not part of
+  // the tsc output. Jest's rootDir is the repo root.
+  const ifcSource =
+    fs.readFileSync(
+        path.resolve(process.cwd(), 'src/ifc/ifc_regression_main.ts'), 'utf8')
+  const ap214Source =
+    fs.readFileSync(
+        path.resolve(
+            process.cwd(),
+            'src/AP214E3_2010/ap214_regression_main.ts'), 'utf8')
+
+  /**
+   * Count non-overlapping matches of a global pattern.
+   *
+   * @param source Text to search.
+   * @param pattern Global regular expression to count matches of.
+   * @return {number} Number of matches.
+   */
+  function countMatches(source: string, pattern: RegExp): number {
+    return (source.match(pattern) ?? []).length
+  }
+
+  test('the IFC child constructs exactly one ConwayGeometry', () => {
+    expect(countMatches(ifcSource, /new ConwayGeometry\(/g)).toBe(1)
+  })
+
+  test('the AP214 child constructs exactly one ConwayGeometry', () => {
+    // The reference for what right looks like here; it has always had one.
+    expect(countMatches(ap214Source, /new ConwayGeometry\(/g)).toBe(1)
+  })
+
+  test('the IFC extraction, telemetry and heap figure name one engine', () => {
+    expect(ifcSource).toContain('new IfcGeometryExtraction(conwayGeom, model)')
+    expect(ifcSource).toContain('conwayGeom.dumpAllocTelemetry(')
+    expect(ifcSource).toContain('const wasmModule = conwayGeom.wasmModule')
+  })
+
+  test('the AP214 extraction, telemetry and heap figure name one engine', () => {
+    expect(ap214Source)
+        .toContain('new AP214GeometryExtraction(conwayGeom, model)')
+    expect(ap214Source).toContain('conwayGeom.dumpAllocTelemetry(')
+    expect(ap214Source).toContain('const wasmModule = conwayGeom.wasmModule')
+  })
+})


### PR DESCRIPTION
Fixes #557.

## What was wrong

`src/ifc/ifc_regression_main.ts` initialised a `ConwayGeometry` at module
scope in `main()`, and then `geometryExtraction` constructed a **second**
one that the extraction actually ran against. Reproduced by probe on
MB-Khaya before the change:

```
PROBE telemetryEngineHeapBytes=16777216 extractionEngineHeapBytes=106496000 sameObject=false
```

That is engine A holding its untouched 16 MB initial arena while engine B
does all the work — exactly the table in the issue.

**Was engine A used for anything else? No.** Its only consumers in the file
were the `initialize()` call in `main()` and `conwayGeom.dumpAllocTelemetry(...)`.
`Environment.checkEnvironment()` and `Logger.initializeWasmCallbacks()` next
to it touch neither engine (they read `Environment.environmentType` and
assign globals). So the telemetry call was the entire reason engine A
existed, and it was pointed at a module that had done nothing.

## What changed

`geometryExtraction` now runs against the module-level `conwayGeom`, the way
`ap214_regression_main.ts` always has. Consequences that fall out of that:

- `peakWasmHeapMb` reads `conwayGeom.wasmModule` instead of the engine
  handed back from the extraction, so `geometryExtraction` no longer has to
  return the engine — and no longer has to be `async`, since the second
  `initialize()` was its only `await`.
- `main()` checks the `initialize()` status and returns on failure, matching
  `ifc_command_line_main.ts`. That check used to exist only on the second
  engine, and would otherwise have been dropped.
- The AP214 child is untouched. It is the reference for what right looks
  like here.

## Digests: byte-identical

Seven IFC models, digest CSV before vs after, `cmp`-clean on every one:
`index.ifc`, `IfcOpenHouse_IFC4`, `171210AISC_Sculpture_param`,
`AC20-FZK-Haus`, `duplex`, `Schependomlaan`, `MB-Khaya`
(993,504-byte and 813,950-byte digests among them).

## The memory the fix removes

The second engine was constructed *after* `settleAndSampleMemoryForPerf`
took the pre-load baseline, so its whole footprint landed inside the
retention window. `retainedRssMb`:

| model | before | after |
|---|---|---|
| MB-Khaya | 379.58 / 385.60 / 388.59 | 326.48 / 326.94 / 327.02 / 329.23 / 333.11 / 333.24 |
| Schependomlaan | 371.75 | 308.89 |
| duplex | 97.73 | 42.52 |
| AC20-FZK-Haus | 95.77 | 36.35 |
| 171210AISC_Sculpture_param | 79.71 | 24.50 |
| IfcOpenHouse_IFC4 | 80.13 | 22.53 |
| index.ifc | 58.96 | 2.38 |

A ~55-60 MB fixed term regardless of model size, which is what a second
engine looks like. `peakRssMb` drops by the same term (MB-Khaya 571 -> 517,
index.ifc 236 -> 183), and `geometryTimeMs` loses the second `initialize()`
that sat inside the timed region (IfcOpenHouse_IFC4 156 -> 70 ms, MB-Khaya
~2730 -> ~2570 ms).

**Worth stating precisely, because it is smaller than the issue's headline
number:** the issue said ~100 MB of MB-Khaya's 388 MB is engine B, and that
was true of engine B's *total* linear memory. The retention window only ever
contained the part allocated inside it. After the fix the single engine is
up at 16 MB before the baseline and still grows to the 101.56 MB
`peakWasmHeapMb` reports during the load, and emscripten does not give that
back — so ~85 MB of arena growth stays inside the window on both children.
The ~55 MB that comes off is the duplicate module: its 16 MB arena plus the
rest of a second emscripten instance's resident footprint. That residual is
a real cost of loading the model and is symmetric across the IFC and AP214
children, which is what makes their rows comparable again.

## The telemetry

After the fix the probe reads:

```
PROBE telemetryEngineHeapBytes=106496000 extractionEngineIsTelemetryEngine=true
```

so `dumpAllocTelemetry` now runs on the engine that did the work.

**What could not be shown by execution:** the dump itself is still silent,
before and after — both runs emit zero bytes on stderr. That is not a second
defect. `DumpAllocTelemetry` compiles to `inline void DumpAllocTelemetry(const char*) {}`
unless the module is built with `CONWAY_ALLOC_TELEMETRY` and the
`-Wl,--wrap=malloc` family (conway-geom `structures/alloc_telemetry.h`), and
the prebuilt wasm this repo ships is a release build without it. There is no
emsdk in this environment, so a telemetry build could not be produced to
demonstrate non-empty output. What is demonstrated is the thing the issue
called the defect: the call now targets the engine that ran the extraction
rather than an idle one.

## Test

`src/ifc/ifc_regression_single_engine.test.ts` pins one engine per
regression child and pins that the extraction, the telemetry call and the
heap figure all name it — for both children, so the AP214 reference cannot
silently drift either.

It asserts against the source text, deliberately: both children are process
entry points that call `main()` at module scope and drive `yargs` off
`process.argv`, so importing either from a test starts a regression run. The
property is structural, and a runtime equivalent would need the children to
expose their engines — more production change than the defect warrants. The
reasoning is written into the test's header comment.

Mutation-checked: with `src/ifc/ifc_regression_main.ts` reverted, 2 of the 4
cases fail (`Expected: 1 / Received: 2` on the constructor count, and the
`new IfcGeometryExtraction(conwayGeom, model)` substring). Restored, 4 pass.

## Doc

`design/new/perf-measurement.md` cited this as one of two reasons retention
is "comparable within a pipeline, not across". That reason is now gone, so
the section is rewritten rather than left standing: the list of places the
baseline cannot sit where the rule wants drops from two to one (the loader
path, which still brings up a `ConwayGeometry` per load inside the timed
region), the IFC-child entry becomes a record of the fix with the
before/after numbers, and the comparability rule is narrowed to
loader-vs-regression-child. #555 (`geometryMemoryMb` differing between the
CLI and the regression child) is a separate cause and is untouched.

The recorded five-run MB-Khaya stability figures are updated to the post-fix
values, with the pre-fix ones kept alongside so a reader of an older
snapshot can still place them.

## Baselines

This moves IFC `retainedRssMb`, `retainedHeapUsedMb`, `retainedExternalMb`,
`rssMb`, `peakRssMb`, `geometryTimeMs` and `totalTimeMs` once. Digests do
not move, so no digest re-blessing. Landing it before the next rc tag is the
point: the first blessed baseline carrying the retention columns should not
bake the second engine in.

## Verification

- `yarn lint`: 0 errors (681 warnings, all pre-existing; the change removes
  one JSDoc warning from the touched file and the new test adds none).
- Full suite via the pre-commit hook: **101 suites / 669 tests, all passing**
  (base `main` is 100 / 665; this adds one suite of four).
- Digests and memory figures above are all from execution, not reading.

## Branch

Branched from `main` (`bbc86d98`) rather than riding on #558's branch. #558
does not touch `ifc_regression_main.ts`, the two changes are independent
(workflow/tooling vs. an engine-lifetime fix), and this one is deadline-gated
on the rc tag while #558 is not — so they should be reviewable and landable
apart. Their `perf-measurement.md` hunks do not overlap (#558 edits from line
237 down; this edits 192-236 and the changelog table).

---
_Generated by [Claude Code](https://claude.ai/code/session_013RHVKvZN2erpMD7svDWALU)_