### PR TITLE
#649: evict at the start of a pump call, and never clone a freed geometry

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -657,12 +657,24 @@ Deliberately small first step; each has a measurable exit.
   "budgeted arena", in the production pump rather than a harness.
   `GeometryResidency` (`src/ifc/geometry_residency.ts`) holds an LRU over
   both of a model's geometry stores against a byte ceiling, evicting at
-  each batch boundary. Configured at open (`GEOMETRY_BUDGET_MB`) or after
-  (`SetGeometryBudget`), and **unlimited by default**, because eviction
-  changes a contract: an evicted asset is gone from `GetGeometry` until
-  something re-extracts it, which is safe for a consumer that copies
-  payloads at delivery (Share#1640) and unsafe for one that fetches
-  lazily later.
+  the START of each pump call. Configured at open (`GEOMETRY_BUDGET_MB`)
+  or after (`SetGeometryBudget`), and **unlimited by default**, because
+  eviction changes a contract: an evicted asset is gone from
+  `GetGeometry` until something re-extracts it, which is safe for a
+  consumer that copies payloads at delivery (Share#1640) and unsafe for
+  one that fetches lazily later.
+
+    Eviction runs at the head of a pump call, not its tail, and that is
+  load-bearing rather than incidental: "at delivery" for a real embedder
+  means *after the pump call returns* — Share's `onMeshBatch` reads the
+  delta back through `GetGeometry` once it has the batch, then yields and
+  pumps again. Tail eviction made that window a lie whenever a single
+  batch's geometry exceeded the whole budget (a 1.9 GB Revit export at
+  64 MB), freeing what the call had just delivered and handing the copy a
+  deleted embind handle — *"Cannot pass deleted object as a pointer of
+  type IfcGeometry"*, Sentry SHARE-1NK. The guarantee is now: everything
+  pump call N delivered is resident until call N+1 begins, at the price of
+  a transient overshoot of up to one batch.
 
   **PSB.ifc at batch 8 — the size Share pumps at:**
 

--- a/src/compat/web-ifc/geometry_budget_copy_window.test.ts
+++ b/src/compat/web-ifc/geometry_budget_copy_window.test.ts
@@ -1,0 +1,319 @@
+/* eslint-disable no-magic-numbers */
+// The copy window a budgeted demand pump has to leave open, and what
+// happens outside it.
+//
+// Share drives conway with DEFER_GEOMETRY + GEOMETRY_BUDGET_MB and copies
+// geometry out BETWEEN pump calls, not inside the mesh callback: the
+// callback only collects delta FlatMeshes, and once
+// ExtractGeometryBatch(Async) has returned, onMeshBatch reads each
+// delivered geometry back through GetGeometry + GetVertexArray/GetIndexArray
+// (the "copy at delivery" invariant of Share#1640). Eviction used to run at
+// the TAIL of the pump call, so a batch whose geometry exceeded the budget
+// was evicted by its own call and the copy that followed found the native
+// already freed — embind aborting with "Cannot pass deleted object as a
+// pointer of type IfcGeometry" on a 1.9 GB Revit export at
+// GEOMETRY_BUDGET_MB=64 (Sentry SHARE-1NK).
+//
+// Two properties, and the second is what keeps the first from being bought
+// by simply never evicting:
+//
+//   1. everything pump call N delivered resolves through GetGeometry, with
+//      the same byte counts an unbudgeted load reports, at any point before
+//      pump call N+1 begins;
+//   2. an asset that is genuinely gone — a later pump call evicted it —
+//      reads as the empty dummy, never as a throw.
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { InMemoryStepByteStore } from '../../step/step_buffer_provider'
+import { IfcAPI } from './ifc_api'
+
+
+const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
+
+const DEFERRED = { ...SETTINGS, DEFER_GEOMETRY: true }
+
+/* The fixture the existing budget tests use: small, and deliberately the
+ * one where eviction is most likely to lose something, because products
+ * later in the file map geometry an aggressive budget has already thrown
+ * away. */
+const FIXTURE = 'data/mapped_shared_representation.ifc'
+
+const BYTES_PER_MIB = 1024 * 1024
+
+/* A budget in BYTES, not MB. This model's whole live set is a few KB, so a
+ * 1 MB budget would never bind and every assertion below would pass while
+ * proving nothing. The existing suite pins that an unbudgeted drain of this
+ * fixture holds more than 2048 bytes, so this binds. */
+const BUDGET_BYTES = 2048
+
+/** Products per pump call — small enough that the drain takes many calls. */
+const BATCH = 4
+
+let fixture: Uint8Array
+
+/** Geometry express ID to the vertex/index byte counts an unbudgeted load
+ * serves for it. */
+let reference: Map<number, [number, number]>
+
+
+/**
+ * Drain a deferred model, collecting the geometry express IDs each pump call
+ * delivered, one entry per call.
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The deferred model to drain.
+ * @param pump Runs one pump call, given the mesh callback.
+ * @param betweenCalls Runs after each pump call returns and before the next
+ * begins — the copy window under test.
+ * @return {Promise<number[]>} Every geometry express ID delivered, in order.
+ */
+async function drain(
+    api: IfcAPI,
+    modelID: number,
+    pump: ( collect: ( geometryExpressID: number ) => void ) =>
+      Promise< { extracted: number, remaining: number } >,
+    betweenCalls?: ( delivered: number[] ) => void ): Promise< number[] > {
+
+  const all: number[] = []
+
+  for ( ; ; ) {
+
+    const delivered: number[] = []
+
+    const { extracted, remaining } = await pump( ( geometryExpressID ) => {
+      delivered.push( geometryExpressID )
+      all.push( geometryExpressID )
+    } )
+
+    betweenCalls?.( delivered )
+
+    if ( remaining === 0 && extracted === 0 ) {
+      break
+    }
+  }
+
+  return all
+}
+
+
+beforeAll( async () => {
+
+  fixture = new Uint8Array( fs.readFileSync( FIXTURE ) )
+
+  // The reference sizes come from an UNBUDGETED deferred load, so they are
+  // this pipeline's own output rather than a hand-written expectation: the
+  // budgeted run has to agree with them byte for byte, not merely serve
+  // something non-empty.
+  const api = new IfcAPI()
+
+  await api.Init()
+
+  const modelID = await api.OpenModelStreamed( fixture, DEFERRED )
+
+  const delivered = await drain(
+      api,
+      modelID,
+      async ( collect ) => api.ExtractGeometryBatch( modelID, BATCH, ( mesh ) => {
+        for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+          collect( mesh.geometries.get( where ).geometryExpressID )
+        }
+      } ) )
+
+  reference = new Map< number, [ number, number ] >()
+
+  for ( const geometryExpressID of delivered ) {
+
+    const geometry = api.GetGeometry( modelID, geometryExpressID )
+
+    reference.set(
+        geometryExpressID,
+        [ geometry.GetVertexDataSize(), geometry.GetIndexDataSize() ] )
+  }
+
+  expect( reference.size ).toBeGreaterThan( 0 )
+
+  // Nothing empty in the reference, or "same as reference" would be
+  // satisfiable by the dummy geometry an evicted asset returns.
+  for ( const [ vertexBytes, indexBytes ] of reference.values() ) {
+    expect( vertexBytes ).toBeGreaterThan( 0 )
+    expect( indexBytes ).toBeGreaterThan( 0 )
+  }
+
+  api.CloseModel( modelID )
+}, 240000 )
+
+
+describe( 'a budgeted pump leaves the copy window open (Sentry SHARE-1NK)', () => {
+
+  test( 'the sync pump: everything call N delivered survives until call N+1',
+      async () => {
+
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const modelID = await api.OpenModelStreamed( fixture, DEFERRED )
+
+        expect( api.SetGeometryBudget( modelID, BUDGET_BYTES / BYTES_PER_MIB )
+            ?.budgetBytes ).toBe( BUDGET_BYTES )
+
+        let checked = 0
+
+        const delivered = await drain(
+            api,
+            modelID,
+            async ( collect ) =>
+              api.ExtractGeometryBatch( modelID, BATCH, ( mesh ) => {
+                for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+                  collect( mesh.geometries.get( where ).geometryExpressID )
+                }
+              } ),
+            ( batch ) => {
+
+              // The copy window: the pump call has returned and the next one
+              // has not started. This is where Share's onMeshBatch reads the
+              // batch it was just handed, and where tail eviction handed it a
+              // freed embind handle instead.
+              for ( const geometryExpressID of batch ) {
+
+                const geometry = api.GetGeometry( modelID, geometryExpressID )
+
+                expect( [
+                  geometry.GetVertexDataSize(),
+                  geometry.GetIndexDataSize(),
+                ] ).toEqual( reference.get( geometryExpressID ) )
+
+                ++checked
+              }
+            } )
+
+        expect( checked ).toBe( delivered.length )
+        expect( checked ).toBeGreaterThan( 0 )
+
+        // ...and the budget was doing something while that held. Without
+        // this the test passes on a budget that never evicted, which is the
+        // shape of vacuous check this area keeps producing: at least one
+        // asset delivered earlier is gone by the end of the drain.
+        const evicted = delivered.filter( ( geometryExpressID ) =>
+          api.GetGeometry( modelID, geometryExpressID ).GetVertexDataSize() === 0 )
+
+        expect( evicted.length ).toBeGreaterThan( 0 )
+
+        api.CloseModel( modelID )
+      }, 240000 )
+
+  test( 'the async pump over an external store: same window',
+      async () => {
+
+        // The pump Share actually drives — ExtractGeometryBatchAsync over a
+        // windowed source — which is a separate code path from the sync one
+        // and carried its own tail-eviction call.
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const modelID = await api.OpenModelStream(
+            new InMemoryStepByteStore( fixture ), DEFERRED )
+
+        expect( modelID ).toBeGreaterThanOrEqual( 0 )
+        expect( api.getPassthrough( modelID )!.sourceIsExternal ).toBe( true )
+
+        expect( api.SetGeometryBudget( modelID, BUDGET_BYTES / BYTES_PER_MIB )
+            ?.budgetBytes ).toBe( BUDGET_BYTES )
+
+        let checked = 0
+
+        const delivered = await drain(
+            api,
+            modelID,
+            async ( collect ) =>
+              await api.ExtractGeometryBatchAsync( modelID, BATCH, ( mesh ) => {
+                for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+                  collect( mesh.geometries.get( where ).geometryExpressID )
+                }
+              } ),
+            ( batch ) => {
+
+              for ( const geometryExpressID of batch ) {
+
+                const geometry = api.GetGeometry( modelID, geometryExpressID )
+
+                expect( [
+                  geometry.GetVertexDataSize(),
+                  geometry.GetIndexDataSize(),
+                ] ).toEqual( reference.get( geometryExpressID ) )
+
+                ++checked
+              }
+            } )
+
+        expect( checked ).toBe( delivered.length )
+        expect( checked ).toBeGreaterThan( 0 )
+
+        const evicted = delivered.filter( ( geometryExpressID ) =>
+          api.GetGeometry( modelID, geometryExpressID ).GetVertexDataSize() === 0 )
+
+        expect( evicted.length ).toBeGreaterThan( 0 )
+
+        api.CloseModel( modelID )
+      }, 240000 )
+
+  test( 'an evicted asset reads as the empty dummy, never as a throw',
+      async () => {
+
+        // The other half of the contract: outside the copy window an evicted
+        // asset is GONE, and "gone" is documented as the dummy geometry
+        // GetGeometry already returns for an unknown id — not an exception.
+        // The compat layer's express-ID map is not purged when the residency
+        // frees a native, so a late caller reaches a deleted embind handle;
+        // this is the assertion that fails, by throwing, without the
+        // isNativeDeleted guard in getGeometry.
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const modelID = await api.OpenModelStreamed( fixture, DEFERRED )
+
+        api.SetGeometryBudget( modelID, BUDGET_BYTES / BYTES_PER_MIB )
+
+        const delivered = await drain(
+            api,
+            modelID,
+            async ( collect ) =>
+              api.ExtractGeometryBatch( modelID, BATCH, ( mesh ) => {
+                for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+                  collect( mesh.geometries.get( where ).geometryExpressID )
+                }
+              } ) )
+
+        expect( delivered.length ).toBeGreaterThan( 0 )
+
+        let gone = 0
+
+        for ( const geometryExpressID of new Set( delivered ) ) {
+
+          // No try/catch: a throw here IS the bug, and swallowing it would
+          // make this assertion unable to fail.
+          const geometry = api.GetGeometry( modelID, geometryExpressID )
+
+          const vertexBytes = geometry.GetVertexDataSize()
+
+          if ( vertexBytes === 0 ) {
+            expect( geometry.GetIndexDataSize() ).toBe( 0 )
+            ++gone
+          } else {
+            expect( [ vertexBytes, geometry.GetIndexDataSize() ] )
+                .toEqual( reference.get( geometryExpressID ) )
+          }
+        }
+
+        // The budget bound: something really was evicted, so the loop above
+        // exercised the deleted-handle path rather than walking a fully
+        // resident model.
+        expect( gone ).toBeGreaterThan( 0 )
+
+        api.CloseModel( modelID )
+      }, 240000 )
+} )

