### PR TITLE
#561: scan only what this call paged for style seeds

### DIFF
--- a/src/ifc/ifc_demand_extraction.test.ts
+++ b/src/ifc/ifc_demand_extraction.test.ts
@@ -363,4 +363,77 @@ describe( 'concurrent windowed product prefetch (conway#526)', () => {
     model.releaseSourceViews( pins )
     model.unpinLocalIDs( pins )
   }, 120000 )
+
+  test( 'the style-seed scan costs one pass over the model, not one per product',
+      async () => {
+
+        // conway#561: the closure walk RETURNS the caller's `seen` set, and
+        // ensureResidentForAggregateExtract shares one set across every
+        // related product of a relationship. Scanning that set for style
+        // seeds per product is therefore O(products x model): on SKYLARK250
+        // it was 5m16s of dead air between the end of parsing and the first
+        // mesh. Scanning `claimed` — what THIS call paged — makes the total
+        // work one pass over the shared set no matter how many products
+        // share it.
+        const model = await windowedModel(
+            new InMemoryStepByteStore(
+                new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ) ) )
+        const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+
+        extraction.quietRecoverableLogging = true
+        extraction.deferDanglingPlacements = true
+
+        const prepPins = await extraction.ensureResidentForDemandPrep()
+
+        try {
+          extraction.prepareDemandExtraction()
+        } finally {
+          model.releaseSourceViews( prepPins )
+          model.unpinLocalIDs( prepPins )
+        }
+
+        const products = [ ...model.types( IfcProduct ) ].map( ( p ) => p.localID )
+
+        expect( products.length ).toBeGreaterThan( 2 )
+
+        // Counted after prepare, so only the prefetch's own lookups land here.
+        const styledItemMap = ( extraction as any ).materials.styledItemMap
+        const realGet = styledItemMap.get.bind( styledItemMap )
+        let lookups = 0
+
+        styledItemMap.get = ( key: number ) => {
+          ++lookups
+          return realGet( key )
+        }
+
+        // The aggregate prefetch's shape: ONE set for every product.
+        const pins = new Set< number >()
+        const leafSpans: { address: number, length: number }[] = []
+
+        try {
+
+          for ( const localID of products ) {
+            await extraction.ensureResidentForProductExtract(
+                localID, pins, leafSpans )
+          }
+
+        } finally {
+          styledItemMap.get = realGet
+        }
+
+        expect( pins.size ).toBeGreaterThan( 0 )
+
+        // Each record is scanned by the one call that claimed it, so the
+        // lookups never exceed the shared set. Pre-fix this was
+        // products.length x |pins| and the assertion fails by ~an order of
+        // magnitude on this fixture alone.
+        expect( lookups ).toBeLessThanOrEqual( pins.size )
+
+        model.releaseSourceViews( pins )
+        model.unpinLocalIDs( pins )
+
+        for ( const span of leafSpans ) {
+          model.unpinAddressRange( span.address, span.length )
+        }
+      }, 120000 )
 } )

--- a/src/ifc/ifc_demand_extraction.test.ts
+++ b/src/ifc/ifc_demand_extraction.test.ts
@@ -436,4 +436,125 @@ describe( 'concurrent windowed product prefetch (conway#526)', () => {
           model.unpinAddressRange( span.address, span.length )
         }
       }, 120000 )
