### PR TITLE
conway#637: audit memory machinery per geometry path, state the policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,7 @@ Check `scripts/` before building tooling — see
 | What a load is actually made of, and what parallelising it can and cannot buy: the measured phase decomposition (PSB/D3D/MB-Khaya), why the parse→geometry barrier is essential, the byte-identical sharded index build, and why #616's aggregate pager outranks all of it on D3D-shaped models | [design/new/parallel-load-pipeline.md](design/new/parallel-load-pipeline.md) |
 | emsdk version, wasm build environment | [design/new/web-build-environment.md](design/new/web-build-environment.md), [design/new/emsdk-upgrade-scalable-allocator.md](design/new/emsdk-upgrade-scalable-allocator.md) |
 | Where a model lands in world space: `COORDINATE_TO_ORIGIN`, why the recentre snaps to a grid, why two exports of one object used to land 76m apart, what a frame change costs in re-blessing and saved cameras | [design/new/coordination-frame.md](design/new/coordination-frame.md) |
+| Which memory machinery (scratch arena, geometry budget/residency, adaptive source-window residency) actually covers which geometry path — audited matrix for STEP and IFC, corrected site counts, and the stated policy for new tessellation entry points | [design/new/geometry-memory-coverage.md](design/new/geometry-memory-coverage.md) |
 
 Add a row here when you write a doc future assistants should find — this
 table is the index, not the filesystem.

--- a/design/new/geometry-memory-coverage.md
+++ b/design/new/geometry-memory-coverage.md
@@ -223,7 +223,7 @@ real gap, and a bigger one than "does the budget apply to STEP too" — STEP
 has no comparable retained-mesh eviction policy to apply, even though it
 does clean up transients the way IFC does.
 
-## Adaptive residency (#616/#617) — format-agnostic, and the one mechanism that is shared
+## Adaptive residency (#616/#617) — a shared class, but wiring decides who gets it
 
 `WindowedStepBufferProvider` (`src/step/step_buffer_provider.ts:354`) is
 constructed inside `StepModelBase.spillSourceToExternalStore`
@@ -238,16 +238,41 @@ construction of `WindowedStepBufferProvider` in the tree is IFC-side
 `ifc_api_proxy_ifc.ts:1245`); `src/AP214E3_2010/` constructs none, and has
 no `ap214_stream_open` — AP214 reaches the mechanism only if a caller
 explicitly spills via `ifc_api_proxy_ap214.ts:213` →
-`spillSourceToExternalStore`. So "both formats get the same adaptive-cap
-policy" is true of the mechanism *when a caller spills*, not of an
-ordinary AP214 open — an AP214 open does not windowed-buffer its source by
-default the way an IFC open does. Once spilling happens, the policy is
-identical: the same thrash detection, the same doubling behaviour
-described in `step_buffer_provider.ts:58-115`, for both formats.
+`spillSourceToExternalStore`.
 