--- a/src/compat/web-ifc/geometry_budget_copy_window.test.ts
+++ b/src/compat/web-ifc/geometry_budget_copy_window.test.ts
@@ -89,6 +89,14 @@ async function drain(
 
     betweenCalls?.( delivered )
 
+    // Stopping on `remaining === 0 && extracted === 0` rather than
+    // `remaining === 0` alone costs one extra zero-work call, but that call
+    // is the contract, not a test convenience: it mirrors Share's own
+    // production stop condition, and it is the only thing that runs the
+    // head eviction that trims the final real batch's overshoot (see the
+    // trailing-batch paragraph on pumpGeometryBatch_ in
+    // ifc_api_proxy_ifc.ts). Stopping at `remaining === 0` alone would leave
+    // that overshoot resident and this suite would never see it evicted.
     if ( remaining === 0 && extracted === 0 ) {
       break
     }

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -82,16 +82,26 @@ export interface Loadersettings {
 
   /**
    * Conway extension (DEFER_GEOMETRY only; M3's budgeted arena): cap the
-   * native geometry a model keeps resident, in MB. At each pump batch the
-   * least-recently-used assets are evicted until the live set fits.
-   * Unset — the default — keeps everything, which is what every consumer
-   * did before this existed.
+   * native geometry a model keeps resident, in MB. At the START of each pump
+   * batch the least-recently-used assets are evicted until the live set
+   * fits. Unset — the default — keeps everything, which is what every
+   * consumer did before this existed.
    *
    * **This changes a contract, so it is opt-in.** An evicted asset is gone
    * from `GetGeometry` until something re-extracts it, which is safe for a
    * consumer that copies payloads at delivery (the invariant Share#1640
    * asserts) and unsafe for one that keeps geometry IDs and fetches them
    * lazily later.
+   *
+   * **What "at delivery" means, precisely.** Everything pump call N
+   * delivered stays resident until pump call N+1 BEGINS, so the copy window
+   * is the whole gap between calls — an embedder may return from the pump,
+   * yield to the event loop, and only then read back the batch's geometry.
+   * Eviction ran at the tail of the pump until Sentry SHARE-1NK, which made
+   * that window a lie: a batch bigger than the whole budget was evicted by
+   * its own call, and the copy that followed hit a freed handle. The price
+   * of the guarantee is that the live set may transiently exceed the budget
+   * by one batch.
    *
    * Budgeted on each native's `getAllocationSize` — vertices, triangles,
    * edges, the triangle-edge structures and the float vertex mirror. That is

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -103,6 +103,24 @@ export interface Loadersettings {
    * of the guarantee is that the live set may transiently exceed the budget
    * by one batch.
    *
+   * **The trailing batch is the consumer's job, not the engine's.** The
+   * "by one batch" overshoot above is normally transient — pump call N+1's
+   * head eviction trims whatever call N left over budget. But nothing forces
+   * a call N+1: a consumer whose loop stops the moment `remaining` reaches 0
+   * never makes that call, so if the FINAL batch pushed `liveBytes` over
+   * budget, that overshoot is permanent, not transient — it persists for the
+   * model's lifetime. Evicting at the tail of that last call instead is not
+   * a fix: it would reintroduce the SHARE-1NK bug above for exactly that
+   * batch, since the embedder's copy happens after the call returns and
+   * there is still no in-engine signal for "the embedder is done copying."
+   * The trim is therefore on the consumer: pump once more after `remaining`
+   * reaches 0 (it extracts nothing and costs only the eviction pass) or call
+   * `SetGeometryBudget` directly. Share's own loop already does the former —
+   * its stop condition is `remaining === 0 && extracted === 0`, not
+   * `remaining === 0` alone, which guarantees exactly one such zero-work
+   * call. See {@link ExtractGeometryBatch}'s doc for the same contract from
+   * the pump-signature side.
+   *
    * Budgeted on each native's `getAllocationSize` — vertices, triangles,
    * edges, the triangle-edge structures and the float vertex mirror. That is
    * deliberately NOT the vertex+index payload `calculateGeometrySize`
@@ -920,8 +938,13 @@ export class IfcAPI {
    * opened with `OpenModelStreamed(data, {DEFER_GEOMETRY: true})`,
    * extract the next `batchSize` products and emit this batch's meshes —
    * the incremental twin of StreamAllMeshes. Feature-detect with
-   * `typeof api.ExtractGeometryBatch === 'function'`; call repeatedly
-   * until `remaining` is 0.
+   * `typeof api.ExtractGeometryBatch === 'function'`; call repeatedly until
+   * `remaining === 0 && extracted === 0` — one call PAST `remaining` alone
+   * first reaching 0. That extra call extracts nothing, but it still runs
+   * the geometry budget's head eviction (see `GEOMETRY_BUDGET_MB`), which is
+   * the only thing that trims an overshoot the final real batch left over
+   * budget; stopping at `remaining === 0` alone can leave that overshoot
+   * resident for the model's lifetime.
    *
    * DELTA CONTRACT: an entity may be emitted again in a LATER call with
    * a FlatMesh containing only its NEW placed instances (shared/mapped
@@ -950,6 +973,13 @@ export class IfcAPI {
    * Same contract as the setting: an evicted asset is gone from GetGeometry
    * until something re-extracts it, which is safe for a consumer that copies
    * payloads at delivery and unsafe for one that fetches lazily later.
+   *
+   * Same trailing-batch caveat as the setting, too: this eviction pass runs
+   * against the live set as it stands right now, so it does not by itself
+   * guarantee a LATER pump call won't push `liveBytes` back over budget.
+   * Calling this explicitly after a demand pump's `remaining` reaches 0 is
+   * exactly the "pump once more" trim `GEOMETRY_BUDGET_MB` describes — a
+   * direct call here is equivalent to that trailing zero-work pump call.
    *
    * @param modelID handle retrieved by an open
    * @param megabytes the ceiling, in MB of native allocation (see

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -47,6 +47,7 @@ import {
   ap214PreviewAdapter,
   StreamedPreviewChannel,
 } from './streamed_preview_channel'
+import { isNativeDeleted } from './native_geometry_liveness'
 
 /* Moving-window size for the streamed columnar parse (matches the IFC
  * proxy; the window bounds parse-time scratch, not the source buffer,
@@ -982,9 +983,34 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
         // eslint-disable-next-line no-unused-vars
         const [geometryObject, _] = mapResult
         if (geometryObject !== void 0) {
-          const clone = geometryObject.clone()
 
-          return clone
+          // A map entry is not proof the native is still alive: this map is
+          // keyed by express ID, and the extraction below it frees natives
+          // with no back-channel to it (dropNonSceneGeometry,
+          // deleteTemporaries). Cloning a freed handle aborts inside embind
+          // rather than returning — the IFC twin's instance of exactly that
+          // is Sentry SHARE-1NK, where eviction under GEOMETRY_BUDGET_MB
+          // was the freeing party. See isNativeDeleted; the catch is the
+          // backstop for any other way the handle can be unusable. Either
+          // way this degrades to the dummy below rather than throwing
+          // through a consumer's mesh loop.
+          if (!isNativeDeleted(geometryObject)) {
+
+            try {
+              const clone = geometryObject.clone()
+
+              return clone
+            } catch (error) {
+              Logger.error(
+                  `[GetGeometry]: clone failed for expressID ` +
+                  `${geometryExpressID}: ` +
+                  `${error instanceof Error ? error.message : String(error)}`)
+            }
+          } else {
+            Logger.error(
+                `[GetGeometry]: geometry for expressID ${geometryExpressID} ` +
+                `was freed (evicted under the geometry budget, or released)`)
+          }
         } else {
           Logger.error(`[GetGeometry]: Geometry Object not found for expressID: 
           ${geometryExpressID}`)

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -62,6 +62,7 @@ import { shimIfcEntityMap, shimIfcEntityReverseMap } from './shim_schema_mapping
 import { EntityTypesIfcCount } from '../../ifc/ifc4_gen/entity_types_ifc.gen'
 import { IfcProduct, IfcRelAggregates, IfcRoot } from '../../ifc/ifc4_gen'
 import { CanonicalMeshType } from '../../index'
+import { isNativeDeleted } from './native_geometry_liveness'
 
 // Batch size used when a whole-model consumer (streamAllMeshes) drains
 // a deferred model's remaining products synchronously.
@@ -145,10 +146,11 @@ interface IfcProxyLoadState {
 /**
  * The placements of a FlatMesh whose native geometry is still alive.
  *
- * There is no "is this deleted" predicate on the binding, so liveness is
- * probed by the cheapest call that touches the native and throws when it is
- * gone. Only used on the degraded StreamAllMeshes path, where the
- * alternative is handing a consumer a handle that aborts on read.
+ * Liveness is `isNativeDeleted` first — embind's own predicate, which costs
+ * a property read — with the cheapest call that touches the native kept as
+ * the backstop for a handle that is unusable for some other reason. Only
+ * used on the degraded StreamAllMeshes path, where the alternative is
+ * handing a consumer a handle that aborts on read.
  *
  * @param mesh The accumulated per-entity mesh.
  * @param geometryMap Express ID to [geometry, material, transform].
@@ -166,7 +168,7 @@ function livePlacements(
     const placed = mesh.geometries.get(where)
     const entry = geometryMap.get(placed.geometryExpressID)
 
-    if (entry === void 0) {
+    if (entry === void 0 || isNativeDeleted(entry[0])) {
       continue
     }
 
@@ -1484,9 +1486,31 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         // eslint-disable-next-line no-unused-vars
         const [geometryObject, _] = mapResult
         if (geometryObject !== void 0) {
-          const clone = geometryObject.clone()
 
-          return clone
+          // A map entry is not proof the native is still alive — eviction
+          // under GEOMETRY_BUDGET_MB frees it without purging this map, and
+          // cloning a freed handle aborts inside embind rather than
+          // returning. See isNativeDeleted for the full account; the catch
+          // is the backstop for any other way the handle can be unusable.
+          // Either way this degrades to the dummy below, which is the
+          // documented behaviour for an evicted asset.
+          if (!isNativeDeleted(geometryObject)) {
+
+            try {
+              const clone = geometryObject.clone()
+
+              return clone
+            } catch (error) {
+              Logger.error(
+                  `[GetGeometry]: clone failed for expressID ` +
+                  `${geometryExpressID}: ` +
+                  `${error instanceof Error ? error.message : String(error)}`)
+            }
+          } else {
+            Logger.error(
+                `[GetGeometry]: geometry for expressID ${geometryExpressID} ` +
+                `was freed (evicted under the geometry budget, or released)`)
+          }
         } else {
           Logger.error(`[GetGeometry]: Geometry Object not found for expressID: \n          ${geometryExpressID}`)
         }
@@ -2108,6 +2132,11 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       return this.pumpGeometryBatch_(batchSize, meshCallback)
     }
 
+    // Evict at the START of the call, never at its end — see the identical
+    // note in pumpGeometryBatch_ for why. This is the pump Share drives, and
+    // the one the SHARE-1NK crash came from.
+    this.model[0].geometryResidency.evictToBudget()
+
     const products = this.demandProducts_ ?? []
     const aggregates = this.demandAggregates_ ?? []
     const budget = Math.max(batchSize, 1)
@@ -2228,25 +2257,19 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       }
     }
 
-    // Capture before eviction — and capture even when nobody asked for
-    // meshes. The deferred StreamAllMeshes drain pumps with `noCallback` for
-    // every batch and captures once at the end (see streamAllMeshes), which
-    // works only while geometry survives to be captured. With a budget it
-    // does not: anything evicted before that final capture can no longer be
-    // resolved, so those instances vanish from the model with no error. On
-    // the shared-representation fixture at a 2 KiB budget that path
-    // delivered 3 placements against classic's 16.
+    // Capture even when nobody asked for meshes. The deferred
+    // StreamAllMeshes drain pumps with `noCallback` for every batch and
+    // captures once at the end (see streamAllMeshes), which works only while
+    // geometry survives to be captured. With a budget it does not: anything
+    // evicted before that final capture can no longer be resolved, so those
+    // instances vanish from the model with no error. On the
+    // shared-representation fixture at a 2 KiB budget that path delivered 3
+    // placements against classic's 16.
     if (meshCallback !== void 0) {
       this.streamNewMeshes_(meshCallback)
     } else if (this.model[0].geometryResidency.enabled) {
-      this.streamNewMeshes_(() => { /* capture into meshMap before eviction */ })
+      this.streamNewMeshes_(() => { /* capture into meshMap */ })
     }
