### PR TITLE
#546: classify absent reference-array entries so grid-placed products keep their preview retry

### DIFF
--- a/data/grid_placement_tail_axes.ifc
+++ b/data/grid_placement_tail_axes.ifc
@@ -1,0 +1,189 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('grid_placement_tail_axes.ifc','2026-08-26T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+/* Grid placement with the AXIS half of the placement chain written at the
+   TAIL of the DATA section (conway#546).
+
+   data/grid_placement.ifc covers what a grid placement RESOLVES TO. This
+   one covers what happens when it cannot resolve yet: it is laid out so a
+   mid-parse prefix that stops before the tail block reaches every product
+   and every grid placement, but none of the records the placement chain
+   bottoms out in. That is the layout conway#542 measured on real Archicad
+   and ST-DEVELOPER exports, narrowed to the hops of the grid chain that are
+   read through a REFERENCE ARRAY rather than a scalar field:
+
+     hop 2   IfcVirtualGridIntersection.IntersectingAxes    product #500
+     hop 4a  IfcPolyline.Points                             product #200
+     inverse IfcGrid.UAxes/VAxes/WAxes, via gridByAxis      product #1000
+
+   The third is not a forward hop of the closure at all. IfcGridAxis's route
+   back to its grid is the PartOfU/PartOfV/PartOfW INVERSE attributes, which
+   the generated layer does not carry, so extractGridPlacement finds the grid
+   by scanning every IfcGrid's axis lists (gridByAxis). Those lists are
+   reference arrays too, so a grid whose axes are still ahead of the parse
+   throws there — and the scan visits every grid, not just the one that owns
+   the axis, so ANY grid with an unscanned axis list blocks EVERY grid
+   placement in the file. Product #1000's own axes are fully in the head
+   precisely so it gets past hop 2 and hop 4a and reaches that scan.
+
+   Product #800 is the counterweight: its intersection names a record that
+   IS in the index and is NOT an IfcGridAxis, which is a property of the file
+   rather than of how much of it has been scanned. It must keep throwing
+   UNTAGGED however long the prefix grows, or the permanent-retry and
+   endless-preemption bug conway#543 fixed comes back.
+
+   Record counts are load-bearing, not incidental: the preview channel only
+   rebuilds a generation once the index has grown by GENERATION_GROWTH_FACTOR
+   (2x), so the tail block is deliberately larger than the head, and grid
+   #400 carries a realistic 8x8 of axes to get there. The counts are asserted
+   by the tests that read this file; see them for the current numbers. */
+#1=IFCPROJECT('0kF0kSTOX3ovkcpuOhkPrX',$,'GridTailAxes',$,$,$,$,(#20),#10);
+#10=IFCUNITASSIGNMENT((#11));
+#11=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#20=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-05,#21,$);
+#21=IFCAXIS2PLACEMENT3D(#22,$,$);
+#22=IFCCARTESIANPOINT((0.,0.,0.));
+/* Grid #100: axes and their axis curves are in the head, the curves' own
+   points are in the tail - so a prefix reaches IfcPolyline and stops. */
+#100=IFCGRID('1kF0kSTOX3ovkcpuOhkPrX',$,'HeadGrid',$,$,#101,$,(#110),(#130),$,.RECTANGULAR.);
+#101=IFCLOCALPLACEMENT($,#21);
+#110=IFCGRIDAXIS('A',#111,.T.);
+#111=IFCPOLYLINE((#112,#113));
+#130=IFCGRIDAXIS('1',#131,.T.);
+#131=IFCPOLYLINE((#132,#133));
+/* Product A - blocked at hop 4a, IfcPolyline.Points. */
+#200=IFCBUILDINGELEMENTPROXY('2kF0kSTOX3ovkcpuOhkPrX',$,'TailPoints',$,$,#201,#210,$,.NOTDEFINED.);
+#201=IFCGRIDPLACEMENT(#202,$);
+#202=IFCVIRTUALGRIDINTERSECTION((#110,#130),(0.,0.));
+#210=IFCPRODUCTDEFINITIONSHAPE($,$,(#211));
+#211=IFCSHAPEREPRESENTATION(#20,'Body','CSG',(#212));
+#212=IFCBLOCK(#21,1.,1.,1.);
+/* Grid #400: every one of its sixteen axes is in the tail, so a prefix
+   cannot read the intersection's axis list at all - and cannot complete
+   gridByAxis's scan either, which is what blocks product #1000. */
+#400=IFCGRID('4kF0kSTOX3ovkcpuOhkPrX',$,'TailGrid',$,$,#401,$,(#410,#411,#412,#413,#414,#415,#416,#417),(#420,#421,#422,#423,#424,#425,#426,#427),$,.RECTANGULAR.);
+#401=IFCLOCALPLACEMENT($,#21);
+/* Product B - blocked at hop 2, IfcVirtualGridIntersection.IntersectingAxes. */
+#500=IFCBUILDINGELEMENTPROXY('5kF0kSTOX3ovkcpuOhkPrX',$,'TailAxes',$,$,#501,#510,$,.NOTDEFINED.);
+#501=IFCGRIDPLACEMENT(#502,$);
+#502=IFCVIRTUALGRIDINTERSECTION((#410,#420),(0.,0.));
+#510=IFCPRODUCTDEFINITIONSHAPE($,$,(#511));
+#511=IFCSHAPEREPRESENTATION(#20,'Body','CSG',(#512));
+#512=IFCBLOCK(#21,1.,1.,1.);
+/* Product C - the counterweight. #900 is an IFCDIRECTION where an
+   IFCGRIDAXIS belongs, and it sits in the head with everything else, so
+   this is a typing defect in the file rather than a not-yet-scanned
+   reference. It must never enter the retry queue however long the index
+   grows.
+
+   #900 exists for this and is referenced by nothing else, deliberately.
+   StepModelBase.getTypedElementByLocalID skips its type check entirely
+   when the record has already been materialised by an UNTYPED read
+   ('element.entity' is returned before the check), so pointing this at a
+   record the rest of the file also uses would make the counterweight
+   depend on which pass touched it first - the whole-model walk would sail
+   past the type check and fail downstream instead. That leniency is
+   pre-existing and unrelated to conway#546; it reproduces identically on
+   'main' and is tracked as conway#606. */
+#800=IFCBUILDINGELEMENTPROXY('8kF0kSTOX3ovkcpuOhkPrX',$,'MistypedAxis',$,$,#801,#810,$,.NOTDEFINED.);
+#801=IFCGRIDPLACEMENT(#802,$);
+#802=IFCVIRTUALGRIDINTERSECTION((#900,#130),(0.,0.));
+#900=IFCDIRECTION((0.,1.));
+#810=IFCPRODUCTDEFINITIONSHAPE($,$,(#811));
+#811=IFCSHAPEREPRESENTATION(#20,'Body','CSG',(#812));
+#812=IFCBLOCK(#21,1.,1.,1.);
+/* Grid #600: entirely in the head, points included. Its only job is to let
+   product #1000 resolve its own intersection completely, so the only thing
+   left to block that product is gridByAxis's scan of grid #400. */
+#600=IFCGRID('6kF0kSTOX3ovkcpuOhkPrX',$,'ScannedGrid',$,$,#601,$,(#610),(#630),$,.RECTANGULAR.);
+#601=IFCLOCALPLACEMENT($,#21);
+#610=IFCGRIDAXIS('U',#611,.T.);
+#611=IFCPOLYLINE((#612,#613));
+#612=IFCCARTESIANPOINT((0.,0.));
+#613=IFCCARTESIANPOINT((1.,0.));
+#630=IFCGRIDAXIS('V',#631,.T.);
+#631=IFCPOLYLINE((#632,#633));
+#632=IFCCARTESIANPOINT((0.,0.));
+#633=IFCCARTESIANPOINT((0.,1.));
+/* Product D - past hop 2 and hop 4a, blocked on the gridByAxis scan. */
+#1000=IFCBUILDINGELEMENTPROXY('9kF0kSTOX3ovkcpuOhkPrX',$,'TailGridScan',$,$,#1001,#1010,$,.NOTDEFINED.);
+#1001=IFCGRIDPLACEMENT(#1002,$);
+#1002=IFCVIRTUALGRIDINTERSECTION((#610,#630),(0.,0.));
+#1010=IFCPRODUCTDEFINITIONSHAPE($,$,(#1011));
+#1011=IFCSHAPEREPRESENTATION(#20,'Body','CSG',(#1012));
+#1012=IFCBLOCK(#21,1.,1.,1.);
+/* ---- TAIL: everything below this line is what a mid-parse prefix misses. */
+#112=IFCCARTESIANPOINT((0.,0.));
+#113=IFCCARTESIANPOINT((1.,0.));
+#132=IFCCARTESIANPOINT((0.,0.));
+#133=IFCCARTESIANPOINT((0.,1.));
+#410=IFCGRIDAXIS('U1',#430,.T.);
+#411=IFCGRIDAXIS('U2',#431,.T.);
+#412=IFCGRIDAXIS('U3',#432,.T.);
+#413=IFCGRIDAXIS('U4',#433,.T.);
+#414=IFCGRIDAXIS('U5',#434,.T.);
+#415=IFCGRIDAXIS('U6',#435,.T.);
+#416=IFCGRIDAXIS('U7',#436,.T.);
+#417=IFCGRIDAXIS('U8',#437,.T.);
+#420=IFCGRIDAXIS('V1',#438,.T.);
+#421=IFCGRIDAXIS('V2',#439,.T.);
+#422=IFCGRIDAXIS('V3',#440,.T.);
+#423=IFCGRIDAXIS('V4',#441,.T.);
+#424=IFCGRIDAXIS('V5',#442,.T.);
+#425=IFCGRIDAXIS('V6',#443,.T.);
+#426=IFCGRIDAXIS('V7',#444,.T.);
+#427=IFCGRIDAXIS('V8',#445,.T.);
+#430=IFCPOLYLINE((#450,#451));
+#431=IFCPOLYLINE((#452,#453));
+#432=IFCPOLYLINE((#454,#455));
+#433=IFCPOLYLINE((#456,#457));
+#434=IFCPOLYLINE((#458,#459));
+#435=IFCPOLYLINE((#460,#461));
+#436=IFCPOLYLINE((#462,#463));
+#437=IFCPOLYLINE((#464,#465));
+#438=IFCPOLYLINE((#466,#467));
+#439=IFCPOLYLINE((#468,#469));
+#440=IFCPOLYLINE((#470,#471));
+#441=IFCPOLYLINE((#472,#473));
+#442=IFCPOLYLINE((#474,#475));
+#443=IFCPOLYLINE((#476,#477));
+#444=IFCPOLYLINE((#478,#479));
+#445=IFCPOLYLINE((#480,#481));
+#450=IFCCARTESIANPOINT((0.,0.));
+#451=IFCCARTESIANPOINT((1.,0.));
+#452=IFCCARTESIANPOINT((0.,1.));
+#453=IFCCARTESIANPOINT((1.,1.));
+#454=IFCCARTESIANPOINT((0.,2.));
+#455=IFCCARTESIANPOINT((1.,2.));
+#456=IFCCARTESIANPOINT((0.,3.));
+#457=IFCCARTESIANPOINT((1.,3.));
+#458=IFCCARTESIANPOINT((0.,4.));
+#459=IFCCARTESIANPOINT((1.,4.));
+#460=IFCCARTESIANPOINT((0.,5.));
+#461=IFCCARTESIANPOINT((1.,5.));
+#462=IFCCARTESIANPOINT((0.,6.));
+#463=IFCCARTESIANPOINT((1.,6.));
+#464=IFCCARTESIANPOINT((0.,7.));
+#465=IFCCARTESIANPOINT((1.,7.));
+#466=IFCCARTESIANPOINT((0.,0.));
+#467=IFCCARTESIANPOINT((0.,1.));
+#468=IFCCARTESIANPOINT((1.,0.));
+#469=IFCCARTESIANPOINT((1.,1.));
+#470=IFCCARTESIANPOINT((2.,0.));
+#471=IFCCARTESIANPOINT((2.,1.));
+#472=IFCCARTESIANPOINT((3.,0.));
+#473=IFCCARTESIANPOINT((3.,1.));
+#474=IFCCARTESIANPOINT((4.,0.));
+#475=IFCCARTESIANPOINT((4.,1.));
+#476=IFCCARTESIANPOINT((5.,0.));
+#477=IFCCARTESIANPOINT((5.,1.));
+#478=IFCCARTESIANPOINT((6.,0.));
+#479=IFCCARTESIANPOINT((6.,1.));
+#480=IFCCARTESIANPOINT((7.,0.));
+#481=IFCCARTESIANPOINT((7.,1.));
+ENDSEC;
+END-ISO-10303-21;

--- a/scripts/layout_report.mjs
+++ b/scripts/layout_report.mjs
@@ -64,11 +64,45 @@ const OPEN = 0x28
 const ZERO = 0x30
 const NINE = 0x39
 
-/* The placement CHAIN: what a placement resolves through, transitively. */
+/* The placement CHAIN: what a placement resolves through, transitively,
+ * AND what gates a product that references one directly. */
 const PLACEMENT_NAMES = new Set([
   'IFCLOCALPLACEMENT', 'IFCAXIS2PLACEMENT3D', 'IFCAXIS2PLACEMENT2D',
   'IFCCARTESIANPOINT', 'IFCDIRECTION', 'IFCGRIDPLACEMENT',
   'AXIS2_PLACEMENT_3D', 'AXIS2_PLACEMENT_2D', 'CARTESIAN_POINT', 'DIRECTION',
+])
+
+/* Types the closure expands THROUGH but which do not, by themselves, gate a
+ * product that merely references one. The grid chain below the placement,
+ * missing entirely until conway#546.
+ *
+ * IFCGRIDPLACEMENT was in the set above but nothing it references was, so
+ * the walk expanded exactly one hop and stopped at
+ * IFCVIRTUALGRIDINTERSECTION — never reaching the axes, their axis curves,
+ * or the points those bottom out in. The direction of that error is why it
+ * is worth naming: a closure that stops early makes a grid-placed product
+ * look usable SOONER than it is, so every curve below came out optimistic.
+ * The engine reads the whole chain — resolveVirtualGridIntersection walks
+ * IntersectingAxes, gridAxisLine reduces IfcGridAxis.AxisCurve to a segment
+ * of an IfcPolyline or an IfcLine.
+ *
+ * IFCVECTOR is here for the IfcLine arm alone: IfcLine.Dir is an IfcVector,
+ * which carries the IfcDirection. Curve types gridAxisLine does not reduce
+ * (IFCCIRCLE, IFCTRIMMEDCURVE, ...) are deliberately absent — the engine
+ * warns and drops the placement rather than resolving through them, so
+ * expanding them here would model a chain that is never walked.
+ *
+ * Separate from the set above because an IFCGRID references its own axes,
+ * and an IfcGrid is itself a placed product. Folding these in there made
+ * every grid look as if it could not be emitted until its axis points were
+ * scanned — which the engine does not require, since a grid places off its
+ * own IfcLocalPlacement and carries no representation. Measured on a
+ * grid-plus-swept-polyline control: with them folded in, the grid product's
+ * usable-at moved a whole decile later and the blocker attribution changed;
+ * split like this the same file reports byte-identically to before. */
+const PLACEMENT_CHAIN_ONLY_NAMES = new Set([
+  'IFCVIRTUALGRIDINTERSECTION', 'IFCGRIDAXIS', 'IFCPOLYLINE', 'IFCLINE',
+  'IFCVECTOR',
 ])
 
 /* What makes a record a PRODUCT for this purpose, as opposed to a geometry
@@ -311,6 +345,9 @@ function report(path) {
   })
   const offsetOf = new Uint32Array(maxId + 1)
   const isPlacement = new Uint8Array(maxId + 1)
+  /* The subset of isPlacement that gates a product REFERENCING it. See
+   * PLACEMENT_CHAIN_ONLY_NAMES for why the two differ. */
+  const gatesProduct = new Uint8Array(maxId + 1)
   const isProductPlacement = new Uint8Array(maxId + 1)
   const isLeaf = new Uint8Array(maxId + 1)
   let leafBytes = 0
@@ -334,8 +371,11 @@ function report(path) {
       typeIndex.set(name, slot)
     }
     typeOf[id] = slot
-    if (PLACEMENT_NAMES.has(name)) {
+    if (PLACEMENT_NAMES.has(name) || PLACEMENT_CHAIN_ONLY_NAMES.has(name)) {
       isPlacement[id] = 1
+    }
+    if (PLACEMENT_NAMES.has(name)) {
+      gatesProduct[id] = 1
     }
     if (PRODUCT_PLACEMENT_NAMES.has(name)) {
       isProductPlacement[id] = 1
@@ -483,7 +523,7 @@ function report(path) {
       if (isProductPlacement[ref] === 1) {
         hasPlacement = true
       }
-      if (isPlacement[ref] === 1) {
+      if (gatesProduct[ref] === 1) {
         const chainAt = placementResolveAt[ref]
         if (chainAt > placementAt) {
           placementAt = chainAt
@@ -497,7 +537,7 @@ function report(path) {
       for (let s = 0; s < SHARD_COUNTS.length; ++s) {
         const p = Math.max(
             bandProgress(at, SHARD_COUNTS[s]),
-            isPlacement[ref] === 1 ? shardChainProgress[s][ref] : 0)
+            gatesProduct[ref] === 1 ? shardChainProgress[s][ref] : 0)
         if (p > shardReady[s]) {
           shardReady[s] = p
         }

--- a/src/compat/web-ifc/ifc_api_preview_channel.test.ts
+++ b/src/compat/web-ifc/ifc_api_preview_channel.test.ts
@@ -157,6 +157,25 @@ describe( 'ColumnarIndexSink.snapshot', () => {
   } )
 } )
 
+/* data/grid_placement_tail_axes.ifc, by construction — see that file's
+ * header comment. Exact rather than "greater than": the fixture is
+ * synthetic and committed alongside this test, and the counts are what pin
+ * that the MISTYPED product did not get retried with the three that should
+ * have. */
+const GRID_TAIL_GRIDS = 3
+const GRID_TAIL_DEFERRING = 4
+
+/* The deferrals a longer prefix can fix: #200 on IfcPolyline.Points, #500
+ * on IfcVirtualGridIntersection.IntersectingAxes, and #1000 on the
+ * IfcGrid.UAxes read inside gridByAxis. All three are reference arrays.
+ * #800 is mistyped and must stay out of this count. */
+const GRID_TAIL_RETRYABLE = 3
+
+/* One unit per tick (tickMaxAttempts_ = 1), so a generation of seven needs
+ * at least seven; a few spare so the assertions are about the channel. */
+const GRID_TAIL_TICKS_TO_EXHAUST = 16
+
+
 describe( 'StreamedPreviewChannel', () => {
 
   test( 'a full drain reproduces the classic instance set exactly', async () => {
@@ -655,6 +674,101 @@ describe( 'StreamedPreviewChannel', () => {
 
     expect( payloads.length ).toBeGreaterThan( 0 )
     expect( channel.previewYield.firstMeshMs ).toBeGreaterThanOrEqual( 0 )
+
+    channel.stop()
+  }, 240000 )
+
+
+  test( 'a grid-placed product blocked on a reference array is retried', () => {
+
+    // The resident twin of the store channel's conway#546 test — the two
+    // channels carry independent copies of the deferral catch
+    // (streamed_preview_channel.ts:322 against store_preview_channel.ts:498),
+    // so a classification fix has to be demonstrated on both or half of it
+    // is untested.
+    //
+    // data/grid_placement_tail_axes.ifc writes the reference-array hops of
+    // a grid placement chain after the products that need them:
+    // IfcPolyline.Points (#200), IfcVirtualGridIntersection.IntersectingAxes
+    // (#500), and IfcGrid.UAxes as read by gridByAxis's inverse scan
+    // (#1000). Product #800 is the counterweight — its intersection names
+    // an IFCDIRECTION where an IFCGRIDAXIS belongs, which no amount of
+    // extra parse can fix.
+    const text =
+      fs.readFileSync( 'data/grid_placement_tail_axes.ifc', 'utf8' )
+    const lines = text.split( '\n' )
+    const tailAt = lines.findIndex( ( line ) => line.startsWith( '/* ---- TAIL' ) )
+
+    expect( tailAt ).toBeGreaterThan( 0 )
+
+    const prefixText =
+      `${lines.slice( 0, tailAt ).join( '\n' )}\nENDSEC;\nEND-ISO-10303-21;\n`
+    const prefixBytes = new Uint8Array( Buffer.from( prefixText, 'latin1' ) )
+    const fullBytes = new Uint8Array( Buffer.from( text, 'latin1' ) )
+
+    const sink = new ColumnarIndexSink<EntityTypesIfc>()
+    const payloads: PreviewMeshPayload[] = []
+
+    // The source buffer is the WHOLE file throughout, as it is on a
+    // resident open — only the index grows.
+    const channel = new StreamedPreviewChannel(
+        fullBytes, conwayGeometry, sink, ifcPreviewAdapter(), true,
+        ( mesh ) => payloads.push( mesh ), void 0, void 0, 1 )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = channel as any
+
+    internals.tickBudgetMs_ = Number.MAX_SAFE_INTEGER
+    internals.tickMaxAttempts_ = 1
+
+    expect( buildIndexStreaming(
+        new BufferByteSource( prefixBytes ),
+        IfcStepParser.Instance,
+        POOL,
+        void 0,
+        sink ).result ).toBe( ParseResult.COMPLETE )
+
+    for ( let tick = 0; tick < GRID_TAIL_TICKS_TO_EXHAUST; ++tick ) {
+      internals.lastInlineTick_ = 0
+      channel.maybeTickInline()
+    }
+
+    const afterPrefix = channel.previewYield
+
+    expect( afterPrefix.emitted ).toBe( GRID_TAIL_GRIDS )
+    expect( afterPrefix.deferred ).toBe( GRID_TAIL_DEFERRING )
+
+    // THE assertion, and it reads 0 without the fix: all three array hops
+    // are records that had simply not been scanned yet, and the fourth
+    // deferral — the mistyped one — must stay out of the retry queue.
+    expect( afterPrefix.deferredOnPlacement ).toBe( GRID_TAIL_RETRYABLE )
+    expect( afterPrefix.retried ).toBe( 0 )
+    expect( payloads ).toHaveLength( 0 )
+
+    sink.reset()
+
+    expect( buildIndexStreaming(
+        new BufferByteSource( fullBytes ),
+        IfcStepParser.Instance,
+        POOL,
+        void 0,
+        sink ).result ).toBe( ParseResult.COMPLETE )
+
+    for ( let tick = 0; tick < GRID_TAIL_TICKS_TO_EXHAUST; ++tick ) {
+      internals.lastInlineTick_ = 0
+      channel.maybeTickInline()
+    }
+
+    const afterFull = channel.previewYield
+
+    expect( afterFull.retried ).toBe( GRID_TAIL_RETRYABLE )
+    expect( afterFull.emitted ).toBe( GRID_TAIL_GRIDS + GRID_TAIL_RETRYABLE )
+    expect( payloads ).toHaveLength( GRID_TAIL_RETRYABLE )
+    expect( payloads.every( ( p ) => p.vertexData !== void 0 ) ).toBe( true )
+
+    // And the mistyped product never joined them.
+    expect( afterFull.deferredOnPlacement ).toBe( GRID_TAIL_RETRYABLE )
+    expect( afterFull.deferred ).toBe( GRID_TAIL_DEFERRING )
 
     channel.stop()
   }, 240000 )

--- a/src/compat/web-ifc/store_preview_channel.test.ts
+++ b/src/compat/web-ifc/store_preview_channel.test.ts
@@ -17,6 +17,28 @@ import { StorePreviewChannel } from './store_preview_channel'
 import type { PreviewMeshPayload } from './streamed_preview_channel'
 
 
+/* data/grid_placement_tail_axes.ifc, by construction — see that file's
+ * header comment for which record is which. Exact rather than "greater
+ * than": the fixture is synthetic and committed alongside this test, and
+ * the counts are what pin that the MISTYPED product did not get retried
+ * along with the three that should have. */
+const GRID_TAIL_PRODUCTS = 7
+const GRID_TAIL_GRIDS = 3
+const GRID_TAIL_DEFERRING = 4
+
+/* The deferrals a longer prefix can fix: product #200 on IfcPolyline.Points,
+ * #500 on IfcVirtualGridIntersection.IntersectingAxes, and #1000 on the
+ * IfcGrid.UAxes read inside gridByAxis. All three are reference arrays, and
+ * before conway#546 none of them classified. The fourth deferral, #800, is
+ * mistyped and must stay out of this count. */
+const GRID_TAIL_RETRYABLE = 3
+
+/* One product per tick (tickMaxAttempts_ = 1), so a generation of seven
+ * needs at least seven; a few spare so the assertions are about the
+ * channel rather than about arithmetic. */
+const TICKS_TO_EXHAUST = 16
+
+
 describe( 'StorePreviewChannel', () => {
 
   let conwayGeometry: ConwayGeometry
@@ -217,6 +239,126 @@ describe( 'StorePreviewChannel', () => {
     // one missing holds this at zero.
     expect( afterFull.retried ).toBeGreaterThan( 0 )
     expect( afterFull.emitted ).toBeGreaterThan( 0 )
+
+    channel.stop()
+  }, 120000 )
+
+
+  test( 'a grid-placed product blocked on a reference array is retried',
+      async () => {
+
+    // conway#546, the store half. The sibling test above covers the SCALAR
+    // hops of a placement chain; this one covers the hops of a grid
+    // placement that are read through a REFERENCE ARRAY, which #543's
+    // classification narrowing left untagged:
+    //
+    //   hop 2    IfcVirtualGridIntersection.IntersectingAxes   product #500
+    //   hop 4a   IfcPolyline.Points                           product #200
+    //   inverse  IfcGrid.UAxes, inside gridByAxis             product #1000
+    //
+    // The third is not a forward hop at all: IfcGridAxis has no schema route
+    // back to its grid, so extractGridPlacement scans every IfcGrid's axis
+    // lists. Product #1000's own intersection resolves completely off the
+    // prefix, so that scan is the only thing left to block it.
+    //
+    // Before the fix all three threw a bare untagged Error out of the
+    // generated array getter, extractPlacementStrict_ had nothing to re-tag,
+    // and the forward-only unit cursor meant none of them could ever preview.
+    const text =
+      fs.readFileSync( 'data/grid_placement_tail_axes.ifc', 'utf8' )
+    const lines = text.split( '\n' )
+    const tailAt = lines.findIndex( ( line ) => line.startsWith( '/* ---- TAIL' ) )
+
+    expect( tailAt ).toBeGreaterThan( 0 )
+
+    const prefixText =
+      `${lines.slice( 0, tailAt ).join( '\n' )}\nENDSEC;\nEND-ISO-10303-21;\n`
+    const prefixBytes = new Uint8Array( Buffer.from( prefixText, 'latin1' ) )
+    const fullBytes = new Uint8Array( Buffer.from( text, 'latin1' ) )
+
+    const store = new InMemoryStepByteStore( fullBytes )
+    const sink = new ColumnarIndexSink< number >()
+    const payloads: PreviewMeshPayload[] = []
+
+    const channel = new StorePreviewChannel(
+        store, sink, conwayGeometry, true, ( mesh ) => payloads.push( mesh ),
+        64, 48 * 1024 * 1024, 1 )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = channel as any
+
+    internals.tickBudgetMs_ = Number.MAX_SAFE_INTEGER
+    internals.tickMaxAttempts_ = 1
+
+    expect( buildIndexStreaming(
+        new BufferByteSource( prefixBytes ),
+        IfcStepParser.Instance,
+        4 * 1024,
+        void 0,
+        sink ).result ).toBe( ParseResult.COMPLETE )
+
+    // Enough ticks to run the whole generation out: this fixture is small
+    // enough to exhaust, so the rebuild below comes through the
+    // exhaustion arm rather than preemption (which the sibling test
+    // already pins).
+    for ( let tick = 0; tick < TICKS_TO_EXHAUST; ++tick ) {
+      internals.lastInlineTick_ = 0
+      await channel.maybeTickAsync()
+    }
+
+    const afterPrefix = channel.previewYield
+
+    // Three grids place fine off their own IfcLocalPlacement and carry no
+    // geometry; the four proxies all defer.
+    expect( channel.productCount ).toBe( GRID_TAIL_PRODUCTS )
+    expect( afterPrefix.emitted ).toBe( GRID_TAIL_GRIDS )
+    expect( afterPrefix.deferred ).toBe( GRID_TAIL_DEFERRING )
+
+    // THE assertion. Three of the four deferrals are reference-array hops
+    // that had simply not been scanned yet, and all three must now be
+    // classified — this reads 0 without the fix. The fourth is product
+    // #800, whose intersection names an IFCDIRECTION where an IFCGRIDAXIS
+    // belongs: indexed, wrong, and unfixable by more parsing, so it must
+    // NOT be classified or the endless-preemption bug #543 fixed returns.
+    expect( afterPrefix.deferredOnPlacement ).toBe( GRID_TAIL_RETRYABLE )
+    expect( afterPrefix.retried ).toBe( 0 )
+
+    // Exactly nothing, not merely no geometry. The fixture has no spatial
+    // containment (no site, no storey), so the prefix-generation spatial
+    // walk conway#518 added has no plate to emit either — asserting the
+    // whole stream is empty is strictly stronger than filtering it.
+    expect( payloads ).toHaveLength( 0 )
+
+    // Stage two: the reset-and-replay the streaming builder performs when
+    // it grows its window, so top-level localIDs stay in dense parse order
+    // and the deferred ids the channel holds still mean what they meant.
+    sink.reset()
+
+    expect( buildIndexStreaming(
+        new BufferByteSource( fullBytes ),
+        IfcStepParser.Instance,
+        4 * 1024,
+        void 0,
+        sink ).result ).toBe( ParseResult.COMPLETE )
+
+    for ( let tick = 0; tick < TICKS_TO_EXHAUST; ++tick ) {
+      internals.lastInlineTick_ = 0
+      await channel.maybeTickAsync()
+    }
+
+    const afterFull = channel.previewYield
+
+    // All three come back through the retry queue and become pixels.
+    // `retried` rather than the mesh count alone is what separates this
+    // from a channel that merely got lucky on a later generation.
+    expect( afterFull.retried ).toBe( GRID_TAIL_RETRYABLE )
+    expect( afterFull.emitted ).toBe( GRID_TAIL_GRIDS + GRID_TAIL_RETRYABLE )
+    expect( payloads ).toHaveLength( GRID_TAIL_RETRYABLE )
+    expect( payloads.every( ( p ) => p.vertexData !== void 0 ) ).toBe( true )
+
+    // And the mistyped one never joined them, however long the index got.
+    expect( afterFull.deferredOnPlacement ).toBe( GRID_TAIL_RETRYABLE )
+    expect( afterFull.deferred ).toBe( GRID_TAIL_DEFERRING )
 
     channel.stop()
   }, 120000 )

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -52,7 +52,10 @@ import {
 } from '../../dependencies/conway-geom'
 import { Uint32Sink } from '../step/parsing/uint32_sink'
 import { StepBufferNotResidentError } from '../step/step_buffer_provider'
-import { DanglingReferenceError } from '../step/dangling_reference_error'
+import {
+  DanglingReferenceError,
+  unresolvedReferenceError,
+} from '../step/dangling_reference_error'
 import { DanglingPlacementError } from './dangling_placement_error'
 import { CanonicalMaterial, ColorRGBA, exponentToRoughness } from '../core/canonical_material'
 import { CanonicalMesh, CanonicalMeshType } from '../core/canonical_mesh'
@@ -8083,11 +8086,19 @@ export class IfcGeometryExtraction {
 
     if ( relatedObject === void 0 ) {
 
-      // What the getter does with the same entry: extractBufferElement
-      // returns undefined for a reference that resolves to nothing (or to
-      // something that is not an IfcObjectDefinition) and the getter throws
-      // this exact message.
-      throw new Error( 'Value in STEP was incorrectly typed' )
+      // What the getter does with the same entry, and it has to STAY what
+      // the getter does: `extractBufferElement` now classifies an entry it
+      // cannot resolve rather than returning undefined for the caller to
+      // throw over (conway#546), so mirroring the old bare Error here would
+      // have quietly broken the correspondence this method exists to keep.
+      //
+      // Behaviour-neutral on today's paths: all three callers catch
+      // permissively (`instanceof Error`, or a bare catch that breaks the
+      // loop) and none discriminates on DanglingReferenceError, so this
+      // changes the message a prefix read logs and nothing else. Recorded
+      // rather than mutation-verified, for the same reason the #536 review
+      // left this fallback un-verified.
+      throw unresolvedReferenceError( this.model, relatedExpressID )
     }
 
     return relatedObject instanceof IfcProduct ? relatedObject : void 0

--- a/src/scripts/layout_report_grid_closure.test.ts
+++ b/src/scripts/layout_report_grid_closure.test.ts
@@ -1,0 +1,200 @@
+import { execFileSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
+
+
+/**
+ * `scripts/layout_report.mjs`'s placement closure, over the grid chain
+ * (conway#546).
+ *
+ * The script is the static analyser that produced conway#542's published
+ * per-file "products deferring" percentages. It walks a product's placement
+ * closure transitively and reports, per prefix, how many products could be
+ * emitted — and which record arrived last in the chain that blocked the
+ * rest. `IFCGRIDPLACEMENT` was in its `PLACEMENT_NAMES` set but nothing that
+ * a grid placement references was, so the walk expanded exactly ONE hop and
+ * stopped at `IFCVIRTUALGRIDINTERSECTION`, never reaching the axes, their
+ * axis curves, or the points those bottom out in.
+ *
+ * **The direction of that error is what makes it worth a test.** A closure
+ * that stops early makes a grid-placed product look usable SOONER than it
+ * is, so the deferral and sharded-readiness curves came out optimistic — a
+ * silently flattering number, which is the same failure mode as the
+ * fixed-point defect codex found in round 2 of #543.
+ *
+ * Driven through the CLI rather than by import: the script's module body
+ * runs the whole tool on `process.argv`, so importing it under Jest would
+ * hand it Jest's own arguments. `render_glb_paths.test.ts` drives
+ * `scripts/render_glb.cjs` the same way.
+ */
+
+/* The report's blocker block, verbatim enough to slice on. */
+const BLOCKER_HEADING = 'deferred by (last record in the chain to arrive):'
+
+/* data/grid_placement_tail_axes.ifc, by construction. Three of its four
+ * deferring proxies bottom out in an axis polyline's points, which is what
+ * the extended closure now reaches. */
+const GRID_TAIL_LEAF_BLOCKED = 3
+
+/* The one that does NOT: product #1000, whose engine-side blocker is an
+ * INVERSE lookup the forward closure structurally cannot follow. See the
+ * residual test below. */
+const GRID_TAIL_INVERSE_BLOCKED = 1
+
+
+/**
+ * Run the report and return everything below the blocker heading.
+ *
+ * @param file The model to report on.
+ * @return The blocker attribution lines, or '' when there are none.
+ */
+function blockerBlock(file: string): string {
+
+  const script = path.resolve(process.cwd(), 'scripts/layout_report.mjs')
+  const out =
+    execFileSync(process.execPath, [script, file], { stdio: 'pipe' }).toString()
+
+  const at = out.indexOf(BLOCKER_HEADING)
+
+  return at < 0 ? '' : out.slice(at + BLOCKER_HEADING.length)
+}
+
+
+describe('layout_report grid-placement closure', () => {
+
+  let workDir: string
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'layout-report-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true })
+  })
+
+  test('the closure runs past the intersection to the axis leaf points', () => {
+
+    // The fixture writes the axis chain after the products that need it, so
+    // on a leading prefix every grid-placed product is blocked and the
+    // report has to say WHICH record it is blocked on. Before conway#546 the
+    // walk stopped at IFCVIRTUALGRIDINTERSECTION and attributed all four to
+    // it — which is the report saying "these are ready once the intersection
+    // is scanned", exactly the optimistic claim, since an intersection is
+    // useless without the axes it names.
+    const blockers = blockerBlock('data/grid_placement_tail_axes.ifc')
+
+    // What actually arrives last for three of them: the axis polylines'
+    // points. conway#542 measured that the last record in a blocked chain is
+    // a leaf on 100% of the corpus files that defer, and this is the grid
+    // spelling of it.
+    expect(blockers).toMatch(
+        new RegExp(`\\s${GRID_TAIL_LEAF_BLOCKED}\\s+\\(\\s*\\d+%\\)\\s+IFCCARTESIANPOINT`))
+  })
+
+  test('the inverse gridByAxis dependency is a known, unmodelled residual', () => {
+
+    // Deliberately pinning a GAP, so it cannot be quietly forgotten and so
+    // the follow-up that closes it fails here rather than passing silently.
+    //
+    // extractGridPlacement resolves the intersection and then calls
+    // gridByAxis, which scans EVERY IfcGrid's UAxes/VAxes/WAxes because
+    // IfcGridAxis carries no schema route back to its grid (PartOfU/V/W are
+    // INVERSE attributes the generated layer drops). Those lists are
+    // reference arrays, so conway#546 classifies their throw too — meaning
+    // the engine additionally requires every IfcGrid record AND its axis
+    // lists to be indexed before ANY grid placement resolves.
+    //
+    // This walker cannot see that. Its closure runs forward from a product
+    // through the records it references, and a product never references the
+    // grid — the grid references the axis, not the reverse. So product
+    // #1000, whose own intersection and axis curves are entirely inside the
+    // prefix, is reported as blocked only on its own intersection record,
+    // while the engine holds it until grid #400's axis list arrives at the
+    // tail. The report is therefore still OPTIMISTIC for it, in the same
+    // silently-flattering direction conway#546 exists to correct.
+    //
+    // Closing this needs an inverse pass (grid -> axes) rather than another
+    // entry in a type set, which is why it is tracked separately.
+    const blockers = blockerBlock('data/grid_placement_tail_axes.ifc')
+
+    expect(blockers).toMatch(
+        new RegExp(`\\s${GRID_TAIL_INVERSE_BLOCKED}\\s+\\(\\s*\\d+%\\)\\s+IFCVIRTUALGRIDINTERSECTION`))
+  })
+
+  test('a grid nothing is placed against does not gate its own product', () => {
+
+    // The counterweight, and the reason the grid types live in their own
+    // set rather than in PLACEMENT_NAMES. An IFCGRID references its axes
+    // and is itself a placed product, so folding the axis chain into the
+    // set that gates a REFERENCING product made every grid look unusable
+    // until its axis points were scanned. The engine requires no such
+    // thing: a grid places off its own IfcLocalPlacement and carries no
+    // representation.
+    //
+    // The polyline here is the shape the corpus actually has thousands of
+    // — a swept-solid profile curve — and it must stay off the placement
+    // closure too.
+    const file = path.join(workDir, 'polyline_no_grid_placement.ifc')
+
+    fs.writeFileSync(file, [
+      'ISO-10303-21;',
+      'HEADER;',
+      'FILE_DESCRIPTION((\'\'),\'2;1\');',
+      'FILE_NAME(\'n.ifc\',\'2026-01-01T00:00:00\',(\'\'),(\'\'),\'\',\'\',\'\');',
+      'FILE_SCHEMA((\'IFC4\'));',
+      'ENDSEC;',
+      'DATA;',
+      '#1=IFCPROJECT(\'0kF0kSTOX3ovkcpuOhkPrX\',$,\'N\',$,$,$,$,(#20),#10);',
+      '#10=IFCUNITASSIGNMENT((#11));',
+      '#11=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);',
+      '#20=IFCGEOMETRICREPRESENTATIONCONTEXT($,\'Model\',3,1.0E-05,#21,$);',
+      '#21=IFCAXIS2PLACEMENT3D(#22,$,$);',
+      '#22=IFCCARTESIANPOINT((0.,0.,0.));',
+      '#23=IFCDIRECTION((0.,0.,1.));',
+      // A grid with a polyline axis and a line axis. No product is placed
+      // against it, so none of this is on any placement closure.
+      '#100=IFCGRID(\'1kF0kSTOX3ovkcpuOhkPrX\',$,\'G\',$,$,#101,$,(#110),(#130),$,.RECTANGULAR.);',
+      '#101=IFCLOCALPLACEMENT($,#21);',
+      '#110=IFCGRIDAXIS(\'A\',#111,.T.);',
+      '#111=IFCPOLYLINE((#112,#113));',
+      '#112=IFCCARTESIANPOINT((0.,0.));',
+      '#113=IFCCARTESIANPOINT((1.,0.));',
+      '#130=IFCGRIDAXIS(\'1\',#131,.T.);',
+      '#131=IFCLINE(#132,#134);',
+      '#132=IFCCARTESIANPOINT((0.,0.));',
+      // The axis leaf that only an over-broad closure reaches, and it is
+      // written LAST so an over-broad walk would name it as the blocker.
+      '#134=IFCVECTOR(#135,1.);',
+      // An ordinary local-placed product whose GEOMETRY uses a polyline.
+      '#200=IFCBUILDINGELEMENTPROXY(\'2kF0kSTOX3ovkcpuOhkPrX\',$,\'S\',$,$,#201,#210,$,.NOTDEFINED.);',
+      '#201=IFCLOCALPLACEMENT($,#202);',
+      '#202=IFCAXIS2PLACEMENT3D(#203,$,$);',
+      '#203=IFCCARTESIANPOINT((1.,2.,3.));',
+      '#210=IFCPRODUCTDEFINITIONSHAPE($,$,(#211));',
+      '#211=IFCSHAPEREPRESENTATION(#20,\'Body\',\'SweptSolid\',(#212));',
+      '#212=IFCEXTRUDEDAREASOLID(#213,#21,#23,2.);',
+      '#213=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#214);',
+      '#214=IFCPOLYLINE((#215,#216,#217,#215));',
+      '#215=IFCCARTESIANPOINT((0.,0.));',
+      '#216=IFCCARTESIANPOINT((1.,0.));',
+      '#217=IFCCARTESIANPOINT((1.,1.));',
+      '#135=IFCDIRECTION((0.,1.));',
+      'ENDSEC;',
+      'END-ISO-10303-21;',
+      '',
+    ].join('\n'))
+
+    const blockers = blockerBlock(file)
+
+    // #135 is the grid axis' direction and the last record in the file. It
+    // may only be named here if the walk followed IFCGRID -> IFCGRIDAXIS,
+    // which is the over-correction this asserts is absent.
+    expect(blockers).not.toContain('IFCDIRECTION')
+
+    // And the file does defer, so the assertion above is not vacuous —
+    // #200's own placement chain bottoms out at #203, written after it.
+    expect(blockers).toContain('IFCCARTESIANPOINT')
+  })
+})

--- a/src/step/dangling_reference_error.test.ts
+++ b/src/step/dangling_reference_error.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from '@jest/globals'
 
 import IfcStepParser from '../ifc/ifc_step_parser'
-import { IfcAxis2Placement3D } from '../ifc/ifc4_gen'
+import { IfcAxis2Placement3D, IfcPolyline } from '../ifc/ifc4_gen'
 import EntityTypesIfc from '../ifc/ifc4_gen/entity_types_ifc.gen'
 import IfcStepModel from '../ifc/ifc_step_model'
 import ParsingBuffer from '../parsing/parsing_buffer'
-import { DanglingReferenceError } from './dangling_reference_error'
+import {
+  DanglingReferenceError,
+  MISTYPED_VALUE_MESSAGE,
+} from './dangling_reference_error'
 import { BufferByteSource } from './parsing/byte_source'
 import { ColumnarIndexSink, StepIndexColumns } from './parsing/columnar_index'
 import { ParseResult } from './parsing/step_parser'
@@ -314,5 +317,127 @@ describe( 'DanglingReferenceError wording', () => {
     expect( new DanglingReferenceError( 7, 0 ).message ).toBe(
         'Reference to #7 is not present in this prefix index ' +
         '(highest indexed so far: #0)' )
+  } )
+} )
+
+
+/**
+ * conway#546: the scalar paths above are only half the story. A placement
+ * chain also hops through REFERENCE ARRAYS — `IfcPolyline.Points` is the
+ * one a grid axis bottoms out in — and those are read by
+ * `extractBufferElement`, which used to answer an unresolved entry with
+ * `undefined` and leave the throwing to the generated getter. The getter
+ * throws a bare, untagged `Error`, so an array hop that had merely not been
+ * scanned yet was indistinguishable from a malformed one: the preview
+ * channels counted the deferral and queued nothing, and their forward-only
+ * unit cursor meant the product could never preview (see
+ * `store_preview_channel.test.ts` for that end of it).
+ *
+ * The bet these three pin is the DISTINCTION, in both directions. An
+ * absent record must classify — that is the recovery #543 dropped. An
+ * entry that is indexed but is the wrong entity type must NOT, because a
+ * longer prefix cannot change that answer and tagging it would put a
+ * permanently broken placement back in the retry queue, which is also
+ * what buys early generation preemption (the endless-preemption bug #543
+ * fixed).
+ */
+
+/** A two-point polyline whose points are both written after it. */
+const ARRAY_FORWARD_REFERENCE = new TextEncoder().encode(
+    `${HEADER}#1=IFCPOLYLINE((#2,#3));\n` +
+    '#2=IFCCARTESIANPOINT((0.,0.));\n' +
+    '#3=IFCCARTESIANPOINT((1.,0.));\n' + FOOTER )
+
+/**
+ * The same array hop, but #2 is an IFCDIRECTION and the entry wants an
+ * IFCCARTESIANPOINT. Indexed, present, and wrong — the case a longer
+ * prefix cannot fix.
+ */
+const ARRAY_MISTYPED_ENTRY = new TextEncoder().encode(
+    `${HEADER}#1=IFCPOLYLINE((#2));\n` +
+    '#2=IFCDIRECTION((0.,0.,1.));\n' + FOOTER )
+
+
+/**
+ * Read a polyline's Points and return whatever comes back out.
+ *
+ * @param model The model to read the polyline out of.
+ * @return {unknown} The thrown value. Reading Points must throw.
+ */
+function throwOnPoints( model: IfcStepModel ): unknown {
+
+  const polyline = model.getElementByExpressID( 1 ) as IfcPolyline | undefined
+
+  expect( polyline ).not.toBe( void 0 )
+
+  let caught: unknown
+
+  try {
+    void polyline!.Points
+  } catch ( ex ) {
+    caught = ex
+  }
+
+  expect( caught ).toBeInstanceOf( Error )
+
+  return caught
+}
+
+
+describe( 'reference-array classification', () => {
+
+  test( 'an array entry absent from a prefix classifies as dangling', () => {
+
+    const model = new IfcStepModel(
+        ARRAY_FORWARD_REFERENCE, prefixColumns( ARRAY_FORWARD_REFERENCE ) )
+
+    const caught = throwOnPoints( model )
+
+    // The whole point: before conway#546 this was a bare Error carrying
+    // MISTYPED_VALUE_MESSAGE, which extractPlacementStrict_ could not
+    // re-tag, so the product was deferred and never retried.
+    expect( caught ).toBeInstanceOf( DanglingReferenceError )
+    expect( ( caught as DanglingReferenceError ).expressID ).toBe( 2 )
+    expect( ( caught as Error ).message ).toBe(
+        'Reference to #2 is not present in this prefix index ' +
+        '(highest indexed so far: #1)' )
+  } )
+
+  test( 'the same array entry resolves once the parse reaches it', () => {
+
+    // The control. Without this the test above could pass against a file
+    // whose #2 never arrives, which is a different defect entirely.
+    const { columns, result } = buildColumnarIndexStreaming(
+        new BufferByteSource( ARRAY_FORWARD_REFERENCE ),
+        IfcStepParser.Instance,
+        POOL_BYTES )
+
+    expect( result ).toBe( ParseResult.COMPLETE )
+
+    const model = new IfcStepModel( ARRAY_FORWARD_REFERENCE, columns )
+    const polyline = model.getElementByExpressID( 1 ) as IfcPolyline
+
+    expect( polyline.Points.map( ( point ) => point.expressID ) ).toEqual( [2, 3] )
+  } )
+
+  test( 'an indexed array entry of the wrong type stays untagged', () => {
+
+    // The counterweight, and the reason this is a classification rather
+    // than a blanket tag. #2 IS in the index — it is simply not an
+    // IfcCartesianPoint — so no amount of extra parse changes the answer
+    // and the preview must not keep retrying it.
+    const { columns, result } = buildColumnarIndexStreaming(
+        new BufferByteSource( ARRAY_MISTYPED_ENTRY ),
+        IfcStepParser.Instance,
+        POOL_BYTES )
+
+    expect( result ).toBe( ParseResult.COMPLETE )
+
+    const model = new IfcStepModel( ARRAY_MISTYPED_ENTRY, columns )
+
+    const caught = throwOnPoints( model )
+
+    expect( caught ).not.toBeInstanceOf( DanglingReferenceError )
+    expect( ( caught as Error ).message ).toBe( MISTYPED_VALUE_MESSAGE )
   } )
 } )

--- a/src/step/dangling_reference_error.ts
+++ b/src/step/dangling_reference_error.ts
@@ -20,9 +20,10 @@
  * PREEMPTION, so one malformed placement could keep paying for rebuilds
  * that could never satisfy it (conway#542, codex round 1 on #543).
  *
- * Deliberately thrown only from the reference-resolution failure paths in
- * `StepEntityBase`; it carries no fallback meaning, so a caller that does
- * not care can keep treating it as the `Error` it extends.
+ * Deliberately minted in one place only — {@link unresolvedReferenceError}
+ * below, which every reference-resolution failure path routes through. It
+ * carries no fallback meaning, so a caller that does not care can keep
+ * treating it as the `Error` it extends.
  *
  * The two causes above also want two different MESSAGES, which is what
  * `highestIndexedExpressID` selects (conway#580). Against a complete
@@ -68,4 +69,79 @@ export class DanglingReferenceError extends Error {
 
     this.name = 'DanglingReferenceError'
   }
+}
+
+
+/**
+ * The slice of a step model {@link unresolvedReferenceError} reads.
+ *
+ * Narrower than `StepModelBase` on purpose: this module is imported by the
+ * step layer *and* by `IfcGeometryExtraction`, and taking the concrete
+ * model type here would drag its whole generic parameter list — and a
+ * cycle back through `step_entity_base` — into both.
+ */
+export interface UnresolvedReferenceModel {
+
+  /**
+   * @param expressID The referenced record.
+   * @return {number | undefined} Its local ID, or undefined when the index
+   * does not hold it.
+   */
+  resolveExpressID( expressID: number ): number | undefined
+
+  /** Whether the index is known to be an incomplete prefix. */
+  readonly indexIsPrefix: boolean
+
+  /** Highest express ID the index holds. A maximum, not a scan boundary. */
+  readonly maxIndexedExpressID: number
+}
+
+/**
+ * What every untagged reference failure has said since before
+ * {@link DanglingReferenceError} existed, and what the generated
+ * single-valued and typed-array getters both throw for a mistyped entry.
+ * Kept identical so classifying a path changes only the absent case.
+ */
+export const MISTYPED_VALUE_MESSAGE = 'Value in STEP was incorrectly typed'
+
+/**
+ * Classify a reference that failed to resolve.
+ *
+ * `getElementByExpressID` / `getTypedElementByExpressID` answer `undefined`
+ * for two opposite causes: the record is not in the index at all, or it is
+ * indexed but is the wrong entity type. A mid-parse prefix reader must tell
+ * them apart — the first may resolve once more of the file is scanned, the
+ * second never will — so the absent case gets its own error type (see
+ * {@link DanglingReferenceError}). Called only on a throwing path, so
+ * neither the extra index lookup nor the maximum-ID scan behind it costs
+ * anything in the common case.
+ *
+ * Shared rather than duplicated because three call sites must agree on the
+ * answer or the preview's retry queue goes wrong in one of two directions:
+ * `StepEntityBase`'s scalar and reference-array extraction, and
+ * `IfcGeometryExtraction.relatedProductByExpressID_`, which deliberately
+ * mirrors what the generated array getter throws for the same entry.
+ *
+ * @param model The model whose index decides absence.
+ * @param expressID The reference's target, or undefined when the field did
+ * not hold a reference at all (an unresolved inline element).
+ * @return {Error} The error to throw: `DanglingReferenceError` only when
+ * the record is absent from the index, an untagged `Error` otherwise.
+ */
+export function unresolvedReferenceError(
+    model: UnresolvedReferenceModel,
+    expressID: number | undefined ): Error {
+
+  if ( expressID !== void 0 && model.resolveExpressID( expressID ) === void 0 ) {
+
+    // Hand the highest indexed ID over ONLY for a prefix index, so the
+    // message can report absence-so-far instead of claiming the record is
+    // missing from the file (conway#580). A complete model keeps the
+    // absolute wording, because there the claim is true.
+    return new DanglingReferenceError(
+        expressID,
+        model.indexIsPrefix ? model.maxIndexedExpressID : void 0 )
+  }
+
+  return new Error( MISTYPED_VALUE_MESSAGE )
 }

--- a/src/step/step_entity_base.ts
+++ b/src/step/step_entity_base.ts
@@ -23,7 +23,7 @@ import { stepBufferBase } from './step_buffer_provider'
 import { StepEntityConstructorAbstract } from './step_entity_constructor'
 import StepEntityInternalReference,
 { StepEntityInternalReferencePrivate } from './step_entity_internal_reference'
-import { DanglingReferenceError } from './dangling_reference_error'
+import { unresolvedReferenceError } from './dangling_reference_error'
 import StepModelBase from './step_model_base'
 
  
@@ -388,16 +388,9 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
 
 
   /**
-   * Classify a reference field that failed to resolve.
-   *
-   * `getElementByExpressID` / `getTypedElementByExpressID` answer
-   * `undefined` for two opposite causes: the record is not in the index at
-   * all, or it is indexed but is the wrong entity type. A mid-parse prefix
-   * reader must tell them apart — the first may resolve once more of the
-   * file is scanned, the second never will — so the absent case gets its
-   * own error type (see {@link DanglingReferenceError}). Called only on a
-   * throwing path, so neither the extra index lookup nor the maximum-ID
-   * scan behind it costs anything in the common case.
+   * Classify a reference field that failed to resolve, against this
+   * entity's model. See {@link unresolvedReferenceError} for what the two
+   * answers mean and why they must not be conflated.
    *
    * @param expressID The reference's target, or undefined when the field
    * did not hold a reference at all (an unresolved inline element).
@@ -405,19 +398,7 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
    */
   private unresolvedReferenceError_( expressID: number | undefined ): Error {
 
-    if ( expressID !== void 0 &&
-      this.model.resolveExpressID( expressID ) === void 0 ) {
-
-      // Hand the highest indexed ID over ONLY for a prefix index, so the
-      // message can report absence-so-far instead of claiming the record
-      // is missing from the file (conway#580). A complete model keeps the
-      // absolute wording, because there the claim is true.
-      return new DanglingReferenceError(
-          expressID,
-          this.model.indexIsPrefix ? this.model.maxIndexedExpressID : void 0 )
-    }
-
-    return new Error( 'Value in STEP was incorrectly typed' )
+    return unresolvedReferenceError( this.model, expressID )
   }
 
   /**
@@ -592,6 +573,33 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
   /**
    * Extract a reference from a buffer, without type check.
    *
+   * One entry of a SELECT array, and — unlike its typed sibling
+   * {@link extractBufferElement} — it deliberately still answers
+   * `undefined` rather than classifying (conway#546).
+   *
+   * `undefined` here is **load-bearing signal, not a failure**. A select
+   * whose members include a typed ENUM is generated as a nullish fallback
+   * on this exact call:
+   *
+   * ```ts
+   * this.extractBufferReference( buffer, cursor, endCursor ) ??
+   *   IfcNullStyleDeserializeStep( buffer, stepEnterTypedValue( … ), … )
+   * ```
+   *
+   * so `IFCNULLSTYLE(.NULL.)` reaches its deserialiser only because this
+   * returns `undefined` for an entry that is not a reference at all. Two
+   * such sites exist (`IfcPresentationStyleAssignment.Styles` and the
+   * AP214 `presentation_style_assignment.styles`), both covered by
+   * `ifc_typed_select_enum.test.ts` / `ap214_typed_select_enum.test.ts` —
+   * throwing here breaks all four of those tests.
+   *
+   * Not classifying costs nothing for the defect this was written for: no
+   * hop of any placement chain is a select array. `IfcGridPlacement` →
+   * `IfcVirtualGridIntersection.IntersectingAxes` → `IfcGridAxis` →
+   * `AxisCurve` → `IfcPolyline.Points` are typed reference fields
+   * throughout, so they route through `extractElement` and
+   * `extractBufferElement` and never through here.
+   *
    * @param buffer The buffer to extract from.
    * @param cursor The position in the buffer to extract from.
    * @param endCursor The ending cursor.
@@ -613,6 +621,13 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
 
   /**
    * Extract a flat array of references
+   *
+   * Tolerant by construction: an entry that does not resolve is pushed as
+   * `undefined`, which is why the element type says so. Unchanged by
+   * conway#546, and the second reason that change left
+   * {@link extractBufferReference} alone — this is its one caller outside
+   * the generated code, and making it throw would have altered what every
+   * consumer of a reference array gets back.
    *
    * @param offset The offset in the vtable to extract from
    * @param baseOffset The base offset in the vtable to extract from
@@ -827,12 +842,33 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
    * Used by other extraction methods with wrappers to perform
    * semantically correct extraction.
    *
+   * One entry of a typed reference array. Unresolved entries throw,
+   * classified: `DanglingReferenceError` when the record is simply absent
+   * from the index, an untagged `Error` when it is indexed but is the
+   * wrong entity type (conway#546).
+   *
+   * It used to return `undefined` for both, and each of the 153 generated
+   * call sites answered that with an identical bare
+   * `Error( MISTYPED_VALUE_MESSAGE )` — so a reference-array hop of a
+   * placement chain that had merely not been scanned yet was
+   * indistinguishable from a malformed one. `extractPlacementStrict_` can
+   * only re-tag a `DanglingReferenceError`, so the preview channels
+   * counted such a product as deferred and never queued it for retry, and
+   * their forward-only unit cursor meant it could not preview at all
+   * (conway#543's classification narrowing, found by codex round 3).
+   *
+   * There is no `optional` arm and so no `nullOnErrors` interaction to
+   * preserve: unlike {@link extractElement}, an array entry is never
+   * absent-by-design. The generated `=== void 0` guards are unreachable
+   * now rather than wrong, and the return type keeps its `| undefined` so
+   * they stay valid TypeScript.
+   *
    * @param buffer The buffer to extract from
    * @param cursor The cursor to extract from.
    * @param endCursor The end of the memory space to extract from.
    * @param entityConstructor The entity constructor to use for type checks.
-   * @return {StepEntityBase | undefined } The extracted element, or null if optional
-   * and this value isn't specified.
+   * @return {StepEntityBase | undefined } The extracted element. Never
+   * undefined — see above.
    */
   protected extractBufferElement< T extends StepEntityConstructorAbstract< EntityTypeIDs > >(
       buffer: Uint8Array,
@@ -849,7 +885,7 @@ export default abstract class StepEntityBase<EntityTypeIDs extends number> imple
           extractInlineElementAddress( buffer, cursor, endCursor ), entityConstructor )
 
     if ( value === void 0 ) {
-      return
+      throw this.unresolvedReferenceError_( expressID )
     }
 
     return value as InstanceType< T >


### PR DESCRIPTION
Closes #546. M3 work under #394 — referenced here rather than in the title, for the reason set out under "What this publishes on merge" below.

## The defect, reproduced before it was fixed

`DanglingReferenceError` was minted only on the **scalar** paths (`extractReference`, `extractElement`). The typed **reference-array** helper `extractBufferElement` returned `undefined` instead, and all 153 generated array getters answered that with a bare untagged `Error` — which `extractPlacementStrict_` cannot re-tag. A grid-placed product whose axis chain was still ahead of the parse was counted as deferred and never queued for retry, and `unitOrdinal_` is forward-only, so it could never preview.

Run against `data/grid_placement_tail_axes.ifc` (the fixture this PR adds), driving `StorePreviewChannel` through a prefix index and then the full index:

| | before | after |
|---|---|---|
| stage 1 `deferred` | 4 | 4 |
| stage 1 `deferredOnPlacement` | **0** | **3** |
| stage 1 retry queue | `[]` | `[12, 20, 43]` |
| stage 2 `retried` | **0** | **3** |
| stage 2 preview meshes | **0** | **3** |

The issue's cheap repro (`--emit-tail-placements` over `data/grid_placement.ifc`, then `preview_timeline.mjs`) **does not** reproduce it as written — see "What did not reproduce" below.

## Three hops are re-classified, not the two the issue enumerates

| hop | field | kind | product in the fixture |
|---|---|---|---|
| 2 | `IfcVirtualGridIntersection.IntersectingAxes` | forward, reference array | `#500` |
| 4a | `IfcPolyline.Points` | forward, reference array | `#200` |
| — | `IfcGrid.UAxes`/`VAxes`/`WAxes`, via `gridByAxis` | **inverse lookup**, reference array | `#1000` |

`IfcGridAxis` carries no schema route back to its grid — `PartOfU`/`PartOfV`/`PartOfW` are INVERSE attributes the generated layer drops — so `extractGridPlacement` finds the grid by **scanning every `IfcGrid`'s axis lists** (`ifc_geometry_extraction.ts:5917-5944`). Those lists are `extractBufferElement` arrays (`IfcGrid.gen.ts:46,79,112`), so this change re-tags their throw too. Region 1's catch absorbs only `StepBufferNotResidentError` (`:6062-6066`), so it propagates into `extractPlacementStrict_` and is tagged.

- **The scan visits every grid, not just the axis' owner.** Any `IfcGrid` with an unscanned axis list blocks *every* grid placement in the file. `gridByAxis_` memoises only after a *complete* scan, so a prefix throw is not sticky.
- **`layout_report.mjs` cannot model it.** A forward closure from a product never reaches an `IfcGrid` — the grid references the axis, not the reverse. So the tool remains **optimistic for grid-placed products in exactly the silently-flattering direction #546 exists to correct.** This PR closes the forward half only. Filed as **#607**, and **pinned by a test here**: `'the inverse gridByAxis dependency is a known, unmodelled residual'` asserts the residual count is exactly 1, so #607's fix will fail it rather than silently passing.

The fourth fixture product (`#1000`) landed here rather than in #607 because this PR is what classifies that path; shipping a newly-classified hop with no test is the "guard that did not cover the path it was written for" failure #536 was reviewed for.

## Route decision, per helper

Route **(b)**, hand-written helpers. (a) needs a generator-revision bump in `external/IFC-gen-internal` plus ~2300 regenerated files. The two array helpers are **not symmetric**:

### `extractBufferElement` — classified

Now throws `unresolvedReferenceError_`: `DanglingReferenceError` for an absent record, the **identical** untagged `Error( 'Value in STEP was incorrectly typed' )` for an indexed record of the wrong type.

- **0** callers outside the generated code — repo-wide across `*.ts`/`*.js`/`*.mjs`/`*.cjs` excluding `compiled/`, `node_modules/`, `dependencies/`, `_gen/`: five hits, all the definition or a doc comment. No subclass override, no re-export.
- All **153** generated call sites across 2291 generated files share **exactly one** statement shape, by a normalised-shape scan: `const ID = this.extractBufferElement(...)` / `if ( ID === void 0 ) { throw new Error( 'S' ) }`. One distinct shape, zero non-conforming.
- **0** consume the `undefined` before that throw (no `??`, no other branch).
- No `optional` arm, so no `nullOnErrors` interaction to preserve — and no generated file references `nullOnErrors` at all.

A re-classification of an already-throwing path; the generated `=== void 0` guards become unreachable rather than wrong.

### `extractBufferReference` — deliberately NOT classified

**The issue's route-(b) inference is wrong here, and this was measured rather than reasoned about.** The blanket version was implemented and it broke four tests. `undefined` is load-bearing signal: a select whose members include a typed ENUM is generated as a nullish fallback on this exact call —

```ts
this.extractBufferReference( buffer, cursor, endCursor ) ??
  IfcNullStyleDeserializeStep( buffer, stepEnterTypedValue( …, 'IFCNULLSTYLE' ), … )
```

— so `IFCNULLSTYLE(.NULL.)` reaches its deserialiser *only* because the helper returns `undefined`. Two such sites (`IfcPresentationStyleAssignment.Styles`, AP214 `presentation_style_assignment.styles`). Note the guard shape differs from the issue's description: these 90 sites are followed by an `instanceof`-chain throw, not a `=== void 0` throw — which is why a shape audit looking only for "a throw nearby" would have called it safe.

Verified per type rather than asserted: across `IfcLocalPlacement`, `IfcAxis2Placement3D/2D`, `IfcGridPlacement`, `IfcVirtualGridIntersection`, `IfcGridAxis`, `IfcPolyline`, `IfcLine`, `IfcVector`, `IfcGrid`, `IfcCartesianPoint`, `IfcDirection` — and the AP214 twins — **zero** use `extractBufferReference`. `IfcGridPlacement.PlacementRefDirection` *is* a select, but a scalar field, so it goes through `extractReference(…, optional=true)` and is classified under `nullOnErrors = false`, which `extractPlacementStrict_` sets — consistent with this change, and already so before it.

`extractArray`, the one non-generated caller, keeps its tolerant contract.

### The third site the issue does not mention

`relatedProductByExpressID_` is **classified**, because leaving it would have silently broken the correspondence its comment asserts. Stated honestly: **behaviour-neutral today and not mutation-verified.** All three callers catch permissively and none discriminates on `DanglingReferenceError`. Same footing as the fallback #536 left un-verified; the code comment says so.

## Why the untagged invariant holds

**The array path now behaves exactly as the scalar path already did, and has since #543.** `unresolvedReferenceError()` is the same function `extractReference`/`extractElement` have been calling; this PR routes a third caller into it. Any state that made it over-tag would already be over-tagging every scalar placement hop on `main`.

- **Residency-independent.** `resolveExpressID` bottoms out in `expressIDMap_.get()` and reads no source bytes.
- **`indexIsPrefix` selects wording, not the tag** (#580). A dangling reference on a *complete* index still tags, and cannot cause #543's endless preemption there, because preemption is gated on `growthReady` and a complete index does not grow.

One caveat, tracked as **#606**: `StepModelBase.getTypedElementByLocalID` returns a memoized `element.entity` *before* its type check, so on a memo hit a typed getter returns success instead of rejecting and the untagged arm is never reached. That weakens the invariant's coverage rather than the invariant itself, and is pre-existing.

## Tool: `layout_report.mjs`

The closure now follows `IFCGRIDPLACEMENT` → `IFCVIRTUALGRIDINTERSECTION` → `IFCGRIDAXIS` → `AxisCurve` → leaf points, via a **second set**, `PLACEMENT_CHAIN_ONLY_NAMES` — types the walk expands *through* but which do not by themselves gate a product that merely references one.

The split was found by a negative control, not by design. An `IFCGRID` references its own axes and is itself a placed product, so folding the grid chain into `PLACEMENT_NAMES` made **every grid look unusable until its axis points were scanned**. Measured on a grid-plus-swept-polyline control: with one set the grid product's usable-at moved a whole decile later and the blocker attribution changed; split, the same file reports byte-identically.

**Report output**, base (`9430923`) vs head:

| file | result |
|---|---|
| 9 non-grid `data/*.ifc` | byte-identical |
| grid-plus-polyline negative control (no `IFCGRIDPLACEMENT`) | byte-identical |
| `data/grid_placement.ifc` | changed — **sharded curves lower; prefix curves and blocker attribution byte-identical** |
| `data/grid_placement_tail_axes.ifc` | changed — prefix product curve lower, blocker attribution `4 IFCVIRTUALGRIDINTERSECTION / 3 IFCLOCALPLACEMENT` → `3 IFCLOCALPLACEMENT / 3 IFCCARTESIANPOINT / 1 IFCVIRTUALGRIDINTERSECTION` |

*(An earlier version of this table put the blocker move on the `grid_placement.ifc` row; it belongs to the tail-axes row. Base re-derived two ways — `git show 9430923:scripts/layout_report.mjs`, and the head script with `PLACEMENT_CHAIN_ONLY_NAMES` emptied.)*

**The nine "byte-identical" fixtures are on their own vacuous** — none contains `IFCPOLYLINE`, `IFCLINE`, `IFCVECTOR` or `IFCGRIDAXIS` at all. The control exists for that reason. Both changed files move in the **pessimistic** direction.

## STEP digest movement in `visual-diff`: inherited, not this PR

`visual-diff` reports three sub-threshold digest-changed models (`supercap.step`, `nist_ctc_02_asme1_rc.stp`, `Right_Hand.step`). **This PR moves none of them.**

| test (same models, same command) | result |
|---|---|
| HEAD vs the engine change reverted to `210cadb7`, **same wasm** | **byte-identical, all three** |
| HEAD vs published `1.603.1553` (= my base commit `210cadb7`) | **byte-identical, all three** |
| HEAD vs published `1.594.1554` (= `latest`, the actual visual-diff base) | `supercap` identical; `nist_ctc_02` 1 row; `Right_Hand` 14 rows |

Every differing row is a `MANIFOLD_SOLID_BREP` mesh hash — no placement entity, nothing this PR touches. `visual-diff`'s base is `npm pack @bldrs-ai/conway@latest` (`build.yml:878`), and `latest` is `main`'s `9430923`, which pins conway-geom `1ceeefd4`; my branch is cut from `210cadb7`, which pins `80263bb0`. That bump is #594/#604, *"seed the NURBS inverse solve from the previous boundary point"* — precisely the change that moves solid-BREP hashes on B-spline-heavy STEP. **The drift is my branch lagging main, and would appear on any branch cut from `210cadb7`.**

**Nothing to re-bless for this PR**; the `1ceeefd4` baselines belong to #604. Merging `main` forward would make the deltas vanish — deliberately not done, since a merge commit lands ungated and CI is green as it stands. `supercap.step` is reported by CI but **not reproduced** in my digest comparison; flagged as unexplained rather than absorbed.

Instrumentation was validated before being believed: the first run produced header-only CSVs because all three models were still LFS pointer stubs. After `git lfs pull` the row counts were 7 / 3 / 40 against committed baselines of 7 / 5 / 41.

## What this publishes on merge

Checked against `build.yml:1722-1735` and `:1783-1799`, because #533 burned this repo once.

`PR_NUM` is the first `#N` in the **merge commit message**. On a squash merge that is `<title> (#605)`, so the title's `#546` wins and this publishes **`1.546.<commit-count>`**. On a merge commit it would be `1.605.<commit-count>`.

`1.546.x` is below the live `1.594.1554` in its middle segment — **and that is the handled, expected case**: the publish step compares against `npm view @bldrs-ai/conway@latest`, detects the new version is not the higher SemVer, warns, and publishes with an explicit `--tag latest`. The strictly-monotonic commit-count segment makes that legitimate. Leading with `#394` would publish `1.394.x`, which the same path would also handle. **The reason to lead with `#546` is attribution** — the release should name the fix, not the epic — not avoidance of a publish failure.

## Tests

Baseline on this tree before any edit: **116 suites / 804 tests**. After: **117 / 812** (+1 suite, +8 tests), all passing. Lint unchanged at 0 errors / 720 warnings. `yarn check-compiled-fresh` green alongside every count.

- `data/grid_placement_tail_axes.ifc` — laid out so a prefix reaches every product and every grid placement but no axis chain. `#200` blocks at hop 4a, `#500` at hop 2, `#1000` at the `gridByAxis` inverse scan, `#800` is the counterweight: its intersection names an **`IFCDIRECTION`** where an `IFCGRIDAXIS` belongs. `#900` is referenced by nothing else on purpose — see #606, which would otherwise make the counterweight depend on which pass materialised the record first.
- Asserted on `previewYield.deferredOnPlacement` **and** `.retried`, on **both** channels, with exact counts. Payload assertions are symmetric across the two channels and assert the whole stream is empty at stage one — this fixture has no spatial containment, so the prefix-generation plate walk (#518) has nothing to emit either, making that strictly stronger than filtering.
- Three step-level tests: an absent array entry classifies; the same entry resolves once parsed; an indexed entry of the wrong type stays untagged.
- Three `layout_report.mjs` tests driven through the CLI: the extended closure, the **known residual** (#607), and the negative control.

### Mutation checks

AGENTS.md's commit-first / `git restore --worktree` / undo-before-pop sequence.

**Engine** — revert `src/step/step_entity_base.ts` to `210cadb7`, rebuild: exactly 3 failures.

```
● reference-array classification › an array entry absent from a prefix classifies as dangling
  Expected constructor: DanglingReferenceError
  Received constructor: Error
● StorePreviewChannel › a grid-placed product blocked on a reference array is retried
  Expected: 3   Received: 0        (afterPrefix.deferredOnPlacement)
● StreamedPreviewChannel › a grid-placed product blocked on a reference array is retried
  Expected: 3   Received: 0        (afterPrefix.deferredOnPlacement)
```

The control tests keep passing under the revert — they pin the fixture and the untagged invariant, not the fix.

**Tool**, two mutations. Against `main`'s script — the closure and residual tests fail (residual is 4 there, not 1), the negative control passes. Against an over-broad variant (chain-only types folded back into the gating set) — the closure and negative-control tests fail, pinning the split.

## Corpus check — closed

Settled on the **real bytes** (see #546 comment 5432875744): `IFCGRIDPLACEMENT` and `IFCVIRTUALGRIDINTERSECTION` are **0** in PSB, D3D, DOWA and MB-Khaya; `BLSN_007.stp` is STEP and structurally 0. #542's "no effect on the published figures" is confirmed on all five published files, not just the 47-model public tree.

Sharpening #607: PSB and D3D **do** carry grid axes (1408 and 272) while placing nothing by grid placement — grids appear in real exports as *annotation*, not as placement. So the `gridByAxis` inverse scan is never reached on the corpus, and the residual is latent there rather than active.

## What did not reproduce, and one adjacent defect

**The issue's repro recipe 1 does not work as written.** `--emit-tail-placements` over `data/grid_placement.ifc` then `preview_timeline.mjs` reports `0 meshes from 0 units, 0 deferred` — 74 records is far below `FIRST_GENERATION_MIN_RECORDS`, so no generation is ever built. Recipe 2 — a hand-authored variant for hop 2 — is what the fixture became, and it covers all three hops.

**Adjacent, pre-existing, filed as #606:** `StepModelBase.getTypedElementByLocalID` returns a memoized element **without checking its type**. The first counterweight draft pointed at `#22` and hit it, surfacing as `TypeError: Cannot read properties of undefined (reading 'type')` in `gridAxisLine`. **Verified identical on `main`.**

## Verification environment

- `dependencies/conway-geom` at the pinned `80263bb0`; never staged.
- The container had **no wasm Dist at all** (only `.d.ts` stubs), failing 233 tests on a pristine `main` before `yarn wasm-prebuilt`. The wasm under test is that prebuilt — which is `1.603.1553`'s, i.e. built from this branch's own pin `80263bb0`, confirmed by md5. Orthogonal to this change (pure TypeScript), but named because it is a real confounder and because it is what makes the digest comparisons above clean.
- Not merged with `main`'s `9430923`, to avoid landing an ungated merge commit.