+
+  test( 'an aborted walk still pages the style seeds for what it claimed',
+      async () => {
+
+        // conway#561 review (codex P2): `claimed` partitions the shared set
+        // only across walks that COMPLETE. The closure walk claims and pins
+        // each record into `seen` BEFORE awaiting residency, and has no
+        // internal catch — so a store rejection leaves its claims in `seen`
+        // and unwinds, the guard contains the failure without retrying
+        // (conway#526), and no sibling can ever claim those records again.
+        // Scanning the cumulative set used to recover their style seeds by
+        // accident; scanning `claimed` does not, which would silently strip
+        // colours from every product sharing geometry with the failed one.
+        const model = await windowedModel(
+            new InMemoryStepByteStore(
+                new Uint8Array( fs.readFileSync( 'data/index.ifc' ) ) ) )
+        const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+
+        extraction.quietRecoverableLogging = true
+        extraction.deferDanglingPlacements = true
+
+        const prepPins = await extraction.ensureResidentForDemandPrep()
+
+        try {
+          extraction.prepareDemandExtraction()
+        } finally {
+          model.releaseSourceViews( prepPins )
+          model.unpinLocalIDs( prepPins )
+        }
+
+        const products = [ ...model.types( IfcProduct ) ].map( ( p ) => p.localID )
+
+        expect( products.length ).toBeGreaterThan( 1 )
+
+        const failing = products[ 0 ]
+        const sibling = products[ 1 ]
+
+        // A seed owned by a record the aborted walk is GUARANTEED to claim:
+        // the product's own record is wave 1, added to `seen` before the
+        // first await. Planted rather than discovered so the test does not
+        // depend on where index.ifc happens to put a styled item.
+        const sentinel = products[ products.length - 1 ]
+
+        ;( extraction as any ).materials.styledItemMap.set( failing, sentinel )
+
+        // Reject partway through the BFS, after wave 1 has been claimed.
+        const realEnsureResident = model.ensureResidentByLocalID.bind( model )
+        let countdown = -1
+        let injected = false
+
+        ;( model as any ).ensureResidentByLocalID = ( id: number ) => {
+
+          if ( countdown > 0 && --countdown === 0 ) {
+            injected = true
+            return Promise.reject( new Error( 'simulated store read failure' ) )
+          }
+
+          return realEnsureResident( id )
+        }
+
+        // Every seed list handed to the closure walk, so "was the sentinel
+        // paged" is observable without reaching into the walk.
+        const realClosure = model.ensureResidentClosureByLocalID.bind( model )
+        const seedLists: number[][] = []
+
+        ;( model as any ).ensureResidentClosureByLocalID =
+          ( id: number, extraLocalIDs?: Iterable< number >, ...rest: unknown[] ) => {
+
+            if ( extraLocalIDs !== void 0 ) {
+              seedLists.push( [ ...extraLocalIDs ] )
+            }
+
+            return ( realClosure as any )( id, extraLocalIDs, ...rest )
+          }
+
+        const pins = new Set< number >()
+        const leafSpans: { address: number, length: number }[] = []
+
+        try {
+
+          countdown = 5
+
+          await extraction.ensureResidentForProductExtract(
+              failing, pins, leafSpans )
+
+          countdown = -1
+
+          // A probe that never fires looks exactly like a clean model: if
+          // the closure finished before the fifth read the scenario never
+          // happened and the assertions below prove nothing.
+          expect( injected ).toBe( true )
+          expect( pins.has( failing ) ).toBe( true )
+
+          const sentinelPagings =
+            seedLists.filter( ( seeds ) => seeds.includes( sentinel ) ).length
+
+          // Pre-fix this is 0: the aborted walk never reaches the style
+          // pass, and `failing` is in the shared set forever.
+          expect( sentinelPagings ).toBe( 1 )
+
+          // The sibling skips `failing` (it is already in `seen`), which is
+          // exactly why the aborted walk had to page the seed itself — and
+          // it must not re-page it either.
+          await extraction.ensureResidentForProductExtract(
+              sibling, pins, leafSpans )
+
+          expect( seedLists.filter(
+              ( seeds ) => seeds.includes( sentinel ) ).length ).toBe( 1 )
+
+        } finally {
+          ;( model as any ).ensureResidentByLocalID = realEnsureResident
+          ;( model as any ).ensureResidentClosureByLocalID = realClosure
+        }
+
+        model.releaseSourceViews( pins )
+        model.unpinLocalIDs( pins )
+
+        for ( const span of leafSpans ) {
+          model.unpinAddressRange( span.address, span.length )
+        }
+      }, 120000 )
 } )

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -7226,15 +7226,27 @@ export class IfcGeometryExtraction {
           localID, extra, seen, descend, leafSpans, isFace, claimed )
     const styleExtra: number[] = []
 
