### PR TITLE
#554: fix the rc timeouts the gc settle broke, and make the A/B opt-in

### DIFF
--- a/.github/workflows/rc-regression.yml
+++ b/.github/workflows/rc-regression.yml
@@ -286,10 +286,10 @@ jobs:
       # job and the private corpus is what sizes it. Measured wall times for
       # this step (GitHub Actions step timestamps):
       #
-      #   private, run 32550854090 (rc-1.549.1515, no settle)   19m55s  passed
-      #   private, run 32601766596 (same code, no settle)       19m12s  passed
-      #   private, run 32601886424 (with the #556 settle)       20m01s  KILLED
-      #   public,  run 32601886424 (with the settle)             5m15s  passed
+      #   private, run 32550854090 (@1e55a8e0, no settle)       19m55s  passed
+      #   private, run 32601766596 (@1e55a8e0, no settle)       19m12s  passed
+      #   private, run 32601886424 (@4c0d768b, #556 settle)     20m01s  KILLED
+      #   public,  run 32601886424 (@4c0d768b, #556 settle)      5m15s  passed
       #
       # The private step had been running at 19m55s against a 20-min cap —
       # 5 seconds of headroom — before this workflow gained a second pass.

--- a/.github/workflows/rc-regression.yml
+++ b/.github/workflows/rc-regression.yml
@@ -50,6 +50,17 @@ on:
         type: choice
         options: [both, public, private]
         default: both
+      # The gc-settle A/B (the control pass + its comparison), OFF by default.
+      # The question it was built to answer has been answered — see "The gc-off
+      # control pass" below — so a release does not pay for it any more, but
+      # the machinery is the only way to ask again and stays one checkbox away.
+      # Turn it on when the settle changes, or when a timing movement needs
+      # explaining. A tag push supplies no inputs, so the default applies and
+      # both steps skip.
+      perf_ab:
+        description: 'Also run the gc-off control pass and A/B comparison'
+        type: boolean
+        default: false
 
 env:
   EMSDK_VERSION: '6.0.2'
@@ -104,28 +115,31 @@ jobs:
     # engine over ~100 models with --parallel and reserves multi-GB shared.
     runs-on: ubuntu-24.04-4vcpu-8gb-150gbssd
     # Outer backstop against a wedged run. A healthy run is
-    # build-from-warm-cache + LFS checkout + TWO serial (--concurrency 1)
-    # passes over the corpus — the blessed one and the gc-off control (see
-    # "Control perf pass" below) — each with its own 35-min cap, the batch
-    # self-exits, and per-model work is timeout-bounded, so this rarely fires.
+    # build-from-warm-cache + LFS checkout + ONE serial (--concurrency 1) pass
+    # over the corpus, plus a SECOND identical pass only when the `perf_ab`
+    # input is set (see "The gc-off control pass" below) — each pass with its
+    # own 35-min cap, the batch self-exits, and per-model work is
+    # timeout-bounded, so this rarely fires.
     #
-    # The budget this 90 is built from, PRIVATE (the binding corpus — it is
-    # ~4x the public one in wall time), measured on run 32601886424 unless
-    # noted:
+    # THIS 90 IS SIZED FOR THE perf_ab RUN, not for a release. The budget,
+    # PRIVATE (the binding corpus — it is ~4x the public one in wall time),
+    # measured on run 32601886424 unless noted:
     #
     #   checkout + node + deps + tsc, warm WASM cache   1m57s  -> budget  5m
     #   private corpus LFS checkout                     1m33s  -> budget  5m
     #   blessed digest pass                            ~20m30s -> cap    35m
-    #   gc-off control pass                            ~20m    -> cap    35m
+    #   gc-off control pass (perf_ab only)             ~20m    -> cap    35m
     #   gates, summaries, artifact, bless, PR, post       ~15s  -> budget  3m
     #                                                            --------
-    #                                                              83m
+    #                                       perf_ab run:           83m
+    #                                       plain rc  :            48m
     #
-    # 90 leaves ~7 min over that, and every heavy pass is separately capped,
-    # so a wedge is cancelled inside its own step long before this ceiling —
-    # this number only has to bound the untimed steps. It is back at the old
-    # 90 because the job now does twice the corpus work it did when 45 was
-    # written; that is the two-pass A/B, not drift.
+    # 90 leaves ~7 min over the perf_ab budget, and every heavy pass is
+    # separately capped, so a wedge is cancelled inside its own step long
+    # before this ceiling — this number only has to bound the untimed steps.
+    # A plain rc uses barely half of it, and that slack is not waste: a job
+    # cap costs nothing on a run that does not hit it, and sizing it to the
+    # 48m case would red every deliberate A/B run.
     #
     # NOT sized for a cold WASM-cache rebuild on top of two long passes: that
     # combination is already pathological and should be cancelled. A cold