-
-    // Evict AFTER the capture, never before: the delta capture resolves each
-    // new node's geometry to emit it, so evicting first would drop assets
-    // this batch is about to deliver and re-extract them immediately. A
-    // no-op unless a budget is configured.
-    this.model[0].geometryResidency.evictToBudget()
 
     const {totalWork, remaining} = this.demandProgress_()
 
@@ -3008,6 +3031,33 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       batchSize: number,
       meshCallback?: (mesh: FlatMesh) => void ): {extracted: number, remaining: number} {
 
+    // Evict at the START of the call, not at its end. The contract this buys:
+    // every asset a pump call delivers stays resident at least until the NEXT
+    // pump call begins, so an embedder that copies payloads out between calls
+    // can never be handed a geometry ID whose native has already been freed.
+    //
+    // This used to run at the tail, after the delta capture, on the reasoning
+    // that the capture had to resolve each new node's geometry first. True,
+    // but incomplete: the capture is not the last read of that geometry. The
+    // embedder's is, and it happens AFTER the call returns — Share's
+    // onMeshBatch calls GetGeometry/GetVertexArray on the delta it just
+    // received, then yields and pumps again (the "copy at delivery"
+    // invariant of Share#1640). Tail eviction could therefore free geometry
+    // the very same call had just delivered — trivially so whenever one
+    // batch's assets exceed the whole budget, as they do on 1.9 GB Revit
+    // exports at GEOMETRY_BUDGET_MB=64 — and the embedder's copy then hit a
+    // freed embind handle: "Cannot pass deleted object as a pointer of type
+    // IfcGeometry" (Sentry SHARE-1NK).
+    //
+    // The cost is a transient overshoot of up to one batch's bytes, which is
+    // the deliberate trade: a budget that is momentarily exceeded by a batch
+    // beats a budget that hands out dangling handles. A no-op unless a
+    // budget is configured. Both pumps need this — the async twin is what
+    // Share drives, this one is what a synchronous embedder and the test
+    // suite drive, and a budget honoured on only one of them is a budget
+    // that silently does not apply.
+    this.model[0].geometryResidency.evictToBudget()
+
     const products = this.demandProducts_ ?? []
     const aggregates = this.demandAggregates_ ?? []
 
@@ -3086,28 +3136,19 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       }
     }
 