-    for ( const visitedID of visited ) {
+    // `claimed`, not `visited`: the closure walk returns the CALLER'S set,
+    // which the aggregate prefetch shares across every related product of one
+    // IfcRelAggregates (ensureResidentForAggregateExtract). Scanning it per
+    // product is therefore O(products x model), not O(product) — on SKYLARK250
+    // (1,992 products under two relationships, ~3,000 records of closure each)
+    // it reaches ~6 M lookups on the last product and costs minutes before the
+    // first mesh, all inside one un-yielding await chain (conway#561).
+    //
+    // Every record lands in exactly one call's `claimed`, so the union of the
+    // style seeds collected across the walks sharing a set is unchanged; only
+    // the repetition goes away. This is the same distinction conway#526 drew
+    // for the faceset payload pass below.
+    for ( const claimedID of claimed ) {
 
-      const styled = this.materials.styledItemMap.get( visitedID )
+      const styled = this.materials.styledItemMap.get( claimedID )
 
       if ( styled !== void 0 ) {
         styleExtra.push( styled )
       }
 
-      const definition = this.materials.materialDefinitionsMap.get( visitedID )
+      const definition = this.materials.materialDefinitionsMap.get( claimedID )
 
       if ( definition !== void 0 ) {
         styleExtra.push( definition )

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -7221,23 +7221,92 @@ export class IfcGeometryExtraction {
     // Only the former may be read synchronously afterwards (conway#526).
     const claimed = new Set< number >()
 
-    const visited =
-      await this.model.ensureResidentClosureByLocalID(
-          localID, extra, seen, descend, leafSpans, isFace, claimed )
+    let visited: Set< number >
+
+    try {
+
+      visited =
+        await this.model.ensureResidentClosureByLocalID(
+            localID, extra, seen, descend, leafSpans, isFace, claimed )
+
+    } catch ( error ) {
+
+      // The walk claims and pins each record into the SHARED `seen` BEFORE
+      // awaiting its residency — that is what makes overlapping walks pin
+      // once — and it has no internal catch, so a store rejection leaves
+      // those claims in `seen` and unwinds. The guard above then contains
+      // the failure to this product and does not retry (conway#526), so no
+      // sibling product will ever claim those records again: they fail
+      // `seen.has(...)` in every later walk. pageStyleSeeds_ is the only
+      // thing that pages their styled items and material definitions, so
+      // skipping it here would silently strip colours from every OTHER
+      // product sharing geometry with this one — no error, wrong render.
+      //
+      // Only when the set is shared. With no `seen` the claims are visible
+      // to nobody, a later walk over this product re-claims and re-scans
+      // them, and a recovery walk here would pin records through a set the
+      // caller has no handle on to unpin.
+      if ( seen !== void 0 ) {
+
+        try {
+          await this.pageStyleSeeds_(
+              localID, claimed, seen, descend, isFace, leafSpans )
+        } catch {
+          // Best effort: the store is already failing for this product, and
+          // the original rejection is the one worth surfacing.
+        }
+      }
+
+      throw error
+    }
+
+    await this.pageStyleSeeds_(
+        localID, claimed, visited, descend, isFace, leafSpans )
+
+    await this.ensureResidentVisitedFacesetPayloads_( claimed, visited, leafSpans )
+
+    return visited
+  }
+
+  /**
+   * Page the styled-item and material-definition records seeded by
+   * `claimed` — the records ONE closure walk actually paged — so the
+   * synchronous extract that follows can read them.
+   *
+   * `claimed`, not the walk's returned set: the walk returns the CALLER'S
+   * set, which the aggregate prefetch shares across every related product
+   * of one IfcRelAggregates (see ensureResidentForAggregateExtract).
+   * Scanning that per product is O(products x model), not O(product) — on
+   * SKYLARK250 (1,992 products under two relationships, ~3,000 records of
+   * closure each) it reaches ~6 M lookups on the last product and costs
+   * minutes before the first mesh, inside one un-yielding await chain
+   * (conway#561). Every record lands in exactly one walk's `claimed`, so
+   * the union of seeds collected across the walks sharing a set is
+   * unchanged; only the repetition goes. Same distinction conway#526 drew
+   * for {@link ensureResidentVisitedFacesetPayloads_}.
+   *
+   * That "exactly one walk" holds only for walks that COMPLETE, which is
+   * why the aborted path calls this too — see the catch in
+   * {@link ensureResidentForProductExtractUnguarded_}.
+   *
+   * @param localID The product whose walk claimed these records.
+   * @param claimed Records this walk paged.
+   * @param seen The set the walk pinned through, extended by this one.
+   * @param descend Closure-walk descent predicate.
+   * @param isFace Closure-walk packed-leaf predicate.
+   * @param leafSpans Optional out-array of coalesced pin ranges.
+   * @return {Promise<void>} Resolves when the seeds are resident.
+   */
+  private async pageStyleSeeds_(
+      localID: number,
+      claimed: Set< number >,
+      seen: Set< number >,
+      descend: ( localID: number ) => boolean,
+      isFace: ( localID: number ) => boolean,
+      leafSpans?: { address: number, length: number }[] ): Promise< void > {
+
     const styleExtra: number[] = []
 
-    // `claimed`, not `visited`: the closure walk returns the CALLER'S set,
-    // which the aggregate prefetch shares across every related product of one
-    // IfcRelAggregates (ensureResidentForAggregateExtract). Scanning it per
-    // product is therefore O(products x model), not O(product) — on SKYLARK250
-    // (1,992 products under two relationships, ~3,000 records of closure each)
-    // it reaches ~6 M lookups on the last product and costs minutes before the
-    // first mesh, all inside one un-yielding await chain (conway#561).
-    //
-    // Every record lands in exactly one call's `claimed`, so the union of the
-    // style seeds collected across the walks sharing a set is unchanged; only
-    // the repetition goes away. This is the same distinction conway#526 drew
-    // for the faceset payload pass below.
     for ( const claimedID of claimed ) {
 
       const styled = this.materials.styledItemMap.get( claimedID )
@@ -7253,15 +7322,14 @@ export class IfcGeometryExtraction {
       }
     }
 
-    if ( styleExtra.length > 0 ) {
-      await this.model.ensureResidentClosureByLocalID(
-          localID, styleExtra, visited, descend, leafSpans, isFace, claimed )
+    if ( styleExtra.length === 0 ) {
+      return
     }
 
-    await this.ensureResidentVisitedFacesetPayloads_( claimed, visited, leafSpans )
-
-    return visited
+    await this.model.ensureResidentClosureByLocalID(
+        localID, styleExtra, seen, descend, leafSpans, isFace, claimed )
   }
+
 
   /**
    * Page a faceset's Coordinates record and its Faces[] run as one


### PR DESCRIPTION
Addresses the dominant term in #561 — the 5m16s a Share user spends between the end of Parsing and the first mesh on SKYLARK250. **Does not close #561**: §5 of that issue (the aggregate prefetch pages a whole relationship's closure before the stepper's first step, with no yield and no progress event) is untouched and is still worth ~42 s here.

Two commits: the change, and the fix for the P2 the review raised against it.

## 1. `d2b2d43a` — scan only what this call paged

`ensureResidentClosureByLocalID` returns the **caller's** `seen` set, not this call's closure (`step_model_base.ts`, `return seen`). `ensureResidentForAggregateExtract` passes one `pinned` set for every related product of an `IfcRelAggregates`. So the style-seed scan in `ensureResidentForProductExtractUnguarded_` re-walked the whole cumulative set once per product — **O(products × model)**.

SKYLARK250 is the worst case by construction: 7.8 M records, 1,992 products, and *all* of them are `RelatedObject`s of two relationships, so the per-product worklist is empty and one prefetch call covers ~1,960 products. Measured growth (per prefetch call, first 400 products):

| prefetch # | call ms | `seen` size | cumulative |
|---:|---:|---:|---:|
| 50 | 0.8 | 11,823 | 0.1 s |
| 150 | 2.4 | 40,374 | 0.3 s |
| 300 | 62.6 | 895,082 | 7.5 s |
| 400 | 58.4 | 1,213,690 | 13.4 s |

`ensureResidentVisitedFacesetPayloads_`, three lines below, already iterates `claimed` — #526 fixed the payload pass and left the style pass on `visited`.

## 2. `bc301045` — keep the style seeds of an aborted walk's claims

The review's P2, and it was right. `claimed` partitions `seen` only across walks that **complete**. The closure walk adds each record to *both* sets before awaiting residency (that is what makes overlapping walks pin once) and has no internal catch, so a store rejection leaves its claims in `seen` and unwinds; the guard contains the failure and deliberately does not retry (#526). Those records then fail `seen.has(...)` in every later walk and enter no other call's `claimed`.

Scanning cumulative `visited` recovered their style seeds by accident, via whichever sibling walked next. Scanning `claimed` did not — so one contained paging failure would have silently stripped styled items and material definitions from every other product sharing geometry with the failed one. Wrong colours, no error.

The style pass moves into `pageStyleSeeds_`, and the catch runs it for what the walk did claim before rethrowing. **That seam rather than hoisting `claimed` into the public guard**: the failure and the recovery then sit in the same function as the walk that produced them and share its `descend`/`isFace`/`extra` locals, so the public wrapper keeps its single job (contain and log) and there is no second place that has to know how the walk is parameterised.

It is also *stronger* than the behaviour it restores: recovery no longer depends on a sibling walking later, which the last product of a relationship does not have.

Two deliberate narrowings, both commented in the diff:

- **Guarded on `seen !== undefined`.** With no shared set the claims are visible to nobody, a later walk over the same product re-claims and re-scans them, and a recovery walk would pin records through a set the caller has no handle on to unpin.
- **The recovery's own failure is swallowed.** The store is already failing for this product; the original rejection is the one worth surfacing.

Costs nothing on a clean load — the recovery runs only in the catch.

Known and *not* changed here: `ensureResidentVisitedFacesetPayloads_` has the same abort property, and had it before this PR (it has taken `claimed` since #526). A sibling that skips an orphaned faceset fails its synchronous read loudly, per-product and logged, rather than silently — a different failure mode, pre-existing, and widening into it is not this PR.

## Measured

Share's own load path reproduced in Node — `OpenModelStream(fdStore, {COORDINATE_TO_ORIGIN, USE_FAST_BOOLS, DEFER_GEOMETRY, GEOMETRY_BUDGET_MB: 64})` then `ExtractGeometryBatchAsync(modelID, 8, …)` with a macrotask yield between calls, the same shape and constants as `Share/src/viewer/ifc/conwayDirectIfcLoader.js`. Node v22.22.2, x86_64, 4 cores, 15 GB. Probe script is pasted in full in #561.

| | dead window (last parse tick → first mesh) | `ensureResidentForProductExtract` | store bytes | meshes | pump calls |
|---|---:|---:|---:|---:|---:|
| `2fc6f409` | **315,903 ms** | 314,948 ms / 2,002 calls | 763.4 MB | 1,995 | 252 |
| `d2b2d43a` | **41,658 ms** | 40,672 ms / 2,002 calls | 763.4 MB | 1,995 | 252 |
| `bc301045` | **45,652 ms** | 44,380 ms / 2,002 calls | 763.4 MB | 1,995 | 252 |

Same paging volume, same output. The 41.7 / 45.7 spread between the two fixed runs is this box's run-to-run noise (design/new/perf-measurement.md documents worse on the shared runners); against a 315.9 s baseline it is not a signal, and the call count is identical, which is what would move if the O(products × model) term had come back. No `Error paging product localID` lines in either run, so the recovery path never executed — as intended.

## Blast radius

None outside windowed (store-backed) opens. `ensureResidentForProductExtract` returns before doing any work when `!this.model.isSourceExternal`, which is every model in the regression corpus and every CLI/bench path — **no digest can move**, and no re-blessing is needed. (That the bench cannot exercise this at all is #562.)

## Tests

Both new tests live in `ifc_demand_extraction.test.ts`, in the `conway#526` describe block since they turn on the same `claimed`/`seen` distinction. Both were run against a revert of their own source change, rebuilt, to show they fail:

**`the style-seed scan costs one pass over the model, not one per product`** — drives the aggregate prefetch's shape (one shared `seen` across every product) over a windowed `data/index.ifc` and counts `styledItemMap` lookups. Against `claimed` → `visited`:

```
✕ the style-seed scan costs one pass over the model, not one per product
    Expected: <= 142
    Received:    739
```

**`an aborted walk still pages the style seeds for what it claimed`** — plants a style seed on a product's own record (wave 1, so it is guaranteed claimed), rejects the store read partway through that product's BFS, and asserts the seed is paged exactly once — then runs a sibling through the same shared set and asserts it is still exactly once (the sibling cannot recover it, and must not re-page it). Against the branch with the catch removed:

```
✕ an aborted walk still pages the style seeds for what it claimed
    Expected: 1
    Received: 0
```

The test asserts the injection actually fired before asserting anything else — a probe that never fires looks exactly like a clean model.

Local gate green on both commits: husky pre-commit (`yarn lint && yarn test`) passed; `yarn lint` 0 errors and 681 warnings, unchanged from `main`; `compiled/src/ifc` + `compiled/src/compat` separately, 34 suites / 219 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RHVKvZN2erpMD7svDWALU