-This is the one row in this matrix where "applies across formats" is
-correct, with that qualification — included here so the matrix is
-complete rather than only correcting claims.
+**The first-order gate is the open mode, not the format** — a correction
+this doc's own earlier revision got wrong by framing it as IFC-versus-AP214
+(**[code]**, and raised in review on #639). Two sibling paths in
+`ifc_api_proxy_ifc.ts` make it plain:
+
+| Open | Model construction | Windowed? |
+|---|---|---|
+| buffer-backed (`:1054`) | `new IfcStepModel(data, columns)` | **no** — the source stays resident |
+| store-backed (`:1245`) | `new WindowedStepBufferProvider(store)` → `new IfcStepModel(void 0, columns, provider)` | yes |
+
+The same split is in the parser: `parseDataToModel` /
+`parseDataToModelAsync` construct `new IfcStepModel(input.buffer, …)` with a
+resident buffer (`ifc_step_parser.ts:48-71`), while only the
+`parseStreamToModel` / `parseStreamToModelAsync` pair installs a provider
+(`:118`, `:159`). **So an ordinary buffer-backed IFC open gets no adaptive
+source residency either.** It is not that IFC windows by default and AP214
+does not.
+
+Two qualifications stack, and both belong on any claim about this
+mechanism:
+
+1. **Open mode** — buffer-backed opens, in either format, are unwindowed.
+2. **Format** — IFC additionally has an *open-time* store-backed path that
+   installs the provider (`ifc_stream_open.ts:129,211`,
+   `ifc_api_proxy_ifc.ts:1245`); `src/AP214E3_2010/` constructs none and has
+   no `ap214_stream_open`, so AP214 reaches the mechanism only when a caller
+   explicitly spills.
+
+Once a provider is installed the policy is identical for both formats —
+the same thrash detection and doubling behaviour described in
+`step_buffer_provider.ts:58-115`. The *class* is genuinely shared; the
+*wiring* is not, and the wiring is what decides whether a given load is
+protected.
 
 On D3D specifically: per conway#635, adaptive residency grows the window to
 the whole 213.6 MB file "by design," so on this model it *costs* ~150 MB
@@ -265,16 +290,16 @@ describes `IfcModelGeometry`'s cache behaviour and has no AP214 counterpart.
 
 ## The matrix, per geometry path
 
-| Path | Scratch arena | Geometry budget / residency (extracted-mesh cache) | Adaptive residency (source window) |
+| Path | Scratch arena | Geometry budget / residency (extracted-mesh cache) | Adaptive residency (source window) — **gated on open mode, see below** |
 |---|---|---|---|
-| IFC extrusion / profile (`IfcExtrudedAreaSolid` → `Extrude()`) | **no** — [code] | yes (IFC-only) | yes (shared) |
-| IFC CSG / boolean composition | **no** — [code] | yes (IFC-only) | yes (shared) |
-| IFC advanced BREP, planar face | yes, via `TriBounds` — [code] | yes (IFC-only) | yes (shared) |
-| IFC advanced BREP, conical/cylindrical/B-spline face | yes — [code] | yes (IFC-only) | yes (shared) |
-| IFC advanced BREP, spherical/toroidal/revolution/extrusion-surface face | **no** (main body) — [code] | yes (IFC-only) | yes (shared) |
-| STEP (AP214) solid extrusion (`Extrude()`) | **no** — [code] | **no AP214 analogue exists** — [code] | yes (shared) |
-| STEP (AP214) advanced BREP, planar face | yes, via `TriBounds` — [code] | **no** — [code] | yes (shared) |
-| STEP (AP214) advanced BREP, curved face | same per-surface split as IFC (shared compiled function) — [code] | **no** — [code] | yes (shared) |
+| IFC extrusion / profile (`IfcExtrudedAreaSolid` → `Extrude()`) | **no** — [code] | yes (IFC-only) | only on a **store-backed** open — [code] |
+| IFC CSG / boolean composition | **no** — [code] | yes (IFC-only) | only on a **store-backed** open — [code] |
+| IFC advanced BREP, planar face | yes, via `TriBounds` — [code] | yes (IFC-only) | only on a **store-backed** open — [code] |
+| IFC advanced BREP, conical/cylindrical/B-spline face | yes — [code] | yes (IFC-only) | only on a **store-backed** open — [code] |
+| IFC advanced BREP, spherical/toroidal/revolution/extrusion-surface face | **no** (main body) — [code] | yes (IFC-only) | only on a **store-backed** open — [code] |
+| STEP (AP214) solid extrusion (`Extrude()`) | **no** — [code] | **no AP214 analogue exists** — [code] | only if a caller **explicitly spills** — [code] |
+| STEP (AP214) advanced BREP, planar face | yes, via `TriBounds` — [code] | **no** — [code] | only if a caller **explicitly spills** — [code] |
+| STEP (AP214) advanced BREP, curved face | same per-surface split as IFC (shared compiled function) — [code] | **no** — [code] | only if a caller **explicitly spills** — [code] |
 
 The scratch-arena column is identical for STEP and IFC on every advanced-BREP
 row because `AddFaceToGeometry` is one compiled function shared by both
@@ -358,12 +383,17 @@ it by default:
    mechanical-CAD assemblies don't show IFC's cold-representation pattern,
    measured on corpus X") recorded here or in a successor doc, not an
    absence nobody chose.
-4. **The STEP-source adaptive residency window (#616/#617) is correctly
-   format-agnostic already** because it sits below both front ends at the
-   byte-source layer. Any future format that parses through
-   `StepModelBase` inherits it automatically — this is the shape the other
-   two mechanisms should be steered toward where feasible, rather than each
-   format wiring its own copy.
+4. **The STEP-source adaptive residency window (#616/#617) is
+   format-agnostic in its *class* but not in its *wiring*, and the wiring
+   is what protects a load.** Inheriting `StepModelBase` does **not** get a
+   format windowed automatically: the provider is installed by the open
+   path, so a buffer-backed open is unwindowed in either format, and AP214
+   has no open-time installation at all. The policy ask is therefore the
+   mirror of item 3's: **state which open modes are expected to be
+   windowed, and make an unwindowed open of a large source a deliberate,
+   recorded choice rather than a property of which entry point the caller
+   happened to call.** Sharing a base class is where this mechanism is
+   ahead of the other two; it is not yet where it needs to be.
 5. **Byte-identical is the bar for any coverage extension**, per conway#637's
    verification section: an arena or a residency policy changes *where*
    something lives, never *what* is computed. Digest re-blessing is only

--- a/design/new/geometry-memory-coverage.md
+++ b/design/new/geometry-memory-coverage.md
@@ -46,8 +46,10 @@ whose own message says "the three ParameterVertex surface tessellators
 commit message names *spherical*, but `TriangulateSphericalSurface()`
 (`mesh_utils.h:1324`) has no `ScratchArenaScope` and never constructs a
 `WingedEdgeMesh<ParameterVertex>` — it builds `WingedEdgeMesh<glm::dvec3>` on
-the default heap resource (**[code]**, read in full: lines 1324–2344 contain
-no `ScratchArenaScope`, no `ThreadScratchResource`). The commit's *code* covers
+the default heap resource (**[code]**, read in full: lines 1324–1655 —
+`TriangulateSphericalSurface()`'s own span, ending where
+`TriangulateToroidalSurface()` begins at `:1656` — contain no
+`ScratchArenaScope`, no `ThreadScratchResource`). The commit's *code* covers
 conical, not spherical; the commit's *prose* says the opposite. Site 4
 (`TriangulateBounds`) landed separately, in `2afcf37 "AFTP phase 2: wire
 TriangulateBounds scratch to the arena"`.
@@ -67,7 +69,7 @@ natural way to conclude the opposite, and a review round did exactly that
 
 1. `ConwayGeometryProcessor.cpp:705-711` — the `!parameters.advancedBrep`
    branch. This covers planar **non-advanced** faces only.
-2. `ConwayGeometryProcessor.cpp:745-747` — the **fall-through `else` at the
+2. `ConwayGeometryProcessor.cpp:745-748` — the **fall-through `else` at the
    end of the `advancedBrep` branch**, after the seven
    `surface.<kind>.Active` tests. This is the one a planar advanced face
    reaches.
@@ -107,7 +109,7 @@ row read from the named function body):
 | `TriConical` | `TriangulateConicalSurface` | `<ParameterVertex>` on `ThreadScratchResource()` | **yes** — site 1 |
 | `TriSphere` | `TriangulateSphericalSurface` | `<glm::dvec3>`, default heap | **no** |
 | `TriToroidal` | `TriangulateToroidalSurface` | `<glm::dvec3>`, default heap | **no** |
-| `TriRevolution` | `TriangulateRevolution` | `<glm::dvec3>`, default heap | **no** (falls back to `TriangulateBounds` — arena-covered — only on a degenerate-unwrap exit) |
+| `TriRevolution` | `TriangulateRevolution` | `<glm::dvec3>`, default heap | **no** |
 | `TriExtrusion` | `TriangulateExtrusion` (surface-of-linear-extrusion tessellator) | `<glm::dvec3>` main body; delegates to `TriangulateBounds` on several fallback branches | **partially** — main algorithm no, several named fallbacks yes |
 
 Four of eight advanced-BREP surface tags are arena-covered; four are not.
@@ -157,7 +159,8 @@ tag (`TriBounds`) that does have coverage.
 One corroborating detail: `AllocTelemetryScope`, the instrument the AFTP
 telemetry pass reads (`structures/alloc_telemetry.h:17`), is placed only
 around `AddFaceToGeometry`/`AddFaceToGeometrySimple`
-(`ConwayGeometryProcessor.cpp:676`, `:807`). It never wraps
+(`ConwayGeometryProcessor.cpp:676`, `:624`). `StageFaceToGeometrySimple`
+(`:807`) has no telemetry scope of its own. It never wraps
 `getExtrudedAreaSolid`/`Extrude()`. So "the AFTP telemetry pass recorded zero
 scoped faces on ordinary extrusion/profile/CSG IFC models" is expected on
 architectural grounds alone — the instrument was never placed on that call
@@ -188,11 +191,20 @@ worth confirming rather than assuming." **It does not; it is IFC-only.**
   AP214 mechanical-CAD format).
 - The AP214 (STEP mechanical) model class, `AP214StepModel`
   (`src/AP214E3_2010/ap214_step_model.ts:21`), holds
-  `geometry = new AP214ModelGeometry()` — **[code]**, and
-  `AP214ModelGeometry` (`src/AP214E3_2010/ap214_model_geometry.ts`) has no
-  `residency`, `budget`, or `evict` member at all — repo-grep over that file
-  is empty for all three terms. There is no AP214 analogue of
-  `GeometryResidency`.
+  `geometry = new AP214ModelGeometry()` (`ap214_step_model.ts:25`) —
+  **[code]**, and `AP214ModelGeometry`
+  (`src/AP214E3_2010/ap214_model_geometry.ts`) has no `residency`,
+  `budget`, or `evict` member at all — repo-grep over that file is empty
+  for all three terms. There is no AP214 analogue of `GeometryResidency`.
+  `AP214ModelGeometry` does have `delete(localID)` and
+  `deleteTemporaries()` (`ap214_model_geometry.ts:59,77`), and
+  `deleteTemporaries()` is called on the AP214 load path
+  (`ap214_geometry_extraction.ts:6746`), the exact mirror of the IFC call
+  at `ifc_geometry_extraction.ts:8649` — so AP214 does shed CSG/boolean
+  temporaries the same way IFC does. What it lacks is specifically a
+  *budgeted LRU over retained meshes*: no cap, no recency tracking, no
+  byte ceiling, nothing driven by `GEOMETRY_BUDGET_MB`, and no
+  `GeometryResidency` registration.
 - The `GEOMETRY_BUDGET_MB` open setting wires in only through
   `ifc_api_proxy_ifc.ts:437-440` (`model.geometryResidency.setBudgetBytes(...)`),
   which only exists on the IFC front end
@@ -203,27 +215,39 @@ So `demandGeometry` (the issue's name for this mechanism) does not exist
 under that literal name anywhere in the tree (**[code]**, repo-wide grep is
 empty); the actual API is `GeometryResidency.evictToBudget()` /
 `.setBudgetBytes()`, called from `ifc_api_proxy_ifc.ts` only. **A STEP
-(AP214) load gets no eviction, no LRU, no budget of any kind on its
-extracted-geometry cache** — it retains everything for the process
-lifetime, full stop. This is a real gap, and a bigger one than "does the
-budget apply to STEP too" — STEP has no comparable machinery to apply.
+(AP214) load sheds its CSG/boolean temporaries via `deleteTemporaries()`,
+same as IFC, but has no budgeted LRU, no recency tracking, and no byte
+ceiling over the meshes it retains** — nothing driven by
+`GEOMETRY_BUDGET_MB`, and no `GeometryResidency` registration. This is a
+real gap, and a bigger one than "does the budget apply to STEP too" — STEP
+has no comparable retained-mesh eviction policy to apply, even though it
+does clean up transients the way IFC does.
 
 ## Adaptive residency (#616/#617) — format-agnostic, and the one mechanism that is shared
 
 `WindowedStepBufferProvider` (`src/step/step_buffer_provider.ts:354`) is
-constructed from `StepModelBase.openStreamed` (`src/step/step_model_base.ts:822`)
-— **[code]**. `StepModelBase` is the common ancestor of both `IfcStepModel`
-and `AP214StepModel` (both `extends StepModelBase<...>` —
-`ifc_step_model.ts:21`, `ap214_step_model.ts:21`). This mechanism operates
-on the raw STEP-source byte window during parsing, before any format-specific
-geometry extraction begins, so it is genuinely shared: both formats get the
-same adaptive-cap policy, the same thrash detection, the same doubling
-behaviour described in `step_buffer_provider.ts:58-115`.
+constructed inside `StepModelBase.spillSourceToExternalStore`
+(`src/step/step_model_base.ts:811`, construction at `:822`) — **[code]**.
+(There is no `StepModelBase.openStreamed` — grepped empty.)
+`StepModelBase` is the common ancestor of both `IfcStepModel` and
+`AP214StepModel` (both `extends StepModelBase<...>` — `ifc_step_model.ts:21`,
+`ap214_step_model.ts:21`), and `spillSourceToExternalStore` itself is
+format-agnostic — the *class* is shared. But every **open-time**
+construction of `WindowedStepBufferProvider` in the tree is IFC-side
+(`ifc_step_parser.ts:118,159`, `ifc_stream_open.ts:129,211`,
+`ifc_api_proxy_ifc.ts:1245`); `src/AP214E3_2010/` constructs none, and has
+no `ap214_stream_open` — AP214 reaches the mechanism only if a caller
+explicitly spills via `ifc_api_proxy_ap214.ts:213` →
+`spillSourceToExternalStore`. So "both formats get the same adaptive-cap
+policy" is true of the mechanism *when a caller spills*, not of an
+ordinary AP214 open — an AP214 open does not windowed-buffer its source by
+default the way an IFC open does. Once spilling happens, the policy is
+identical: the same thrash detection, the same doubling behaviour
+described in `step_buffer_provider.ts:58-115`, for both formats.
 
 This is the one row in this matrix where "applies across formats" is
-correct as stated (issue text didn't claim this one needed confirming, and
-the audit backs that up) — included here so the matrix is complete rather
-than only correcting claims.
+correct, with that qualification — included here so the matrix is
+complete rather than only correcting claims.
 
 On D3D specifically: per conway#635, adaptive residency grows the window to
 the whole 213.6 MB file "by design," so on this model it *costs* ~150 MB
@@ -287,10 +311,6 @@ was evaluated and excluded.
   used for Arty_Z7 against D3D, this time keyed to the new tags. This is a
   wasm rebuild plus a telemetry pass, which is why it's out of scope here
   rather than attempted.
-- **Whether `TriangulateRevolution`'s degenerate-fallback path to
-  `TriangulateBounds` fires often enough on real corpora to matter.** Read
-  from code that the fallback exists; not measured how frequently it is
-  taken.
 - **Whether an AP214-side `GeometryResidency` analogue is wanted at all.**
   This audit establishes that none exists, not whether AP214's load profile
   needs one — STEP mechanical-CAD models may have a different retained-vs-
@@ -311,8 +331,14 @@ it by default:
    arena-backed by construction, not by retrofit.** The pattern already
    exists and is cheap to apply: construct on `conway::ThreadScratchResource()`
    under a `ScratchArenaScope` (or `conway::ScratchAllocator<T>` for a bare
-   `std::vector`) at the top of the function, exactly as sites 1–4 above do.
-   A new `Triangulate*` function, a new CSG entry point, or a new solid-sweep
+   `std::vector`) immediately before the scratch structure it covers, as
+   sites 1–4 above do — at the top of the function for sites 1–3, or, for
+   site 4, at the top of the branch that actually allocates
+   (`geometry_utils.h:767`, inside `TriangulateBounds`'s
+   `else if (bounds.size() > 0)` arm, not the function's top-level
+   `if` at `:743`). The scope should sit as close to its allocation as the
+   function's control flow allows, not necessarily at the function's own
+   entry. A new `Triangulate*` function, a new CSG entry point, or a new solid-sweep
    helper should default to this rather than needing someone to notice its
    allocation profile first. The four currently-uncovered advanced-BREP
    tags (`TriSphere`, `TriToroidal`, `TriRevolution`, `TriExtrusion`) and

--- a/design/new/geometry-memory-coverage.md
+++ b/design/new/geometry-memory-coverage.md
@@ -1,0 +1,340 @@
+# What memory machinery protects a geometry load? An audited matrix
+
+Companion to [`emsdk-upgrade-scalable-allocator.md`](emsdk-upgrade-scalable-allocator.md)
+(the AFTP work that built the scratch arena) and to the still-unmerged
+`load-performance-ledger.md` / `browser-memory-analysis.md` on
+`claude/github-issue-394-sqdt6b` in bldrs-ai/conway, which this doc's audit
+was commissioned to check (conway#637, sub-issue of conway#635). Read this
+doc, not the ledger, for the current, verified state of arena coverage — the
+ledger's §7 claim about scope is superseded below.
+
+**Scope of this doc.** Audit and policy only (conway#637 items 1 and 4).
+Measuring D3D's per-face allocation profile (item 2) and extending arena
+coverage (item 3) are out of scope here — see [Unmeasured](#unmeasured-and-what-it-would-take)
+and [Policy](#the-policy) for what those need.
+
+**Method.** Every claim below is either **[code]** — read from the pinned
+`dependencies/conway-geom` revision, cited file:line, verified by grep and by
+reading the function body, not by trusting a comment or a commit message — or
+**[inferred]** — reasoned from adjacent code without a direct read of the
+executing path. Nothing here is asserted from memory of a previous audit.
+Pinned revision: `conway-geom@6d7c054` (submodule HEAD as checked out for
+this audit, 2026-08-28).
+
+## Verified: the arena is at four sites, not two
+
+conway#637 states `ScratchArenaScope` appears "at exactly two sites in
+production code, both in `mesh_utils.h`." **That undercounts by half.** A
+full-repo grep for `ScratchArenaScope` construction against the pinned
+revision finds:
+
+| # | Site | Function | Covers |
+|---|---|---|---|
+| 1 | `conway_geometry/operations/mesh_utils.h:2628` | `TriangulateConicalSurface()` | per-face `WingedEdgeMesh<ParameterVertex>` for conical surfaces |
+| 2 | `conway_geometry/operations/mesh_utils.h:3014` | `TriangulateCylindricalSurface()` | same, cylindrical surfaces |
+| 3 | `conway_geometry/operations/mesh_utils.h:5298` | `TriangulateBspline()` | same, B-spline/NURBS surfaces |
+| 4 | `conway_geometry/operations/geometry_utils.h:767` | `TriangulateBounds()` | the earcut scratch (`std::vector` over `conway::ScratchAllocator`) for **planar** bound polygons |
+
+(Three more constructions exist in
+`conway_geometry/structures/scratch_arena_test.cpp` — unit-test code, not a
+production path, correctly excluded from the issue's count.)
+
+Sites 1–3 all landed in one commit,
+`49dede4 "AFTP phase 2: arena-back WingedEdgeMesh — 67% fewer allocator calls"`,
+whose own message says "the three ParameterVertex surface tessellators
+(bspline / cylindrical / spherical)" — a second drift worth flagging: the
+commit message names *spherical*, but `TriangulateSphericalSurface()`
+(`mesh_utils.h:1324`) has no `ScratchArenaScope` and never constructs a
+`WingedEdgeMesh<ParameterVertex>` — it builds `WingedEdgeMesh<glm::dvec3>` on
+the default heap resource (**[code]**, read in full: lines 1324–2344 contain
+no `ScratchArenaScope`, no `ThreadScratchResource`). The commit's *code* covers
+conical, not spherical; the commit's *prose* says the opposite. Site 4
+(`TriangulateBounds`) landed separately, in `2afcf37 "AFTP phase 2: wire
+TriangulateBounds scratch to the arena"`.
+
+**Consequence for the issue's central claim.** conway#637 says the ledger's
+"scoped to `AddFaceToGeometry`" line is wrong, and that the real scope is
+narrower — "two curved-surface triangulators... A planar-faced BREP gets
+nothing either." Site 4 directly refutes the second half: **a planar-faced
+BREP face *does* get arena coverage**, via `TriangulateBounds`, which is the
+function `AddFaceToGeometry` dispatches to for every non-advanced-BREP face
+(**[code]**, `ConwayGeometryProcessor.cpp:705-711`). So the corrected
+picture is not "two sites, planar gets nothing" — it is "four sites, and
+the gap is elsewhere." See the matrix below for where.
+
+## The dispatcher and its eight tagged paths
+
+`AddFaceToGeometry` (`ConwayGeometryProcessor.cpp:674`) is the single
+entry point for advanced-BREP face tessellation, shared identically by the
+STEP (AP214) and IFC front ends — both call the same compiled function
+through the wasm binding. It classifies each face by surface type and
+dispatches to one of eight `Triangulate*` functions, each already wrapped in
+an `AllocTagScope` telemetry tag (`ConwayGeometryProcessor.cpp:705-750`) —
+the AFTP instrument built exactly to attribute allocations per surface kind.
+Cross-referencing those eight tags against arena coverage (**[code]**, each
+row read from the named function body):
+
+| `AllocSite` tag | Function | `WingedEdgeMesh` variant | Arena-covered? |
+|---|---|---|---|
+| `TriBounds` | `TriangulateBounds` | n/a (earcut over `ScratchAllocator` vectors) | **yes** — site 4 |
+| `TriBspline` | `TriangulateBspline` | `<ParameterVertex>` on `ThreadScratchResource()` | **yes** — site 3 |
+| `TriCylinder` | `TriangulateCylindricalSurface` | `<ParameterVertex>` on `ThreadScratchResource()` | **yes** — site 2 |
+| `TriConical` | `TriangulateConicalSurface` | `<ParameterVertex>` on `ThreadScratchResource()` | **yes** — site 1 |
+| `TriSphere` | `TriangulateSphericalSurface` | `<glm::dvec3>`, default heap | **no** |
+| `TriToroidal` | `TriangulateToroidalSurface` | `<glm::dvec3>`, default heap | **no** |
+| `TriRevolution` | `TriangulateRevolution` | `<glm::dvec3>`, default heap | **no** (falls back to `TriangulateBounds` — arena-covered — only on a degenerate-unwrap exit) |
+| `TriExtrusion` | `TriangulateExtrusion` (surface-of-linear-extrusion tessellator) | `<glm::dvec3>` main body; delegates to `TriangulateBounds` on several fallback branches | **partially** — main algorithm no, several named fallbacks yes |
+
+Four of eight advanced-BREP surface tags are arena-covered; four are not.
+This is a materially different — and more precise — picture than "two
+sites" in either direction: more sites are covered than the issue states,
+and the uncovered set is bigger than "everything except cones and
+cylinders" (it also includes spheres, tori, revolution surfaces, and most of
+extrusion-surface tessellation).
+
+**A naming trap worth flagging explicitly**: `TriangulateExtrusion` in
+`mesh_utils.h` (an `ExtrusionSurface`-typed advanced-BREP face — rare) is a
+different function from `Extrude()` in `geometry_utils.h` (the solid
+sweep behind `IfcExtrudedAreaSolid` — the common case). Same word, disjoint
+call graphs, opposite arena status (see next section). Don't conflate them
+when reading either the code or this doc.
+
+## The path the issue is actually about: IFC extrusion/profile/CSG
+
+D3D's geometry is "a Tekla IFC4 export" of ordinary extrusions — not
+advanced-BREP faces at all. That path does not go through
+`AddFaceToGeometry`:
+
+- `IfcExtrudedAreaSolid` → `ifc_geometry_extraction.ts:2359`
+  `extractExtrudedAreaSolid` → `conwayModel.getExtrudedAreaSolid()` →
+  `ConwayGeometryProcessor::getExtrudedAreaSolid`
+  (`ConwayGeometryProcessor.cpp:3248`) → `Extrude()`
+  (`geometry_utils.h:1043`) (**[code]**, full call chain read).
+- `Extrude()` builds its cap polygons as
+  `std::vector<std::vector<Point>>` (default `std::allocator`, not
+  `conway::ScratchAllocator`) and calls `mapbox::earcut<uint32_t>` directly
+  — **[code]**, read in full, lines 1043–1200+. No `ScratchArenaScope`, no
+  `ThreadScratchResource`, anywhere in the function.
+- CSG/boolean composition (`manifold_utils.h` and the rest of
+  `conway_geometry/operations` outside `mesh_utils.h`/`geometry_utils.h`)
+  has **zero** `ScratchArenaScope` or `ScratchAllocator` occurrences —
+  **[code]**, repo-wide grep, confirmed empty outside the two files already
+  covered above.
+
+So: **IFC extrusion/profile/CSG — the path that produced #635's numbers —
+has no arena coverage anywhere in its call graph**, confirming the issue's
+premise for this specific path. But the *reason* is not "planar BREP gets
+nothing" (refuted above); it's that solid extrusion is a structurally
+separate code path from `AddFaceToGeometry` altogether, sharing only the
+word "extrusion" and the underlying earcut library with the one advanced-BREP
+tag (`TriBounds`) that does have coverage.
+
+One corroborating detail: `AllocTelemetryScope`, the instrument the AFTP
+telemetry pass reads (`structures/alloc_telemetry.h:17`), is placed only
+around `AddFaceToGeometry`/`AddFaceToGeometrySimple`
+(`ConwayGeometryProcessor.cpp:676`, `:807`). It never wraps
+`getExtrudedAreaSolid`/`Extrude()`. So "the AFTP telemetry pass recorded zero
+scoped faces on ordinary extrusion/profile/CSG IFC models" is expected on
+architectural grounds alone — the instrument was never placed on that call
+graph — independent of whether the arena mechanism would help there. This
+doesn't change the coverage conclusion (already independently confirmed by
+reading `Extrude()`), but it does mean the "zero" reading is not itself
+evidence of anything beyond "the instrument wasn't there" — worth naming so
+nobody later treats that zero as a measurement of the extrusion path's
+per-face allocation cost. It isn't one.
+
+Format note: both AP214 (STEP) and IFC extraction call
+`getExtrudedAreaSolid` for their respective extruded-solid entities
+(**[code]**, `ap214_geometry_extraction.ts:2409-2415` mirrors
+`ifc_geometry_extraction.ts:2385-2391`) — same compiled `Extrude()`, same
+gap, both formats. The split that matters is *solid extrusion vs.
+advanced-BREP face*, not *STEP vs. IFC*.
+
+## Geometry budget (`GEOMETRY_BUDGET_MB`, `GeometryResidency`) — IFC-only, not cross-format
+
+conway#637 says the geometry budget "appears to apply across formats —
+worth confirming rather than assuming." **It does not; it is IFC-only.**
+
+- `GeometryResidency` (`src/ifc/geometry_residency.ts`) is instantiated
+  exactly once, as `IfcStepModel.geometryResidency`
+  (`src/ifc/ifc_step_model.ts:29`) — **[code]**. `IfcStepModel` is conway's
+  IFC-over-STEP-physical-file model class (the class handles IFC's schema;
+  "Step" in the name refers to the SPF encoding IFC files use, not the
+  AP214 mechanical-CAD format).
+- The AP214 (STEP mechanical) model class, `AP214StepModel`
+  (`src/AP214E3_2010/ap214_step_model.ts:21`), holds
+  `geometry = new AP214ModelGeometry()` — **[code]**, and
+  `AP214ModelGeometry` (`src/AP214E3_2010/ap214_model_geometry.ts`) has no
+  `residency`, `budget`, or `evict` member at all — repo-grep over that file
+  is empty for all three terms. There is no AP214 analogue of
+  `GeometryResidency`.
+- The `GEOMETRY_BUDGET_MB` open setting wires in only through
+  `ifc_api_proxy_ifc.ts:437-440` (`model.geometryResidency.setBudgetBytes(...)`),
+  which only exists on the IFC front end
+  (`ifc_api_proxy_ap214.ts` has no matching code — **[code]**, grepped
+  empty).
+
+So `demandGeometry` (the issue's name for this mechanism) does not exist
+under that literal name anywhere in the tree (**[code]**, repo-wide grep is
+empty); the actual API is `GeometryResidency.evictToBudget()` /
+`.setBudgetBytes()`, called from `ifc_api_proxy_ifc.ts` only. **A STEP
+(AP214) load gets no eviction, no LRU, no budget of any kind on its
+extracted-geometry cache** — it retains everything for the process
+lifetime, full stop. This is a real gap, and a bigger one than "does the
+budget apply to STEP too" — STEP has no comparable machinery to apply.
+
+## Adaptive residency (#616/#617) — format-agnostic, and the one mechanism that is shared
+
+`WindowedStepBufferProvider` (`src/step/step_buffer_provider.ts:354`) is
+constructed from `StepModelBase.openStreamed` (`src/step/step_model_base.ts:822`)
+— **[code]**. `StepModelBase` is the common ancestor of both `IfcStepModel`
+and `AP214StepModel` (both `extends StepModelBase<...>` —
+`ifc_step_model.ts:21`, `ap214_step_model.ts:21`). This mechanism operates
+on the raw STEP-source byte window during parsing, before any format-specific
+geometry extraction begins, so it is genuinely shared: both formats get the
+same adaptive-cap policy, the same thrash detection, the same doubling
+behaviour described in `step_buffer_provider.ts:58-115`.
+
+This is the one row in this matrix where "applies across formats" is
+correct as stated (issue text didn't claim this one needed confirming, and
+the audit backs that up) — included here so the matrix is complete rather
+than only correcting claims.
+
+On D3D specifically: per conway#635, adaptive residency grows the window to
+the whole 213.6 MB file "by design," so on this model it *costs* ~150 MB
+rather than saving any — a documented, measured cost (ledger, not re-verified
+here since it's outside this audit's scope), not a bug in the mechanism.
+
+## `geometry_residency.ts` (the 8 MB / 85 MB figure)
+
+This is the same `GeometryResidency` class discussed above (the file *is*
+`src/ifc/geometry_residency.ts`) — not a separate mechanism. The 8 MB live
+set under an 85 MB heap on MB-Khaya (10.6×) is documented in the file's own
+header comment (lines ~24-50) as the measured effect of its LRU eviction
+policy. Same IFC-only scope as the budget section above: this number
+describes `IfcModelGeometry`'s cache behaviour and has no AP214 counterpart.
+
+## The matrix, per geometry path
+
+| Path | Scratch arena | Geometry budget / residency (extracted-mesh cache) | Adaptive residency (source window) |
+|---|---|---|---|
+| IFC extrusion / profile (`IfcExtrudedAreaSolid` → `Extrude()`) | **no** — [code] | yes (IFC-only) | yes (shared) |
+| IFC CSG / boolean composition | **no** — [code] | yes (IFC-only) | yes (shared) |
+| IFC advanced BREP, planar face | yes, via `TriBounds` — [code] | yes (IFC-only) | yes (shared) |
+| IFC advanced BREP, conical/cylindrical/B-spline face | yes — [code] | yes (IFC-only) | yes (shared) |
+| IFC advanced BREP, spherical/toroidal/revolution/extrusion-surface face | **no** (main body) — [code] | yes (IFC-only) | yes (shared) |
+| STEP (AP214) solid extrusion (`Extrude()`) | **no** — [code] | **no AP214 analogue exists** — [code] | yes (shared) |
+| STEP (AP214) advanced BREP, planar face | yes, via `TriBounds` — [code] | **no** — [code] | yes (shared) |
+| STEP (AP214) advanced BREP, curved face | same per-surface split as IFC (shared compiled function) — [code] | **no** — [code] | yes (shared) |
+
+The scratch-arena column is identical for STEP and IFC on every advanced-BREP
+row because `AddFaceToGeometry` is one compiled function shared by both
+front ends — coverage there was never a format question, only a
+surface-type question. The geometry-budget column is the one that actually
+splits by format, and it splits because the mechanism was built once, for
+`IfcStepModel`, and never given an AP214 counterpart — not because AP214
+was evaluated and excluded.
+
+## Unmeasured, and what it would take
+
+- **Whether the arena mechanism (not just its current placement) would help
+  the extrusion/CSG path.** conway#637 is explicit that the ledger's "single
+  largest identified lever" framing is a hypothesis riding on an analogy
+  (Arty_Z7's 60× peak-to-retained ratio, D3D's similarly-shaped ratio),
+  not a finding. This audit does not change that status — nothing here
+  measures D3D's per-face allocation profile. Restated per the issue's
+  claim-discipline bar: **treat "extending arena scope is the largest
+  lever" as unproven** until measured.
+- **Method for that measurement, from what this audit found in the
+  instrumentation already in the tree:** `AllocTelemetryScope`
+  (`structures/alloc_telemetry.h`) and its `AllocTagScope`/`AllocSite`
+  attribution enum already exist and already cover all eight
+  `AddFaceToGeometry` surface tags. They do **not** cover
+  `getExtrudedAreaSolid`/`Extrude()` or the CSG/boolean call graph. The
+  minimal extension for item 2 is: (a) wrap `Extrude()` (and, separately,
+  whatever CSG entry point composes voids/booleans for extrusions) in an
+  `AllocTelemetryScope`, matching the existing per-face-in-`AddFaceToGeometry`
+  placement; (b) add `AllocSite` tags for the solid-extrusion cap earcut and
+  for CSG, distinct from the existing `TriExtrusion` tag (which is the
+  *surface* tessellator and must not be conflated with this — see the
+  naming trap noted above); (c) rebuild with `CONWAY_ALLOC_TELEMETRY` per
+  `alloc_telemetry.h`'s header comment; (d) run the same AFTP telemetry pass
+  used for Arty_Z7 against D3D, this time keyed to the new tags. This is a
+  wasm rebuild plus a telemetry pass, which is why it's out of scope here
+  rather than attempted.
+- **Whether `TriangulateRevolution`'s degenerate-fallback path to
+  `TriangulateBounds` fires often enough on real corpora to matter.** Read
+  from code that the fallback exists; not measured how frequently it is
+  taken.
+- **Whether an AP214-side `GeometryResidency` analogue is wanted at all.**
+  This audit establishes that none exists, not whether AP214's load profile
+  needs one — STEP mechanical-CAD models may have a different retained-vs-
+  transient shape than IFC's per-product extraction pattern. That's a
+  measurement question for whoever picks up the budget-coverage gap, not
+  answered here.
+
+## The policy
+
+Today, whether a geometry path gets memory machinery is an accident of which
+function happened to get profiled (curved advanced-BREP faces, because
+Arty_Z7 surfaced them) rather than a property anyone decided a tessellation
+entry point should have. Stating the policy so the next entry point inherits
+it by default:
+
+1. **Every per-face or per-solid tessellation scratch structure (temporary
+   mesh, edge map, candidate heap, boundary-polygon buffer) is
+   arena-backed by construction, not by retrofit.** The pattern already
+   exists and is cheap to apply: construct on `conway::ThreadScratchResource()`
+   under a `ScratchArenaScope` (or `conway::ScratchAllocator<T>` for a bare
+   `std::vector`) at the top of the function, exactly as sites 1–4 above do.
+   A new `Triangulate*` function, a new CSG entry point, or a new solid-sweep
+   helper should default to this rather than needing someone to notice its
+   allocation profile first. The four currently-uncovered advanced-BREP
+   tags (`TriSphere`, `TriToroidal`, `TriRevolution`, `TriExtrusion`) and
+   the two currently-uncovered non-advanced-BREP paths (`Extrude()`, CSG)
+   are the concrete backlog this principle names — extending them is
+   conway#637 item 3, gated on the item-2 measurement above.
+2. **Telemetry attribution (`AllocTagScope`/`AllocSite`) is added at the
+   same time as the scratch structure, not after.** It's what makes the
+   next audit possible without re-deriving this matrix by hand. Every
+   tessellation or CSG entry point should carry a tag whether or not it is
+   yet arena-backed — an untagged path is invisible to the AFTP telemetry
+   pass by construction, which is exactly the trap `Extrude()` fell into.
+3. **The extracted-geometry residency budget (`GeometryResidency`) is a
+   per-model-class decision, not an IFC-specific one, and any future format
+   front end should decide it explicitly rather than inherit silence.**
+   If AP214 stays unbudgeted, that should be a stated choice (e.g. "STEP
+   mechanical-CAD assemblies don't show IFC's cold-representation pattern,
+   measured on corpus X") recorded here or in a successor doc, not an
+   absence nobody chose.
+4. **The STEP-source adaptive residency window (#616/#617) is correctly
+   format-agnostic already** because it sits below both front ends at the
+   byte-source layer. Any future format that parses through
+   `StepModelBase` inherits it automatically — this is the shape the other
+   two mechanisms should be steered toward where feasible, rather than each
+   format wiring its own copy.
+5. **Byte-identical is the bar for any coverage extension**, per conway#637's
+   verification section: an arena or a residency policy changes *where*
+   something lives, never *what* is computed. Digest re-blessing is only
+   for models whose output legitimately changes (there should be none), and
+   any digest churn on an extension is a bug in the extension, not an
+   accepted cost.
+
+## Summary of what changed by doing this audit
+
+- The issue's site count (2) is revised to **4** production
+  `ScratchArenaScope` constructions, plus one nested subdivision-heap
+  allocation (`tesselation_utils.h:409`) that rides inside three of those
+  four scopes rather than opening its own.
+- The issue's inherited claim that "a planar-faced BREP gets nothing" is
+  **refuted**: `TriangulateBounds` (site 4) covers exactly that case.
+- The issue's "worth confirming" on cross-format geometry budget is
+  **resolved: it does not apply across formats.** AP214 has no residency
+  or budget mechanism at all, not a differently-tuned one.
+- The issue's characterization of the IFC extrusion/CSG gap is
+  **confirmed** by reading `Extrude()` and the CSG call graph directly —
+  genuinely zero arena coverage there, for a different structural reason
+  (separate call graph, not "planar BREP") than the ledger implied.
+- The "largest lever" framing remains a **hypothesis**, unchanged by this
+  audit, with a concrete measurement method now written down for whoever
+  picks up item 2.

--- a/design/new/geometry-memory-coverage.md
+++ b/design/new/geometry-memory-coverage.md
@@ -56,11 +56,36 @@ TriangulateBounds scratch to the arena"`.
 "scoped to `AddFaceToGeometry`" line is wrong, and that the real scope is
 narrower — "two curved-surface triangulators... A planar-faced BREP gets
 nothing either." Site 4 directly refutes the second half: **a planar-faced
-BREP face *does* get arena coverage**, via `TriangulateBounds`, which is the
-function `AddFaceToGeometry` dispatches to for every non-advanced-BREP face
-(**[code]**, `ConwayGeometryProcessor.cpp:705-711`). So the corrected
-picture is not "two sites, planar gets nothing" — it is "four sites, and
-the gap is elsewhere." See the matrix below for where.
+BREP face *does* get arena coverage**, via `TriangulateBounds`. So the
+corrected picture is not "two sites, planar gets nothing" — it is "four
+sites, and the gap is elsewhere." See the matrix below for where.
+
+**`TriangulateBounds` is called from two places, and only the second one
+makes the claim above true** (**[code]**). Reading just the first is the
+natural way to conclude the opposite, and a review round did exactly that
+(#639), so both are spelled out here:
+
+1. `ConwayGeometryProcessor.cpp:705-711` — the `!parameters.advancedBrep`
+   branch. This covers planar **non-advanced** faces only.
+2. `ConwayGeometryProcessor.cpp:745-747` — the **fall-through `else` at the
+   end of the `advancedBrep` branch**, after the seven
+   `surface.<kind>.Active` tests. This is the one a planar advanced face
+   reaches.
+
+A planar `IfcAdvancedFace` / `advanced_face` takes route 2: the extractors
+set `advancedBrep: true` (`ifc_geometry_extraction.ts:5083`,
+`ap214_geometry_extraction.ts:4774`), and `extractSurface` for an `IfcPlane`
+sets only `nativeSurface.transformation` (`ifc_geometry_extraction.ts:5101-5103`)
+— never any of the seven `Active` flags, which each default to `false`
+(`IfcGeometryReps.h`). With no curved-surface flag set, the chain is
+`advancedBrep: true` → the `else` at :711 → every `Active` false → the
+final `else` at :745 → `TriangulateBounds` → the `ScratchArenaScope` at
+`geometry_utils.h:767`.
+
+**Do not reason about this from the `AllocSite` tag.** Both call sites tag
+their work `AllocSite::TriBounds`, so the telemetry cannot separate "planar
+non-advanced" from "planar advanced, fallen through" — a distinction that
+matters precisely when deciding whether the advanced-BREP path is covered.
 
 ## The dispatcher and its eight tagged paths
 


### PR DESCRIPTION
Addresses items 1 and 4 of #637 (sub-issue of #635): audit which memory
machinery (scratch arena, geometry budget/residency, adaptive STEP-source
window residency) covers which geometry path across STEP and IFC, and write
the policy down so the next tessellation entry point is covered by default.

New doc: [`design/new/geometry-memory-coverage.md`](../blob/claude/transient-memory-reclamation-a1y9km/design/new/geometry-memory-coverage.md),
linked from `AGENTS.md`'s "Where to read more" table.

**This PR addresses only 2 of #637's 4 work items** and must not close it —
items 2 and 3 remain open, and item 3 needs rescoping first (see below).
An earlier revision of this description carried `Closes: none (partial)` on
the line above `Refs #637, #635`, and GitHub bridged that keyword to the
following reference and registered #639 as closing #637. Verified clear
(`closed_by_pull_requests: 0`). Keep closing keywords out of this body
entirely — `Closes: none` is not a safe way to say "closes nothing".

## Key findings (all read from code, cited file:line; `conway-geom@6d7c054`)

- **The scratch arena is at 4 production `ScratchArenaScope` sites, not 2.**
  #637 states "exactly two," both in `mesh_utils.h`. A third
  (`TriangulateBspline`) and a fourth — `TriangulateBounds` in
  `geometry_utils.h:767`, covering **planar** bound polygons — also construct
  one. Commit-message drift is flagged too: the commit adding sites 1–3
  describes them as "bspline / cylindrical / spherical," but the code covers
  conical, not spherical.
- **This refutes the ledger's "a planar-faced BREP gets nothing" claim**,
  which #637 carried forward. **`TriangulateBounds` has two call sites and
  only the second supports this** — the fall-through `else` at
  `ConwayGeometryProcessor.cpp:745-748`, where a planar advanced face lands
  because a plane activates none of the seven curved-surface flags. The doc
  spells out the full chain, because reading only the `!advancedBrep`
  dispatch leads to the opposite conclusion.
- **Both call sites tag their work `AllocSite::TriBounds`**, so the AFTP
  telemetry cannot distinguish "planar non-advanced" from "planar advanced,
  fallen through". Anyone designing item 2's measurement needs to know the
  tag is ambiguous before building on it.
- **The geometry budget (`GEOMETRY_BUDGET_MB`, `GeometryResidency`) is
  IFC-only.** `AP214ModelGeometry` has no budgeted LRU, no recency tracking,
  no byte ceiling and no `GeometryResidency` registration. It *does* have
  `delete()`/`deleteTemporaries()`, called on the AP214 load path — so AP214
  sheds CSG temporaries like IFC does; what it lacks is the budget, not all
  cleanup.
- **IFC extrusion/profile/CSG genuinely has zero arena coverage**, confirmed
  by reading `Extrude()` (`geometry_utils.h:1043`) and the CSG/boolean call
  graph — but for a different structural reason than "planar BREP gets
  nothing": solid extrusion is a separate call graph from `AddFaceToGeometry`
  altogether, used identically by AP214 and IFC. **Consequence: item 3 of
  #637 as originally framed ("extend the `AddFaceToGeometry` scopes") would
  never have reached the extrusion path. It needs rescoping.**
- **Adaptive residency (#616/#617) is gated on open mode, not format.** A
  buffer-backed open is unwindowed in *either* format —
  `ifc_api_proxy_ifc.ts:1054` builds `new IfcStepModel(data, columns)` with
  the source resident, while `:1245` installs a `WindowedStepBufferProvider`;
  the same split is in `parseDataToModel` vs `parseStreamToModel`
  (`ifc_step_parser.ts:48-71` vs `:118,159`). Format is a *second* gate: IFC
  has an open-time store-backed path, AP214 reaches the mechanism only via an
  explicit spill. The class is shared; the wiring is not, and the wiring is
  what decides whether a load is protected.
- Full per-tag matrix (all 8 `AddFaceToGeometry` surface types; 4 covered, 4
  not) and a per-path matrix (STEP vs IFC × arena / budget / adaptive-window)
  are in the doc.

## Explicitly left as hypothesis, per #637's instruction

The ledger's "extending the arena scopes is the single largest identified
lever" is **not** treated as a finding — it rests on an Arty_Z7 analogy nobody
has measured against D3D at the per-face level. The doc writes down the method
for that measurement (extending the existing `AllocTelemetryScope`/`AllocSite`
instrumentation, which covers all 8 `AddFaceToGeometry` tags but not
`Extrude()` or CSG) as the "what item 2 needs" section, rather than attempting
it.

## Review history

Three rounds, and the doc changed materially in two of them.

Codex raised a P2 arguing `TriangulateBounds` proves coverage only for planar
non-advanced faces. Both premises were correct but it missed the second call
site; answered with the traced call chain, independently confirmed by a
separate review round, and the doc now names both sites so the next reader
does not re-derive it. Resolved.

Codex then raised a second P2 on adaptive residency — **valid, and the more
useful of the two.** The doc had framed source windowing as IFC-versus-AP214
with an unconditional "yes (shared)" in every matrix row; the real first-order
gate is open mode, and a buffer-backed IFC open is unwindowed too. Fixed in
`96a7086`: matrix column re-headed and all eight rows qualified, and policy
item 4 rewritten — inheriting `StepModelBase` does not window a format
automatically. Resolved.

An independent review round found four further defects, fixed in `082a302`:
a `TriangulateRevolution` → `TriangulateBounds` fallback that **does not
exist in the code** (mis-read from `TriangulateExtrusion`'s header comment)
and had seeded a bogus follow-up work item; the overstated AP214 "retains
everything, full stop" claim; a reference to a nonexistent
`StepModelBase.openStreamed`; and several off-by-one or wrong-function
citations.

## Scope

Items 2 and 3 are out of scope — they need a wasm build, the AFTP telemetry
pass, and full-corpus digest re-blessing. Docs-only change; no code touched,
so `build.yml`'s `paths-ignore` correctly runs no jobs.

Refs #637, #635.