-    // Capture before eviction — and capture even when nobody asked for
-    // meshes. The deferred StreamAllMeshes drain pumps with `noCallback` for
-    // every batch and captures once at the end (see streamAllMeshes), which
-    // works only while geometry survives to be captured. With a budget it
-    // does not: anything evicted before that final capture can no longer be
-    // resolved, so those instances vanish from the model with no error. On
-    // the shared-representation fixture at a 2 KiB budget that path
-    // delivered 3 placements against classic's 16.
+    // Capture even when nobody asked for meshes. The deferred
+    // StreamAllMeshes drain pumps with `noCallback` for every batch and
+    // captures once at the end (see streamAllMeshes), which works only while
+    // geometry survives to be captured. With a budget it does not: anything
+    // evicted before that final capture can no longer be resolved, so those
+    // instances vanish from the model with no error. On the
+    // shared-representation fixture at a 2 KiB budget that path delivered 3
+    // placements against classic's 16.
     if (meshCallback !== void 0) {
       this.streamNewMeshes_(meshCallback)
     } else if (this.model[0].geometryResidency.enabled) {
-      this.streamNewMeshes_(() => { /* capture into meshMap before eviction */ })
+      this.streamNewMeshes_(() => { /* capture into meshMap */ })
     }
-
-    // Evict AFTER the capture, never before: the delta capture resolves
-    // each new node's geometry to emit it, so evicting first would drop
-    // assets this batch is about to deliver and re-extract them at once.
-    // A no-op unless a budget is configured. Both pumps need this — the
-    // async twin is what Share drives, this one is what a synchronous
-    // embedder and the test suite drive, and a budget honoured on only
-    // one of them is a budget that silently does not apply.
-    this.model[0].geometryResidency.evictToBudget()
 
     const {totalWork, remaining} = this.demandProgress_()
 

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2073,7 +2073,11 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * meshes through `meshCallback` — the incremental twin of
    * streamAllMeshes. Placed-geometry math (coordination, scaling,
    * centering) is identical; the shared meshMap is updated so