@@ -278,9 +292,11 @@ jobs:
       # rather than changed: `exposeGcRequested()` in
       # ifc_regression_batch_main.ts returns true when the variable is unset,
       # so this pins the condition being blessed against the control pass
-      # below, which sets it to '0'. Do NOT make the control pass the blessed
-      # one — that would put a release's numbers under a configuration nobody
-      # ships.
+      # below, which sets it to '0'. Keep it pinned even though that control
+      # pass is now opt-in — the point of writing the default down is that the
+      # blessed configuration does not move when the A/B is off. Do NOT make
+      # the control pass the blessed one — that would put a release's numbers
+      # under a configuration nobody ships.
       #
       # THE 35 IS DERIVED, NOT ROUND. This step is the longest thing in the
       # job and the private corpus is what sizes it. Measured wall times for
@@ -428,7 +444,21 @@ jobs:
           print("\nNo new failures. Pre-existing known-failers do not block the rc.")
           EOF
 
-      # --- The gc-off control pass (conway#554) ---
+      # --- The gc-off control pass (conway#554) — OPT-IN, DEFAULT OFF ---
+      #
+      # THE COMPARISON HAS BEEN MADE. Run 32601886424's public job executed
+      # both passes on one runner: blessed (settle on) 5m15s, control (settle
+      # off) 5m06s — the settle costs about +2.9% of pass wall-clock, on one
+      # corpus, and does not move the timing columns it was feared to move.
+      # The call off that measurement (Pablo, conway#554) is that the settle
+      # is ALWAYS ON going forwards, so the control condition is no longer
+      # something a release needs to re-measure every time. It now runs only
+      # when the `perf_ab` dispatch input is set — see the input's comment at
+      # the top of this file. That is why this step and the comparison below
+      # both carry an `if:`, and why an rc tag runs ONE pass, not two.
+      #
+      # Everything below this line is why the pass is built the way it is, and
+      # still applies on the runs where it is switched back on.
       #
       # The second half of an A/B whose only variable is whether the retention
       # settle runs. conway#554 defines the retention columns so that both of
@@ -471,28 +501,58 @@ jobs:
       # No new checkout: the corpus is already materialized in `models`, so
       # this doubles the perf compute and costs zero extra LFS bandwidth.
       #
-      # Default step condition (success()) on purpose: when the failure gate
-      # above reddened the rc, the release is already bad and a methodology
-      # control is not worth another ~20 minutes of large-runner time. It gets
-      # its chance on the re-run.
+      # THE `if:` SPELLS OUT `success()` DELIBERATELY. Actions inserts
+      # `success()` implicitly only when an `if:` contains NO status function,
+      # so the `perf_ab` test alone would still carry it —
+      # but that behaviour is exactly the load-bearing kind that should not be
+      # implicit here. The `success()` half is what makes a reddened rc skip
+      # this: when the failure gate above failed, the release is already bad
+      # and a methodology control is not worth another ~20 minutes of
+      # large-runner time. It gets its chance on the re-run.
       #
-      # continue-on-error for the mirror-image reason. Every step after this
-      # one that carries no `if:` — dropping changes.csv, the churn summary,
-      # and the re-bless PR that IS the release's regression report — runs on
-      # the implicit success(), so without this a control pass that timed out
-      # or crashed would silently withhold the rc's entire deliverable. The
-      # control is the least important thing in this job and must never be
-      # able to block the most important.
+      # WHY THE INPUT IS READ TWO WAYS. A `type: boolean` dispatch input
+      # arrives as a real boolean in the typed `inputs` context and as the
+      # string 'true'/'false' in the raw `github.event.inputs` payload, and
+      # Actions' comparison rules make each test fail against the OTHER
+      # representation (a boolean/string compare casts both to numbers, and
+      # 'true' is NaN). Guessing wrong here fails SILENTLY — the A/B would
+      # simply never run when someone ticked the box, and nothing would say
+      # so. Neither could be verified without dispatching this workflow, which
+      # needs REBLESS_TOKEN and both corpora, so both forms are tested. Either
+      # one alone would work if the representation is what it is assumed to
+      # be; together they do not depend on the assumption. On a tag push both
+      # contexts are empty, both halves are false, and the step skips — which
+      # is the path every release takes.
+      #
+      # continue-on-error for the mirror-image reason, and it still earns its
+      # place now that this step is usually skipped: a SKIPPED step cannot
+      # fail, so it changes nothing on the default path, but on a `perf_ab`
+      # run every step after this one that carries no `if:` — dropping
+      # changes.csv, the churn summary, and the re-bless PR that IS the
+      # release's regression report — runs on the implicit success(), so
+      # without this a control pass that timed out or crashed would silently
+      # withhold the rc's entire deliverable. The control is the least
+      # important thing in this job and must never be able to block the most
+      # important.
       #
       # SAME 35-MIN CAP AS THE BLESSED PASS, for the same reason: this pass
       # IS a second full digest run over the same corpus, so it costs what
       # that one costs. Public, run 32601886424, shows them near-equal —
       # digest 5m15s, control 5m06s (the control is the cheaper half; it is
