### PR TITLE
#647: bump conway-geom to 1a36ff1 — stated-closure trim-head re-seed, with its callers

### DIFF
--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -5393,11 +5393,20 @@ export class AP214GeometryExtraction {
           const { pointer, length } = result
 
           // Use them in your WASM call
-          const bound3D: Bound3DObject = this.wasmModule.createSimpleBound3D(
+          // Through conwayModel, not wasmModule: the wrapper types
+          // closedByConstruction as required, and that is the ONLY place a
+          // missing argument is caught - embind does no arity check and would
+          // convert the absent bool to false, silently dropping closure.
+          // See bldrs-ai/conway-geom#195.
+          const bound3D: Bound3DObject = this.conwayModel.createSimpleBound3D(
             pointer,
             length,
             bound.orientation,
             bound.type === EntityTypesAP214.FACE_OUTER_BOUND ? 0 : 1,
+            // A poly loop IS a closed polygon and does not repeat its head.
+            // Passed explicitly rather than re-derived on the wasm side, so the
+            // closure fact crosses the boundary with the entity that knows it.
+            true,
           )
 
           // Push your result somewhere (push_back copies, so free the

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -5275,11 +5275,20 @@ export class IfcGeometryExtraction {
           const { pointer, length } = result
 
           // Use them in your WASM call
-          const bound3D: Bound3DObject = this.wasmModule.createSimpleBound3D(
+          // Through conwayModel, not wasmModule: the wrapper types
+          // closedByConstruction as required, and that is the ONLY place a
+          // missing argument is caught - embind does no arity check and would
+          // convert the absent bool to false, silently dropping closure.
+          // See bldrs-ai/conway-geom#195.
+          const bound3D: Bound3DObject = this.conwayModel.createSimpleBound3D(
             pointer,
             length,
             bound.Orientation,
             bound.type === EntityTypesIfc.IFCFACEOUTERBOUND ? 0 : 1,
+            // A poly loop IS a closed polygon and does not repeat its head.
+            // Passed explicitly rather than re-derived on the wasm side, so the
+            // closure fact crosses the boundary with the entity that knows it.
+            true,
           )
 
           // Push your result somewhere


### PR DESCRIPTION
#647: bump `dependencies/conway-geom` from `f74a85d` to **`1a36ff1`**, pulling in bldrs-ai/conway-geom#191, #193, #194 and #195. For bldrs-ai/conway#647, part of the epic bldrs-ai/conway#641.

## What it pulls in

`resetContinuity()` scopes the inverse solve's continuity seed to one bound — correct and deliberate, since a cross-loop seed can converge silently onto a different sheet — but it leaves the **first point of every bound with no seed at all**, cold-started from the grid. On a surface that passes near itself (a multi-turn thread flank, the conway#594 configuration) the grid can pick the wrong basin, and the bad uv then seeds its successors until the descent recovers.

Since the loop is **closed**, its first point neighbours its last, and after the first pass the solver's continuity seed holds exactly that last point's solution. Re-solving the head from there is seeded by a genuine neighbour instead of a grid guess. `resetContinuity`'s cross-loop guarantee is untouched — the seed used here comes from the **same bound**.

## ⚠️ This commit is atomic on purpose

Gitlink and the two TypeScript call sites land **together**, because they cannot be separated safely. conway-geom#195 gives `createSimpleBound3D` a fifth argument, `closedByConstruction`, and **nothing in the stack catches a caller that omits it** — measured, all three safety nets are absent:

- embind performs **no arity check** on a non-overloaded binding;
- `_embind_register_bool` converts a missing argument to **`false` silently**;
- `ConwayGeomWasm.d.ts` is `declare const ConwayGeomWasm: any`.

A four-argument call therefore builds clean, runs clean, and silently drops closure — reinstating the exact cold-start error the parameter exists to fix. Either half of this change landing alone ships that regression with no diagnostic anywhere, so the land order (conway-geom → rebuild Dist → conway) is satisfied here **by construction** rather than by discipline.

Both call sites now go through the typed `ConwayGeometry.createSimpleBound3D` wrapper added in #195, which declares the argument required.

### The build is the ABI verification

**No model in the 7-model regression corpus calls `createSimpleBound3D` at all** — measured, zero calls — so the corpus is structurally incapable of detecting an arity mismatch on this boundary. The compile is the only thing that exercises it, which is why the wrapper's type is load-bearing rather than cosmetic. Verified in both directions against this exact submodule checkout:

| call | result |
|---|---|
| as committed (5 args, via the wrapper) | **tsc green** |
| fifth argument deleted | **`error TS2554: Expected 5 arguments, but got 4`** |
| 4 args via the raw `wasmModule` (the old form) | **compiles clean** — silent closure loss |

## Blast radius, measured not predicted

**53 of 848 B-spline faces (6.25%) have their loop head rewritten** across the three models carrying B-spline geometry — more than the ~10 faces predicted to cold-start-fail, since the re-solve fires whenever the second pass differs at all, not only on outright failure. Per-head outcome on Right_Hand (51 rewrites):

| outcome | heads |
|---|---|
| residual **improved** | **45** |
| unchanged | 5 |
| **worsened** | **1** — by **1.0141×** (1.4%) |

Named rather than rounded away. No face's loop-median residual moves more than 1.5× either direction on any model.

| model | cold-start failures | unpaired half-edges | pixels changed |
|---|---|---|---|
| **Orbiter** | **8 → 0** | **1096 → 947** (−13.6%) | 0.012% |
| **Right_Hand** | **2 → 0** | **3668 → 3415** (−6.9%) | 2.58% (owner-approved, below) |
| **nist_ctc_02** | 0 → 0 | 414 → 414 | **0.190%** (corrected — see below) |
| create-a-tube, driver board, nist_ctc_01, supercap | — | — | **byte-identical** |

**10 → 0 cold-start failures engine-wide, none introduced.**

## Result on the target (`#50720`)

| | before | after | sibling `#50718` |
|---|---|---|---|
| emitted area | 328.28 mm² | **49.04 mm²** | 49.06 mm² |
| largest triangle | 5.697 mm² | **0.041 mm²** | 0.033 mm² |

The two flanks of one symmetric thread now agree to **three significant figures**; a chord across a 3 mm shank becomes an ordinary triangle.

## Correction: nist_ctc_02 is not "0 pixels"

An earlier revision of this body claimed nist_ctc_02 was unchanged. **That was wrong, and CI was right to flag it.** It was true only for the single camera angle my rig defaults to. Re-rendered from several directions, same local build both sides:

| VIEW_DIR | changed | maxDelta |
|---|---|---|
| 1,1,1 (my default) | 0.000% | 0 |
| 1,0,0 / 0,1,0 / 1,-1,0.5 | 0.000% | 0 |
| **0,0,1** | **0.190%** | 54 |
| −1,1,0.5 | 0.009% | 55 |

**The digest was the honest instrument** — it showed movement, I reported that correctly, and then let a single-camera pixel count override it. Worth recording as a methodology fact: a pixel diff from one angle is not evidence of no change.

Root-caused rather than accepted: exactly **one** of nist_ctc_02's 34 B-spline faces changed, and it improved — head residual 4.80e-02 → **2.59e-03** (18.5×), head/loop-median ratio 59.3 → **3.20**, loop median unchanged. A marginal cold start, below the 100× threshold my failure sweep used, which is why it was classed "marginal" rather than caught. Its retriangulation is what CI sees.

Not fully matched: CI's 1.00% against my worst angle's 0.190% — same order, comparable Δmax (54–55 vs 65), consistent with tighter framing, but I have not reproduced the exact figure and am not claiming to.

## Right_Hand's 2.58%, investigated and owner-approved

6 of the rewritten heads sit in its fingertip region and **every one improved** (up to 29×). On that crop: unpaired half-edges −56 on a **larger** mesh (a mis-stitched head would degrade pairing, not improve it), region area +4.2% — the wrong-basin head had been collapsing part of its own chart. **The owner reviewed the before/after fingertip crop and approved it.**

## Review rounds carried by this bump

**codex on #655** found the proximity closure gate admits an open one-turn arc at 40 samples (`gap/median = 1.35 < 2.0`). Verified, and the family is worse than the single point: the ratio's terms do not scale together, so across sampling densities 120/60/40/30/20 it reads 4.05/2.02/1.35/1.01/0.68 against an adjacency-closed loop's ~1.0. **No threshold separates the classes.** Fixed in conway-geom#195 by requiring **stated closure** — the producer's flag, or a literally duplicated head — with no proximity anywhere. Corpus byte-identical: all 859 arriving bounds are exact-duplication closures, so nothing real is declined.

**Substitute review round on conway-geom#195** (codex was at usage limits) raised five findings, all confirmed empirically and all fixed before merge: the untyped ABI boundary above; a **vacuous** composition test that re-implemented the production AND in a local lambda (moved into a shipped helper, red-proven both halves); a stale `closedByConstruction` in the packed face-set slot recycler; an over-claimed comment on the degeneracy filter; and a self-contradicting design comment, resolved by **measuring the pass's reach** (859 arrivals, all exact-duplication, zero flag-closed, zero `createSimpleBound3D` calls) and rewriting the justification honestly rather than picking on preference.

## Verification

`yarn build-codex-MT` clean; `yarn test` **128 suites, 905 tests, all passing** — no in-repo constant moves (`gearGeometryArrayLength()` and every other AP214 golden holds unchanged, including the nema motor's b-spline faces). conway-geom's native suite at the bumped SHA: **86 checks, 0 failures**, red-proven on every pass it covers. The husky pre-commit gate (build-incremental + check-compiled-fresh + eslint + jest) passed on the commit.

## What this does not fix

**#647 stays open** — this fixes the flank's cold-start mechanism the issue was amended to describe, but closes after the owner smokes the shank in Share. Separately: **#648** (FilamentGuide) is not fixed by this and not expected to be — its flanks agree at 35 runs each, a property of the trim that needs multi-run decomposition in the triangulator, not a seeding fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)