-   * getFlatMesh keeps working. Call repeatedly until `remaining` is 0.
+   * getFlatMesh keeps working. Call repeatedly until
+   * `remaining === 0 && extracted === 0` — one call past `remaining` alone
+   * first reaching 0, needed only to run the geometry budget's head
+   * eviction against the final real batch (see the trailing-batch
+   * paragraph on `pumpGeometryBatch_` below).
    *
    * Requires a model opened with deferred geometry
    * (`OpenModelStreamed(data, {..., DEFER_GEOMETRY: true})`); on a
@@ -3056,6 +3060,26 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // Share drives, this one is what a synchronous embedder and the test
     // suite drive, and a budget honoured on only one of them is a budget
     // that silently does not apply.
+    //
+    // That "transient" word only holds while pumping continues. Nothing
+    // forces a caller to make another call: a consumer that stops the
+    // instant `remaining` reaches 0 never triggers another head eviction,
+    // so if the FINAL batch pushed liveBytes over budget, that overshoot is
+    // permanent for the model's lifetime rather than transient. Tail-evicting
+    // that last call instead is not on the table — it would reintroduce the
+    // exact SHARE-1NK crash above for that one batch, because the embedder's
+    // copy still happens after the call returns and there is no in-engine
+    // signal for "the embedder has finished copying the last batch." The
+    // trim is therefore the consumer's one remaining obligation: make one
+    // more pump call after `remaining` reaches 0 (it extracts nothing, but
+    // still runs this head eviction) or call `SetGeometryBudget` directly.
+    // Share's production loop already does the former — its stop condition
+    // is `remaining === 0 && extracted === 0`, which guarantees exactly one
+    // such zero-work call — and geometry_budget_copy_window.test.ts's drain
+    // helper stops the same way, mirroring the real consumer rather than
+    // masking the issue. See
+    // GEOMETRY_BUDGET_MB's and ExtractGeometryBatch's doc comments in
+    // ifc_api.ts for the same contract stated from the embedder side.
     this.model[0].geometryResidency.evictToBudget()
 
     const products = this.demandProducts_ ?? []

