### PR TITLE
#638: a streaming-consumer ownership contract for the demand pumps

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -676,6 +676,44 @@ Deliberately small first step; each has a measurable exit.
   pump call N delivered is resident until call N+1 begins, at the price of
   a transient overshoot of up to one batch.
 
+    **Implementation, third landed piece — a streaming-consumer ownership
+  contract (2026-08-29, conway#638).** The budget above bounds *native*
+  bytes. The JS side had its own, larger problem: a deferred open builds
+  each `PlacedGeometry` once and files that one object into **three**
+  pointer spines — the model's cumulative per-entity `meshMap`, its
+  `vectorFlatMesh`, and whatever the embedder keeps from the mesh
+  callback. Measured on a D3D load that graph is **475 MB** of V8 heap,
+  the largest single bucket, and dropping any one spine alone frees only
+  ~4.4 MB, because the other two keep the same graph alive (4.4 MB is
+  the *predicted* size of one 562 351-entry spine at 8 B, so that number
+  confirms the model rather than refuting it). A consumer that assembles
+  every batch as it lands — Share's incremental batched builder — never
+  reads the two conway holds.
+
+    `STREAMING_CONSUMER` (a `DEFER_GEOMETRY`-only open setting, default
+  off, both proxies) lets the caller say so: the pump hands each delta
+  `FlatMesh` to the callback and keeps no reference, so neither conway
+  spine grows. **It drops JS pointer spines and nothing else** — the
+  natives are owned by the geometry store and freed only by eviction or
+  `ReleaseModelGeometry`, so the copy-window guarantee above is
+  untouched, as is the trailing zero-work pump call that trims the final
+  batch. The retention was never load-bearing for Share's empty-pump
+  fallback, which the issue text originally claimed: that fallback fires
+  only when the pump produced *nothing*, and in that case `meshMap` was
+  empty going in and a fresh scene walk serves it.
+
+    What is load-bearing is a late whole-model ask. `StreamAllMeshes`,
+  `LoadAllGeometry` and `GetFlatMesh` on such a model **re-walk the live
+  scene** rather than replaying a cache that no longer exists — with the
+  delta capture, not the classic walk, because only the delta capture
+  seeds coordination from the frame the stream actually used. Because the
+  re-walk clears and restarts at instance zero, it is *idempotent*, which
+  incidentally closes the latent doubling bug a second `StreamAllMeshes`
+  has on the retaining path (Share's `IfcItemsMap.js:274-283`). Once the
+  natives are genuinely gone — released, or evicted in their entirety —
+  those entry points **throw and name the contract** rather than
+  returning a model with no geometry in it.
+
   **PSB.ifc at batch 8 — the size Share pumps at:**
 
   | budget | live | wasm peak | delta meshes | geometry |

--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -709,10 +709,32 @@ Deliberately small first step; each has a measurable exit.
   seeds coordination from the frame the stream actually used. Because the
   re-walk clears and restarts at instance zero, it is *idempotent*, which
   incidentally closes the latent doubling bug a second `StreamAllMeshes`
-  has on the retaining path (Share's `IfcItemsMap.js:274-283`). Once the
-  natives are genuinely gone — released, or evicted in their entirety —
-  those entry points **throw and name the contract** rather than
-  returning a model with no geometry in it.
+  has on the retaining path (Share's `IfcItemsMap.js:274-283`).
+
+    **A re-walk does not recover evicted geometry, and the reporting had
+  to be rebuilt around that.** Eviction deletes the mesh from the store
+  (`IfcModelGeometry.delete`), so the walk resolves nothing for that scene
+  node, parks it, and the placement is *absent* from the rebuilt map
+  rather than present-and-dead. The retaining path's `livePlacements`
+  filter therefore reads zero however much was lost — it can only see
+  placements that made it into the map, and all of those are live. The
+  first version of this shipped a throw keyed on that filter, which made
+  it unreachable: at a 1-byte budget on `mapped_shared_representation.ifc`
+  the model served **0 placements, logged "0 across 0", and did not
+  throw** — the exact silent-empty failure the contract exists to
+  prevent, in Share's own production config. The signal is instead the
+  count of instances the re-walk **parked**: partial loss warns with that
+  count, total loss (nothing resolved) **throws and names the contract**,
+  as does any whole-model ask after `ReleaseModelGeometry`. A model that
+  genuinely has no geometry still returns empty, quietly, as classic does.
+
+    **Scope.** The synchronous whole-model entry points drain through the
+  synchronous pump, which refuses a windowed source outright. So on a
+  model opened over an external store — Share's configuration — the late
+  whole-model ask is not reachable through `StreamAllMeshes` at all. That
+  predates this contract and is identical with and without it; it is noted
+  because the contract's promise about that ask is otherwise easy to read
+  as broader than it is.
 
   **PSB.ifc at batch 8 — the size Share pumps at:**
 

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -96,10 +96,28 @@ export interface Loadersettings {
    * **A late whole-model ask still works, until the natives are gone.**
    * `StreamAllMeshes`, `LoadAllGeometry` and `GetFlatMesh` on such a model
    * re-walk the live scene rather than replaying a cache, which costs a walk
-   * but returns the same placements the pump delivered. Once the geometry has
-   * been released — or evicted in its entirety under a budget — there is
-   * nothing left to walk, and those entry points throw a descriptive error
-   * naming this contract rather than silently returning an empty model.
+   * but returns the same placements the pump delivered.
+   *
+   * **What a budget does to that ask.** The re-walk reads the geometry store,
+   * and `GEOMETRY_BUDGET_MB` eviction deletes from it, so an evicted
+   * placement is not recovered by the re-walk — it is simply absent from
+   * what the ask returns. Partial loss is served with a warning naming the
+   * count of unresolved instances; total loss — nothing resolved at all —
+   * throws a descriptive error naming this contract, as does a whole-model
+   * ask after `ReleaseModelGeometry`. What never happens is a silent empty
+   * model. A consumer that needs every placement should copy at delivery
+   * from the pump, which is what the budget's own contract already says.
+   *
+   * **Scope: the sync `StreamAllMeshes` cannot serve a windowed source.**
+   * On a model opened over an external store (`OpenModelStream`), the
+   * synchronous whole-model entry points drain through the synchronous pump,
+   * which refuses a windowed source outright — *"ExtractGeometryBatch is
+   * synchronous and cannot page a windowed source"*. That predates this
+   * setting and is identical with and without it, but it means the late
+   * whole-model ask described above is reachable on a resident source only.
+   * Share pumps `ExtractGeometryBatchAsync` over a store, so on Share's
+   * configuration the ask is not available at all — which is consistent with
+   * this setting, whose premise is that the consumer already has the stream.
    *
    * Ignored on a non-deferred open, which has no pump and no accumulation to
    * suppress.

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -69,6 +69,44 @@ export interface Loadersettings {
   DEFER_GEOMETRY?: boolean
 
   /**
+   * Conway extension (DEFER_GEOMETRY only; conway#638): the caller declares
+   * that IT owns the pumped mesh stream, so conway keeps no reference to it.
+   *
+   * Default (absent/false) is the historical behaviour, unchanged: every
+   * `PlacedGeometry` the pump builds is filed into the model's cumulative
+   * per-entity `meshMap` and its `vectorFlatMesh` spine as well as being
+   * handed to the mesh callback, so a later whole-model ask can be served
+   * out of that cache. On a D3D-scale model that cache is the largest single
+   * bucket of JS heap a load holds — 475 MB of `FlatMesh`/`PlacedGeometry`
+   * measured — and a consumer that assembles each batch as it lands (Share's
+   * incremental batched builder) never reads it.
+   *
+   * With this set, the pump delivers each delta `FlatMesh` to the callback
+   * and drops it. **The callback is the only delivery**: whatever the
+   * consumer does not copy or keep is gone.
+   *
+   * **This drops JS pointer spines, never native geometry.** The natives
+   * behind the delivered placements are owned by the model's geometry store
+   * and are freed only by `GEOMETRY_BUDGET_MB` eviction or
+   * `ReleaseModelGeometry`, neither of which this setting touches. The
+   * copy-window guarantee above — everything pump call N delivered stays
+   * resident until call N+1 begins — therefore holds exactly as it does
+   * without this flag.
+   *
+   * **A late whole-model ask still works, until the natives are gone.**
+   * `StreamAllMeshes`, `LoadAllGeometry` and `GetFlatMesh` on such a model
+   * re-walk the live scene rather than replaying a cache, which costs a walk
+   * but returns the same placements the pump delivered. Once the geometry has
+   * been released — or evicted in its entirety under a budget — there is
+   * nothing left to walk, and those entry points throw a descriptive error
+   * naming this contract rather than silently returning an empty model.
+   *
+   * Ignored on a non-deferred open, which has no pump and no accumulation to
+   * suppress.
+   */
+  STREAMING_CONSUMER?: boolean
+
+  /**
    * Conway extension (OpenModelStreamed + DEFER_GEOMETRY only; demand/tiled
    * rendering slice A2): receive PREVIEW mesh payloads while the parse is
    * still running — self-contained (geometry copied out of the wasm heap),

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -1694,7 +1694,10 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
    * whole-model ask idempotent.
    *
    * AP214 has no geometry residency, so the only way the natives go missing
-   * here is ReleaseModelGeometry — the one case this throws on.
+   * here is ReleaseModelGeometry — the one case this throws on. The IFC twin
+   * returns a count of instances its re-walk could not resolve, for the
+   * eviction case; there is no analogue here, and this walk has no
+   * park-and-retry arm to count, so it returns nothing.
    *
    * @param entryPoint The public method being served, for the error message.
    */

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -130,6 +130,21 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
   /** Was this model opened without extraction (DEFER_GEOMETRY)? */
   private deferredMode_: boolean = false
 
+  /**
+   * Did the open declare the caller the owner of the pumped mesh stream
+   * (STREAMING_CONSUMER)? The AP214 twin of the IFC proxy's field of the
+   * same name — same contract, same reason it is ANDed with deferredMode_
+   * where it is set; see that one for the full note.
+   */
+  private streamingConsumer_: boolean = false
+
+  /**
+   * The array behind model[4]'s hand-rolled Vector<FlatMesh>, held so
+   * recaptureWholeModel_ can truncate the spine (Vector has push, not
+   * clear). IFC twin: flatMeshArray_ there.
+   */
+  private readonly flatMeshArray_: FlatMesh[]
+
   /** Parse/load tracker — deferred opens resume it for the Geometry phase. */
   private progressTracker_?: ProgressTracker
 
@@ -257,6 +272,12 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
     this.conwaywasm = loadState.conwaywasm
     this.conwayGeometry_ = loadState.conwayGeometry
     this.deferredMode_ = loadState.deferred === true
+
+    // Only a deferred open has a pump, and only a pump accumulates — see
+    // streamingConsumer_ for why the AND lives here rather than at each use.
+    this.streamingConsumer_ =
+      this.deferredMode_ && settings?.STREAMING_CONSUMER === true
+
     this.progressTracker_ = loadState.tracker
 
     const statistics = Logger.getStatistics(modelID)
@@ -347,6 +368,8 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
     }
 
     const coordinationMatrix: glmatrix.mat4 = glmatrix.mat4.create()
+
+    this.flatMeshArray_ = flatMeshArray
 
     this.model = [
       model,
@@ -1462,15 +1485,23 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
    * coordination x nativeTransform composition, occurrence paths),
    * processed in walk order exactly once per instance. The shared
    * meshMap accumulates each entity's FULL vector so getFlatMesh stays
-   * whole-model correct; the derived coordination matrix is remembered
-   * across calls (demandCoordination_) without leaking through
+   * whole-model correct — unless `retain` is off, which is the
+   * STREAMING_CONSUMER contract; see that parameter. The derived
+   * coordination matrix is remembered across calls
+   * (demandCoordination_) without leaking through
    * getCoordinationMatrix (classic identity contract).
    *
    * @param meshCallback Receives one delta FlatMesh per entity that
    * gained instances this call.
+   * @param retain Whether to file each placement into the cumulative
+   * meshMap/vectorFlatMesh as well as delivering it. Defaults to the inverse
+   * of streamingConsumer_ — that default IS the STREAMING_CONSUMER contract.
+   * recaptureWholeModel_ is the one caller that forces it true on such a
+   * model, to rebuild the cache for a late whole-model ask.
    */
   private streamNewMeshes_(
-      meshCallback: (mesh: FlatMesh) => void ): void {
+      meshCallback: (mesh: FlatMesh) => void,
+      retain: boolean = !this.streamingConsumer_ ): void {
 
     // Released models: the scene's natives are freed — nothing new can
     // exist to capture, and walking would touch freed objects.
@@ -1586,29 +1617,36 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
         occurrencePath,
       }
 
-      let mesh = meshMap.get(entity.localID)
+      // The cumulative per-entity cache, and the bulk of what
+      // STREAMING_CONSUMER exists to not build (conway#638). The delta below
+      // is a separate array, so skipping this costs the callback nothing —
+      // the consumer receives exactly the same stream either way.
+      if (retain) {
 
-      if (mesh === void 0) {
+        let mesh = meshMap.get(entity.localID)
 
-        const placedArray = new Array<PlacedGeometry>()
-        const placedVector: Vector<PlacedGeometry> = {
-          get: (index: number) => placedArray[index] ?? placed,
-          size: () => placedArray.length,
-          push: (parameter: PlacedGeometry) => {
-            placedArray.push(parameter)
-          },
+        if (mesh === void 0) {
+
+          const placedArray = new Array<PlacedGeometry>()
+          const placedVector: Vector<PlacedGeometry> = {
+            get: (index: number) => placedArray[index] ?? placed,
+            size: () => placedArray.length,
+            push: (parameter: PlacedGeometry) => {
+              placedArray.push(parameter)
+            },
+          }
+          const flatMesh: FlatMesh = {
+            geometries: placedVector,
+            expressID: entity.expressID,
+          }
+
+          mesh = [placedVector, flatMesh]
+          meshMap.set(entity.localID, mesh)
         }
-        const flatMesh: FlatMesh = {
-          geometries: placedVector,
-          expressID: entity.expressID,
-        }
 
-        mesh = [placedVector, flatMesh]
-        meshMap.set(entity.localID, mesh)
+        mesh[0].push(placed)
+        mesh[1].geometries = mesh[0]
       }
-
-      mesh[0].push(placed)
-      mesh[1].geometries = mesh[0]
 
       let delta = deltas.get(entity.localID)
       if (delta === void 0) {
@@ -1635,9 +1673,61 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
         expressID: deltaExpressIDs.get(localID)!,
       }
 
-      vectorFlatMesh.push(deltaMesh)
+      // The second spine over the same graph (conway#638): one entry per
+      // delta mesh, never dropped. Read only by loadAllGeometry's return
+      // value, which a streaming consumer is not using — it took delivery
+      // through the callback below instead.
+      if (retain) {
+        vectorFlatMesh.push(deltaMesh)
+      }
+
       meshCallback(deltaMesh)
     }
+  }
+
+  /**
+   * Re-materialise the whole-model per-entity meshes on a
+   * STREAMING_CONSUMER model, which by contract has kept none. The AP214
+   * twin of the IFC proxy's method of the same name; see it for why the
+   * DELTA capture rather than the classic walk does the re-walk (the
+   * coordination seed), and for why clearing first is what makes a repeated
+   * whole-model ask idempotent.
+   *
+   * AP214 has no geometry residency, so the only way the natives go missing
+   * here is ReleaseModelGeometry — the one case this throws on.
+   *
+   * @param entryPoint The public method being served, for the error message.
+   */
+  private recaptureWholeModel_( entryPoint: string ): void {
+
+    if (this.released_) {
+
+      throw new Error(
+          `${entryPoint}: this model was opened with STREAMING_CONSUMER, so ` +
+          `conway kept no reference to the meshes the pump delivered — the ` +
+          `caller owns them — and ReleaseModelGeometry has since freed the ` +
+          `natives a re-walk would need. Nothing can be served. Copy at ` +
+          `delivery, or open without STREAMING_CONSUMER if a whole-model ` +
+          `ask after release is required.` )
+    }
+
+    this.model[2].clear()
+
+    // Rewind the per-entity capture watermarks so the walk emits from
+    // instance zero again. AP214 re-walks the whole scene every pass and
+    // suppresses by these counts, so this is the whole of the rewind — there
+    // is no scene cursor to reset as there is on the IFC side.
+    this.demandCapturedCounts_.clear()
+
+    this.streamNewMeshes_(() => { /* rebuilding the cache, not delivering */ },
+        true)
+
+    // Truncated AFTER the walk: retaining also pushes each delta into the
+    // spine, and the caller then pushes one entry per whole-model entity on
+    // top. Emptying it here leaves the caller's pass as the only writer, so
+    // LoadAllGeometry returns each entity exactly once however many times it
+    // is asked.
+    this.flatMeshArray_.length = 0
   }
 
   /**
@@ -1663,6 +1753,10 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
     // Deferred models: pump any remainder to completion and serve the
     // accumulated full per-entity meshes — re-running the classic walk
     // would push every instance a second time (mirrors the IFC proxy).
+    //
+    // Under STREAMING_CONSUMER there is no such accumulation, by contract,
+    // and the drain is followed by a full re-walk instead — see
+    // recaptureWholeModel_.
     if (this.deferredMode_) {
 
       const noCallback = void 0
@@ -1676,7 +1770,17 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
           DEFERRED_DRAIN_BATCH_AP214, noCallback, unbudgeted).remaining > 0) {
         // draining
       }
-      this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
+
+      if (this.streamingConsumer_) {
+        // Nothing was accumulated to absorb stragglers into: this open
+        // declared the caller the owner of the stream. Rebuild the whole
+        // model from the live scene instead — same placements, one walk,
+        // and it throws rather than serving an empty model when the natives
+        // are gone.
+        this.recaptureWholeModel_('StreamAllMeshes')
+      } else {
+        this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
+      }
 
       const [, , meshMap, , vectorFlatMesh] = this.model
 
@@ -1851,6 +1955,21 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
    * @return {Vector<FlatMesh>}
    */
   loadAllGeometry(): Vector<FlatMesh> {
+
+    // A STREAMING_CONSUMER model has no cached meshes to hand back, and the
+    // classic walk below cannot build them: it seeds coordination from
+    // model[5], which a deferred open never writes. Route the whole ask
+    // through streamAllMeshes, which drains the pump, re-walks with the
+    // frame the stream actually used, and throws if the natives are gone.
+    // It leaves one entry per entity in the spine, which is what this
+    // returns.
+    if (this.streamingConsumer_) {
+
+      this.streamAllMeshes(() => { /* the spine is the return value */ })
+
+      return this.model[4]
+    }
+
     const [model,
       scene,
       meshMap,
@@ -2069,6 +2188,11 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
     // eslint-disable-next-line no-unused-vars
     const [model, scene, meshMap] = this.model
 
+    // Empty is the STEADY state under STREAMING_CONSUMER, not the
+    // not-loaded-yet state it means elsewhere, so this fires on the FIRST
+    // single-mesh ask on such a model and the re-walk it routes into (see
+    // loadAllGeometry) is what serves it. That re-walk repopulates the map,
+    // so subsequent asks are cache hits again.
     if (meshMap.size <= 0) {
 
       this.loadAllGeometry()

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2302,9 +2302,15 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     //
     // STREAMING_CONSUMER makes that capture a no-op — there is no meshMap to
     // save anything into — so it is skipped rather than run for its side
-    // effect of advancing the scene cursor. Nothing is lost by not advancing
-    // it: the only whole-model path on such a model rewinds the cursor to
-    // zero and re-walks anyway (recaptureWholeModel_).
+    // effect of advancing the scene cursor, which the only whole-model path
+    // on such a model rewinds to zero anyway (recaptureWholeModel_).
+    //
+    // Note what is NOT being claimed: that nothing is lost. Under a budget,
+    // geometry evicted before a no-callback drain finishes is unrecoverable
+    // on this contract exactly as it is here, and the re-walk does not get
+    // it back — it reports it, and throws when that accounts for the whole
+    // model. Skipping the capture is not what loses it; having no cache to
+    // capture INTO is, and that is the contract the caller opted into.
     if (meshCallback !== void 0) {
       this.streamNewMeshes_(meshCallback)
     } else if (this.model[0].geometryResidency.enabled &&
@@ -3208,9 +3214,15 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     //
     // STREAMING_CONSUMER makes that capture a no-op — there is no meshMap to
     // save anything into — so it is skipped rather than run for its side
-    // effect of advancing the scene cursor. Nothing is lost by not advancing
-    // it: the only whole-model path on such a model rewinds the cursor to
-    // zero and re-walks anyway (recaptureWholeModel_).
+    // effect of advancing the scene cursor, which the only whole-model path
+    // on such a model rewinds to zero anyway (recaptureWholeModel_).
+    //
+    // Note what is NOT being claimed: that nothing is lost. Under a budget,
+    // geometry evicted before a no-callback drain finishes is unrecoverable
+    // on this contract exactly as it is here, and the re-walk does not get
+    // it back — it reports it, and throws when that accounts for the whole
+    // model. Skipping the capture is not what loses it; having no cache to
+    // capture INTO is, and that is the contract the caller opted into.
     if (meshCallback !== void 0) {
       this.streamNewMeshes_(meshCallback)
     } else if (this.model[0].geometryResidency.enabled &&
@@ -3537,9 +3549,22 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * is the price of the ask, paid at the moment of the ask rather than on
    * every load against the chance of one.
    *
+   * **A re-walk does not recover evicted geometry, and this is how the
+   * caller finds that out.** `GEOMETRY_BUDGET_MB` eviction deletes the mesh
+   * from the model's geometry store (`IfcModelGeometry.delete`), so the walk
+   * resolves nothing for that scene node, parks it, and the placement never
+   * enters the rebuilt map at all — it is missing rather than present-and-
+   * dead. That makes the retaining path's `livePlacements` filter blind here
+   * (it can only see placements that made it into the map, and all of those
+   * are live), which is why the count this returns, not that filter, is what
+   * streamAllMeshes reports and throws on.
+   *
    * @param entryPoint The public method being served, for the error message.
+   * @return {number} Scene nodes the re-walk could not resolve — placed
+   * instances whose geometry is gone, and so missing from what the rebuilt
+   * map can serve. Zero on a healthy model.
    */
-  private recaptureWholeModel_( entryPoint: string ): void {
+  private recaptureWholeModel_( entryPoint: string ): number {
 
     // The natives a re-walk would read are freed. There is no cache to fall
     // back on — that is the contract — so say so instead of walking an empty
@@ -3573,6 +3598,13 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // the caller's own pass as the only writer, so LoadAllGeometry returns
     // each entity exactly once however many times it is asked.
     this.flatMeshArray_.length = 0
+
+    // The parked map was emptied above and this walk is the only thing that
+    // has written to it since, so its size IS the number of instances this
+    // re-walk could not resolve. The drain has already run to completion by
+    // the time anything calls this, so a node still unresolved here is not
+    // waiting on extraction — its geometry is gone.
+    return this.demandPendingNodes_.size
   }
 
   /**
@@ -3649,13 +3681,20 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
           // draining
         }
 
+        // Placed instances the re-walk could not resolve, which on this path
+        // is the ONLY signal that anything was lost: evicted geometry is
+        // deleted from the store, so those placements never reach the
+        // rebuilt map and the livePlacements filter below cannot see them.
+        // Zero on the retaining path, where that filter is the signal.
+        let unresolvedInstances = 0
+
         if (this.streamingConsumer_) {
           // Nothing was accumulated to absorb stragglers into: this open
           // declared the caller the owner of the stream. Rebuild the whole
           // model from the live scene instead — same placements, one walk,
           // and it throws rather than serving an empty model when the
           // natives are gone.
-          this.recaptureWholeModel_('StreamAllMeshes')
+          unresolvedInstances = this.recaptureWholeModel_('StreamAllMeshes')
         } else {
           this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
         }
@@ -3686,31 +3725,58 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
           meshCallback(mesh[1])
         })
 
-        // A STREAMING_CONSUMER model that served NOTHING while the re-walk
-        // did find entities to serve has had every one of them freed under
-        // the budget. There is no cache to fall back on here — that is the
-        // contract — so returning quietly would hand back a model with no
-        // geometry and no explanation. The retaining path keeps its warning
-        // instead of this throw because there it is a partial loss of a
-        // cache that still holds something.
-        if (this.streamingConsumer_ && servedEntities === 0 &&
-            droppedEntities > 0) {
+        if (this.streamingConsumer_) {
 
-          throw new Error(
-              `StreamAllMeshes: this model was opened with ` +
-              `STREAMING_CONSUMER, so conway kept no reference to the meshes ` +
-              `the pump delivered — the caller owns them — and every ` +
-              `placement the re-walk found (${droppedInstances} instance(s) ` +
-              `across ${droppedEntities} entit(ies)) is backed by geometry a ` +
-              `GEOMETRY_BUDGET_MB eviction has already freed. Nothing can be ` +
-              `served. Copy at delivery, raise the budget, or open without ` +
-              `STREAMING_CONSUMER.` )
-        }
+          // Served nothing, and something was lost on the way: either the
+          // re-walk parked instances whose geometry is gone, or the model
+          // evicted at all. Both conditions, not just the first, because
+          // `everEvicted` also covers a model whose every scene node was
+          // freed before the walk could even park it. What must NOT throw is
+          // a model that genuinely has no geometry — no eviction, nothing
+          // parked, nothing to serve — where empty is the right answer and
+          // classic returns it too.
+          //
+          // This deliberately does NOT key on droppedEntities the way the
+          // retaining path below does. That counter is fed by the
+          // livePlacements filter, which can only ever see placements that
+          // reached the rebuilt map — and evicted ones never do, because
+          // eviction deletes the mesh from the store rather than leaving a
+          // dead handle in it. Keying on it made this throw unreachable and
+          // let a fully-evicted model return silently empty, which is the
+          // exact failure the contract exists to prevent.
+          if (servedEntities === 0 && (unresolvedInstances > 0 || degraded)) {
 
-        // One line for the whole call, not one per dropped instance: this
-        // fires on a path that may drop thousands, and a per-instance log
-        // would bury the fact that anything was dropped at all.
-        if (degraded) {
+            throw new Error(
+                `StreamAllMeshes: this model was opened with ` +
+                `STREAMING_CONSUMER, so conway kept no reference to the ` +
+                `meshes the pump delivered — the caller owns them — and the ` +
+                `re-walk that serves a late whole-model ask resolved none of ` +
+                `the model (${unresolvedInstances} placed instance(s) ` +
+                `unresolved), because a GEOMETRY_BUDGET_MB eviction has ` +
+                `already freed the geometry behind them. Nothing can be ` +
+                `served. Copy at delivery, raise the budget, or open without ` +
+                `STREAMING_CONSUMER.` )
+          }
+
+          // Partial loss is a warning, matching the retaining path, but the
+          // number comes from the re-walk rather than the filter — see above
+          // for why the filter reads zero here however much was lost.
+          if (unresolvedInstances > 0) {
+            Logger.warning(
+                `[geometry budget] StreamAllMeshes re-walked a ` +
+                `STREAMING_CONSUMER model that evicted under a budget: ` +
+                `${unresolvedInstances} placed instance(s) could not be ` +
+                `resolved because their geometry was freed, and are missing ` +
+                `from the ${servedEntities} entit(ies) this call served. ` +
+                `Pump ExtractGeometryBatch and copy at delivery to receive ` +
+                `everything.`)
+          }
+
+        } else if (degraded) {
+
+          // One line for the whole call, not one per dropped instance: this
+          // fires on a path that may drop thousands, and a per-instance log
+          // would bury the fact that anything was dropped at all.
           Logger.warning(
               `[geometry budget] StreamAllMeshes served a model that evicted ` +
               `under a budget: ${droppedInstances} instance(s) across ` +
@@ -3881,12 +3947,6 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   }
 
   /**
-   *
-   * @param modelID
-   * @param types
-   * @param meshCallback
-   */
-  /*
    * Deliberately NOT routed through recaptureWholeModel_ under
    * STREAMING_CONSUMER. This entry point has no deferred branch at all — it
    * runs the classic walk on a deferred model today, seeding coordination
@@ -3895,6 +3955,10 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * that behind a flag. Under the contract meshMap is at least empty when it
    * starts, so its walk builds a clean set rather than doubling a cached
    * one. Fixing the deferred coordination seed here is separate work.
+   *
+   * @param modelID
+   * @param types
+   * @param meshCallback
    */
   streamAllMeshesWithTypes(
       types: Array<number>,

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -203,6 +203,28 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   /** Was this model opened without extraction (DEFER_GEOMETRY)? */
   private deferredMode_: boolean = false
 
+  /**
+   * Did the open declare the caller the owner of the pumped mesh stream
+   * (STREAMING_CONSUMER)? When true the delta capture hands each FlatMesh to
+   * the callback and keeps nothing: meshMap and vectorFlatMesh stay empty
+   * for the model's whole pumped life, and a late whole-model ask is served
+   * by re-walking the scene (see recaptureWholeModel_).
+   *
+   * Deliberately ANDed with deferredMode_ at the one place it is set: on a
+   * classic open there is no pump, so there is no accumulation the flag
+   * could suppress, and letting it be true there would only give
+   * streamAllMeshes a branch it can never need.
+   */
+  private streamingConsumer_: boolean = false
+
+  /**
+   * The array behind model[4]'s hand-rolled Vector<FlatMesh>. Held so
+   * recaptureWholeModel_ can truncate the spine — Vector has push but no
+   * clear, and a re-walk that appends to whatever a previous one left would
+   * make LoadAllGeometry return each entity once per call.
+   */
+  private readonly flatMeshArray_: FlatMesh[]
+
   /** Parse/load tracker — deferred opens resume it for the Geometry phase. */
   private progressTracker_?: ProgressTracker
 
@@ -419,6 +441,12 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     this.conwaywasm = loadState.conwaywasm
     this.conwayGeometry_ = loadState.conwayGeometry
     this.deferredMode_ = loadState.deferred === true
+
+    // Only a deferred open has a pump, and only a pump accumulates — see
+    // streamingConsumer_ for why the AND lives here rather than at each use.
+    this.streamingConsumer_ =
+      this.deferredMode_ && settings?.STREAMING_CONSUMER === true
+
     this.progressTracker_ = loadState.tracker
 
     const statistics = Logger.getStatistics(modelID)
@@ -519,6 +547,8 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     }
 
     const coordinationMatrix: glmatrix.mat4 = glmatrix.mat4.create()
+
+    this.flatMeshArray_ = flatMeshArray
 
     this.model = [
       model,
@@ -2269,9 +2299,16 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // instances vanish from the model with no error. On the
     // shared-representation fixture at a 2 KiB budget that path delivered 3
     // placements against classic's 16.
+    //
+    // STREAMING_CONSUMER makes that capture a no-op — there is no meshMap to
+    // save anything into — so it is skipped rather than run for its side
+    // effect of advancing the scene cursor. Nothing is lost by not advancing
+    // it: the only whole-model path on such a model rewinds the cursor to
+    // zero and re-walks anyway (recaptureWholeModel_).
     if (meshCallback !== void 0) {
       this.streamNewMeshes_(meshCallback)
-    } else if (this.model[0].geometryResidency.enabled) {
+    } else if (this.model[0].geometryResidency.enabled &&
+        !this.streamingConsumer_) {
       this.streamNewMeshes_(() => { /* capture into meshMap */ })
     }
 
@@ -3168,9 +3205,16 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // instances vanish from the model with no error. On the
     // shared-representation fixture at a 2 KiB budget that path delivered 3
     // placements against classic's 16.
+    //
+    // STREAMING_CONSUMER makes that capture a no-op — there is no meshMap to
+    // save anything into — so it is skipped rather than run for its side
+    // effect of advancing the scene cursor. Nothing is lost by not advancing
+    // it: the only whole-model path on such a model rewinds the cursor to
+    // zero and re-walks anyway (recaptureWholeModel_).
     if (meshCallback !== void 0) {
       this.streamNewMeshes_(meshCallback)
-    } else if (this.model[0].geometryResidency.enabled) {
+    } else if (this.model[0].geometryResidency.enabled &&
+        !this.streamingConsumer_) {
       this.streamNewMeshes_(() => { /* capture into meshMap */ })
     }
 
@@ -3190,26 +3234,6 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     }
   }
 
-  /**
-   * Walk the scene and emit every not-yet-captured placed instance as
-   * per-entity DELTA FlatMeshes — the incremental core of
-   * streamAllMeshes with identical placed-geometry math, processed in
-   * walk order exactly once per instance (per-entity watermarks). An
-   * entity re-emits with only its NEW instances when shared/mapped
-   * geometry attributes more to it in later batches; consumers render
-   * deltas additively (the shared meshMap still accumulates each
-   * entity's FULL vector, so getFlatMesh stays whole-model correct).
-   *
-   * Also fixes a latent multi-call bug: the derived coordination
-   * matrix is remembered (demandCoordination_), so later batches place
-   * with the SAME coordination the first batch established
-   * (streamAllMeshes never needed this — it runs once). It is NOT
-   * exposed through getCoordinationMatrix, which keeps the classic
-   * identity contract consumers stamp onto assembled models.
-   *
-   * @param meshCallback Receives one delta FlatMesh per entity that
-   * gained instances this call.
-   */
   /**
    * Set the resident-geometry budget, in bytes, after the open.
    *
@@ -3235,8 +3259,36 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     return { budgetBytes: residency.budgetBytes, liveBytes: residency.liveBytes }
   }
 
+  /**
+   * Walk the scene and emit every not-yet-captured placed instance as
+   * per-entity DELTA FlatMeshes — the incremental core of
+   * streamAllMeshes with identical placed-geometry math, processed in
+   * walk order exactly once per instance (per-entity watermarks). An
+   * entity re-emits with only its NEW instances when shared/mapped
+   * geometry attributes more to it in later batches; consumers render
+   * deltas additively (the shared meshMap accumulates each entity's FULL
+   * vector so getFlatMesh stays whole-model correct — unless `retain` is
+   * off, which is the STREAMING_CONSUMER contract; see that parameter).
+   *
+   * Also fixes a latent multi-call bug: the derived coordination
+   * matrix is remembered (demandCoordination_), so later batches place
+   * with the SAME coordination the first batch established
+   * (streamAllMeshes never needed this — it runs once). It is NOT
+   * exposed through getCoordinationMatrix, which keeps the classic
+   * identity contract consumers stamp onto assembled models.
+   *
+   * @param meshCallback Receives one delta FlatMesh per entity that
+   * gained instances this call.
+   * @param retain Whether to file each placement into the cumulative
+   * meshMap/vectorFlatMesh as well as delivering it. Defaults to the
+   * inverse of streamingConsumer_, which is the whole of the
+   * STREAMING_CONSUMER contract; recaptureWholeModel_ is the one caller
+   * that forces it true on such a model, to rebuild the cache for a late
+   * whole-model ask.
+   */
   private streamNewMeshes_(
-      meshCallback: (mesh: FlatMesh) => void ): void {
+      meshCallback: (mesh: FlatMesh) => void,
+      retain: boolean = !this.streamingConsumer_ ): void {
 
     // Released models: the scene's natives are freed — nothing new can
     // exist to capture, and walking would touch freed objects.
@@ -3395,29 +3447,38 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         flatTransformation: newTransformArr,
       }
 
-      let mesh = meshMap.get(entity.expressID)
+      // The cumulative per-entity cache, and the bulk of what
+      // STREAMING_CONSUMER exists to not build: every placement ever
+      // pumped, kept for the lifetime of the model against the chance
+      // that someone later asks for the whole thing. The delta below is
+      // a separate array, so skipping this costs the callback nothing —
+      // the consumer receives exactly the same stream either way.
+      if (retain) {
 
-      if (mesh === void 0) {
+        let mesh = meshMap.get(entity.expressID)
 
-        const placedArray = new Array<PlacedGeometry>()
-        const placedVector: Vector<PlacedGeometry> = {
-          get: (index: number) => placedArray[index] ?? placed,
-          size: () => placedArray.length,
-          push: (parameter: PlacedGeometry) => {
-            placedArray.push(parameter)
-          },
+        if (mesh === void 0) {
+
+          const placedArray = new Array<PlacedGeometry>()
+          const placedVector: Vector<PlacedGeometry> = {
+            get: (index: number) => placedArray[index] ?? placed,
+            size: () => placedArray.length,
+            push: (parameter: PlacedGeometry) => {
+              placedArray.push(parameter)
+            },
+          }
+          const flatMesh: FlatMesh = {
+            geometries: placedVector,
+            expressID: entity.expressID,
+          }
+
+          mesh = [placedVector, flatMesh]
+          meshMap.set(entity.expressID, mesh)
         }
-        const flatMesh: FlatMesh = {
-          geometries: placedVector,
-          expressID: entity.expressID,
-        }
 
-        mesh = [placedVector, flatMesh]
-        meshMap.set(entity.expressID, mesh)
+        mesh[0].push(placed)
+        mesh[1].geometries = mesh[0]
       }
-
-      mesh[0].push(placed)
-      mesh[1].geometries = mesh[0]
 
       let delta = deltas.get(entity.expressID)
       if (delta === void 0) {
@@ -3440,9 +3501,78 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       }
       const deltaMesh: FlatMesh = {geometries: placedVector, expressID}
 
-      vectorFlatMesh.push(deltaMesh)
+      // The second spine over the same graph (conway#638): one entry per
+      // delta mesh, never dropped. Read only by loadAllGeometry's return
+      // value, which a streaming consumer is not using — it took delivery
+      // through the callback below instead.
+      if (retain) {
+        vectorFlatMesh.push(deltaMesh)
+      }
+
       meshCallback(deltaMesh)
     }
+  }
+
+  /**
+   * Re-materialise the whole-model per-entity meshes on a
+   * STREAMING_CONSUMER model, which by contract has kept none.
+   *
+   * Re-walks with the DELTA capture from instance zero rather than with the
+   * classic walk at the bottom of streamAllMeshes, and the difference is
+   * load-bearing: the classic walk seeds its coordination from `model[5]`,
+   * which a deferred open never writes, so it would place every instance in
+   * an identity frame while the placements the consumer already received are
+   * in the frame `demandCoordination_` holds. streamNewMeshes_ seeds from
+   * that field, so what this rebuilds is what was streamed.
+   *
+   * Clearing first is what makes the ask idempotent. On the retaining path a
+   * second StreamAllMeshes re-pushes every instance into the still-populated
+   * cache and doubles every triangle count (documented from the consumer
+   * side in Share's IfcItemsMap.js:274-283); here each call starts from an
+   * empty map and instance zero, so the second returns exactly what the
+   * first did.
+   *
+   * The cost is honest and worth stating: a model that is asked for the
+   * whole stream ends up holding the cache the contract was avoiding. That
+   * is the price of the ask, paid at the moment of the ask rather than on
+   * every load against the chance of one.
+   *
+   * @param entryPoint The public method being served, for the error message.
+   */
+  private recaptureWholeModel_( entryPoint: string ): void {
+
+    // The natives a re-walk would read are freed. There is no cache to fall
+    // back on — that is the contract — so say so instead of walking an empty
+    // scene and returning a model with no geometry in it.
+    if (this.released_) {
+
+      throw new Error(
+          `${entryPoint}: this model was opened with STREAMING_CONSUMER, so ` +
+          `conway kept no reference to the meshes the pump delivered — the ` +
+          `caller owns them — and ReleaseModelGeometry has since freed the ` +
+          `natives a re-walk would need. Nothing can be served. Copy at ` +
+          `delivery, or open without STREAMING_CONSUMER if a whole-model ` +
+          `ask after release is required.` )
+    }
+
+    this.model[2].clear()
+
+    // Rewind the delta cursor so the walk starts at instance zero. The
+    // parked-node map goes with it: those nodes are below the cursor now
+    // and the walk yields them again on its own, so leaving their retry
+    // counts behind would only expire nodes early on a second ask.
+    this.demandSceneCursor_ = 0
+    this.demandPendingNodes_.clear()
+
+    this.streamNewMeshes_(() => { /* rebuilding the cache, not delivering */ },
+        true)
+
+    // Truncated AFTER the walk, not before: retaining also pushes each delta
+    // into the spine, and the caller (streamAllMeshes / loadAllGeometry) then
+    // pushes one entry per whole-model entity on top. Emptying it here leaves
+    // the caller's own pass as the only writer, so LoadAllGeometry returns
+    // each entity exactly once however many times it is asked.
+    this.flatMeshArray_.length = 0
   }
 
   /**
@@ -3470,6 +3600,10 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // populate) the shared meshMap — re-running the classic walk would
     // push every instance a second time. Pump any remainder to
     // completion and serve the accumulated full per-entity meshes.
+    //
+    // Under STREAMING_CONSUMER there is no such accumulation, by contract,
+    // and the drain below is followed by a full re-walk instead — see
+    // recaptureWholeModel_.
     if (this.deferredMode_) {
 
       // A budget cannot hold across this call, and pretending otherwise
@@ -3514,13 +3648,24 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
             DEFERRED_DRAIN_BATCH, noCallback).remaining > 0) {
           // draining
         }
-        this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
+
+        if (this.streamingConsumer_) {
+          // Nothing was accumulated to absorb stragglers into: this open
+          // declared the caller the owner of the stream. Rebuild the whole
+          // model from the live scene instead — same placements, one walk,
+          // and it throws rather than serving an empty model when the
+          // natives are gone.
+          this.recaptureWholeModel_('StreamAllMeshes')
+        } else {
+          this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
+        }
 
         const [, , meshMap, geometryMaterialTransformMap, vectorFlatMesh] =
           this.model
 
         let droppedInstances = 0
         let droppedEntities = 0
+        let servedEntities = 0
 
         meshMap.forEach((mesh) => {
 
@@ -3536,9 +3681,31 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
             }
           }
 
+          ++servedEntities
           vectorFlatMesh.push(mesh[1])
           meshCallback(mesh[1])
         })
+
+        // A STREAMING_CONSUMER model that served NOTHING while the re-walk
+        // did find entities to serve has had every one of them freed under
+        // the budget. There is no cache to fall back on here — that is the
+        // contract — so returning quietly would hand back a model with no
+        // geometry and no explanation. The retaining path keeps its warning
+        // instead of this throw because there it is a partial loss of a
+        // cache that still holds something.
+        if (this.streamingConsumer_ && servedEntities === 0 &&
+            droppedEntities > 0) {
+
+          throw new Error(
+              `StreamAllMeshes: this model was opened with ` +
+              `STREAMING_CONSUMER, so conway kept no reference to the meshes ` +
+              `the pump delivered — the caller owns them — and every ` +
+              `placement the re-walk found (${droppedInstances} instance(s) ` +
+              `across ${droppedEntities} entit(ies)) is backed by geometry a ` +
+              `GEOMETRY_BUDGET_MB eviction has already freed. Nothing can be ` +
+              `served. Copy at delivery, raise the budget, or open without ` +
+              `STREAMING_CONSUMER.` )
+        }
 
         // One line for the whole call, not one per dropped instance: this
         // fires on a path that may drop thousands, and a per-instance log
@@ -3719,6 +3886,16 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * @param types
    * @param meshCallback
    */
+  /*
+   * Deliberately NOT routed through recaptureWholeModel_ under
+   * STREAMING_CONSUMER. This entry point has no deferred branch at all — it
+   * runs the classic walk on a deferred model today, seeding coordination
+   * from model[5] — so it is already wrong there for reasons that predate
+   * and are wider than this contract, and gating it here would only hide
+   * that behind a flag. Under the contract meshMap is at least empty when it
+   * starts, so its walk builds a clean set rather than doubling a cached
+   * one. Fixing the deferred coordination seed here is separate work.
+   */
   streamAllMeshesWithTypes(
       types: Array<number>,
       meshCallback: (mesh: FlatMesh) => void) {
@@ -3887,6 +4064,21 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * @return {Vector<FlatMesh>}
    */
   loadAllGeometry(): Vector<FlatMesh> {
+
+    // A STREAMING_CONSUMER model has no cached meshes to hand back, and the
+    // classic walk below cannot build them: it seeds coordination from
+    // model[5], which a deferred open never writes. Route the whole ask
+    // through streamAllMeshes, which drains the pump, re-walks with the
+    // frame the stream actually used, and throws if the natives are gone.
+    // It leaves one entry per entity in the spine, which is what this
+    // returns.
+    if (this.streamingConsumer_) {
+
+      this.streamAllMeshes(() => { /* the spine is the return value */ })
+
+      return this.model[4]
+    }
+
     const [model,
       scene,
       meshMap,
@@ -4100,6 +4292,13 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     // eslint-disable-next-line no-unused-vars
     const [model, scene, meshMap] = this.model
 
+    // Empty is the STEADY state under STREAMING_CONSUMER, not the
+    // not-loaded-yet state it means elsewhere, so this fires on the FIRST
+    // single-mesh ask on such a model and the re-walk it routes into (see
+    // loadAllGeometry) is what serves it. That re-walk repopulates the map,
+    // so subsequent asks are cache hits again — the contract stops conway
+    // paying for the cache on every load, not from ever building one when a
+    // caller asks for something only the cache can answer.
     if (meshMap.size <= 0) {
 
       this.loadAllGeometry()

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -3727,23 +3727,35 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
         if (this.streamingConsumer_) {
 
-          // Served nothing, and something was lost on the way: either the
-          // re-walk parked instances whose geometry is gone, or the model
-          // evicted at all. Both conditions, not just the first, because
-          // `everEvicted` also covers a model whose every scene node was
-          // freed before the walk could even park it. What must NOT throw is
-          // a model that genuinely has no geometry — no eviction, nothing
-          // parked, nothing to serve — where empty is the right answer and
-          // classic returns it too.
+          // Served nothing, and the re-walk found instances it could not
+          // resolve: the geometry behind them is gone. What must NOT throw is
+          // a model that genuinely has no geometry — nothing parked, nothing
+          // to serve — where empty is the right answer and classic returns it
+          // too.
           //
-          // This deliberately does NOT key on droppedEntities the way the
-          // retaining path below does. That counter is fed by the
+          // `unresolvedInstances` is the whole signal today; `degraded` is a
+          // failsafe that is NOT independently reachable, and saying so is
+          // the point of this paragraph. Eviction removes geometry from the
+          // store and never touches the scene, which is append-only
+          // (IfcSceneBuilder.nodeCount's contract) — so every instance an
+          // eviction costs us is an instance the walk parks, and there is no
+          // state today in which the model evicted but the walk parked
+          // nothing. It is kept because it costs a boolean read and it fails
+          // in the safe direction: any future path that removes geometry
+          // WITHOUT leaving a parked node behind would otherwise reintroduce
+          // exactly the silent empty model this guard exists to prevent. No
+          // test pins it, and none can, because the state cannot be
+          // constructed through the public API.
+          //
+          // What this deliberately does NOT key on is droppedEntities, the
+          // way the retaining path below does. That counter is fed by the
           // livePlacements filter, which can only ever see placements that
           // reached the rebuilt map — and evicted ones never do, because
           // eviction deletes the mesh from the store rather than leaving a
           // dead handle in it. Keying on it made this throw unreachable and
-          // let a fully-evicted model return silently empty, which is the
-          // exact failure the contract exists to prevent.
+          // let a fully-evicted model return silently empty: measured at a
+          // 1-byte budget on mapped_shared_representation.ifc as 0 placements
+          // served, "0 instance(s) across 0 entit(ies)" logged, no throw.
           if (servedEntities === 0 && (unresolvedInstances > 0 || degraded)) {
 
             throw new Error(

--- a/src/compat/web-ifc/streaming_consumer_ownership.test.ts
+++ b/src/compat/web-ifc/streaming_consumer_ownership.test.ts
@@ -27,6 +27,7 @@ import * as fs from 'fs'
 
 import { beforeAll, describe, expect, test } from '@jest/globals'
 
+import Logger, { LogLevel } from '../../logging/logger'
 import { InMemoryStepByteStore } from '../../step/step_buffer_provider'
 import { FlatMesh, IfcAPI } from './ifc_api'
 import { IfcApiProxyAP214 } from './ifc_api_proxy_ap214'
@@ -206,6 +207,40 @@ function streamAll( api: IfcAPI, modelID: number ): Placement[] {
   } )
 
   return served
+}
+
+
+/**
+ * Run a whole-model ask with the log sink captured.
+ *
+ * The partial-loss path's ONLY output to a consumer is a warning line — the
+ * placements it lost are simply not in what it returns — so the line has to
+ * be asserted on directly, not inferred from a count. Logger echoes to the
+ * sink immediately, which matters here because StreamAllMeshes clears the
+ * buffer on its way out.
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The open model.
+ * @return {object} What was served, and every line the call logged.
+ */
+function streamAllCapturingLogs( api: IfcAPI, modelID: number ):
+  { served: Placement[], logged: string[] } {
+
+  const logged: string[] = []
+
+  Logger.clearLogs()
+  Logger.setLogLevel( LogLevel.WARNING )
+  Logger.setSink( ( _level, message ) => {
+    logged.push( message )
+  } )
+
+  try {
+    return { served: streamAll( api, modelID ), logged }
+  } finally {
+    Logger.setSink()
+    Logger.setLogLevel( LogLevel.INFO )
+    Logger.clearLogs()
+  }
 }
 
 
@@ -424,13 +459,35 @@ describe( 'STREAMING_CONSUMER under a geometry budget (IFC only — AP214 has ' 
 
         drain( api, ownedID )
 
-        const partial = streamAll( api, ownedID )
+        const { served: partial, logged } = streamAllCapturingLogs( api, ownedID )
 
         // Partial loss is a warning, not a throw: something is still there
         // to hand back, and refusing to hand it back would be worse than the
         // silence this contract is fixing.
         expect( partial.length ).toBeGreaterThan( 0 )
         expect( partial.length ).toBeLessThan( whole.length )
+
+        // The warning is the ONLY thing that tells a consumer it received a
+        // partial model — the lost placements are simply absent from what
+        // came back — so assert the line exists and that the number in it is
+        // the real loss, not merely that it is non-zero. This is the exact
+        // assertion the round-1 code would have failed: it reported "0
+        // instance(s) across 0 entit(ies)" while losing 13 of 16, and
+        // `whole.length - 0 === 16` is not the 3 that was served.
+        const warned = logged.find( ( line ) =>
+          line.includes( 'StreamAllMeshes re-walked a STREAMING_CONSUMER' ) )
+
+        expect( warned ).toBeDefined()
+
+        const reported =
+          /(\d+) placed instance\(s\) could not be resolved/.exec( warned! )
+
+        expect( reported ).not.toBeNull()
+
+        const unresolved = Number( reported![ 1 ] )
+
+        expect( unresolved ).toBeGreaterThan( 0 )
+        expect( partial.length ).toBe( whole.length - unresolved )
       }, 240000 )
 } )
 

--- a/src/compat/web-ifc/streaming_consumer_ownership.test.ts
+++ b/src/compat/web-ifc/streaming_consumer_ownership.test.ts
@@ -27,6 +27,7 @@ import * as fs from 'fs'
 
 import { beforeAll, describe, expect, test } from '@jest/globals'
 
+import { InMemoryStepByteStore } from '../../step/step_buffer_provider'
 import { FlatMesh, IfcAPI } from './ifc_api'
 import { IfcApiProxyAP214 } from './ifc_api_proxy_ap214'
 import { IfcApiProxyIfc } from './ifc_api_proxy_ifc'
@@ -51,15 +52,28 @@ const STEP_FIXTURE = 'data/nema-23-76mm.step'
 /** Products (IFC) / scaled units (AP214) per pump call. */
 const BATCH = 4
 
+/* MB is the API's unit and bytes are the engine's, so a budget small enough
+ * to bind on a fixture this size has to be expressed as a fraction. */
+const BYTES_PER_MIB = 1024 * 1024
+
 let ifcFixture: Uint8Array
 let stepFixture: Uint8Array
 
 
-/** One delivered placement, flattened to something comparable by value. */
+/**
+ * One delivered placement, flattened to something comparable by value.
+ *
+ * Every field a consumer renders from is here, not just the identifying
+ * ones: colour comes off the material and `occurrencePath` off the AP214
+ * scene walk, so both are things a re-walk could plausibly get wrong while
+ * still agreeing on which geometry goes where.
+ */
 interface Placement {
   expressID: number
   geometryExpressID: number
   flatTransformation: number[]
+  color: number[]
+  occurrencePath?: readonly number[]
 }
 
 
@@ -81,6 +95,9 @@ function placements( mesh: FlatMesh ): Placement[] {
       expressID: mesh.expressID,
       geometryExpressID: placed.geometryExpressID,
       flatTransformation: [ ...placed.flatTransformation ],
+      color: [ placed.color.x, placed.color.y, placed.color.z, placed.color.w ],
+      occurrencePath: placed.occurrencePath === void 0 ?
+        void 0 : [ ...placed.occurrencePath ],
     } )
   }
 
@@ -107,6 +124,34 @@ function drain( api: IfcAPI, modelID: number ): Placement[] {
   for ( ; ; ) {
 
     const { extracted, remaining } = api.ExtractGeometryBatch(
+        modelID, BATCH, ( mesh ) => {
+          delivered.push( ...placements( mesh ) )
+        } )
+
+    if ( remaining === 0 && extracted === 0 ) {
+      break
+    }
+  }
+
+  return delivered
+}
+
+
+/**
+ * Async twin of {@link drain}, for a model opened over an external store.
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The deferred model to drain.
+ * @return {Promise<Placement[]>} Every placement delivered, in order.
+ */
+async function drainAsync(
+    api: IfcAPI, modelID: number ): Promise< Placement[] > {
+
+  const delivered: Placement[] = []
+
+  for ( ; ; ) {
+
+    const { extracted, remaining } = await api.ExtractGeometryBatchAsync(
         modelID, BATCH, ( mesh ) => {
           delivered.push( ...placements( mesh ) )
         } )
@@ -176,7 +221,9 @@ function asSortedKeys( all: Placement[] ): string[] {
 
   return all.map( ( placement ) =>
     `${placement.expressID}/${placement.geometryExpressID}/` +
-    `${placement.flatTransformation.join( ',' )}` ).sort()
+    `${placement.flatTransformation.join( ',' )}/` +
+    `${placement.color.join( ',' )}/` +
+    `${placement.occurrencePath?.join( '.' ) ?? '-'}` ).sort()
 }
 
 
@@ -304,5 +351,156 @@ describe.each( [
         const served = streamAll( api, retainingID )
 
         expect( served.length ).toBeGreaterThan( 0 )
+      }, 240000 )
+} )
+
+
+describe( 'STREAMING_CONSUMER under a geometry budget (IFC only — AP214 has ' +
+  'no geometry residency)', () => {
+
+  // Share's production configuration is DEFER_GEOMETRY + GEOMETRY_BUDGET_MB
+  // together, and it is the combination that breaks the contract's promise
+  // in the least visible way: eviction DELETES the mesh from the store
+  // (IfcModelGeometry.delete), so the re-walk that serves a late whole-model
+  // ask resolves nothing for that scene node, parks it, and the placement is
+  // absent from the rebuilt map rather than sitting in it with a dead
+  // handle. The retaining path's livePlacements filter therefore reads zero
+  // losses however much was lost — which is exactly how the first version of
+  // this work shipped a throw that could never fire.
+
+  test( 'total eviction throws rather than serving an empty model',
+      async () => {
+
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const ownedID = await api.OpenModelStreamed( ifcFixture, DEFERRED_OWNED )
+
+        // One byte: nothing survives a pump call, so by the end of the drain
+        // the model's whole geometry store has been evicted.
+        expect( api.SetGeometryBudget( ownedID, 1 / BYTES_PER_MIB )
+            ?.budgetBytes ).toBe( 1 )
+
+        const delivered = drain( api, ownedID )
+
+        // The pump still DELIVERED — the copy window is intact, this is a
+        // model that streamed correctly and then lost its natives — so the
+        // throw below is about the late ask, not about a broken load.
+        expect( delivered.length ).toBeGreaterThan( 0 )
+
+        expect( () => streamAll( api, ownedID ) )
+            .toThrow( /STREAMING_CONSUMER/ )
+
+        // ...and it names what it could not resolve, rather than the "0
+        // instance(s) across 0 entit(ies)" the filter-based count reported.
+        expect( () => streamAll( api, ownedID ) )
+            .toThrow( /[1-9][0-9]* placed instance\(s\) unresolved/ )
+      }, 240000 )
+
+  test( 'partial eviction serves what survived and does not throw',
+      async () => {
+
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        // The unbudgeted reference: what a late whole-model ask returns when
+        // nothing was evicted. Without it "served fewer" is unanchored.
+        const wholeID = await api.OpenModelStreamed( ifcFixture, DEFERRED_OWNED )
+
+        drain( api, wholeID )
+
+        const whole = streamAll( api, wholeID )
+
+        expect( whole.length ).toBeGreaterThan( 0 )
+
+        const ownedID = await api.OpenModelStreamed( ifcFixture, DEFERRED_OWNED )
+
+        // 2 KiB binds on this fixture (the existing budget suite pins that an
+        // unbudgeted drain holds more) without evicting everything.
+        expect( api.SetGeometryBudget( ownedID, 2048 / BYTES_PER_MIB )
+            ?.budgetBytes ).toBe( 2048 )
+
+        drain( api, ownedID )
+
+        const partial = streamAll( api, ownedID )
+
+        // Partial loss is a warning, not a throw: something is still there
+        // to hand back, and refusing to hand it back would be worse than the
+        // silence this contract is fixing.
+        expect( partial.length ).toBeGreaterThan( 0 )
+        expect( partial.length ).toBeLessThan( whole.length )
+      }, 240000 )
+} )
+
+
+describe( 'STREAMING_CONSUMER on the pump and entry points Share drives ' +
+  '(IFC only)', () => {
+
+  test( 'the async pump over an external store retains nothing either',
+      async () => {
+
+        // ExtractGeometryBatchAsync over a windowed source is the pump Share
+        // actually drives, and it is a separate code path from the sync one
+        // with its own capture call. A contract honoured on only one of them
+        // is a contract that silently does not apply.
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const retainingID = await api.OpenModelStream(
+            new InMemoryStepByteStore( ifcFixture ), DEFERRED )
+
+        const reference = await drainAsync( api, retainingID )
+
+        expect( reference.length ).toBeGreaterThan( 0 )
+        expect( retained( api, retainingID ).meshMap ).toBeGreaterThan( 0 )
+
+        const ownedID = await api.OpenModelStream(
+            new InMemoryStepByteStore( ifcFixture ), DEFERRED_OWNED )
+
+        expect( api.getPassthrough( ownedID )!.sourceIsExternal ).toBe( true )
+
+        const owned = await drainAsync( api, ownedID )
+
+        expect( asSortedKeys( owned ) ).toEqual( asSortedKeys( reference ) )
+        expect( retained( api, ownedID ) )
+            .toEqual( { meshMap: 0, vectorFlatMesh: 0 } )
+      }, 240000 )
+
+  test( 'GetFlatMesh on a flagged model is served by the re-walk',
+      async () => {
+
+        // GetFlatMesh is named in the setting's docstring as one of the
+        // entry points the re-walk serves, and it reaches it by a different
+        // route from StreamAllMeshes: its `meshMap.size <= 0` test means
+        // "not loaded yet" everywhere else and means "steady state" here.
+        //
+        // IFC only: AP214's getFlatMesh looks up an expressID against a map
+        // its own capture keys by localID, so it returns the dummy on that
+        // proxy with and without this flag. Pre-existing and out of scope.
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const retainingID = await api.OpenModelStreamed( ifcFixture, DEFERRED )
+
+        const delivered = drain( api, retainingID )
+        const subject = delivered[ 0 ].expressID
+
+        const reference = placements( api.GetFlatMesh( retainingID, subject ) )
+
+        expect( reference.length ).toBeGreaterThan( 0 )
+
+        const ownedID = await api.OpenModelStreamed( ifcFixture, DEFERRED_OWNED )
+
+        drain( api, ownedID )
+
+        expect( retained( api, ownedID ).meshMap ).toBe( 0 )
+
+        expect( asSortedKeys( placements(
+            api.GetFlatMesh( ownedID, subject ) ) ) )
+            .toEqual( asSortedKeys( reference ) )
       }, 240000 )
 } )

--- a/src/compat/web-ifc/streaming_consumer_ownership.test.ts
+++ b/src/compat/web-ifc/streaming_consumer_ownership.test.ts
@@ -1,0 +1,308 @@
+/* eslint-disable no-magic-numbers */
+// The STREAMING_CONSUMER ownership contract (conway#638), on both formats.
+//
+// A deferred open builds each PlacedGeometry once and files that same object
+// into THREE pointer spines: the model's cumulative per-entity `meshMap`, its
+// `vectorFlatMesh`, and — through the mesh callback — whatever the embedder
+// keeps. On a D3D-scale load that graph is 475 MB of JS heap, and a consumer
+// that assembles every batch as it lands never reads the two conway holds.
+//
+// STREAMING_CONSUMER says so out loud: conway hands each delta FlatMesh to
+// the callback and keeps no reference. What has to hold for that to be safe,
+// and what each test below pins:
+//
+//   1. the flag changes WHAT IS RETAINED, never WHAT IS DELIVERED — the
+//      callback sees the same entities, the same placements and the same
+//      transforms as an unflagged run of the same model;
+//   2. without the flag nothing changes at all, so the flag cannot leak into
+//      the path every existing consumer is on;
+//   3. a late whole-model ask still works while the natives are alive — it
+//      is served by re-walking the scene, not by replaying a cache that no
+//      longer exists — and is idempotent, which the retaining path is not
+//      (a second StreamAllMeshes there re-pushes into the cache and doubles
+//      every count: Share's IfcItemsMap.js:274-283);
+//   4. once the natives ARE gone, the same ask throws and names the
+//      contract, rather than quietly returning a model with no geometry.
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { FlatMesh, IfcAPI } from './ifc_api'
+import { IfcApiProxyAP214 } from './ifc_api_proxy_ap214'
+import { IfcApiProxyIfc } from './ifc_api_proxy_ifc'
+
+
+const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
+
+const DEFERRED = { ...SETTINGS, DEFER_GEOMETRY: true }
+
+const DEFERRED_OWNED = { ...DEFERRED, STREAMING_CONSUMER: true }
+
+/* Deliberately the fixture with shared/mapped representations: an entity's
+ * instance set grows across batches there, which is exactly the case where
+ * "keep no reference" could lose a placement if the delta and the cache were
+ * not independent of each other. */
+const IFC_FIXTURE = 'data/mapped_shared_representation.ifc'
+
+/* Real served geometry rather than structure-only (as1-assembly has zero
+ * meshes even classically), so the counts below can be non-zero. */
+const STEP_FIXTURE = 'data/nema-23-76mm.step'
+
+/** Products (IFC) / scaled units (AP214) per pump call. */
+const BATCH = 4
+
+let ifcFixture: Uint8Array
+let stepFixture: Uint8Array
+
+
+/** One delivered placement, flattened to something comparable by value. */
+interface Placement {
+  expressID: number
+  geometryExpressID: number
+  flatTransformation: number[]
+}
+
+
+/**
+ * Flatten a delivered FlatMesh into comparable placement records.
+ *
+ * @param mesh The mesh handed to a callback.
+ * @return {Placement[]} One record per placed instance on it.
+ */
+function placements( mesh: FlatMesh ): Placement[] {
+
+  const out: Placement[] = []
+
+  for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+
+    const placed = mesh.geometries.get( where )
+
+    out.push( {
+      expressID: mesh.expressID,
+      geometryExpressID: placed.geometryExpressID,
+      flatTransformation: [ ...placed.flatTransformation ],
+    } )
+  }
+
+  return out
+}
+
+
+/**
+ * Drain a deferred model, collecting every placement the pump delivered.
+ *
+ * Stops on `remaining === 0 && extracted === 0`, which is the documented
+ * consumer stopping condition rather than a test convenience: the final
+ * zero-work call is what runs the geometry budget's head eviction (see the
+ * trailing-batch note on pumpGeometryBatch_). This suite must not weaken it.
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The deferred model to drain.
+ * @return {Placement[]} Every placement delivered, in delivery order.
+ */
+function drain( api: IfcAPI, modelID: number ): Placement[] {
+
+  const delivered: Placement[] = []
+
+  for ( ; ; ) {
+
+    const { extracted, remaining } = api.ExtractGeometryBatch(
+        modelID, BATCH, ( mesh ) => {
+          delivered.push( ...placements( mesh ) )
+        } )
+
+    if ( remaining === 0 && extracted === 0 ) {
+      break
+    }
+  }
+
+  return delivered
+}
+
+
+/**
+ * The two conway-held spines' current sizes, as an observable stand-in for
+ * "does conway still hold the graph".
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The open model.
+ * @return {object} `meshMap` entry count and `vectorFlatMesh` length.
+ */
+function retained( api: IfcAPI, modelID: number ):
+  { meshMap: number, vectorFlatMesh: number } {
+
+  const passthrough = api.getPassthrough( modelID )
+
+  if ( !( passthrough instanceof IfcApiProxyIfc ) &&
+       !( passthrough instanceof IfcApiProxyAP214 ) ) {
+    throw new Error( 'expected a conway proxy for the open model' )
+  }
+
+  return {
+    meshMap: passthrough.model[ 2 ].size,
+    vectorFlatMesh: passthrough.model[ 4 ].size(),
+  }
+}
+
+
+/**
+ * Collect a whole-model StreamAllMeshes into placement records.
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The open model.
+ * @return {Placement[]} Every placement served.
+ */
+function streamAll( api: IfcAPI, modelID: number ): Placement[] {
+
+  const served: Placement[] = []
+
+  api.StreamAllMeshes( modelID, ( mesh ) => {
+    served.push( ...placements( mesh ) )
+  } )
+
+  return served
+}
+
+
+/**
+ * Order-independent comparison key for a set of placements. The pump
+ * delivers per batch and a whole-model walk delivers per entity, so the two
+ * agree on content, not on sequence.
+ *
+ * @param all The placements to key.
+ * @return {string[]} Sorted, one string per placement.
+ */
+function asSortedKeys( all: Placement[] ): string[] {
+
+  return all.map( ( placement ) =>
+    `${placement.expressID}/${placement.geometryExpressID}/` +
+    `${placement.flatTransformation.join( ',' )}` ).sort()
+}
+
+
+beforeAll( () => {
+  ifcFixture = new Uint8Array( fs.readFileSync( IFC_FIXTURE ) )
+  stepFixture = new Uint8Array( fs.readFileSync( STEP_FIXTURE ) )
+} )
+
+
+describe.each( [
+  [ 'IFC', () => ifcFixture ],
+  [ 'AP214/STEP', () => stepFixture ],
+] )( 'STREAMING_CONSUMER on %s', ( _format, fixture ) => {
+
+  test( 'the pump delivers the same stream and retains none of it',
+      async () => {
+
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        // The reference is this pipeline's own unflagged output, not a
+        // hand-written expectation: the flagged run has to agree with it
+        // placement for placement and transform for transform.
+        const retainingID = await api.OpenModelStreamed( fixture(), DEFERRED )
+        const reference = drain( api, retainingID )
+
+        expect( reference.length ).toBeGreaterThan( 0 )
+
+        // ...and the unflagged path really is the retaining one, or "the
+        // flagged run retains nothing" would be pinning a difference that
+        // does not exist.
+        const retainingSpines = retained( api, retainingID )
+
+        expect( retainingSpines.meshMap ).toBeGreaterThan( 0 )
+        expect( retainingSpines.vectorFlatMesh ).toBeGreaterThan( 0 )
+
+        const ownedID = await api.OpenModelStreamed( fixture(), DEFERRED_OWNED )
+        const owned = drain( api, ownedID )
+
+        expect( asSortedKeys( owned ) ).toEqual( asSortedKeys( reference ) )
+
+        // The contract itself: conway kept nothing.
+        expect( retained( api, ownedID ) )
+            .toEqual( { meshMap: 0, vectorFlatMesh: 0 } )
+      }, 240000 )
+
+  test( 'a late whole-model ask is served by re-walking, and repeats exactly',
+      async () => {
+
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const retainingID = await api.OpenModelStreamed( fixture(), DEFERRED )
+
+        drain( api, retainingID )
+
+        const reference = streamAll( api, retainingID )
+
+        expect( reference.length ).toBeGreaterThan( 0 )
+
+        const ownedID = await api.OpenModelStreamed( fixture(), DEFERRED_OWNED )
+
+        drain( api, ownedID )
+
+        // Nothing cached to replay — this is a fresh walk of the live scene,
+        // and it must reproduce the retaining model's whole-model answer.
+        const first = streamAll( api, ownedID )
+
+        expect( asSortedKeys( first ) ).toEqual( asSortedKeys( reference ) )
+
+        // Idempotent, which the retaining path is not: there the second call
+        // re-pushes every instance into the still-populated cache and
+        // doubles the counts (Share's IfcItemsMap.js:274-283). Here each
+        // call clears and re-walks.
+        const second = streamAll( api, ownedID )
+
+        expect( asSortedKeys( second ) ).toEqual( asSortedKeys( first ) )
+
+        // LoadAllGeometry rides the same re-walk and must not double either.
+        expect( api.LoadAllGeometry( ownedID ).size() )
+            .toBe( api.LoadAllGeometry( ownedID ).size() )
+      }, 240000 )
+
+  test( 'a whole-model ask after the natives are released throws by contract',
+      async () => {
+
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const ownedID = await api.OpenModelStreamed( fixture(), DEFERRED_OWNED )
+
+        drain( api, ownedID )
+
+        expect( api.ReleaseModelGeometry( ownedID ) ).toBe( true )
+
+        // Never a silent empty model: the cache that used to answer this is
+        // gone by contract and the natives a re-walk needs are gone by
+        // request, so the only honest answer is a loud one.
+        expect( () => streamAll( api, ownedID ) )
+            .toThrow( /STREAMING_CONSUMER/ )
+
+        expect( () => api.LoadAllGeometry( ownedID ) )
+            .toThrow( /STREAMING_CONSUMER/ )
+      }, 240000 )
+
+  test( 'without the flag, release still replays the retained cache',
+      async () => {
+
+        // The leak guard for the test above: the throw must belong to the
+        // contract, not to "released deferred models throw now".
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const retainingID = await api.OpenModelStreamed( fixture(), DEFERRED )
+
+        const delivered = drain( api, retainingID )
+
+        expect( delivered.length ).toBeGreaterThan( 0 )
+        expect( api.ReleaseModelGeometry( retainingID ) ).toBe( true )
+
+        const served = streamAll( api, retainingID )
+
+        expect( served.length ).toBeGreaterThan( 0 )
+      }, 240000 )
+} )


### PR DESCRIPTION
Part of #638 (and so of #635). **This is the conway half only** — the Share half (`captured` in `conwayDirectIfcLoader.js`, plus the pin bump) and the joint three-spine measurement are still owed, so this deliberately carries no closing keyword.

## What this establishes

A deferred open builds each `PlacedGeometry` **once** and files that same object into **three** pointer spines: the model's cumulative per-entity `meshMap` (`model[2]`), its `vectorFlatMesh` (`model[4]`), and whatever the embedder keeps from the mesh callback. A consumer that assembles each batch as it lands — Share's incremental batched builder — never reads the two conway holds.

`STREAMING_CONSUMER` is a new `DEFER_GEOMETRY`-only open setting, **default off and bit-for-bit unchanged when off**, that lets the caller declare it owns delivery. Under it the delta capture hands each `FlatMesh` to the callback and keeps no reference: both conway spines stay empty for the model's pumped life.

Landed in **both** proxies — `ifc_api_proxy_ifc.ts` and `ifc_api_proxy_ap214.ts` — because the AP214 one is the STEP path and a fix in only one frees nothing on the other format.

**A late whole-model ask still works.** `StreamAllMeshes`, `LoadAllGeometry` and `GetFlatMesh` on such a model re-walk the live scene rather than replaying a cache that no longer exists. When a budget has taken the geometry out from under that re-walk, partial loss is served with a warning naming the count of unresolved instances and total loss throws — never a silent empty model.

## What this only hopes

- **The bytes.** No memory number is claimed here. Dropping one spine frees ~4.4 MB of the measured 475 MB, which is the *predicted* size of one 562,351-entry spine at 8 B — a confirmation of the model, not a result. The real figure requires all three spines dropped in one experiment, on a Share build against this conway, and is owed by the joint measurement, not by this PR.
- **That Share will use it.** Nothing consumes the flag yet. The contract is backward-compatible by construction so conway can publish before Share bumps its pin.
- **That the re-walk is cheap.** It is a full scene walk. It is the price of an ask that the retaining path paid on every load instead.
- **That the re-walk restores anything.** It does not. It re-*derives* placements from live natives; geometry a budget already evicted is gone, and the re-walk's job there is to report that accurately rather than to recover it.

## Scope of the whole-model ask (narrower than it first reads)

The synchronous whole-model entry points drain through the **synchronous** pump, which refuses a windowed source outright — *"ExtractGeometryBatch is synchronous and cannot page a windowed source"*. So on a model opened over an external store, which is **Share's own configuration**, the late whole-model ask is not reachable through `StreamAllMeshes` at all. That is pre-existing and identical with and without this flag (verified both ways), and no code here changes it; it is called out in the setting's docstring, the design doc and here because the promise above otherwise reads broader than it is.

## Correcting the issue body

#638's body says `streamAllMeshes` replays `meshMap` to back Share's fallback, so "owner 2 exists to serve owner 1's fallback". [The design comment refutes that](https://github.com/bldrs-ai/conway/issues/638#issuecomment-5455957015) and re-tracing confirms it: Share's fallback fires only when the pump produced nothing, and in that case `meshMap` was empty going in — a fresh scene walk serves it. The retention across pumped batches never backed the fallback. This PR is built on the comment, not the body.

## Accumulation-site decisions

Line numbers in #638's investigation predate #654 (which moved eviction to head-of-pump); everything below was re-located against the current tree.

| Site | Decision under the flag | Why |
|---|---|---|
| `streamNewMeshes_` — per-entity `meshMap` fill | **Skipped** | The bulk of the 475 MB. The delta is a separate array, so the callback stream is unchanged. |
| `streamNewMeshes_` — `vectorFlatMesh.push(deltaMesh)` | **Skipped** | Read only by `loadAllGeometry`'s return, which a streaming consumer is not using. |
| Both pumps — the no-callback `else if (residency.enabled)` capture-before-eviction | **Skipped** | It exists to save FlatMesh metadata into `meshMap` before eviction; with no `meshMap` it can save nothing. Skipping the call is not what loses budget-evicted geometry — having no cache to capture into is, and that is the contract the caller opted into. |
| `streamAllMeshes` — deferred internal drain + straggler absorb | **Replaced** by `recaptureWholeModel_` | Nothing to absorb into. Re-walks from instance zero and serves that. |
| `streamAllMeshes` — released-model replay branch | **Unreachable** (`released_ && !deferredMode_`) | The flag implies deferred; the flagged release path is the new throw. |
| `loadAllGeometry` | **Routed** through `streamAllMeshes` | Its own classic walk seeds coordination from `model[5]`, which a deferred open never writes — it would place every instance in an identity frame. |
| `getFlatMesh` | **Unchanged code**, new meaning, tested | `meshMap.size <= 0` is the STEADY state here, so its existing `loadAllGeometry()` call is what serves the first single-mesh ask; the re-walk repopulates, so later asks are cache hits. |
| `streamAllMeshesWithTypes` | **Deliberately not gated** | It has no deferred branch at all today and runs the classic walk on deferred models regardless — already wrong there for reasons wider than this contract. Gating it would hide that behind a flag. Documented in its JSDoc. |

`geometryMaterialTransformMap` (`model[3]`) is **untouched**: it is what `GetGeometry` resolves through, it is keyed per geometry rather than per instance, and dropping it would break the embedder's copy.

## Review history

Both rounds found real defects. Recording them because the second one is the interesting kind — a correct fix with an assertion that could not have caught it failing.

**Round 1 — the throw could never fire, and the failure it guarded happened silently.** It keyed on `droppedEntities`, fed by the retaining path's `livePlacements` filter over the rebuilt `meshMap`. But an evicted placement never reaches that map: `GEOMETRY_BUDGET_MB` eviction *deletes* the mesh from the store (`GeometryResidency.evictToBudget` → `IfcModelGeometry.delete`), so the re-walk resolves nothing for that scene node, parks it, and the placement ends up **absent** rather than present-and-dead. The filter can only see placements that made it into the map, and every one of those is live.

Measured on `data/mapped_shared_representation.ifc`, in Share's own production shape (`DEFER_GEOMETRY` + `GEOMETRY_BUDGET_MB`), whose whole-model answer is **16 placements**:

| budget | before | after |
|---|---|---|
| 1 byte (total eviction) | served **0** placements, logged *"0 instance(s) across 0 entit(ies)"*, **no throw** | **throws**, naming *"16 placed instance(s) unresolved"* |
| 2 KiB (partial) | served 3, logged *"0 across 0"* | serves 3, warns *"13 placed instance(s) could not be resolved … missing from the 3 entit(ies) this call served"* |

The signal is now what the re-walk **parked**. `recaptureWholeModel_` empties the parked-node map before walking, so its size afterwards *is* the count of placed instances whose geometry is gone.

**Round 2 — the partial-loss warning was unpinned, and a comment named an impossible state.** Stubbing the warning to `if (false)` left all twelve tests green: the partial test asserted only `0 < served < whole`, which the round-1 code satisfied *while* reporting "0 across 0". The test now captures the log sink, parses the count out of the line, and asserts `served === whole - unresolved` — an identity, and one round-1's code would have failed, since 16 − 0 is not the 3 it served.

Separately, the throw's `degraded` disjunct was justified by "a model whose every scene node was freed before the walk could park them", which cannot happen: `IfcSceneBuilder`'s scene array is append-only (only ever `push`ed; its `nodeCount` contract says so), and eviction touches the geometry store, not the scene — which is exactly what *causes* parking. So the disjunct is not independently reachable, and removing it leaves the suite green. **It is kept** — a boolean read that fails in the safe direction, so any future path that removes geometry without leaving a parked node cannot reintroduce the silent empty model — but the comment now says that outright, including that no test pins it and none can, because the state is not constructible through the public API.

None of the eviction machinery is reachable on the AP214 proxy, which has no geometry residency and whose walk has no park-and-retry arm; its `recaptureWholeModel_` returns nothing and throws only on release, and that asymmetry is stated in its doc comment.

## Falsifiability evidence

Every revert below was applied to the **current** 12-test suite, rebuilt, run, and restored.

| revert | what it removes | result |
|---|---|---|
| **A** | the retention gate (`retain` defaults to `true` in both proxies) | **4 failed / 8 passed** |
| **B** | the re-walk routing (`streamAllMeshes` falls back to straggler-absorb) | **7 failed / 5 passed** |
| **C** | the round-2 guard fix (back to `servedEntities === 0 && droppedEntities > 0`) | **1 failed / 11 passed** |
| **E** | the partial-loss warning (`if (false)`) | **1 failed / 11 passed** |

- **A** fails "the pump delivers the same stream and retains none of it" on both formats with `Expected {meshMap: 0, vectorFlatMesh: 0}` / `Received {meshMap: 16, vectorFlatMesh: 16}` (IFC) and `{meshMap: 2, vectorFlatMesh: 3}` (STEP), plus the async-pump and `GetFlatMesh` tests, which assert the same emptiness.
- **B** fails the whole-model ask on both formats — the flagged model serves an **empty** set against the retaining model's **16** placements on IFC (**268** on STEP) — plus the release throw, both budget tests and `GetFlatMesh`, all of which route through `recaptureWholeModel_`.
- **C** fails "total eviction throws rather than serving an empty model" with *"Received function did not throw"* — the silent-empty regression itself — and nothing else, so the guard fix is pinned independently.
- **E** fails "partial eviction serves what survived" at `expect(warned).toBeDefined()`, and nothing else, so the warning is pinned independently of the throw.

An earlier revision of this section reported B as "2 failed on both formats" and cited "18 placements". Both were wrong: the count was measured against the round-1 suite before the four new tests existed, and 18 was Jest's `- Expected - 18` **diff-line** count (16 entries plus two bracket lines), not a placement count. Re-measured directly: 16 placements across 16 entities on the IFC fixture, 268 across 2 on the STEP one.

## Numbers

- **Baseline, measured on the untouched tree at `deabdf1`:** `yarn lint` 0 errors / 725 warnings; `yarn test` **129 suites / 908 tests**, green, 98.6 s.
- **Now:** `yarn lint` 0 errors / **725** warnings (unchanged); `yarn test` **130 suites / 920 tests**, green, 102.5 s. `+1 suite, +12 tests`, nothing pre-existing touched.
- Full `yarn precommit` (build + `check-compiled-fresh` + lint + jest) passed on all three commits.

## Tests

`src/compat/web-ifc/streaming_consumer_ownership.test.ts` — 12 tests. Four run over **both** formats (`data/mapped_shared_representation.ifc`, deliberately the fixture where an entity's instance set grows across batches; `data/nema-23-76mm.step`), four are IFC-only.

Both formats:

1. **the pump delivers the same stream and retains none of it** — flagged and unflagged drains compared placement-for-placement on identity, full transform, **colour and `occurrencePath`**; the flagged model's two spines asserted empty. The unflagged model's spines are asserted **non-empty first**, so "retains nothing" pins a real difference.
2. **a late whole-model ask is served by re-walking, and repeats exactly** — must reproduce the retaining model's whole-model answer, and a second call must equal the first. Also pins `LoadAllGeometry` against doubling.
3. **a whole-model ask after the natives are released throws by contract** — `StreamAllMeshes` and `LoadAllGeometry` both throw `/STREAMING_CONSUMER/`.
4. **without the flag, release still replays the retained cache** — the leak guard for (3).

IFC-only (AP214 has no geometry residency, and no store-backed open):

5. **total eviction throws rather than serving an empty model** — 1-byte budget; asserts the pump still *delivered* first, so the throw is about the late ask and not a broken load, then that the message names a **non-zero** unresolved count.
6. **partial eviction serves what survived and does not throw** — 2 KiB budget, anchored against an unbudgeted whole-model reference, with the warning line captured and its reported count asserted as the exact loss (`served === whole − unresolved`).
7. **the async pump over an external store retains nothing either** — `ExtractGeometryBatchAsync` over `InMemoryStepByteStore`, a separate capture site from the sync pump and the one Share actually drives.
8. **`GetFlatMesh` on a flagged model is served by the re-walk** — reaches the re-walk by a different route from `StreamAllMeshes`. IFC only because AP214's `getFlatMesh` looks up an expressID against a map its own capture keys by localID, returning the dummy with and without this flag (pre-existing, out of scope).

The drain helpers stop on `remaining === 0 && extracted === 0`, mirroring production and preserving #654's trailing head-eviction call rather than weakening it.

## Review focus (the load-bearing claims to attack)

- **The copy window is preserved.** This drops conway's own JS pointer spines and frees no native — natives are freed only by `GeometryResidency` eviction or `ReleaseModelGeometry`, neither reached here, and eviction timing is untouched. `geometry_budget_copy_window.test.ts` is unmodified and green, and review confirmed the resident set is identical flagged and unflagged at 2 KiB. **Attack:** any path by which dropping the last JS reference to a `FlatMesh`/`PlacedGeometry` reaches a native free?
- **`recaptureWholeModel_`'s return value is `demandPendingNodes_.size`.** The claim is that the map is emptied immediately before the walk and nothing else writes to it in between, so its size afterwards is exactly the walk's unresolved count. If some other path can populate it, the count over-reports and the throw could fire spuriously.
- **The throw's boundaries.** `servedEntities === 0 && (unresolvedInstances > 0 || degraded)`. A model that genuinely has no geometry must *not* throw. Is there a non-eviction reason a fully-drained deferred model could park every node, where a throw would be wrong?
- **Constraint 3 — the final zero-work pump call still runs its head eviction under the flag.** The flag touches only the *capture* branch after the extraction, never the `evictToBudget()` at the head.
- **Default-path byte-identity.** `streamingConsumer_` is ANDed with `deferredMode_` at its single assignment and every new branch sits behind it. The gated regression digests are the real check, and they run for the first time on this flip.
- **The re-walk uses the delta capture rather than the classic walk**, because only the delta capture seeds coordination from `demandCoordination_`. If that reasoning is wrong the placements would be silently reframed.
- **`recaptureWholeModel_` truncates `flatMeshArray_` after the walk, not before.** Reason in the comment; the two-call `LoadAllGeometry` assertion pins it. A reviewer may reasonably think this is the wrong place to solve the doubling.

## Known pre-existing, deliberately not fixed here

- `model[4]`'s hand-rolled `Vector<FlatMesh>.get()` bounds-checks against `placedGeometryArray.length` rather than `flatMeshArray.length` (both proxies), so it returns the dummy for indices it should serve. Confirmed identical with and without this flag.
- AP214's `getFlatMesh` looks up an expressID against a map its own capture keys by localID.

Both are being filed separately.

## Sequencing

conway publishes first; Share's pin bump and its `captured` half follow, then the joint measurement. #638 stays open.