-      # the one without the settle). It has never actually run on private:
-      # the first two-pass rc died in the digest step above, so the control
-      # was skipped. Left at 20 it would have blown the same cap on the next
-      # rc, one step later and after another full LFS pass.
+      # the one without the settle). Left at 20 it would have blown the same
+      # cap the digest step blew, one step later and after another full LFS
+      # pass.
+      #
+      # The cap stays at 35 even though this step is now usually skipped, and
+      # it stays UNPROVEN on private: this pass has still never executed there
+      # (the first two-pass rc died in the digest step above), so the only
+      # private evidence is that a near-identical pass takes ~20 minutes. A
+      # `perf_ab` run is deliberate and infrequent; sizing its cap down to
+      # save minutes it does not spend would just re-run the failure this
+      # workflow was fixed for, on the run where someone is trying to measure
+      # something.
       - name: Control perf pass (CONWAY_PERF_EXPOSE_GC=0)
+        if: ${{ success() && (inputs.perf_ab == true || github.event.inputs.perf_ab == 'true') }}
         timeout-minutes: 35
         continue-on-error: true
         env:
@@ -543,6 +603,17 @@ jobs:
       # "did the settle move the timing columns, and by how much against the
       # scatter between models" is readable without downloading anything.
       #
+      # Gated on the same `perf_ab` input as the control pass, so the two move
+      # together: with the A/B off there is no second pass and nothing to
+      # difference, and an ungated compare step would print a "not run" panel
+      # into every release's summary for a question that is settled. The
+      # missing-CSV branch below is kept anyway — on a `perf_ab` run the
+      # control pass is continue-on-error, so it can be enabled and still
+      # produce no perf-nogc.csv. `!cancelled()` rather than `success()` for
+      # the same reason as the summary step above: a reddened gate elsewhere
+      # should not cost the comparison, and when the gate is what reddened,
+      # the control pass skipped and this reports exactly that.
+      #
       # continue-on-error, and the script itself never exits non-zero on a
       # finding: this runs BEFORE the steps that bless the snapshot and open
       # the re-bless PR, both of which are gated on the steps before them
@@ -552,14 +623,14 @@ jobs:
       # children) is reported as a ::warning:: and said plainly in the table
       # header instead.
       - name: Compare the two perf passes
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && (inputs.perf_ab == true || github.event.inputs.perf_ab == 'true') }}
         continue-on-error: true
         run: |
           PERF="${GITHUB_WORKSPACE}/perf.csv"
           CONTROL="${GITHUB_WORKSPACE}/perf-nogc.csv"
           if [ ! -f "$PERF" ] || [ ! -f "$CONTROL" ]; then
             echo "### GC-settle A/B (${{ matrix.target.repo }})" >> "$GITHUB_STEP_SUMMARY"
-            echo "_Not run: the control pass produced no perf-nogc.csv (skipped, or the rc failed its gate)._" >> "$GITHUB_STEP_SUMMARY"
+            echo "_Not run: perf_ab was set, but the control pass produced no perf-nogc.csv — it failed, timed out, or the rc's failure gate skipped it._" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           node scripts/perf_ab_compare.cjs \
@@ -571,7 +642,11 @@ jobs:
 
       # Both passes' CSVs plus the joined per-model comparison. Missing paths
       # only warn in upload-artifact@v4 as long as one matches, so a skipped
