### PR TITLE
Bump conway-geom to 99e57cd2, and read both trim representations for UNSPECIFIED

### DIFF
--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -2581,7 +2581,14 @@ export class AP214GeometryExtraction {
 
     let dimension: number | undefined = void 0
 
-    // use Cartesian if unspecified
+    // UNSPECIFIED reads BOTH representations — see the matching comment in
+    // src/ifc/ifc_geometry_extraction.ts's extractIfcTrimmedCurve, which this
+    // block mirrors line for line. In short: UNSPECIFIED means "either
+    // representation may be used", the choice is made downstream in
+    // conway-geom's getIfcLine (Cartesian pair when its endpoints are
+    // distinct, parameters otherwise), and leaving the parameters at zero here
+    // collapsed a parameter-only UNSPECIFIED trim to a single point
+    // (conway#578). The two scans are independent, not exclusive.
     if (
       from.master_representation === trimming_preference.CARTESIAN ||
       from.master_representation === trimming_preference.UNSPECIFIED) {
@@ -2635,7 +2642,11 @@ export class AP214GeometryExtraction {
           break
         }
       }
-    } else {
+    }
+
+    if (
+      from.master_representation === trimming_preference.PARAMETER ||
+      from.master_representation === trimming_preference.UNSPECIFIED) {
       // use parameter value
       for (let trimIndex = 0; trimIndex < from.trim_1.length; trimIndex++) {
         const trim1 = from.trim_1[trimIndex]

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -3632,7 +3632,24 @@ export class IfcGeometryExtraction {
     let trim2Cartesian3D: Vector3 = { x: 0, y: 0, z: 0 }
     let trim2Double: number = 0
 
-    // use Cartesian if unspecified
+    // UNSPECIFIED reads BOTH representations, because IFC defines it as
+    // "either may be used" rather than as a third one: the reader chooses.
+    // The choice is made downstream, in conway-geom's getIfcLine, which takes
+    // the Cartesian pair when its two endpoints are distinct and falls back to
+    // the parameters otherwise (conway-geom#170/#179).
+    //
+    // Reading only the Cartesian side here left that fallback with nothing to
+    // fall back TO. Both parameters stayed at their zero initialisers, so an
+    // UNSPECIFIED trim carrying only IFCPARAMETERVALUEs collapsed to
+    // placement + vector * 0 twice, and IfcCurve::Add3d's duplicate test
+    // reduced the curve to a single point (conway#578). The two scans below
+    // are independent, not exclusive, for that reason — do not fold them back
+    // into an if/else.
+    //
+    // CARTESIAN and PARAMETER each still run exactly one scan, so neither
+    // moves. A trim that supplies both is Cartesian-wins, which is
+    // conway-geom#170's own wording: "use the Cartesian trim points when both
+    // are present, else the parameter values".
     if (
       from.MasterRepresentation === IfcTrimmingPreference.CARTESIAN ||
       from.MasterRepresentation === IfcTrimmingPreference.UNSPECIFIED) {
@@ -3680,7 +3697,11 @@ export class IfcGeometryExtraction {
           break
         }
       }
-    } else {
+    }
+
+    if (
+      from.MasterRepresentation === IfcTrimmingPreference.PARAMETER ||
+      from.MasterRepresentation === IfcTrimmingPreference.UNSPECIFIED) {
       // use parameter value
       for (let trimIndex = 0; trimIndex < from.Trim1.length; trimIndex++) {
         const trim1 = from.Trim1[trimIndex]

--- a/src/ifc/ifc_trimmed_curve_unspecified.test.ts
+++ b/src/ifc/ifc_trimmed_curve_unspecified.test.ts
@@ -1,0 +1,149 @@
+/* eslint-disable no-magic-numbers */
+// IFCTRIMMEDCURVE with MasterRepresentation = .UNSPECIFIED. over an IFCLINE.
+//
+// IFC defines UNSPECIFIED as "either representation may be used", so the
+// reader chooses. conway-geom#170/#179 put that choice in getIfcLine: it takes
+// the Cartesian endpoint pair when the two are distinct, and falls back to the
+// parameters otherwise. The extractor therefore has to fill BOTH sides for
+// UNSPECIFIED, and until conway#578 it filled only the Cartesian one — so a
+// parameter-only UNSPECIFIED trim reached the wasm with every field zeroed,
+// getIfcLine evaluated placement + vector * 0 twice, and IfcCurve::Add3d's
+// duplicate test reduced the whole curve to a single point.
+//
+// No model in either regression corpus contains this construct — that is
+// precisely why it went unnoticed, and why it needs a test of its own rather
+// than digest coverage. The fixture is inline rather than a data/*.ifc file
+// because the Tier-A quick-check in build.yml globs data/*.ifc and would
+// demand a committed golden for it.
+import { describe, expect, test, beforeAll } from '@jest/globals'
+
+import { ConwayGeometry, CurveObject } from '../../dependencies/conway-geom'
+import { ExtractResult } from '../core/shared_constants'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ParseResult } from '../step/parsing/step_parser'
+import { IfcTrimmedCurve } from './ifc4_gen/index'
+import { IfcGeometryExtraction } from './ifc_geometry_extraction'
+import IfcStepParser from './ifc_step_parser'
+
+
+// One basis line — placement (1,2,3), direction (1,0,0), magnitude 10 — under
+// four trimmed curves that differ only in master representation and in which
+// representation their trims actually carry.
+//
+//   #100  UNSPECIFIED, parameters only   <- the regressing case
+//   #101  UNSPECIFIED, Cartesian only
+//   #102  CARTESIAN,   Cartesian only    <- control, must never move
+//   #103  PARAMETER,   parameters only   <- control, must never move
+const FIXTURE = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('trimmed-line-unspecified.ifc','2026-08-24T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCCARTESIANPOINT((1.,2.,3.));
+#2= IFCDIRECTION((1.,0.,0.));
+#3= IFCVECTOR(#2,10.);
+#4= IFCLINE(#1,#3);
+#5= IFCCARTESIANPOINT((2.,2.,2.));
+#6= IFCCARTESIANPOINT((7.,7.,7.));
+#100= IFCTRIMMEDCURVE(#4,(IFCPARAMETERVALUE(0.25)),(IFCPARAMETERVALUE(0.75)),.T.,.UNSPECIFIED.);
+#101= IFCTRIMMEDCURVE(#4,(#5),(#6),.T.,.UNSPECIFIED.);
+#102= IFCTRIMMEDCURVE(#4,(#5),(#6),.T.,.CARTESIAN.);
+#103= IFCTRIMMEDCURVE(#4,(IFCPARAMETERVALUE(0.25)),(IFCPARAMETERVALUE(0.75)),.T.,.PARAMETER.);
+ENDSEC;
+END-ISO-10303-21;
+`
+
+let extraction: IfcGeometryExtraction
+
+/**
+ * Parse the inline fixture and stand up a geometry extractor over it.
+ *
+ * @return {Promise<ExtractResult | boolean>} True when the extractor is ready.
+ */
+async function initialize(): Promise<ExtractResult | boolean> {
+
+  const parser = IfcStepParser.Instance
+  const input = new ParsingBuffer(Buffer.from(FIXTURE, 'utf8'))
+
+  if (parser.parseHeader(input)[1] !== ParseResult.COMPLETE) {
+    return ExtractResult.INCOMPLETE
+  }
+
+  const conwayGeometry: ConwayGeometry = new ConwayGeometry()
+
+  if (!await conwayGeometry.initialize()) {
+    return ExtractResult.INCOMPLETE
+  }
+
+  const [, model] = parser.parseDataToModel(input)
+
+  if (model === void 0) {
+    return ExtractResult.INCOMPLETE
+  }
+
+  extraction = new IfcGeometryExtraction(conwayGeometry, model)
+
+  return extraction.isInitialized()
+}
+
+/**
+ * Extract one trimmed curve by express ID and read its points back.
+ *
+ * @param expressID The IFCTRIMMEDCURVE to extract.
+ * @return {number[][]} The curve's 3D points, in order.
+ */
+function trimmedCurvePoints(expressID: number): number[][] {
+
+  const entity = extraction.model.getElementByExpressID(expressID)
+
+  expect(entity).toBeInstanceOf(IfcTrimmedCurve)
+
+  const curve: CurveObject | undefined =
+    extraction.extractIfcTrimmedCurve(entity as IfcTrimmedCurve)
+
+  expect(curve).toBeDefined()
+
+  const points: number[][] = []
+
+  for (let index = 0; index < curve!.getPointsSize(); ++index) {
+
+    const point = curve!.get3d(index)
+
+    points.push([point.x, point.y, point.z])
+  }
+
+  return points
+}
+
+beforeAll(async () => {
+  expect(await initialize()).toBe(true)
+})
+
+describe('IFCTRIMMEDCURVE over IFCLINE, master representation UNSPECIFIED', () => {
+
+  test('parameter-only UNSPECIFIED yields the parameter trim, not a single point', () => {
+
+    // The regression conway#578 fixes. Before it, the extractor left
+    // trim1Double/trim2Double at zero, both endpoints evaluated to the line's
+    // own placement, and Add3d's duplicate test left exactly [[1,2,3]].
+    expect(trimmedCurvePoints(100)).toEqual([[3.5, 2, 3], [8.5, 2, 3]])
+  })
+
+  test('Cartesian-only UNSPECIFIED still yields the Cartesian trim', () => {
+
+    // Cartesian stays the preferred representation when both endpoints are
+    // present and distinct — conway-geom#170's "use the Cartesian trim points
+    // when both are present, else the parameter values".
+    expect(trimmedCurvePoints(101)).toEqual([[2, 2, 2], [7, 7, 7]])
+  })
+
+  test('CARTESIAN is unaffected', () => {
+    expect(trimmedCurvePoints(102)).toEqual([[2, 2, 2], [7, 7, 7]])
+  })
+
+  test('PARAMETER is unaffected', () => {
+    expect(trimmedCurvePoints(103)).toEqual([[3.5, 2, 3], [8.5, 2, 3]])
+  })
+})


### PR DESCRIPTION
Bumps the `dependencies/conway-geom` submodule from `de840a68` to `99e57cd2`
(conway-geom `main`), picking up three merged upstream PRs — **plus one
extractor fix on top of them**, so the bump is strictly better rather than
net-better-with-a-known-regression.

**Three files:** the submodule pointer, and the UNSPECIFIED trim branch of both
geometry extractors. That second part is a defect codex found in the upstream
range and is written up in full below. The AP214 gear golden, which conway#567
had to move alongside its pointer, does **not** move here.

## What the three upstream PRs do

In `main` order, `de840a68..99e57cd2`:

**[conway-geom#181](https://github.com/bldrs-ai/conway-geom/pull/181)
(`0a8753e0`) — recover spherical corner blends at the pole.** The sphere's
dual parameterization maps each half as `direction(xy) * radius`, and the
radius factor vanishes at the half's own centre: a *removable* singularity
whose limit is the origin from every approach direction. `glm::normalize` of a
zero-length vector is NaN, though, so the value has to be written down rather
than computed. Until now it wasn't, and `manifold_utils.h`'s non-finite CDT
input guard dropped the whole face. Every corner blend of a filleted box is
such a face. On the `box-fillet-r8` fixture, area goes 79.32% → 99.98% of
OCCT and volume 84.96% → 99.99%. **Zero digest churn** — no corpus model has a
spherical face whose boundary touches its axis.

**[conway-geom#179](https://github.com/bldrs-ai/conway-geom/pull/179)
(`744daaa8`) — trimmed-line select handling, plus the `-03` genie.lua typos.**
`getIfcLine` was the only curve in `ConwayGeometryProcessor.cpp` that
enumerated `IfcTrimmingPreference::CARTESIAN` explicitly; the siblings all read
the select as "PARAMETER, else Cartesian", which is what IFC's UNSPECIFIED
calls for. UNSPECIFIED now has its own arm, with representation choice and
sense, and the untrimmed-`LINE` arm moves out of the `trimExists` block where
it could never run. **Zero digest churn** — the corpus contains no
UNSPECIFIED-trimmed or bare `LINE`. This is also the PR whose new arm needs the
extractor fix below.

**[conway-geom#180](https://github.com/bldrs-ai/conway-geom/pull/180)
(`99e57cd2`) — stale tessellation candidates and the NURBS trim-bounds cap.
This one carries all the churn.** Two changes and a comment:

- `tesselate()`: `addCandidate()` rejects border edges at queue time, but every
  subdivision below deletes two triangles and `deleteTriangle()` clears both
  slots of each of their three edges — so an edge that was interior when queued
  can be a border, or fully detached, when it is popped. The loop then indexed
  `mesh.triangles[EMPTY_INDEX]` and the wasm heap trapped. Established rather
  than inferred: a `--profiling-funcs` build named the frame, and a probe on
  `Orbiter_v1.1_Gear_7.5.step` caught stale candidates 1:1 with the traps.
- `boundConvergenceToTrim()`: conway-geom#178 made the NURBS inverse solve's
  convergence target relative, but relative to the 8×8 sample grid of the whole
  *support surface*, because the solve is constructed before any bound is
  projected. This caps it on the *face* actually being tessellated, via a bbox
  over `bounds[].curve.points`. The cap only ever tightens.
- `IfcCurve::Add3d`: a comment recording what the 2^-24 snap is (conway-geom#176
  guessed at a float32 cast on the embind path; there is no float on that path).

## The extractor fix — codex's P1, verified and corrected

Codex flagged that conway-geom#179's new UNSPECIFIED arm would misread what
conway's own extractors send it. **It is right.** Both extractors read only the
Cartesian side for UNSPECIFIED (`ifc_geometry_extraction.ts:3635`,
`ap214_geometry_extraction.ts:2585`) and wrote `trim1Double`/`trim2Double` only
in the mutually exclusive `else`. So an UNSPECIFIED trim carrying nothing but
`IFCPARAMETERVALUE`s reached C++ with all six trim fields at zero; the new arm's
"are the Cartesian endpoints distinct?" sentinel correctly read that as
*absent*, fell back to the parameters — and the parameters were zero too. The
curve evaluated `placement + vector * 0` twice and `IfcCurve::Add3d`'s exact
duplicate test collapsed it to a single point.

Two things in the finding's characterisation did **not** survive measurement,
and both matter for how you read the fix:

1. **The pre-bump fallback was not "the correct basis segment for trims 0 → 1".**
   At `de840a68`, UNSPECIFIED fell through to an arm that emitted the whole
   *untrimmed* basis line for **every** UNSPECIFIED trim, whatever it carried —
   real Cartesian points and real parameters alike. It was right only in the
   coincidence of a 0 → 1 trim on a unit-magnitude direction. The bump already
   turns two of three sub-cases from wrong to right; this commit is about the
   third.
2. **It is not reachable only from a direct embind caller.**
   `ifc_geometry_extraction.ts:3704` and `ap214_geometry_extraction.ts:2658`
   both forward `from.MasterRepresentation.valueOf()` /
   `from.master_representation.valueOf()`, and both generated enums are
   `CARTESIAN = 0, PARAMETER = 1, UNSPECIFIED = 2`. A schema-legal
   `IFCTRIMMEDCURVE` reaches it.

**The fix:** the Cartesian scan and the parameter scan become independent rather
than exclusive. CARTESIAN and PARAMETER each still run exactly one of them, so
neither moves; UNSPECIFIED runs both and lets conway-geom choose,
Cartesian-preferred — conway-geom#170's own wording, "use the Cartesian trim
points when both are present, else the parameter values". Mixed endpoints stay
unrecovered deliberately: that needs per-endpoint availability flags on
`ParamsGetIfcTrimmedCurve`, which is a cross-repo change, and conway-geom#179's
review established why no sentinel can substitute.

### Measured through the extractor, at both submodule SHAs

One basis line — placement `(1,2,3)`, direction `(1,0,0)`, magnitude `10` —
under four trimmed curves, points read back off the `CurveObject`:

| case | `de840a68` (either TS) | `99e57cd2` before fix | `99e57cd2` after fix |
|---|---|---|---|
| UNSPECIFIED, parameters only | untrimmed basis line | `[[1,2,3]]` | **`[[3.5,2,3],[8.5,2,3]]`** |
| UNSPECIFIED, Cartesian only | untrimmed basis line | `[[2,2,2],[7,7,7]]` | `[[2,2,2],[7,7,7]]` |
| CARTESIAN | `[[2,2,2],[7,7,7]]` | unchanged | unchanged |
| PARAMETER | `[[3.5,2,3],[8.5,2,3]]` | unchanged | unchanged |

**The `de840a68` column is identical with and without this change, row for
row.** The old engine ignores UNSPECIFIED entirely, so the extra parameters are
inert there — a bisect across this commit sees no behaviour change on the old
engine, and the fix only takes effect together with the pointer move it ships
with.

### Test

`src/ifc/ifc_trimmed_curve_unspecified.test.ts`, four cases over an inline
fixture. Run against the **un-fixed** extractor it fails on exactly one — the
parameter-only UNSPECIFIED case, receiving the single point — while the three
controls pass either way. That is what pins this as a fix rather than a
rewrite. The fixture is inline rather than a `data/*.ifc` file on purpose:
`build.yml`'s Tier-A quick-check globs `data/*.ifc` and would want a committed
golden for it.

No corpus model contains this construct, so nothing else could catch a
regression here — which is exactly why it needed its own test.

## Digest churn — measured here, 15 rows over 4 models

Built the wasm **twice from this same TypeScript tree**, once at each submodule
SHA, with emsdk 6.0.2 (the version `build.yml` pins), and diffed the digest
CSVs. Both builds are bit-reproducible (`ConwayGeomWasmNodeMT.js` md5
`94fc2d0b…` at `de840a68`, `bba969b8…` at `99e57cd2`, each reproduced on a
second build), so the SHA under test is the SHA in the pointer. Corpus: all
**33 locally materialised models**, public + private, **179,788 digest rows**.

| model | rows changed | of | driver |
|---|---:|---:|---|
| `Arty_Z7.stp` | 1 | 5,162 | NURBS cap |
| `Jetenginestep.stp` | 2 | 1,431 | NURBS cap |
| `nist_ctc_02_asme1_rc.stp` | 1 | 4 | NURBS cap |
| `Orbiter_v1.1_Gear_7.5.step` | 11 | 84 | tesselate guard + NURBS cap |
| **total** | **15** | **179,788** | |

The other **29 models are byte-identical**. Every one of the 15 changed rows is
hash-only — same express ID, same row count, all `MANIFOLD_SOLID_BREP` — which
is what a retessellation looks like rather than a topology change.

**This matches conway-geom#180's own report exactly**, model for model and row
for row. It is an independent reproduction, not a restatement: it was measured
before the commit message was quoted.

**The extractor fix adds nothing to that table.** All 33 models were re-run at
`99e57cd2` with and without the TypeScript change and are byte-identical across
it, both corpora — as are `errors.csv`, `main.csv`, `failed.csv` and
`zero_geometry.csv`. Consistent with, and independent evidence for, the claim
that no corpus model holds an UNSPECIFIED-trimmed `IFCLINE`.

Note the corpus here is a **superset** of conway#567's. That PR measured 31
models / 178,273 rows; `Jetenginestep.stp` (1,431 rows) and
`Orbiter_v1.1_Gear_7.5.step` (84 rows) are additionally materialised now, and
178,273 + 1,431 + 84 = 179,788. Both of the added models are ones #180 moves,
so #567's corpus could not have seen half of this churn.

### Orbiter stops trapping

`Orbiter_v1.1_Gear_7.5.step` is the only model that trapped. Both
`Error extracting face ADVANCED_FACE - memory access out of bounds` entries —
express IDs `#50714` and `#50892` — are gone from `errors.csv`, leaving only
the pre-existing `Outer bound of this face is collinear` row (count 7,
unchanged). `main.csv`'s error column for the model goes `25 → 1`; that column
counts physical CSV lines and the trap entries carried multi-line stack traces,
so in message terms it is 3 grouped rows → 1.

One honest discrepancy: conway-geom#180 reports **8 traps / 4 error rows** on
`Orbiter`. This box shows **2 trapped faces / 2 error rows** before the bump
and 0 after. The geometric outcome reproduces exactly (the same 11 digest
rows), so this looks like an environment-dependent trap count rather than a
different fix; it is not explained here, and it is reported rather than
smoothed over.

## The gear golden, checked not assumed

conway#567 moved `src/AP214E3_2010/ap214_geometry_extraction.test.ts` from
`154644` to `150828` indices for conway-geom#178. #180's `boundConvergenceToTrim()`
tightens **the same inverse solve on the same involute flank splines**, so the
obvious expectation was that it moves again. It does not.

| | at `de840a68` | at `99e57cd2` |
|---|---|---|
| `gearGeometryArrayLength()` | 150828 ✓ | 150828 ✓ |
| AP214 Tier-A suite | 10/10 pass | 10/10 pass |

Consistent with #180's own note that the corpus-wide max
`surfaceDiagonal / trimDiagonal` ratio is 2.273 — three to six decades below
the thresholds where the cap changes an outcome. The gear's solve was already
converging inside the tighter target, so the cap is inert on it.

The `de840a68` number was reproduced locally first, so the toolchain here is
known to agree with CI's before the "unchanged" claim was made. `build.yml`'s
Tier-A `data/` goldens (`block.csv`, `index.csv` — the only two with committed
goldens) are unmoved as well.

## What CI will show — inherited vs this bump's

Read the two apart, because they do not overlap the way you would expect.

`run-ifc-regression` diffs the **smoke subset** against the committed
`test-models` baselines. Those baselines were last blessed at conway
`rc-1.560.1539` (`2fc6f409`, test-models PR #56), which pinned conway-geom
**`4ae67268`** — i.e. *before* #178. So #178's churn is entirely unblessed and
shows up as inherited noise on every PR since conway#567.

Measured against `test-models` `main`, for all 12 smoke models, on `main` and
on this branch:

| smoke model | vs baseline on `main` | vs baseline on this PR | whose churn |
|---|---:|---:|---|
| `nist_ctc_02_asme1_rc.stp` | 1 row | 1 row | **both** — #178 moved this row, #180 moves it again |
| `Right_Hand.step` | 6 rows | 6 rows | inherited (#178 only); byte-identical across this bump |
| other 10 | clean | clean | — |

So — **contrary to what you might expect from a churn-carrying bump, this PR
adds no new model to the visual-diff set.** The count stays at 2. All of this
bump's *additional* models — `Arty_Z7`, `Jetenginestep`, `Orbiter` — are
deliberately excluded from `regression/smoke_models.txt` as RC-tier models, so
their churn is invisible until the rc pass. Inside the subset, #180 only
rewrites the hash of the *same single* `nist_ctc_02` row #178 had already
moved.

**The render base is a different anchor from the model set, and that is what
makes this PR's render table look unlike #567's.** `visual-diff` picks *which*
models to render from the digest-vs-committed-baseline diff above, but it
renders `npm @bldrs-ai/conway@latest` as the base — `1.569.1545` at the time of
writing, i.e. `main` **including** conway#567. So the rendered delta is
`de840a68 → 99e57cd2` only:

| smoke model | why it is rendered | expected Δ pixels |
|---|---|---|
| `Right_Hand.step` | stale baseline w.r.t. #178 | **~0%** — byte-identical across this bump, so base and candidate builds produce the same mesh. #567 showed 14.27% here; a non-zero delta on this PR would be a finding, not inherited noise |
| `nist_ctc_02_asme1_rc.stp` | #178 *and* #180 both moved its one row | small — conway-geom#180 measured 216 / 810,000 px (0.027%) with **0 silhouette px**. #567 showed 0.83% on this model; this should be well under that |

conway-geom#180's own renders (pair mode, shared camera, 900 px) — **upstream's
numbers, not re-measured here**:

| model | changed px | silhouette |
|---|---|---|
| `Orbiter` | 387 / 810,000 (0.048%) | 10 px, **all gained**, 0 lost — surface appearing where the trapped faces left background |
| `nist_ctc` | 216 / 810,000 (0.027%) | 0 px — pure retessellation |
| `Arty_Z7` | 0 px | — |

Sub-threshold renders are expected. Anything with a visible delta beyond the
above needs explaining.

## Baselines are not re-blessed here — one combined pass is coming

Deliberately no `test-models` / `test-models-private` changes in this PR. There
are two unblessed sets outstanding and they overlap:

- **R1 — conway-geom#178, landed via conway#567.** 4 models / 1,179 of 178,273
  rows: `Arty_Z7` 1,169/5,162, `Right_Hand` 6/40, `FM_ARC_DigitalHub` 3/27,480,
  `nist_ctc_02` 1/4.
- **R2 — this bump.** 4 models / 15 of 179,788 rows, per the table above.

`Arty_Z7` and `nist_ctc_02_asme1_rc` appear in **both** sets, which is exactly
why this is one rebless pass and not two: blessing R1 separately would bless a
digest for those two models that R2 immediately invalidates. **The digest
changes in this PR do not need their own bless** — do not read them as an
omission.

## CI cost

The conway-geom submodule SHA keys the WASM build cache
(`Compute conway-geom submodule SHA` → `wasm-${{ runner.os }}-emsdk…-${sha}` in
`build.yml`), so this bump invalidates it and **CI pays one full emcc rebuild**.
Measured on this PR's first `build` run: 10m51s end to end. Real, but modest —
a slow first run here is expected, not a symptom.

## Verified vs assumed

**Verified here:**

- `yarn build-codex-MT` succeeds at both SHAs (emsdk 6.0.2), from the same
  TypeScript tree, in a clean worktree with the submodule initialised at the
  pinned SHA and `git rev-parse HEAD` checked against it at each step. No
  symlinked `dependencies/conway-geom`, `node_modules` or `Dist` — the SHA
  under test *is* the deliverable here. Each SHA's wasm was built twice and is
  bit-reproducible.
- Digest batch over all 33 materialised models at both SHAs: 15 rows / 4
  models changed, 29 models byte-identical, no new load failures, no change to
  `zero_geometry.csv`, and public `errors.csv` byte-identical. Re-run again
  with the extractor fix: byte-identical to the run without it.
- The gear golden holds at `150828` at both SHAs; full AP214 Tier-A suite
  green; `data/` Tier-A goldens unmoved.
- The UNSPECIFIED matrix above, measured through the extractor at both SHAs,
  with and without the fix — including that the fix is a no-op at `de840a68`.
- Gate green: eslint 0 errors, tsc, **107 suites / 752 tests** (up from
  106 / 748 — the four new ones).

**Not verified here, and flagged as such:**

- Perf. #180 reports `Arty_Z7` geometry memory 403.878 MB and wasm heap
  high-water 707 MB *unchanged* across its change, and geometry time within
  noise. Not re-measured on this branch — this is not a perf change and the
  digest evidence is what matters.
- Renders. The pixel figures above are conway-geom#180's, reproduced verbatim,
  not re-rendered here. `visual-diff` will produce this repo's own.
- The 2-vs-8 trap-count difference on `Orbiter` noted above.