--- a/src/compat/web-ifc/native_geometry_liveness.ts
+++ b/src/compat/web-ifc/native_geometry_liveness.ts
@@ -1,0 +1,34 @@
+
+/**
+ * Whether a native geometry handle has already been freed.
+ *
+ * The compat layer's express-ID -> geometry map (`model[3]` in both proxies)
+ * outlives the natives it points at. Eviction under `GEOMETRY_BUDGET_MB`
+ * frees geometry through the residency
+ * (`GeometryResidency.evictToBudget` -> `IfcModelGeometry.delete` ->
+ * `GeometryObject.delete()`) and there is no back-channel that would purge
+ * the map, so a stale entry survives the free. Touching one — `clone()` is
+ * the first thing `getGeometry` does — aborts inside embind with
+ * *"Cannot pass deleted object as a pointer of type IfcGeometry"*, which is
+ * how an evicted asset reached Share as a load failure (Sentry SHARE-1NK)
+ * instead of as the documented "gone from `GetGeometry` until something
+ * re-extracts it".
+ *
+ * Embind's class handles carry the predicate: the emitted glue defines
+ * `isDeleted(){return!this.$$.ptr}` on the handle prototype (verified in
+ * `dependencies/conway-geom/Dist/ConwayGeomWasmNodeMT.js`, not from memory
+ * of embind in general). It is probed by shape rather than assumed, because
+ * a `GeometryObject` here can also be a hand-rolled test double or a future
+ * non-embind binding; anything without the method reads as alive, so the
+ * caller's try/catch — not this — is what covers it.
+ *
+ * @param native The handle to probe. Anything, including undefined.
+ * @return {boolean} True only when the handle positively reports itself
+ * deleted.
+ */
+export function isNativeDeleted( native: unknown ): boolean {
+
+  const probe = ( native as { isDeleted?: () => boolean } | undefined )?.isDeleted
+
+  return typeof probe === 'function' && probe.call( native ) === true
+}

