### PR TITLE
STEP NavTree dies with "Function not implemented." on any product with no name

### DIFF
--- a/.github/workflows/rc-regression.yml
+++ b/.github/workflows/rc-regression.yml
@@ -723,6 +723,24 @@ jobs:
           echo "Changed baseline files: ${CHANGED}" >> "$GITHUB_STEP_SUMMARY"
           git -c color.ui=never diff --stat -- regression/test_models benchmarks | tail -40 >> "$GITHUB_STEP_SUMMARY" || true
 
+      # The bless PR names the release it blesses, not just the ref that
+      # triggered it: on an `rc-*` tag the version is what the tag carries
+      # (`rc-1.564.1548` -> `1.564.1548`), and the short SHA disambiguates a
+      # version that gets re-cut after a bad rc. `workflow_dispatch` has no rc
+      # version at all — `ref_name` is a branch there ('main'), so it stands in
+      # for the version rather than leaving the title half-empty.
+      - name: Compose the re-bless label
+        id: rebless_label
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          case "$REF_NAME" in
+            rc-*) VERSION="${REF_NAME#rc-}" ;;
+            *)    VERSION="$REF_NAME" ;;
+          esac
+          echo "label=${VERSION} (${SHA:0:8})" >> "$GITHUB_OUTPUT"
+
       # Open (or update) a PR in the target repo with only the baseline diff.
       # add-paths scopes the commit to regression/test_models so nothing else
       # in the checkout (e.g. LFS smudge artifacts) can leak in.
@@ -739,8 +757,13 @@ jobs:
             benchmarks
           branch: rebless/${{ github.run_id }}
           base: main
