### PR TITLE
#583: add a placement-aware column to the AP214 regression digest

### DIFF
--- a/design/new/step-regression.md
+++ b/design/new/step-regression.md
@@ -161,6 +161,88 @@ corpus, same shape):
       the #334 basis-only fix (else the golden bakes in the cluster bug).
 
 
+## The placement column (conway#583)
+
+What actually shipped is **not** the post-transform digest §"The digest"
+above specifies. `ap214_regression_main.ts` hashes the OBJ serialisation of
+each geometry **definition**, in its own local frame — the IFC approach
+ported verbatim, which is exactly the thing this doc warned would "pass
+while every part is collapsed onto the origin". conway#583 is that warning
+coming true: `data/ap214-mapped-item-failure.step` relocates five solids by
+500 mm and the digest is byte-identical across the fix.
+
+The correction is a seventh column, `Placement`, rather than a rewrite of
+the six. Three reasons, in the order they mattered:
+
+1. **Comparables.** The existing six do not move, so the diff stays legible
+   across the change: after the re-bless, a row that moves only in
+   `Placement` is geometry that landed somewhere else, and one that moves
+   only in `Hash` is geometry that tessellated differently. A single
+   post-transform hash conflates them, which is a worse instrument than the
+   two-axis one even though it is the one this doc originally specified.
+2. **Keys.** §"Determinism" above worried that assembled geometry has no
+   stable row key and recommended emitting a sorted, unkeyed hash set. Per
+   definition, there is a key — the same expressID the row already carries —
+   so the sort happens *inside* one cell instead of across the file, and
+   localisation survives.
+3. **Cost of the alternative.** Aggregating world-space vertex buffers for
+   every instance is a second full pass over the geometry; hashing 16
+   doubles and an occurrence path per instance is not.
+
+### What is in the value
+
+Per geometry definition: the set of `(occurrence path, absolute 4x4)` pairs
+of every instance of it in the scene, each matrix element rounded to 12
+significant digits, sorted lexicographically, SHA1'd. Details and the
+reasoning for each choice are on `ap214_placement_digest.ts`; the ones worth
+repeating here:
+
+- **Sorted, so the column is order-invariant.** Demand extraction cuts a
+  model into units whose count and boundaries move with `demandItemsPerUnit`
+  and with the pump's wall-clock budget. A column that changed when the
+  scheduler changed would be worse than no column — the digest's whole job
+  is to be stable under things that should not matter. Duplicates are kept,
+  so an instance-count change is still a change.
+- **Occurrence path included.** The same world transform reached through a
+  different NAUO chain is a different assembly, and assembly traversal is
+  inside the class of change this column exists to catch.
+- **No vertex buffers.** conway#582's PR-local parity hash included them;
+  this does not, because `Hash` already carries tessellation and reading
+  buffers back out of the wasm heap is unreliable in the pthreads build
+  (conway#584).
+- **A root-parented instance reads as identity**, not as a distinct "absent"
+  marker, so moving geometry between the scene root and an identity
+  transform — which changes nothing about where it is drawn — does not churn.
+
+### Cost
+
+Measured as the column's own time inside a digest run, and as end-to-end CLI
+wall clock with the column stubbed out:
+
+| model | placed instances | column | digest run |
+|---|---:|---:|---|
+| `DSA2.step` | 57,348 | 406-510 ms | 16.2 s vs 15.5 s without |
+| `Arty_Z7.stp` | 6,816 | 52-87 ms | 60.6 s vs 60.4 s without (in the noise) |
+| `driver board.step` | 279 | 3-5 ms | |
+| everything else in the corpus | <300 | <12 ms | |
+
+DSA2 is the corpus worst case and the only model where the column is
+visible at all: one representation of 28,674 solids, every one of them a
+separate placed instance. ~3% of that model's digest run, and under a second
+of a full pass.
+
+### IFC
+
+**Not applied.** `ifc_regression_main.ts` has the same structural blindness
+— it hashes `model.geometry` / `voidGeometry` / `curves` / `profiles` /
+`materials` per definition, with no transform in any row — so an IFC
+placement regression is invisible to it in exactly the same way. It was left
+alone deliberately: the gap was found on STEP, an IFC column would move every
+IFC baseline as well as every STEP one, and IFC's scene builder has no
+occurrence-path equivalent, so the value would have to be defined
+differently rather than reused. Worth its own issue, not this one's diff.
+
+
 ## Status / cross-refs
 
 - #308 root cause + fix: `ap214_geometry_extraction.ts` `doTransforms` /
@@ -169,3 +251,6 @@ corpus, same shape):
   design. Update that checklist as items land.
 - glb-snapshot-goldens.md is the complementary (GLB-byte) golden effort;
   shares determinism concerns, different artifact.
+- #583 is the placement column above; #582 is where the blindness was
+  found, and is the source of the two placement-sensitive fixtures in
+  `data/`.