-      # control pass still uploads the blessed perf.csv.
+      # control pass still uploads the blessed perf.csv — which since the A/B
+      # became opt-in is the NORMAL case, not the degraded one: on a release
+      # this uploads perf.csv and warns about the other three. The `if:` gates
+      # on perf.csv specifically for that reason; do not tighten it to require
+      # the A/B files, and do not set if-no-files-found: error here.
       - name: Upload steady perf CSVs
         if: ${{ !cancelled() && hashFiles('perf.csv') != '' }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rc-regression.yml
+++ b/.github/workflows/rc-regression.yml
@@ -103,17 +103,35 @@ jobs:
     # Same heavy runner as run-ifc-regression: the batch drives the MT WASM
     # engine over ~100 models with --parallel and reserves multi-GB shared.
     runs-on: ubuntu-24.04-4vcpu-8gb-150gbssd
-    # Outer backstop against a wedged run (down from an old 90). A healthy run
-    # is build-from-warm-cache + LFS checkout + TWO serial (--concurrency 1)
+    # Outer backstop against a wedged run. A healthy run is
+    # build-from-warm-cache + LFS checkout + TWO serial (--concurrency 1)
     # passes over the corpus — the blessed one and the gc-off control (see
-    # "Control perf pass" below) — each with its own tighter 20-min cap, the
-    # batch self-exits, and per-model work is timeout-bounded, so this rarely
-    # fires. Raised from 45 to 70 when the control pass was added: 45 had
-    # ~15 min of headroom over a single-pass run, which a second full pass
-    # would have eaten. 70 still leaves room for a cold WASM-cache rebuild
-    # while cancelling a hang far sooner than the old 90 ceiling. Bump it if a
-    # legitimate cold rebuild is ever cancelled here.
-    timeout-minutes: 70
+    # "Control perf pass" below) — each with its own 35-min cap, the batch
+    # self-exits, and per-model work is timeout-bounded, so this rarely fires.
+    #
+    # The budget this 90 is built from, PRIVATE (the binding corpus — it is
+    # ~4x the public one in wall time), measured on run 32601886424 unless
+    # noted:
+    #
+    #   checkout + node + deps + tsc, warm WASM cache   1m57s  -> budget  5m
+    #   private corpus LFS checkout                     1m33s  -> budget  5m
+    #   blessed digest pass                            ~20m30s -> cap    35m
+    #   gc-off control pass                            ~20m    -> cap    35m
+    #   gates, summaries, artifact, bless, PR, post       ~15s  -> budget  3m
+    #                                                            --------
+    #                                                              83m
+    #
+    # 90 leaves ~7 min over that, and every heavy pass is separately capped,
+    # so a wedge is cancelled inside its own step long before this ceiling —
+    # this number only has to bound the untimed steps. It is back at the old
+    # 90 because the job now does twice the corpus work it did when 45 was
+    # written; that is the two-pass A/B, not drift.
+    #
+    # NOT sized for a cold WASM-cache rebuild on top of two long passes: that
+    # combination is already pathological and should be cancelled. A cold
+    # rebuild on a normal-speed run still fits. Bump it if a legitimate cold
+    # rebuild is ever cancelled here.
+    timeout-minutes: 90
     steps:
       # --- Build conway from source (identical to run-ifc-regression) ---
       - name: Checkout conway
@@ -263,8 +281,33 @@ jobs:
       # below, which sets it to '0'. Do NOT make the control pass the blessed
       # one — that would put a release's numbers under a configuration nobody
       # ships.
+      #
+      # THE 35 IS DERIVED, NOT ROUND. This step is the longest thing in the
+      # job and the private corpus is what sizes it. Measured wall times for
+      # this step (GitHub Actions step timestamps):
+      #
+      #   private, run 32550854090 (rc-1.549.1515, no settle)   19m55s  passed
+      #   private, run 32601766596 (same code, no settle)       19m12s  passed
+      #   private, run 32601886424 (with the #556 settle)       20m01s  KILLED
+      #   public,  run 32601886424 (with the settle)             5m15s  passed
+      #
+      # The private step had been running at 19m55s against a 20-min cap —
+      # 5 seconds of headroom — before this workflow gained a second pass.
+      # conway#556's retention settle (two forced GCs per model, 107 private
+      # models) is what pushed it over: the within-run A/B on public measures
+      # the settle at 5m15s vs the control's 5m06s, +2.9%, which puts private
+      # at ~20m30s, and a cross-run read of public (5m15s vs 4m48s) puts it
+      # nearer 21m45s. Either way it no longer fits under 20.
+      #
+      # 35 is ~1.6x the estimate. Whole-pass wall time is actually stable —
+      # the three private runs above span 3.7% — but PER-MODEL times across
+      # runs are not, and design/new/perf-measurement.md records a 1.55x
+      # median between-run scale factor on one model set. 35 covers even a
+      # whole pass landing at that factor (19m55s x 1.55 = 30m52s) with
+      # ~13% left. Do not trim this back toward the measured 20m: that is the
+      # 99.6%-of-budget state this cap was raised to get out of.
       - name: Regenerate baseline digests
-        timeout-minutes: 20
+        timeout-minutes: 35
         env:
           CONWAY_PERF_EXPOSE_GC: '1'
         run: |
@@ -440,8 +483,17 @@ jobs:
       # or crashed would silently withhold the rc's entire deliverable. The
       # control is the least important thing in this job and must never be
       # able to block the most important.
+      #
+      # SAME 35-MIN CAP AS THE BLESSED PASS, for the same reason: this pass
+      # IS a second full digest run over the same corpus, so it costs what
+      # that one costs. Public, run 32601886424, shows them near-equal —
+      # digest 5m15s, control 5m06s (the control is the cheaper half; it is
+      # the one without the settle). It has never actually run on private:
+      # the first two-pass rc died in the digest step above, so the control
+      # was skipped. Left at 20 it would have blown the same cap on the next
+      # rc, one step later and after another full LFS pass.
       - name: Control perf pass (CONWAY_PERF_EXPOSE_GC=0)
-        timeout-minutes: 20
+        timeout-minutes: 35
         continue-on-error: true
         env:
           CONWAY_PERF_EXPOSE_GC: '0'

--- a/design/new/ci-regression-cost.md
+++ b/design/new/ci-regression-cost.md
@@ -72,16 +72,29 @@ Findings that drove the design:
 Net effect: a PR push dropped from ~13 → ~6 large-runner minutes, a merge from
 ~48 → ~8; the full corpus + perf is paid once per `rc-*` tag.
 
-That rc bill grew with #554's two-pass gc A/B, which runs the whole corpus
-**twice** in each `rebless` job — the blessed pass and a gc-off control. The
-private `rebless` job went from ~24 min to ~45 (its digest pass alone is
-~20 min per side; public is ~5); the two `perf-three-*` jobs are unchanged at
-~27 and ~11. LFS bandwidth did not move — the second pass reuses the first's
-checkout. Whether the control pass is worth that on every rc, or was a
-one-time validation, is open (#554). Sizing note for anyone adding per-model
-work: the private digest pass had 5 seconds of headroom under its 20-minute
-step cap before the settle in #556 pushed it over — see
-`design/new/perf-measurement.md` §"What the second pass costs".
+#554's two-pass gc A/B briefly doubled that rc bill: it ran the whole corpus
+**twice** in each `rebless` job — the blessed pass and a gc-off control — which
+took the private `rebless` job from ~24 min to ~45 (its digest pass alone is
+~20 min per side; public is ~5). **That was a one-time validation, and it is
+now opt-in.** It ran once, on
+[run 32601886424](https://github.com/bldrs-ai/conway/actions/runs/32601886424),
+which priced the retention settle at +2.9% of pass wall-clock on the public
+corpus and answered the question the control condition existed to ask; the
+settle is always on going forwards, so re-measuring it every release bought no
+signal at twice the price of the most expensive job in CI. The control pass and
+its comparison now run only under `workflow_dispatch` with `perf_ab: true` —
+kept rather than deleted, because a between-run comparison cannot answer this
+question (see `design/new/perf-measurement.md` §"The A/B runs as two passes
+inside one rc job"), so a future settle change needs this machinery intact. A
+release is back to one pass. LFS bandwidth never moved either way — a second
+pass reuses the first's checkout — and the two `perf-three-*` jobs are
+unchanged at ~27 and ~11 min.
+
+Sizing note for anyone adding per-model work: the private digest pass — the one
+that runs on *every* rc — had 5 seconds of headroom under its 20-minute step
+cap before the settle in #556 pushed it over, killing that run. Both passes are
+capped at 35 min now; see `design/new/perf-measurement.md` §"What the second
+pass costs".
 
 **Do not "just run everything on PRs again"** to catch breaks earlier — that
 reintroduces the spend this tiering removed. Some delay in finding a break on

--- a/design/new/ci-regression-cost.md
+++ b/design/new/ci-regression-cost.md
@@ -70,7 +70,18 @@ Findings that drove the design:
    concurrency group now cancels superseded runs (#399, see below).
 
 Net effect: a PR push dropped from ~13 → ~6 large-runner minutes, a merge from
-~48 → ~8; the full corpus + perf (~40+ min) is paid once per `rc-*` tag.
+~48 → ~8; the full corpus + perf is paid once per `rc-*` tag.
+
+That rc bill grew with #554's two-pass gc A/B, which runs the whole corpus
+**twice** in each `rebless` job — the blessed pass and a gc-off control. The
+private `rebless` job went from ~24 min to ~45 (its digest pass alone is
+~20 min per side; public is ~5); the two `perf-three-*` jobs are unchanged at
+~27 and ~11. LFS bandwidth did not move — the second pass reuses the first's
+checkout. Whether the control pass is worth that on every rc, or was a
+one-time validation, is open (#554). Sizing note for anyone adding per-model
+work: the private digest pass had 5 seconds of headroom under its 20-minute
+step cap before the settle in #556 pushed it over — see
+`design/new/perf-measurement.md` §"What the second pass costs".
 
 **Do not "just run everything on PRs again"** to catch breaks earlier — that
 reintroduces the spend this tiering removed. Some delay in finding a break on

--- a/design/new/perf-measurement.md
+++ b/design/new/perf-measurement.md
@@ -359,6 +359,31 @@ zero-geometry gate is repeated — a second identical digest run yields
 no extra signal — and the control pass reuses the same LFS checkout, so
 the perf compute roughly doubles and the bandwidth does not.
 
+**What the second pass costs, and the cap it broke.** The private
+corpus is the binding constraint: it runs about 4x the public one in
+wall time, and it is where a per-model increment shows up first. Step
+wall times, from the Actions step timestamps:
+
+| pass | public | private |
+|---|---|---|
+| blessed digest, no settle (rc-1.549.1515) | 4m48s | **19m55s** |
+| blessed digest, with the settle (rc-1.558.1533) | 5m15s | ~20m30s (est.) |
+| gc-off control, with the settle (rc-1.558.1533) | 5m06s | never yet run |
+
+Two facts are worth carrying forward. First, the settle's own cost
+measured *within one run* is public 5m15s against 5m06s — **+2.9%** over
+a full corpus, which is the corpus-scale version of the ~10 ms per load
+in the tables above. Second, and the useful one for whoever next adds
+per-model work: **the private digest step ran at 19m55s against a
+20-minute `timeout-minutes` — 5 seconds of headroom — before this
+change existed.** conway#556's settle added the ~35 s that tipped it,
+and the first two-pass rc (run 32601886424) died there, killed by its
+own cap. Both passes are now capped at 35 min and the job at 90; the
+arithmetic is in `.github/workflows/rc-regression.yml`. A rc `rebless`
+job on private is now a ~45-minute job, not a ~25-minute one, so treat
+per-model work in the regression child as spending a budget that has
+already been doubled once.
+
 **What the pass order can and cannot confound.** Pass 2 runs on a
 warmer machine than pass 1. Model file I/O is outside all three timing
 columns — `parseStartMs` is taken after `readFileSync` in

--- a/design/new/perf-measurement.md
+++ b/design/new/perf-measurement.md
@@ -325,13 +325,32 @@ it does exclude anything that would matter to a regression signal.
 build without editing code — otherwise "flag off" would mean "different
 code", and the comparison would prove nothing about either variable.
 
-### The A/B runs as two passes inside one rc job
+### The A/B runs as two passes inside one rc job — on demand
 
-`.github/workflows/rc-regression.yml` runs the corpus **twice in one
+`.github/workflows/rc-regression.yml` can run the corpus **twice in one
 `rebless` job**: the blessed pass in the shipped configuration, then a
 control pass with `CONWAY_PERF_EXPOSE_GC=0`. `scripts/perf_ab_compare.cjs`
 differences them into the job summary and the run's `perf-serial-*`
 artifact.
+
+**It is opt-in and off by default, because the comparison has been
+made.** Run [32601886424][ab-run]'s public job executed both passes on
+one runner: blessed 5m15s, control 5m06s. The settle costs about
+**+2.9% of pass wall-clock** — one corpus, one run, both halves on the
+same machine, which is the only comparison this question admits (see
+below) — and it does not move the timing columns it was feared to move.
+The decision off that measurement is that **the settle is always on
+going forwards**, so a release no longer re-measures the control
+condition. A tag push runs one pass; `workflow_dispatch` with
+`perf_ab: true` runs both. Turn it on when the settle itself changes,
+or when a timing movement needs explaining — the machinery is the only
+valid way to ask, and it stays runnable rather than deleted.
+
+One caveat on that +2.9%: it is the public corpus only. The control
+pass has still never executed on private, because the run that would
+have produced that figure died in the step before it.
+
+[ab-run]: https://github.com/bldrs-ai/conway/actions/runs/32601886424
 
 **Two separate rc runs cannot answer this, and that was the original
 plan.** Two `run-ifc-regression` jobs an hour apart, on near-identical
@@ -357,7 +376,8 @@ outside the models checkout; blessing it would put a release's numbers
 under a configuration nobody runs. Neither the failure gate nor the
 zero-geometry gate is repeated — a second identical digest run yields
 no extra signal — and the control pass reuses the same LFS checkout, so
-the perf compute roughly doubles and the bandwidth does not.
+the perf compute roughly doubles on the runs that ask for it, and the
+bandwidth does not.
 
 **What the second pass costs, and the cap it broke.** The private
 corpus is the binding constraint: it runs about 4x the public one in
@@ -379,10 +399,11 @@ per-model work: **the private digest step ran at 19m55s against a
 change existed.** conway#556's settle added the ~35 s that tipped it,
 and the first two-pass rc (run 32601886424) died there, killed by its
 own cap. Both passes are now capped at 35 min and the job at 90; the
-arithmetic is in `.github/workflows/rc-regression.yml`. A rc `rebless`
-job on private is now a ~45-minute job, not a ~25-minute one, so treat
-per-model work in the regression child as spending a budget that has
-already been doubled once.
+arithmetic is in `.github/workflows/rc-regression.yml`. With the A/B
+opt-in, a release's private `rebless` job is back to ~25 minutes and a
+`perf_ab` run is the ~45-minute one — but the 35-minute step cap is what
+a plain rc depends on, since the pass that broke its cap is the blessed
+one, which runs every time.
 
 **What the pass order can and cannot confound.** Pass 2 runs on a
 warmer machine than pass 1. Model file I/O is outside all three timing
@@ -553,6 +574,7 @@ against a regression-child figure. Tracked separately.
 | #552 (via #553) | add `peakRssMb`, `externalMb`, `arrayBuffersMb`, `peakWasmHeapMb`; restore `geometryMemoryMb` | memory was one un-GC'd instant, and the wasm heap was invisible |
 | #554 | add `retainedRssMb`, `retainedHeapUsedMb`, `retainedExternalMb`; pass `--expose-gc` to the regression children and the render server; add the teardown the regression children never had | nothing measured what is held after teardown, and a peak cannot see it |
 | #557 | IFC regression child extracts on the engine `main()` initialised, not a second one built in `geometryExtraction` | the alloc telemetry described an idle module, and the second engine put a ~55-60 MB constant in every IFC retention and RSS row plus its init in `geometryTimeMs`; those IFC baselines move once |
+| #554 (decision, after the two-pass A/B ran) | the settle stays **always on**; the gc-off control pass and its comparison become opt-in (`perf_ab` dispatch input), off for a release | the question was answered: run 32601886424's public job priced the settle at +2.9% of pass wall-clock with the timing columns unmoved. Re-measuring a settled condition on every rc doubled the perf portion of the most expensive job in CI for no new signal. Not deleted — a between-run comparison cannot answer this, so the in-one-job machinery is the only way to ask again |
 | #554 (via the two-pass rc A/B) | `parseTimeMs` drops by about 10 ms per load (13-16% at a ~60 ms parse, unresolvable against a 578 ms one), `heapUsedMb` 5-11 MB and `rssMb` 6-9 MB, against the same code without the settle | the pre-load settle collects engine-init garbage *outside* the timed region that used to be collected inside it, and the end-of-load memory instants sample from that collected floor. Not a new column, but a redefinition of three existing ones by methodology: do not difference parse/heapUsed/rss across this boundary. Distinct from #557 above, which moves `geometryTimeMs` and the memory columns on IFC rows only |
 
 Restoring `geometryMemoryMb` checks out against history: SKYLARK250 reads


### PR DESCRIPTION
Two changes to `.github/workflows/rc-regression.yml`, both from the first two-pass rc run ([32601886424](https://github.com/bldrs-ai/conway/actions/runs/32601886424), tag `rc-1.558.1533` @ `4c0d768b`): its private job **failed at "Regenerate baseline digests", killed by its own `timeout-minutes: 20`**, and its public job **succeeded and produced the A/B measurement the two-pass design existed to make.**

1. **Timeouts** — the failure. Both heavy passes go to 35 min, the job to 90.
2. **The A/B becomes opt-in** — the answer. The comparison has been made, so a release stops paying for the control condition.

Nothing else moves: no pass is restructured, the `rc-*` ref gate is untouched, and what gets blessed is unchanged.

## 1. The timeouts

Wall times for `Regenerate baseline digests`, from the Actions step timestamps:

| run | corpus | code | duration | outcome |
|---|---|---|---|---|
| [32550854090](https://github.com/bldrs-ai/conway/actions/runs/32550854090) (`rc-1.549.1515`) | private | `1e55a8e0`, no settle | **19m55s** | passed, **5s of headroom** |
| [32601766596](https://github.com/bldrs-ai/conway/actions/runs/32601766596) | private | `1e55a8e0`, no settle | 19m12s | passed |
| [32601886424](https://github.com/bldrs-ai/conway/actions/runs/32601886424) | private | `4c0d768b`, #556 settle | **20m01s** | **killed at the cap** |
| 32601886424 | public | `4c0d768b`, #556 settle | 5m15s | passed |
| 32601886424 (control, gc off) | public | `4c0d768b` | 5m06s | passed |
| 32550854090 | public | `1e55a8e0`, no settle | 4m48s | passed |

The private step was at **99.6% of its budget before this work existed**. conway#556's settle — two forced GCs per model across 107 private models — is the increment that tipped it. The within-run public A/B prices the settle at **+2.9%** (5m15s vs 5m06s), putting private at **~20m30s**; a cross-run read (+9.4%) puts it nearer 21m45s. Its true duration is unknown — it was killed.

- **`Regenerate baseline digests`: 20 → 35.** ~1.6x the estimate. Whole-pass wall time is empirically stable (the three private runs span 3.7%), but per-model times across runs are not — `perf-measurement.md` records a 1.55x median between-run scale factor — so 35 also covers a whole pass landing at that factor (19m55s × 1.55 = 30m52s) with ~13% left.
- **`Control perf pass`: 20 → 35.** The easy-to-miss half: this step **has never run on private** (the digest step above it died first) and *is* a second full digest run, so it is also a >20-minute step there. Left at 20 it would have blown the same cap on the next A/B run, one step later and after another full LFS pass. Kept generous precisely because it is still unproven on private.
- **Job: 70 → 90**, budgeted against run 32601886424's private timings:

```
checkout + node + deps + tsc, warm WASM cache   1m57s  -> budget  5m
private corpus LFS checkout                     1m33s  -> budget  5m
blessed digest pass                            ~20m30s -> cap    35m
gc-off control pass (perf_ab only)             ~20m    -> cap    35m
gates, summaries, artifact, bless, PR, post       ~15s  -> budget  3m
                                                         --------
                                   perf_ab run:            83m
                                   plain rc  :             48m
```

The comment now says which case the number is for: **90 is sized for the `perf_ab` run.** A plain rc uses barely half; a cap costs nothing on a run that does not hit it, and sizing to 48m would red every deliberate A/B run.

**Timeout values were not lowered when the A/B became opt-in.** The pass that broke its cap is the blessed one, which runs on every rc regardless.

## 2. The A/B becomes opt-in (`perf_ab`, default false)

Pablo's call: the settle is **always on** going forwards, and the comparison that justified checking has now happened — run 32601886424's public job ran both passes on one runner (blessed 5m15s, control 5m06s), which is where the +2.9% above comes from.

New boolean `workflow_dispatch` input `perf_ab`, default `false`. Both the **control pass** and the **A/B comparison** are gated on it. A tag push supplies no inputs, so a release runs **one** pass; a dispatch can set it true to ask again after changing the settle or when a timing movement needs explaining. **Opt-in, not deleted** — a between-run comparison measures which runner you landed on, so the in-one-job machinery is the only valid way to ask.

### What keys off the control pass, and how each degrades

| thing | with the A/B off | verdict |
|---|---|---|
| `Compare the two perf passes` | **skipped**, moved with the control pass | gated deliberately — see below |
| its missing-CSV branch | not reached on a release | **kept**, and reworded: on a `perf_ab` run the control pass is `continue-on-error`, so it can be enabled and still produce nothing |
| `Upload steady perf CSVs` | uploads `perf.csv`, warns on the other three | already correct — it gates on `hashFiles('perf.csv')` and `upload-artifact@v4` warns while one path matches. This is now the *normal* case, and the comment says so |
| `continue-on-error` on the control pass | no-op — a skipped step cannot fail | still load-bearing on a `perf_ab` run: it is what stops a crashed control from withholding the re-bless PR |
| `Bless perf snapshot` / re-bless PR | unchanged | only ever read `perf.csv` |

One deviation to flag: **I gated the comparison step itself**, so on a release it is skipped rather than taking the "no control CSV" path. That path is now reachable only on a `perf_ab` run whose control pass failed. The alternative — leaving the comparison ungated — would print a "not run" panel into every release's summary for a question that is settled. Say the word if you would rather have the panel.

The `if:` on the control pass spells out `success()` rather than leaning on Actions' implicit wrap, so "a reddened rc skips the control" stays visible in the condition instead of being a footnote.

### One thing I could not verify by execution

The input is tested **both ways**: `inputs.perf_ab == true || github.event.inputs.perf_ab == 'true'`. A `type: boolean` dispatch input arrives as a real boolean in the typed `inputs` context and as the string `'true'` in the raw `github.event.inputs` payload; Actions' comparison rules make each test fail against the *other* representation (a boolean/string compare casts both to numbers, and `'true'` is `NaN`). Guessing wrong fails **silently** — the A/B would simply never run when someone ticked the box. There is no boolean-input precedent in this repo to copy, and I cannot dispatch this workflow to check, so both forms are tested and the comment says why.

## Verified by reading vs by execution

Cannot run this workflow (needs `REBLESS_TOKEN`, both corpora, LFS) and did not try.

- **YAML parses**, and a structural diff against `main` — load both with PyYAML, strip `timeout-minutes` and `if:`, compare — shows the **only** remaining content change is one `echo` string (the reworded "not run" message). Everything else in the diff is timeouts, the two new gates, the new input, and comments.
- The compare step's shell **passes `bash -n`** after the reworded message.
- **No other step in this workflow sits near a cap.** These are the only `timeout-minutes` in the file; every other step is untimed and the longest measured 2m17s (public LFS checkout).
- **Per-model `--timeout 300000`** is not at risk: slowest model ~80s standalone, settle costs ~10 ms per load.
- **The other perf job on the rc path**, `perf-three-private` in `build.yml`, ran 26m51s under the settle against a 60-min cap ([job 97102344351](https://github.com/bldrs-ai/conway/actions/runs/32601886429/job/97102344351)); `perf-three-public` 10m45s. Not at risk.
- Skipped-step semantics (a skipped step does not fail the job, so later implicit-`success()` steps still run) is read from the workflow's structure and Actions' documented behaviour, **not** observed here.

## Docs

- `design/new/perf-measurement.md` §"The A/B runs as two passes inside one rc job" — retitled "on demand", records the decision and its basis (+2.9%, run 32601886424), states plainly that the figure is **one corpus** because the control pass has still never run on private, keeps the cost/cap history including the 19m55s-against-20-minutes near-miss, and adds a methodology-changelog row so the decision is findable from the table.
- `design/new/ci-regression-cost.md` — the "is the control pass worth it on every rc?" question is answered rather than left open: what it cost while it ran, why it is kept but off, and that LFS bandwidth never moved.

Refs #554. Fixes the failure mode in run 32601886424; does not close #554.