--- a/src/ifc/geometry_residency.ts
+++ b/src/ifc/geometry_residency.ts
@@ -69,6 +69,13 @@ const BYTES_PER_MIB = 1024 * 1024
  * Share#1640 already asserts — and unsafe for one that holds geometry IDs and
  * fetches lazily later. So a budget is opt-in and unlimited by default:
  * turning it on is a statement about the consumer, not just about memory.
+ *
+ * **When the callers run this.** `evictToBudget` is called at the START of
+ * each pump batch, never at its end, so everything a batch delivered
+ * survives until the next batch begins — "at delivery" has to include the
+ * gap between pump calls, because that is where an embedder's copy actually
+ * happens (Sentry SHARE-1NK). Callers that free geometry outside the pump
+ * are responsible for the same rule.
  */
 export class GeometryResidency {
 


### PR DESCRIPTION
Fixes #649 (Sentry [SHARE-1NK](https://bldrs-ai.sentry.io/issues/7699115915/): `Cannot pass deleted object as a pointer of type IfcGeometry` on large-model loads under `GEOMETRY_BUDGET_MB`, dropping whole demand batches from the rendered model).

## Two defects, both on the window between a pump call returning and the embedder copying what it delivered

1. **Eviction timing.** Both demand pumps ran `evictToBudget()` at the tail of the call, after the delta capture — but the capture is not the last read of that geometry: the embedder's is, and it happens after the call returns (Share's `onMeshBatch` copies via `GetGeometry` + `GetVertexArray`/`GetIndexArray`, the "copy at delivery" invariant of bldrs-ai/Share#1640). A call could therefore free geometry it had itself just delivered — trivially whenever one batch's assets exceed the whole budget, as on ~2 GB Revit exports at 64 MB.
2. **Deleted-wrapper leak.** Eviction frees the native through `IfcModelGeometry.delete()` but never purges the compat layer's expressID → geometry map (`model[3]`), so `getGeometry` cloned a freed embind handle and threw instead of taking the documented "evicted = gone until re-extracted" path.

## The change

- Eviction moves to the **head** of both pumps (the `streamAllMeshes` drain's budget-restore site is unchanged). New explicit contract: **everything pump call N delivers stays resident until pump call N+1 begins** — the embedder's copy window is the whole gap between calls, at the price of a transient overshoot of up to one batch's bytes.
- `getGeometry` in both proxies probes the handle first (`isNativeDeleted`, embind's own predicate, verified against the emitted glue) with a try/catch backstop; a freed handle degrades to the existing not-found path (Logger.error + dummy), never a throw. `livePlacements` uses the same predicate in place of its throw-probe.
- AP214 gets only the `getGeometry` hardening — its pump budget is wall-clock, and it has no geometry residency.
- The contract is documented where a consumer meets it: the `GEOMETRY_BUDGET_MB` docs, the `GeometryResidency` header, and `design/new/streaming-federated-loader.md`.

## Tests

New `src/compat/web-ifc/geometry_budget_copy_window.test.ts`, 3 tests over `data/mapped_shared_representation.ifc` at a 2 KiB budget, sizes checked against an **unbudgeted reference load** rather than "non-empty". Each fix half is pinned independently: reverting only the timing change fails the copy-window tests (`[0, 0]` vs the reference `[144, 36]`); reverting only the guard fails all three with the production `BindingError: Cannot pass deleted object as a pointer of type IfcGeometry*`. Affected suites (all of `compat/web-ifc` + `ifc_demand_extraction` + `geometry_dispatch`): 23 suites / 168 tests green; full pre-commit gate (build + check-compiled-fresh + lint + full jest) passed.

## Review focus (the load-bearing claims to attack)

- The head-of-call eviction preserves everything the tail-of-call placement guaranteed: the delta capture in call N runs before call N+1's eviction, so no asset is freed between extraction and capture.
- The one-batch overshoot is bounded and transient — nothing else reads `liveBytes` between calls in a way this reorders.
- The `isDeleted` probe-by-shape is safe on handles from both the ST and MT wasm builds.

## Companion

bldrs-ai/Share#[pending] hardens `IncrementalBatchedBuilder` so a single bad geometry degrades to one skipped placement instead of a dropped batch, independent of engine version. Related in-flight work: #635 (memory epic — its `meshMap`/`vectorFlatMesh` ownership item touches the same pump/capture region and must preserve this PR's copy-window contract, which the new test suite pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFte6WW6bqxxL7VPAMTr1g

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFte6WW6bqxxL7VPAMTr1g)_