### PR TITLE
#608: bump conway-geom to df11afd — monotone sweep for trimmed b-spline ribbons

### DIFF
--- a/src/AP214E3_2010/ap214_geometry_extraction.test.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.test.ts
@@ -173,7 +173,21 @@ describe('AP214 Geometry Extraction', () => {
     // amplification budget subdividing against that residual. The removed
     // 3816 indices (1272 triangles) are that wasted subdivision, not lost
     // curvature.
-    const testParameter:number = 150828
+    //
+    // Lowered again, 150828 -> 14388, by conway-geom#190: the gear's involute
+    // flanks are trimmed b-spline ribbons, and they are now triangulated by a
+    // monotone sweep over their own boundary rather than ear-clipped and then
+    // refined. Ear clipping had no interior vertices to work with, so it filled
+    // each flank with slivers and `tesselate` spent its budget subdividing
+    // them; the sweep triangulates the same boundary directly. So this is a
+    // 10.5x drop in triangles for the same surface, and the checks that say so
+    // rather than assuming it: the model still reports 82 faces with 0
+    // unreached and 0 degenerate, the mesh is watertight on BOTH sides of the
+    // change (unpaired half-edges 0 -> 0, matched on exact world position),
+    // and a paired render moves 7.9% of pixels with the silhouette and every
+    // tooth unchanged - shading on the flanks, not geometry. Geometry memory
+    // falls 1.955 -> 0.278 MB.
+    const testParameter:number = 14388
     expect(getGearMeshSize()).toBe(testParameter)
 
   })


### PR DESCRIPTION
Bumps `dependencies/conway-geom` from `6d7c054` to **`df11afd`**, pulling in bldrs-ai/conway-geom#190. For bldrs-ai/conway#608, part of the epic bldrs-ai/conway#641.

## What it pulls in

A trimmed b-spline face whose boundary is a **ribbon** — two v-monotone legs meeting at two turning points — is now triangulated by a **monotone two-chain sweep** over its own boundary vertices instead of being ear-clipped.

Ear clipping introduces no interior vertices, so on a high-aspect trimmed strip every ear is a sliver, and a sliver long in v is a **chord across the part**. That is the mechanism behind the 23 faces conway#608 measured at 38×–298× their own deflection target. The sweep emits triangles between **existing boundary vertices only**, so it cannot introduce a T-vertex and the trim polyline reaches the mesh exactly as neighbouring faces build it. Quality still comes from `tesselate`, which splits interior edges only. `MAX_TRIANGLE_AMPLIFACTION` is untouched at 32.

## Expected regression deltas

Digests and visual-diff rows move on **three** models and no others:

| model | faces outside their own target | b-spline shipped tris | unpaired half-edges | geometry memory | pixels changed |
|---|---|---|---|---|---|
| **Orbiter** | **27 → 22** | 148,959 → 232,067 | **1,448 → 1,448** | 22.422 → 23.429 MB | **0.079%** |
| **Right_Hand** | **45 → 44** | 69,567 → 65,567 | **4,035 → 3,664** | 15.379 → **14.947** MB | **0.000%** |
| **nist_ctc_02** | 2 → 4 | 45,121 → 44,245 | 414 → 414 | 6.790 → **6.714** MB | **0.136%** |
| create-a-tube, supercap, nist_ctc_01, driver board | — | — | — | — | **byte-identical** |

Headline faces on Orbiter: `#51059` **118.0× → 0.174×** of its target with max 3D edge 19.49 → 0.36; `#51061` **119.5× → 0.175×**. The two thread flanks are separate faces and both land on area **106.7729 / 106.7698** — nothing in the construction makes them agree, so that is an independent correctness signal.

Topology is the number worth checking: Orbiter's unpaired half-edge count is **unchanged from base**, and Right_Hand's improves. An intermediate design that took it to +69,250 was rejected during review for exactly that reason.

**The repo owner visually approved the sweep on isolated per-screw renders** (the affected solids, three-quarter and flank, same camera per variant) before conway-geom#190 merged.

## In-repo test constant moved with it

`gearGeometryArrayLength()` goes **150828 → 14388**. The gear's involute flanks are trimmed b-spline ribbons, so they take the new path; the drop is the same surface at a tenth of the triangles rather than lost geometry, and the comment in the test carries the evidence:

- 82 faces, **0 unreached, 0 degenerate** before *and* after;
- **watertight on both sides** — unpaired half-edges 0 → 0, matched on exact world position;
- a paired render moves 7.9% of pixels with **silhouette and every tooth unchanged** — shading on the flanks, not shape;
- geometry memory 1.955 → 0.278 MB.

## Verification

`yarn build-codex-MT` clean; `yarn test` **127 suites, 897 tests, all passing**; the husky pre-commit gate (eslint + typecheck + jest) passed on the commit.

## What this does not fix

conway#608 is **partially** addressed and stays open — two faces remain at 2.347× and 4.519× of target (down from 79.3× and 107.5×), capped by boundary sampling because refinement may not split a boundary edge, which is bldrs-ai/conway#619 transposed. Separately tracked: the sweep's degenerate handling (bldrs-ai/conway#645), self-overlapping charts from a non-convergent inverse solve (bldrs-ai/conway#642), and the button-head dome, which is a spherical-surface defect (bldrs-ai/conway#644) and byte-identical under this bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEbApNYfjEPWeGAYjXVhcT)_