-          commit-message: "Bless regression baselines (conway ${{ github.ref_name }} @ ${{ github.sha }})"
-          title: "Bless regression baselines: conway ${{ github.ref_name }}"
+          # Subject matches the PR title; the full ref and SHA stay in the body
+          # so nothing the old one-line message carried is lost.
+          commit-message: |
+            Bless regression baselines: ${{ steps.rebless_label.outputs.label }}
+
+            conway ${{ github.ref_name }} @ ${{ github.sha }}
+          title: "Bless regression baselines: ${{ steps.rebless_label.outputs.label }}"
           body: |
             Full-corpus digest regression for conway **`${{ github.ref_name }}`**
             ([`${{ github.repository }}@${{ github.sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }}),

--- a/data/ap214-unnamed-product-labels.step
+++ b/data/ap214-unnamed-product-labels.step
@@ -1,0 +1,43 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION (('AP214 fixture for NavTree labels on products with no PRODUCT.name. Modelled on the NIST PMI files, which leave PRODUCT.name empty and carry the part identity in PRODUCT.id instead - reading the DERIVED product_definition.name there threw out of resolveLabel and took the whole spatial structure with it. Three roots, none with a NAUO occurrence to borrow a name from: #710 has the identity on PRODUCT.id (nist_ctc_04_asme1_rd / nist_stc_08 shape), #720 has it only on PRODUCT_DEFINITION.id, and #730 has nothing anywhere but whitespace (nist_stc_09 / nist_ftc_09 shape).'),'2;1');
+FILE_NAME('ap214-unnamed-product-labels','2026-01-01T00:00:00',('test'),('bldrs'),'','','');
+FILE_SCHEMA(('AUTOMOTIVE_DESIGN { 1 0 10303 214 1 1 1 1 }'));
+ENDSEC;
+DATA;
+#1 = APPLICATION_PROTOCOL_DEFINITION('international standard','automotive_design',2010,#2);
+#2 = APPLICATION_CONTEXT('mechanical design');
+#10 = CARTESIAN_POINT('',(0.,0.,0.));
+#20 = DIRECTION('',(0.,0.,1.));
+#21 = DIRECTION('',(1.,0.,0.));
+#30 = AXIS2_PLACEMENT_3D('',#10,#20,#21);
+#100 = ( GEOMETRIC_REPRESENTATION_CONTEXT(3) GLOBAL_UNCERTAINTY_ASSIGNED_CONTEXT((#104)) GLOBAL_UNIT_ASSIGNED_CONTEXT((#101,#102,#103)) REPRESENTATION_CONTEXT('Context','3D') );
+#101 = ( LENGTH_UNIT() NAMED_UNIT(*) SI_UNIT(.MILLI.,.METRE.) );
+#102 = ( NAMED_UNIT(*) PLANE_ANGLE_UNIT() SI_UNIT($,.RADIAN.) );
+#103 = ( NAMED_UNIT(*) SI_UNIT($,.STERADIAN.) SOLID_ANGLE_UNIT() );
+#104 = UNCERTAINTY_MEASURE_WITH_UNIT(LENGTH_MEASURE(1.E-07),#101,'','');
+#600 = PRODUCT_CONTEXT('',#2,'mechanical');
+#601 = PRODUCT_DEFINITION_CONTEXT('part definition',#2,'design');
+/* Identity on PRODUCT.id only - the NIST PMI shape. */
+#700 = SHAPE_REPRESENTATION('',(#30),#100);
+#710 = PRODUCT('NIST PMI CTC 04 ASME1','','NIST PMI test model downloaded from http://go.usa.gov/mGVm',(#600));
+#711 = PRODUCT_DEFINITION_FORMATION_WITH_SPECIFIED_SOURCE('D',' ',#710,.NOT_KNOWN.);
+#712 = PRODUCT_DEFINITION('',' ',#711,#601);
+#713 = PRODUCT_DEFINITION_SHAPE('',' ',#712);
+#714 = SHAPE_DEFINITION_REPRESENTATION(#713,#700);
+/* Identity on PRODUCT_DEFINITION.id only. */
+#720 = SHAPE_REPRESENTATION('',(#30),#100);
+#721 = PRODUCT('','','',(#600));
+#722 = PRODUCT_DEFINITION_FORMATION('','',#721);
+#723 = PRODUCT_DEFINITION('BRACKET-REV-C','',#722,#601);
+#724 = PRODUCT_DEFINITION_SHAPE('','',#723);
+#725 = SHAPE_DEFINITION_REPRESENTATION(#724,#720);
+/* No identity anywhere: every candidate is empty or whitespace. */
+#730 = SHAPE_REPRESENTATION('',(#30),#100);
+#731 = PRODUCT('','','',(#600));
+#732 = PRODUCT_DEFINITION_FORMATION('','',#731);
+#733 = PRODUCT_DEFINITION('   ','   ',#732,#601);
+#734 = PRODUCT_DEFINITION_SHAPE('','',#733);
+#735 = SHAPE_DEFINITION_REPRESENTATION(#734,#730);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/AP214E3_2010/ap214_product_structure_extraction.test.ts
+++ b/src/AP214E3_2010/ap214_product_structure_extraction.test.ts
@@ -297,3 +297,45 @@ describe( 'AP214ProductStructureExtraction ephemeral solid layer', () => {
     expect( solids.map( ( solid ) => solid.name ) ).toEqual( [ 'Body1', 'Body2' ] )
   } )
 } )
+
+const UNNAMED_FIXTURE = 'data/ap214-unnamed-product-labels.step'
+const UNNAMED_ROOT_COUNT = 3
+
+describe( 'AP214ProductStructureExtraction labels for products with no name', () => {
+
+  // The regression itself. `product_definition.name` is a DERIVED attribute
+  // whose generated getter calls `get_name_value()`, an unimplemented stub that
+  // throws; resolveLabel used to end on it, so the first product that reached
+  // that line unwound extractProductStructure and Share got no NavTree at all
+  // for the model (red 'Error: Function not implemented.', tree collapsed to
+  // 'AuxScene > Object'). Every root in this fixture reaches that line.
+  test( 'yields a tree rather than throwing', () => {
+
+    expect( () => extractStructure( UNNAMED_FIXTURE ) ).not.toThrow()
+
+    expect( extractStructure( UNNAMED_FIXTURE ).length ).toBe( UNNAMED_ROOT_COUNT )
+  } )
+
+  test( 'falls back to the part number on PRODUCT.id', () => {
+
+    const [ root ] = extractStructure( UNNAMED_FIXTURE )
+
+    expect( root.name ).toBe( 'NIST PMI CTC 04 ASME1' )
+  } )
+
+  test( 'falls back to PRODUCT_DEFINITION.id when the product carries no id', () => {
+
+    const root = extractStructure( UNNAMED_FIXTURE )[1]
+
+    expect( root.name ).toBe( 'BRACKET-REV-C' )
+  } )
+
+  test( 'is empty, not whitespace, when the file names the product nowhere', () => {
+
+    const root = extractStructure( UNNAMED_FIXTURE )[2]
+
+    // '' lets a consumer substitute a type label; '   ' would render as a blank
+    // NavTree row. nist_stc_09_asme1_ap242-e3 is this case for real.
+    expect( root.name ).toBe( '' )
+  } )
+} )

--- a/src/AP214E3_2010/ap214_product_structure_extraction.ts
+++ b/src/AP214E3_2010/ap214_product_structure_extraction.ts
@@ -48,7 +48,11 @@ export interface ProductStructureNode {
    */
   type: string
 
-  /** Display label: `product.name`, falling back to the NAUO name / reference designator. */
+  /**
+   * Display label: `product.name`, falling back to the NAUO name / reference
+   * designator, then to the part number (`product.id` / `product_definition.id`).
+   * `''` when the file names the node nowhere.
+   */
   name: string
 
   /** Express id of the underlying `product_definition` (the part *type*). */
@@ -601,37 +605,99 @@ export class AP214ProductStructureExtraction {
   }
 
   /**
+   * Read one label candidate, treating anything unusable as absent.
+   *
+   * Every candidate below is a STEP string attribute, and the mandatory ones
+   * (`product.name`, `product.id`, `next_assembly_usage_occurrence.name`,
+   * `product_definition.id`) are extracted with `optional: false`, which
+   * throws `'Value in STEP was incorrectly typed'` when the slot actually
+   * holds `$` or a non-string — a shape exporters do emit. `formation` is an
+   * `extractElement` and can throw on a dangling reference the same way. A
+   * node label is cosmetic; a malformed one must never unwind
+   * {@link extractProductStructure} and cost the caller the entire tree, which
+   * is exactly what the derived-attribute read this replaced used to do.
+   *
+   * Whitespace-only counts as absent: the AP203 NIST files carry `' '` in
+   * `product_definition.description`, and a label of one space is not a label.
+   *
+   * @param read Thunk reading the candidate attribute.
+   * @return {string} The trimmed candidate, or `''` if it is absent, blank or
+   * unreadable.
+   */
+  private static labelCandidate( read: () => string | null | undefined ): string {
+
+    try {
+      return read()?.trim() ?? ''
+    } catch {
+      return ''
+    }
+  }
+
+  /**
    * Resolve a node label, preferring the product name, then the occurrence's
-   * own name / reference designator.
+   * own name / reference designator, then the part number (`product.id`).
+   *
+   * Deliberately never reads `product_definition.name`: that attribute is
+   * DERIVED in AP214, and its generated getter calls `get_name_value()` in
+   * `ap214_functions.ts`, an unimplemented stub that throws. It is not a real
+   * attribute of the entity at all — `product_definition` carries only `id`
+   * and `description` as strings — so that read could only ever throw, and did:
+   * it killed the whole NavTree for any file that got this far.
    *
    * @param productDef The product definition for the node.
    * @param occurrence The NAUO edge, when this is an occurrence node.
-   * @return {string} The best available human-readable label.
+   * @return {string} The best available human-readable label, or `''` when the
+   * file carries no usable identifier for the node.
    */
   private resolveLabel(
       productDef: product_definition,
       occurrence: next_assembly_usage_occurrence | undefined ): string {
 
-    const productName = productDef.formation?.of_product?.name
+    const productName =
+      AP214ProductStructureExtraction.labelCandidate(
+          () => productDef.formation?.of_product?.name )
 
-    if ( productName !== void 0 && productName.length > 0 ) {
+    if ( productName.length > 0 ) {
       return productName
     }
 
     if ( occurrence !== void 0 ) {
 
-      if ( occurrence.name.length > 0 ) {
-        return occurrence.name
+      const occurrenceName =
+        AP214ProductStructureExtraction.labelCandidate( () => occurrence.name )
+
+      if ( occurrenceName.length > 0 ) {
+        return occurrenceName
       }
 
-      const referenceDesignator = occurrence.reference_designator
+      const referenceDesignator =
+        AP214ProductStructureExtraction.labelCandidate( () => occurrence.reference_designator )
 
-      if ( referenceDesignator !== null && referenceDesignator.length > 0 ) {
+      if ( referenceDesignator.length > 0 ) {
         return referenceDesignator
       }
     }
 
-    return productDef.name ?? ''
+    // `product.id` is the part number, and it is where the NIST PMI files that
+    // leave `product.name` blank actually put the part identity
+    // ('NIST PMI CTC 04 ASME1'). It is tried ahead of `product_definition.id`
+    // because that one is the definition *discriminator*, not a part name —
+    // literally 'design' in nist_stc_06_asme1_ap242-e3 — and is empty in four
+    // of the six corpus models that reach this line.
+    const productId =
+      AP214ProductStructureExtraction.labelCandidate(
+          () => productDef.formation?.of_product?.id )
+
+    if ( productId.length > 0 ) {
+      return productId
+    }
+
+    // Neither entity's `description` is in the chain: it is prose, not an
+    // identifier. In the same corpus it is empty, whitespace, or the sentence
+    // 'NIST PMI test model downloaded from http://go.usa.gov/mGVm' — worse as a
+    // tree label than the empty string a consumer can substitute a type name
+    // for.
+    return AP214ProductStructureExtraction.labelCandidate( () => productDef.id )
   }
 
   /**


### PR DESCRIPTION
## Symptom

Loading `nist_ctc_04_asme1_rd.stp` in Share (1.564.1548 preview): a red
`Error: Function not implemented.` in the console, the NavTree collapsed to
`AuxScene > Object`, geometry rendering fine anyway. A reload looks normal
because the GLB cache hits and the STEP path never re-runs.

## Root cause — verified, not inferred

`resolveLabel()` in `src/AP214E3_2010/ap214_product_structure_extraction.ts`
ended on:

```ts
return productDef.name ?? ''
```

`name` is **not an attribute of `product_definition` in AP214** — the entity
carries only `id` (index 0) and `description` (index 1) as strings. `name` is
DERIVED, and its generated getter is `return get_name_value(this)`
(`AP214E3_2010_gen/product_definition.gen.ts:60`), where `get_name_value`
(`ap214_functions.ts:156`) is an unimplemented stub that throws. The `?? ''`
was unreachable: the getter threw, `extractProductStructure` unwound, and
`getSpatialStructure` failed for the whole model.

Captured against the real file:

```
THREW: Function not implemented.
    at get_name_value (ap214_functions.js:114)
    at get name (AP214E3_2010_gen/product_definition.gen.js:38)
    at AP214ProductStructureExtraction.resolveLabel (…:392)
    at AP214ProductStructureExtraction.buildNode (…:292)
    at AP214ProductStructureExtraction.extractProductStructure (…:109)
```

It only fires when every earlier branch misses — no `formation.of_product.name`,
and no occurrence with a `name` or `reference_designator` — i.e. exactly a
single-part file.

## The fix, and why this fallback

The chain now ends on real string attributes, **`product.id` before
`product_definition.id`**. Surveying every `product_definition` with a blank
`product.name` across the materialised public STEP corpus (54 models):

| model | `product.name` | `product.id` | `product_definition.id` |
|---|---|---|---|
| `nist_ctc_04_asme1_rd` | `''` | `NIST PMI CTC 04 ASME1` | `''` |
| `nist_ftc_08_asme1_rc` | `''` | `NIST PMI FTC 08 ASME1` | `''` |
| `nist_stc_08_asme1_ap242-e3` | `''` | `NIST PMI STC 08 ASME1` | `''` |
| `nist_stc_06_asme1_ap242-e3` | `''` | `nist_stc_06_asme1` | `design` |
| `nist_stc_09_asme1_ap242-e3` | `''` | `''` | `''` |
| `nist_ftc_09_asme1_ap242-e1` (×4) | `''` | `''` | `''` |

`product.id` is the part number and is where these files actually keep the
identity. `product_definition.id` is the definition *discriminator* — literally
`'design'` in `nist_stc_06_asme1_ap242-e3` — and is empty in four of the six.
So the suggested `product_definition.id` first would have produced `'design'`
for one model and `''` for four; it stays in the chain, but second.

**`description` is deliberately not in the chain.** It is prose, not an
identifier: in this same corpus it is empty, a single space, or
`'NIST PMI test model downloaded from http://go.usa.gov/mGVm'` — worse as a
tree label than the empty string a consumer can substitute a type name for.

**Every candidate now goes through a guarded read** (`labelCandidate`). These
are STEP string attributes extracted with `optional: false`, which throws
`'Value in STEP was incorrectly typed'` on a `$` or a non-string
(`step_entity_base.ts:329`), and `formation` is an `extractElement` that throws
on a dangling reference. A cosmetic label must not be able to cost the caller
the whole tree — which is the failure this PR fixes. Whitespace-only counts as
absent; the AP203 NIST files carry `' '` in `product_definition.description`.
Trimming changes no label anywhere in the corpus (checked: 0 values in the
public, private and in-repo fixtures differ from their trimmed form).

## What the NIST labels actually become

```
nist_ctc_04_asme1_rd.stp        [product] "NIST PMI CTC 04 ASME1"
nist_ftc_08_asme1_rc.stp        [product] "NIST PMI FTC 08 ASME1"
nist_stc_06_asme1_ap242-e3.stp  [product] "nist_stc_06_asme1"
nist_stc_08_asme1_ap242-e3.stp  [product] "NIST PMI STC 08 ASME1"
nist_stc_09_asme1_ap242-e3.stp  [product] ""
nist_ftc_09_asme1_ap242-e1.stp  [product] "" ×4
```

Four of six get a real name. The other two get `''` **because the files carry
nothing else** — `PRODUCT('','','',(#2))` and `PRODUCT_DEFINITION('','',…)`,
with zero NAUOs. There is nothing to recover there, and `''` is what lets Share
fall back to a type label. Flagging it rather than dressing it up.

## Verification

- **New tests** in `ap214_product_structure_extraction.test.ts` over a new
  hermetic fixture `data/ap214-unnamed-product-labels.step` (three roots, none
  with an occurrence to borrow a name from): the tree builds instead of
  throwing, `product.id` arm, `product_definition.id` arm, and the
  empty-not-whitespace case.
- **Revert-check:** with the source change reverted and the tests kept, all four
  fail with `Error message: "Function not implemented."` and the 13 pre-existing
  tests in the file still pass.
- **Suite:** `yarn precommit` green — 113 suites, 783 tests, eslint 0 errors.
- **Digests unchanged.** `resolveLabel` is reachable only from
  `AP214Properties.getSpatialStructure`, never from the regression batch. Run
  anyway, before/after with the source change as the only variable: the digest
  batch over the **full public STEP corpus (57 digest files)** and the **full
  private STEP corpus (14)** is byte-identical, `diff -r` clean. Repeated on the
  NIST subset under the published prebuilt wasm as a cross-check — also
  identical. No baselines need re-blessing for this PR.

## Second, unrelated change: bless PR titles carry the version and commit

`.github/workflows/rc-regression.yml` opened its baseline PR as
`Bless regression baselines: conway rc-1.564.1548`. Now:

| trigger | title |
|---|---|
| tag `rc-1.564.1548` | `Bless regression baselines: 1.564.1548 (3b5621e2)` |
| `workflow_dispatch` on `main` | `Bless regression baselines: main (3b5621e2)` |

A new `Compose the re-bless label` step derives the version from the tag
(`rc-*` stripped) and the short SHA from `github.sha`. `workflow_dispatch` has
no rc version at all, so `ref_name` stands in rather than emitting a
half-empty string. The commit subject now matches the title, with the full ref
and SHA moved to the message body so nothing the old one-line message carried
is lost.

## Note on the other throwing stubs

`ap214_functions.ts` has 13 of them, backing 54 derived getters across the
generated AP214 classes. I traced every one to see whether any other is on a
live load path — **none is**; details in a comment below. Nothing else changed
here.

## Expected inherited churn

`nist_ctc_02_asme1_rc.stp` and `Right_Hand.step` carry digest churn from main's
unblessed baseline lag. Not from this PR, not investigated here.


---
_Generated by [Claude Code](https://claude.ai/code/session_013RHVKvZN2erpMD7svDWALU)_