--- a/regression/README.md
+++ b/regression/README.md
@@ -30,6 +30,42 @@ The digest (-d) or verbose OBJ modes (-v) can be run separately or together. The
 
 Digests for IFC files are stably sorted (by Express ID) and have SHA1 hashes for the individual pieces of geometry produced by Conway, including curves, meshes, profiles and materials, as well as the type and references for the operands for boolean operators, and if the particular element is a void. For an example, check out the manifest of the index.ifc file from the [test models repository](https://github.com/bldrs-ai/test-models) [here](test_models/index.csv).
 
+### Digest columns
+
+IFC digests are `ID,Hash,Type,Operand 1,Operand2,Void`. STEP (AP214)
+digests carry those six unchanged and add a seventh, `Placement`:
+
+| column | meaning |
+|---|---|
+| `ID` | expressID of the element the row is for, or the geometry's local id where it has none. Rows are stably sorted by it. |
+| `Hash` | SHA1 of the OBJ serialisation of that geometry **definition** — its tessellation, in its own local frame. |
+| `Type` | Entity type name. |
+| `Operand 1` / `Operand2` | Boolean-operator operands (IFC only; AP214 leaves them empty). |
+| `Void` | Whether the element is a void (IFC CSG; `FALSE` on every AP214 mesh row, empty on curve rows). |
+| `Placement` | **AP214 only.** SHA1 over the sorted set of places that definition was put: for each placed instance, its full absolute 4x4 transform and the occurrence path (NAUO express ids) that placed it. Empty for a definition the scene never placed, and for curve rows, which are memoized per definition and never enter the scene graph. |
+
+`Hash` and `Placement` are the two independent axes of a STEP regression.
+`Hash` moves when tessellation changes; `Placement` moves when geometry
+lands somewhere else, or under a different assembly occurrence, while
+tessellating identically. Before `Placement` existed the digest could not
+see the second axis at all — `data/ap214-mapped-item-failure.step`
+relocates five solids by 500 mm with a byte-identical digest (conway#583).
+Keeping them in separate columns is deliberate: a row that moves only in
+`Placement` is geometry that was placed differently, and a row that moves
+only in `Hash` is geometry that was tessellated differently, and the diff
+says which.
+
+`Placement` is order-invariant by construction — the per-definition
+records are sorted before hashing — so it does not depend on the walk
+order, on `demandItemsPerUnit`, or on where the pump's wall-clock budget
+happened to end a batch. That property is the point of the column, and
+`src/AP214E3_2010/ap214_placement_digest.test.ts` pins it.
+
+The IFC digest has the same structural blindness and no equivalent column
+yet; see [design/new/step-regression.md](../design/new/step-regression.md)
+§"The placement column" for why that was left alone.
+
+
 ### Batch Mode
 
 There is a batch mode console application that is used for batch mode testing that is expected to be run on repositories of test models and have its results put into the regression baselines folder (the regression folder in the repository), with a sub-folder per set of baselines. The regression baseline application is designed to be run from the Conway repository root.

--- a/src/AP214E3_2010/ap214_placement_digest.test.ts
+++ b/src/AP214E3_2010/ap214_placement_digest.test.ts
@@ -1,0 +1,312 @@
+import fs from 'fs'
+import { describe, expect, test, beforeAll } from '@jest/globals'
+import { AP214GeometryExtraction } from './ap214_geometry_extraction'
+import { AP214SceneBuilder } from './ap214_scene_builder'
+import { ParseResult } from '../step/parsing/step_parser'
+import AP214StepParser from './ap214_step_parser'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import { ExtractResult } from '../core/shared_constants'
+import { CanonicalMeshType } from '../core/canonical_mesh'
+import {
+  canonicalPlacementValue,
+  placementDigests,
+  placementRecord,
+} from './ap214_placement_digest'
+
+
+/**
+ * conway#583: the AP214 regression digest was `ID,Hash,Type,Operand 1,
+ * Operand2,Void` — per geometry DEFINITION, with no placement in it — so it
+ * could not see geometry that tessellated identically and then landed
+ * somewhere else. `Placement` is the column that closes that, and these
+ * tests pin the two properties it has to have:
+ *
+ * - **Sensitivity.** It moves when geometry moves, and when the assembly
+ *   occurrence that placed it changes.
+ * - **Determinism.** It does NOT move with walk order, demand granularity
+ *   or repetition. AP214 demand extraction cuts a model into units whose
+ *   count and boundaries change with `demandItemsPerUnit`; a column that
+ *   moved when the scheduler moved would be worse than no column.
+ */
+
+/** Assembly with a 13-NAUO occurrence tree and real BREP leaves. */
+const ASSEMBLY_FIXTURE = 'data/as1-oc-214.stp'
+
+/** Ten solids in one representation's `items` — cut by the default granularity. */
+const MULTI_ITEM_FIXTURE = 'data/nema-23-76mm.step'
+
+/** Three solids under a NON-IDENTITY leading placement (conway#582). */
+const LEADING_PLACEMENT_FIXTURE = 'data/ap214-sliced-item-ranges.step'
+
+/** A MAPPED_ITEM that pushes its transform and then throws, then five solids. */
+const MAPPED_ITEM_FAILURE_FIXTURE = 'data/ap214-mapped-item-failure.step'
+
+/* Wasm init, and the per-test budgets: these extractions run real BREPs. */
+const WASM_INIT_TIMEOUT_MS = 60_000
+const EXTRACT_TIMEOUT_MS = 120_000
+const MULTI_EXTRACT_TIMEOUT_MS = 300_000
+
+/** Column-major 4x4 identity. */
+const IDENTITY: readonly number[] =
+  [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+
+/** The displacement the mapped-item fixture's leaked transform applies. */
+const LEAK_TRANSLATION_MM = 500
+
+/** Identity translated by {@link LEAK_TRANSLATION_MM} in x. */
+const TRANSLATED: readonly number[] =
+  [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, LEAK_TRANSLATION_MM, 0, 0, 1]
+
+let conwayGeometry: ConwayGeometry
+
+beforeAll( async () => {
+
+  conwayGeometry = new ConwayGeometry()
+
+  expect( await conwayGeometry.initialize() ).toBe( true )
+}, WASM_INIT_TIMEOUT_MS )
+
+
+/** One row of {@link AP214SceneBuilder.walkWithOccurrence}, reduced. */
+type StubRow = [
+  readonly number[] | undefined,
+  undefined,
+  { type: CanonicalMeshType, localID: number },
+  undefined,
+  undefined,
+  readonly number[],
+]
+
+
+/**
+ * A scene stand-in that yields exactly the placed instances given.
+ *
+ * `placementDigests` reads nothing but `walkWithOccurrence()`, so the
+ * order-invariance and sensitivity properties can be pinned without a wasm
+ * extraction — and, more usefully, with placements chosen to differ in one
+ * respect at a time, which no real fixture offers.
+ *
+ * @param rows The placed instances to yield, in the order given.
+ * @return {AP214SceneBuilder} The stand-in.
+ */
+function stubScene( rows: readonly StubRow[] ): AP214SceneBuilder {
+
+  return {
+    * walkWithOccurrence() {
+      yield* rows
+    },
+  } as unknown as AP214SceneBuilder
+}
+
+
+/**
+ * One placed instance of mesh 1, as a stub walk row.
+ *
+ * @param transform Absolute transform, or undefined for a root-parented node.
+ * @param occurrencePath NAUO express ids, root->this placement.
+ * @return {StubRow} The row.
+ */
+function placed(
+    transform: readonly number[] | undefined,
+    occurrencePath: readonly number[] = [] ): StubRow {
+
+  return [
+    transform,
+    void 0,
+    { type: CanonicalMeshType.BUFFER_GEOMETRY, localID: 1 },
+    void 0,
+    void 0,
+    occurrencePath,
+  ]
+}
+
+
+/**
+ * Extract a fixture at one granularity and take the placement digest of
+ * every mesh definition in it.
+ *
+ * The model is re-parsed per call because extraction memoizes geometry into
+ * it — two granularities have to start from equally cold models.
+ *
+ * @param fixture Path to the STEP file.
+ * @param itemsPerUnit Value for `demandItemsPerUnit`.
+ * @return {[Map<number, string>, number]} The digests and the unit count.
+ */
+function digestAt(
+    fixture: string, itemsPerUnit: number ): [Map<number, string>, number] {
+
+  const parser = AP214StepParser.Instance
+  const buffer = new ParsingBuffer( fs.readFileSync( fixture ) )
+
+  expect( parser.parseHeader( buffer )[1] ).toBe( ParseResult.COMPLETE )
+
+  const [ , model ] = parser.parseDataToModel( buffer )
+
+  expect( model ).not.toBe( void 0 )
+
+  const extraction = new AP214GeometryExtraction( conwayGeometry, model! )
+
+  extraction.demandItemsPerUnit = itemsPerUnit
+
+  extraction.prepareDemandExtraction()
+
+  const unitCount = extraction.demandUnitCount
+
+  const [ result, scene ] = extraction.extractAP214GeometryData()
+
+  expect( result ).toBe( ExtractResult.COMPLETE )
+
+  return [ placementDigests( scene ), unitCount ]
+}
+
+
+describe( 'AP214 placement digest value (conway#583)', () => {
+
+  test( 'a moved instance changes the digest', () => {
+
+    expect( placementDigests( stubScene( [ placed( TRANSLATED ) ] ) ).get( 1 ) )
+        .not.toBe( placementDigests( stubScene( [ placed( IDENTITY ) ] ) ).get( 1 ) )
+  } )
+
+  test( 'a different occurrence path changes the digest', () => {
+
+    expect(
+        placementDigests( stubScene( [ placed( IDENTITY, [ 7, 9 ] ) ] ) ).get( 1 ) )
+        .not.toBe(
+            placementDigests( stubScene( [ placed( IDENTITY, [ 9, 7 ] ) ] ) ).get( 1 ) )
+  } )
+
+  test( 'a dropped duplicate instance changes the digest', () => {
+
+    const twice = placementDigests(
+        stubScene( [ placed( IDENTITY ), placed( IDENTITY ) ] ) ).get( 1 )
+
+    expect( twice ).not.toBe(
+        placementDigests( stubScene( [ placed( IDENTITY ) ] ) ).get( 1 ) )
+  } )
+
+  test( 'walk order does not change the digest', () => {
+
+    const forwards = placementDigests( stubScene( [
+      placed( IDENTITY, [ 1 ] ),
+      placed( TRANSLATED, [ 2 ] ),
+      placed( TRANSLATED, [ 3 ] ),
+    ] ) ).get( 1 )
+
+    const backwards = placementDigests( stubScene( [
+      placed( TRANSLATED, [ 3 ] ),
+      placed( TRANSLATED, [ 2 ] ),
+      placed( IDENTITY, [ 1 ] ),
+    ] ) ).get( 1 )
+
+    // Not vacuous: the three instances are genuinely distinct records, so a
+    // digest built in walk order would differ between these two.
+    expect( forwards ).toBe( backwards )
+    expect( forwards ).not.toBe(
+        placementDigests( stubScene( [ placed( IDENTITY, [ 1 ] ) ] ) ).get( 1 ) )
+  } )
+
+  test( 'a root-parented instance reads as identity, not as absent', () => {
+
+    expect( placementDigests( stubScene( [ placed( void 0 ) ] ) ).get( 1 ) )
+        .toBe( placementDigests( stubScene( [ placed( IDENTITY ) ] ) ).get( 1 ) )
+  } )
+
+  test( 'a never-placed definition has no entry', () => {
+
+    expect( placementDigests( stubScene( [] ) ).size ).toBe( 0 )
+  } )
+
+  test( 'negative zero and zero are the same placement', () => {
+
+    expect( canonicalPlacementValue( -0 ) ).toBe( canonicalPlacementValue( 0 ) )
+    expect( placementRecord( [ -0 ], [] ) ).toBe( placementRecord( [ 0 ], [] ) )
+  } )
+
+  test( 'a non-finite matrix element survives into the record', () => {
+
+    expect( placementRecord( [ NaN ], [] ) ).toContain( 'NaN' )
+    expect( placementRecord( [ NaN ], [] ) ).not.toBe( placementRecord( [ 0 ], [] ) )
+  } )
+} )
+
+
+describe( 'AP214 placement digest determinism (conway#583)', () => {
+
+  test( 'an assembly digests identically sliced and unsliced', () => {
+
+    const [ unsliced, unslicedUnits ] = digestAt( ASSEMBLY_FIXTURE, Infinity )
+    const [ sliced, slicedUnits ] = digestAt( ASSEMBLY_FIXTURE, 1 )
+
+    // Without this the equality below would hold trivially.
+    expect( slicedUnits ).toBeGreaterThan( unslicedUnits )
+    expect( unsliced.size ).toBeGreaterThan( 0 )
+
+    expect( sliced ).toStrictEqual( unsliced )
+  }, EXTRACT_TIMEOUT_MS )
+
+  test( 'a ten-solid representation digests identically at every granularity', () => {
+
+    const [ unsliced, unslicedUnits ] = digestAt( MULTI_ITEM_FIXTURE, Infinity )
+    const [ atDefault, defaultUnits ] = digestAt( MULTI_ITEM_FIXTURE, 4 )
+    const [ perItem, perItemUnits ] = digestAt( MULTI_ITEM_FIXTURE, 1 )
+
+    expect( defaultUnits ).toBeGreaterThan( unslicedUnits )
+    expect( perItemUnits ).toBeGreaterThan( defaultUnits )
+    expect( unsliced.size ).toBeGreaterThan( 0 )
+
+    expect( atDefault ).toStrictEqual( unsliced )
+    expect( perItem ).toStrictEqual( unsliced )
+  }, MULTI_EXTRACT_TIMEOUT_MS )
+
+  test( 'a leading placement is in the digest, and survives slicing', () => {
+
+    const [ unsliced, unslicedUnits ] = digestAt( LEADING_PLACEMENT_FIXTURE, Infinity )
+    const [ sliced, slicedUnits ] = digestAt( LEADING_PLACEMENT_FIXTURE, 1 )
+
+    expect( slicedUnits ).toBeGreaterThan( unslicedUnits )
+
+    // Three distinct solids, each placed once, all under the same leading
+    // AXIS2_PLACEMENT_3D — so three entries carrying one common placement.
+    expect( unsliced.size ).toBe( 3 )
+
+    // And that placement is NOT the identity, or dropping the leading
+    // transform would change nothing here and the equality below would be
+    // insensitive to exactly the bug it is meant to catch.
+    const identityOnce =
+      placementDigests( stubScene( [ placed( IDENTITY ) ] ) ).get( 1 )
+
+    for ( const digest of unsliced.values() ) {
+      expect( digest ).not.toBe( identityOnce )
+    }
+
+    expect( sliced ).toStrictEqual( unsliced )
+  }, EXTRACT_TIMEOUT_MS )
+
+  test( 'a mapped item that throws after pushing leaves the digest alone', () => {
+
+    const [ unsliced, unslicedUnits ] = digestAt( MAPPED_ITEM_FAILURE_FIXTURE, Infinity )
+    const [ atDefault, defaultUnits ] = digestAt( MAPPED_ITEM_FAILURE_FIXTURE, 4 )
+    const [ perItem, perItemUnits ] = digestAt( MAPPED_ITEM_FAILURE_FIXTURE, 1 )
+
+    expect( defaultUnits ).toBeGreaterThan( unslicedUnits )
+    expect( perItemUnits ).toBeGreaterThan( defaultUnits )
+    expect( unsliced.size ).toBeGreaterThan( 0 )
+
+    // This is the case the whole column exists for: the five solids behind
+    // the failing mapped item have byte-identical OBJ hashes at every
+    // granularity, so the six pre-existing columns are identical here
+    // whether or not the transform leaks. Only this map can tell.
+    expect( atDefault ).toStrictEqual( unsliced )
+    expect( perItem ).toStrictEqual( unsliced )
+  }, EXTRACT_TIMEOUT_MS )
+
+  test( 'two runs of the same model at the same granularity agree', () => {
+
+    const [ first ] = digestAt( MAPPED_ITEM_FAILURE_FIXTURE, 4 )
+    const [ second ] = digestAt( MAPPED_ITEM_FAILURE_FIXTURE, 4 )
+
+    expect( second ).toStrictEqual( first )
+  }, EXTRACT_TIMEOUT_MS )
+} )

--- a/src/AP214E3_2010/ap214_placement_digest.ts
+++ b/src/AP214E3_2010/ap214_placement_digest.ts
@@ -1,0 +1,170 @@
+import crypto from 'crypto'
+import { CanonicalMeshType } from '../core/canonical_mesh'
+import { AP214SceneBuilder } from './ap214_scene_builder'
+
+
+/**
+ * Elements in a 4x4 placement matrix.
+ *
+ * Named because `no-magic-numbers` is error level here, and because the
+ * identity below has to be exactly this long: a scene-root geometry node has
+ * no parent transform at all, and it is canonicalised to identity rather
+ * than to a shorter "absent" token (see {@link placementRecord}).
+ */
+const MATRIX_ELEMENT_COUNT = 16
+
+/**
+ * Significant decimal digits each matrix element is rounded to before it
+ * enters the hash.
+ *
+ * Absolute transforms are composed inside wasm by repeated 4x4 multiply, so
+ * for a given walk they are bit-for-bit reproducible and no rounding is
+ * strictly needed. The rounding is margin, and it is free: quantisation is a
+ * pure function of the double, so it can only ever collapse a difference,
+ * never invent one. Twelve digits leaves ~1e-9 mm of resolution on a
+ * metre-scale coordinate — four orders coarser than a double's ulp there, and
+ * many orders finer than any real placement change.
+ */
+const PLACEMENT_SIGNIFICANT_DIGITS = 12
+
+/** Column-major 4x4 identity, the placement of a geometry node with no parent. */
+const IDENTITY_TRANSFORM: readonly number[] =
+  Array.from( { length: MATRIX_ELEMENT_COUNT },
+      ( _, index ) => ( index % 5 === 0 ? 1 : 0 ) )
+
+
+/**
+ * Render one matrix element as a canonical decimal string.
+ *
+ * `-0` and `0` collapse to the same text: they are the same placement, and
+ * which one a multiply produces is not a fact about where geometry landed.
+ * Non-finite values are passed through as their own text rather than
+ * discarded, so a NaN in a transform is visible in the digest instead of
+ * hashing the same as a zero.
+ *
+ * @param value The matrix element.
+ * @return {string} Canonical text for that element.
+ */
+export function canonicalPlacementValue( value: number ): string {
+
+  if ( !Number.isFinite( value ) ) {
+    return `${value}`
+  }
+
+  if ( value === 0 ) {
+    return '0'
+  }
+
+  return `${Number( value.toPrecision( PLACEMENT_SIGNIFICANT_DIGITS ) )}`
+}
+
+
+/**
+ * Build the canonical record for one placed instance: where it landed, and
+ * which assembly occurrence put it there.
+ *
+ * The occurrence path is part of the record because a placement is only half
+ * the identity — the same world transform reached through a different NAUO
+ * chain is a different assembly structure, and that is inside the class of
+ * change this column exists to catch (`REPRESENTATION_RELATIONSHIP` /
+ * `MAPPED_ITEM` handling, where the transform comes from the reference
+ * rather than the definition).
+ *
+ * A geometry node with no parent transform records identity rather than an
+ * "absent" marker, so moving geometry between the scene root and an identity
+ * transform node — which changes nothing about where it is drawn — does not
+ * churn the digest.
+ *
+ * @param absoluteTransform The instance's absolute transform, or undefined
+ * for a geometry node parented directly to the scene root.
+ * @param occurrencePath NAUO express ids, root->this placement.
+ * @return {string} The canonical record text.
+ */
+export function placementRecord(
+    absoluteTransform: readonly number[] | undefined,
+    occurrencePath: readonly number[] ): string {
+
+  const matrix = absoluteTransform ?? IDENTITY_TRANSFORM
+
+  return `${occurrencePath.join( '/' )}|${
+    matrix.map( canonicalPlacementValue ).join( ' ' )}`
+}
+
+
+/**
+ * Hash a set of placement records into one digest cell.
+ *
+ * Sorted, so the value does not depend on the order the scene was walked in
+ * — which is the whole point of the column. AP214 demand extraction cuts a
+ * model into units whose count and boundaries change with
+ * `demandItemsPerUnit` and with the pump's wall-clock budget, and a digest
+ * that moved when the scheduler moved would be worse than no digest at all.
+ * Duplicates are kept, so an instance count change is a digest change.
+ *
+ * @param records Placement records for one geometry definition.
+ * @return {string} Hex sha1 over the sorted records.
+ */
+function hashPlacementRecords( records: string[] ): string {
+
+  records.sort()
+
+  return crypto.createHash( 'sha1' ).update( records.join( '\n' ) ).digest( 'hex' )
+}
+
+
+/**
+ * Compute the placement digest of every mesh definition placed in a scene.
+ *
+ * This is the second axis of the AP214 regression digest (conway#583). The
+ * `Hash` column answers "was this tessellated the same way"; this answers
+ * "did every copy of it land in the same place, under the same occurrence".
+ * The two are independent: the mapped-item fixture in `data/` relocates five
+ * solids by 500 mm with byte-identical OBJ hashes, which is exactly the
+ * failure any change to walk order, transform-stack handling or assembly
+ * traversal risks — and exactly what the digest could not see before.
+ *
+ * Only `BUFFER_GEOMETRY` meshes are considered, matching the rows the digest
+ * writes. A definition that is never placed gets no entry, which the caller
+ * writes as an empty cell — distinguishable from a definition placed once at
+ * identity, which gets a hash.
+ *
+ * Design lineage: this is the placement-aware parity hash conway#582 ran as
+ * PR-local evidence, promoted into the digest, less the vertex and index
+ * buffers — the `Hash` column already carries those, and reading them back
+ * out of the wasm heap is unreliable in the pthreads build (conway#584).
+ * It is also the `step-regression.md` §Determinism "sort the hash set"
+ * recommendation, applied per definition row rather than to the whole model
+ * so the value keeps a stable key.
+ *
+ * @param scene The extracted scene.
+ * @return {Map<number, string>} Mesh local id -> hex sha1 placement digest.
+ */
+export function placementDigests( scene: AP214SceneBuilder ): Map<number, string> {
+
+  const recordsByGeometry = new Map<number, string[]>()
+
+  for ( const [absoluteTransform, , mesh, , , occurrencePath] of
+    scene.walkWithOccurrence() ) {
+
+    if ( mesh.type !== CanonicalMeshType.BUFFER_GEOMETRY ) {
+      continue
+    }
+
+    const records = recordsByGeometry.get( mesh.localID )
+    const record = placementRecord( absoluteTransform, occurrencePath )
+
+    if ( records === void 0 ) {
+      recordsByGeometry.set( mesh.localID, [record] )
+    } else {
+      records.push( record )
+    }
+  }
+
+  const result = new Map<number, string>()
+
+  for ( const [localID, records] of recordsByGeometry ) {
+    result.set( localID, hashPlacementRecords( records ) )
+  }
+
+  return result
+}

--- a/src/AP214E3_2010/ap214_regression_main.ts
+++ b/src/AP214E3_2010/ap214_regression_main.ts
@@ -21,6 +21,7 @@ import Environment from '../utilities/environment'
 import { ExtractResult } from '../core/shared_constants'
 import { CanonicalMeshType } from '../core/canonical_mesh'
 import EntityTypesAP214 from './AP214E3_2010_gen/entity_types_ap214.gen'
+import { placementDigests } from './ap214_placement_digest'
 import { Console } from 'console'
 
 
@@ -479,12 +480,28 @@ function doWork() {
           // (ID,Hash,Type,Operand 1,Operand2,Void) so the same diff/bless
           // tooling applies. STEP digests cover final meshes and memoized
           // curves; AP214 has no void/CSG-operand columns to fill.
+          //
+          // `Placement` is the one AP214-only column (conway#583), appended
+          // rather than folded into `Hash` so the two axes stay separable: a
+          // row that moves only in `Placement` is geometry that tessellated
+          // identically and landed somewhere else, which the six shared
+          // columns are structurally blind to. See
+          // design/new/step-regression.md §"The placement column" for why
+          // STEP needs the second axis and IFC does not have one yet, and
+          // ap214_placement_digest.ts for what goes into the value.
           const csvLines: [number | string, string][] = []
+
+          // Keyed by mesh local id, which is what the mesh rows below are
+          // keyed by too. Computed from the scene rather than the geometry
+          // store: the same definition can be placed many times, and the
+          // multiset of those placements is the value.
+          const placements = placementDigests( extraction.scene )
 
           const csvPath       = `${outputPath}.csv`
           const csvFileHandle = await fsPromises.open( csvPath, 'w' )
 
-          await csvFileHandle.write( `ID,Hash,Type,Operand 1,Operand2,Void\n` )
+          await csvFileHandle.write(
+              `ID,Hash,Type,Operand 1,Operand2,Void,Placement\n` )
 
           for ( const mesh of model.geometry ) {
 
@@ -501,7 +518,13 @@ function doWork() {
             const typeName =
               element !== void 0 ? EntityTypesAP214[element.type] : ''
 
-            csvLines.push([rowID, `${rowID},${hash},${typeName},,,FALSE\n`])
+            // Empty for a definition the scene never placed; every placed
+            // definition has a hash, so identity placement and no placement
+            // stay distinguishable.
+            const placement = placements.get( mesh.localID ) ?? ''
+
+            csvLines.push(
+                [rowID, `${rowID},${hash},${typeName},,,FALSE,${placement}\n`])
           }
 
           for ( const [curveItem, objContents] of model.curves.objs() ) {
@@ -511,8 +534,10 @@ function doWork() {
 
             const rowID = curveItem.expressID ?? curveItem.toString()
 
+            // Curves are memoized per definition and never enter the scene
+            // graph, so they have no placement to report.
             csvLines.push([rowID,
-              `${rowID},${hash},${EntityTypesAP214[curveItem.type]},,,\n`])
+              `${rowID},${hash},${EntityTypesAP214[curveItem.type]},,,,\n`])
           }
 
           csvLines.sort( ( a, b ) => {


### PR DESCRIPTION
Fixes #583. Option 1 from the issue: a placement-aware column on the AP214 digest, existing columns unmoved.

> **Read this before reading CI.** Adding a column moves *every* AP214 baseline. `run-ifc-regression` will report digest churn on every STEP model in the smoke subset **by construction**, and that churn is unreadable by inspection — there is nothing to reconcile. The evidence below is the mapped-item fixture and a granularity sweep instead. The bless follows in the rc pass; it is not attempted here.

## The gap

The AP214 digest row was `ID,Hash,Type,Operand 1,Operand2,Void` — per geometry **definition**, with no placement transform in it. It is structurally blind to geometry that tessellates identically and then lands somewhere else, which is precisely what a change to walk order, transform-stack handling or assembly traversal risks. So "zero digest churn" on STEP has always been necessary-but-not-sufficient, and nothing in the harness said so.

Worth noting, because it changes how this reads: **`design/new/step-regression.md` already specified the fix and was not followed.** Its §"The digest" says in as many words that a per-entity, pre-assembly digest — the IFC approach ported verbatim — "would hash each sub-part's local geometry, see no change, and **pass while every part is collapsed onto the origin**". What shipped in `ap214_regression_main.ts` is exactly that. #583 is that warning coming true.

## What this adds

One column, `Placement`. Per geometry definition: SHA1 over the **sorted** set of `(occurrence path, absolute 4x4)` pairs of every instance of that definition in the scene, each matrix element rounded to 12 significant digits.

Carrying comparables, per the standing rule on field changes: the six existing columns do not move, so after the re-bless the two axes stay separable — a row that changes only in `Placement` is geometry that was **placed** differently; a row that changes only in `Hash` is geometry that was **tessellated** differently; the diff says which. A single post-transform hash (what the design doc originally specified) conflates them and would be a worse instrument. The choice is recorded in `design/new/step-regression.md` §"The placement column" and the column table is in `regression/README.md` §"Digest columns".

New file `src/AP214E3_2010/ap214_placement_digest.ts`; `ap214_regression_main.ts` gains an import, the header, one cell on mesh rows and one empty cell on curve rows. **Nothing in `ap214_geometry_extraction.ts`** — deliberately, given #580/#581 are live in that file.

### Departures from #582's parity hash, and why

This is #582's PR-local placement-aware parity hash promoted into the digest, with three changes:

- **No vertex/index buffers.** `Hash` already carries tessellation, so including them would fold two independent axes back into one — and `HEAPF32.slice()` of the SAB-backed heap in the pthreads build silently returns zero bytes (#584), so those bytes were not reliably in #582's hash to begin with.
- **Sorted, not in walk order.** #582 compared walk-order hashes because it had control of both sides. A baseline does not; see determinism below.
- **Keyed per definition, not one hash per model.** `step-regression.md` §"Determinism" worried that assembled geometry has no stable row key and recommended an unkeyed sorted hash set. Per definition there *is* a key — the expressID the row already carries — so the sort happens inside one cell instead of across the file, and localisation survives.

## Proof the fixture's digest moves and the old columns do not

`data/ap214-mapped-item-failure.step` with `extractMappedItem`'s `finally` reverted (the #582 mutation), against the same fixture on this branch as-is:

```
--- fixed                                          +++ transform leaking
ID,Hash,Type,Operand 1,Operand2,Void,Placement
15,5b4bb874…,MANIFOLD_SOLID_BREP,,,FALSE,74ed44c5…  15,5b4bb874…,MANIFOLD_SOLID_BREP,,,FALSE,b5a84947…
100015,5b4bb874…,…,,,FALSE,74ed44c5…                100015,5b4bb874…,…,,,FALSE,b5a84947…
200015,5b4bb874…,…,,,FALSE,74ed44c5…                200015,5b4bb874…,…,,,FALSE,b5a84947…
300015,5b4bb874…,…,,,FALSE,74ed44c5…                300015,5b4bb874…,…,,,FALSE,74ed44c5…
400015,5b4bb874…,…,,,FALSE,74ed44c5…                400015,5b4bb874…,…,,,FALSE,74ed44c5…
```

Five solids, `ID` / `Hash` / `Type` / `Operand 1` / `Operand2` / `Void` **byte-identical on every row** — the old digest is unchanged, as #583 says. `Placement` moves on exactly the three rows the leak reaches at the CLI's default granularity, which is also the "how far the leak reached depended on where the cut fell" behaviour #582 described.

## Determinism

The property the column exists for: it must not depend on walk scheduling, pump granularity or iteration order. Two kinds of evidence.

**Corpus sweep** — column recomputed at `demandItemsPerUnit ∈ {∞, 4, 1}`, `∞` reproducing the pre-#582 flattening. Every model `PLACEMENT-OK`; the unit counts differ so the agreement is not trivial:

| model | defs | placed instances | units at ∞ / 4 / 1 | column |
|---|---:|---:|---|---|
| `DSA2.step` | 57,348 | 57,348 | 1 / 254 / 254 | identical |
| `Arty_Z7.stp` | 5,161 | 6,816 | 55 / 603 / 1,159 | identical |
| `driver board.step` | 279 | 279 | 3 / 367 / 826 | identical |
| `Right_Hand.step` | 29 | 226 | 35 / 257 / 553 | identical |
| `NEMA 23 - 76mm.STEP` | 265 | 268 | 6 / 10 / 30 | identical |
| `Jetenginestep.stp` | 9 | 148 | 8 / 152 / 308 | identical |
| `Orbiter_v1.1_Gear_7.5.step` (private) | 54 | 124 | 14 / 82 / 184 | identical |
| `supercap.step` | 6 | 101 | 23 / 25 / 92 | identical |
| `as1-oc-214.stp` | 5 | 18 | 5 / 31 / 73 | identical |
| `nist_ctc_02_asme1_rc.stp` | 2 | 3 | 6 / 6 / 8 | identical |
| `nist_ctc_01_asme1_rd.stp` | 1 | 1 | 3 / 3 / 3 | identical |
| `create-a-tube.step` | 1 | 1 | 1 / 1 / 2 | identical |
| `data/ap214-mapped-item-failure.step` | 5 | 5 | 1 / 2 / 6 | identical |
| `data/ap214-sliced-item-ranges.step` | 3 | 3 | 1 / 1 / 4 | identical |

Run-to-run: `Right_Hand.step` gave the same column value across three separate processes × three granularities (9 measurements).

**Tests** — `ap214_placement_digest.test.ts`, 13 cases. Six real-fixture cases assert granularity and repeat-run agreement (each asserting the unit counts *differ* first, so the equality is not vacuous); seven pure cases pin sensitivity and invariance one property at a time against a stubbed scene, which no real fixture offers.

Every test was run against a deliberate mutation to prove it pins something (rubric 6):

| mutation | result |
|---|---|
| `records.sort()` removed | ✕ walk-order test only |
| occurrence path dropped from the record | ✕ occurrence-path test only |
| absolute transform dropped from the record | ✕ moved-instance, leading-placement, non-finite tests |
| records deduplicated before hashing | ✕ duplicate-instance test only |
| absent transform given its own token instead of identity | ✕ root-parented test only |
| none | ✓ all 13 |

**One honest caveat.** Order-invariance here is a property of how the column *aggregates* — sorting the records. The scene it reads is itself order-stable, which is #582's result rather than this PR's. `AP214SceneBuilder.addTransform` memoizes a transform node by localID, so if a shared placement were ever reached first through a different parent, the absolute transform it caches would differ — and this column would report that as churn. Correctly: the geometry really would have moved. That is the column doing its job, not a false positive.

## Cost

Measured two ways — the column's own time inside a digest run, and end-to-end CLI wall clock against a build with the column stubbed out:

| model | placed instances | column | digest run with / without |
|---|---:|---:|---|
| `DSA2.step` | 57,348 | 406–510 ms | 16.2 s / 15.5 s |
| `Arty_Z7.stp` | 6,816 | 52–87 ms | 60.6 s / 60.4 s (in the noise) |
| `driver board.step` | 279 | 3–5 ms | |
| every other corpus model | <300 | <12 ms | |

DSA2 is the corpus worst case and the only model where it is visible at all — one representation of 28,674 solids, every one a separate placed instance. ~3% of that model's digest run; under a second added to a full pass. (An 11.7 s outlier in the first sweep was runner contention — load average 8.5 with two other agents building — and did not reproduce: 3–7 ms on re-measure.)

## IFC

**Not applied, and I'd like a decision before it is.** `ifc_regression_main.ts` has the same blindness — it hashes `model.geometry` / `voidGeometry` / `curves` / `profiles` / `materials` per definition, with no transform in any row, so an IFC placement regression is invisible to it in exactly the same way. Left alone deliberately: the gap was found on STEP, an IFC column would move every IFC baseline on top of every STEP one in the same rc, and the IFC scene builder has no occurrence-path equivalent, so the value would have to be defined differently rather than reused. Worth its own issue, not this diff.

## Re-bless list

Nothing here is blessed; it runs from an `rc-*` tag. Precisely what moves:

**`test-models` — `regression/test_models/`:** 53 STEP digest CSVs, one per STEP model in the tree — `Arty_Z7`, `Assem_gearbox_v4 v3`, `DSA2`, `Equiptment_12mLSyringe`, `Equiptment_1mLSyringe`, `Equiptment_3mLSyringe`, `Equiptment_SyringePumpSystem`, `Equiptment_UltrasoundProbe`, `Jetenginestep`, `NEMA 23 - 76mm`, `Right_Hand`, `TestSetup_SimulatedSkull_WavePattern_4mmOffset_2mmAmplitude_10mmTall`, `TestSetup_UltrasoundTransducerScattering`, `a-gear`, `as1-oc-214`, `create-a-tube`, `driver board`, `supercap`, `supercap2`, `supercap3`, and the 33 `nist_ctc_*` / `nist_ftc_*` / `nist_stc_*` files — **plus `main.csv`** (54 STEP rows re-hashed; it still carries a stale `a-gear.stp` row alongside `a-gear.step`).

**`test-models-private` — `regression/test_models/`:** 10 STEP digest CSVs — `BLSN_007`, `DataAqBoardV1.1`, `DragonDirect`, `Orbiter_v1.1_Gear_7.5`, `Pixel_4a_Model`, `SapphieE3DV6_Upgrade`, `Sapphire_Plus_E3D_Mount`, `cg4-cylinder`, `cg4.5-cylinder`, `fangduct_v18` — **plus `main.csv`** (8 STEP rows; `cg4-cylinder` and `cg4.5-cylinder` have header-only baselines and no `main.csv` row, but their header line still changes).

**Not affected:** conway's own `regression/test_models/` and the Tier A goldens in `data/` are IFC-only.

## Verification, and the confounder in it

- `yarn lint`: 0 errors on the changed files. `ap214_regression_main.ts` carries 6 jsdoc/unused-disable warnings; that count is **unchanged** by this diff (6 before, 6 after).
- Full suite: **769 passed, 3 failed** — `ifc_trimmed_curve_unspecified.test.js` (2) and `ap214_geometry_extraction.test.js` `gearGeometryArrayLength` (1).

**Named rather than waved away, since it also bounds what my numbers mean:** those 3 failures are **not** from this diff and **not** from main being red — main's `build` is green at `89a49ea3`. They are an **engine-pin lag in my sandbox**. Main pins conway-geom `99e57cd2` (#578's bump); the checkout I built against is `4ae67268` with a `Dist` from Aug 20. Verified two ways: (a) the same 3 failures reproduce with this PR's source stashed and the tree rebuilt clean from `89a49ea3`, and (b) neither failing file is reachable from this diff — the new module's only importer is the regression CLI, which no test loads. CI builds the pinned submodule, so `build` should be green here; if it is not, that is the thing to look at, not these three.

Consequently every hash value quoted above was produced against `4ae67268`, not the pinned engine. That changes the *values* and none of the *claims*: the determinism sweep is an equality between runs on one engine, and the cost figures are the column's own time, neither of which the pin moves. The mapped-item before/after is likewise an A/B on one engine.