### PR TITLE
Skip untypeable representation items in the AP214 property walk instead of crashing the spatial structure

### DIFF
--- a/data/nist-ctc-properties.step
+++ b/data/nist-ctc-properties.step
@@ -48,6 +48,40 @@ DATA;
 #635=MEASURE_REPRESENTATION_ITEM('volume measure',VOLUME_MEASURE(14644822.6361138),#16);
 #636=MEASURE_REPRESENTATION_ITEM('wetted area measure',AREA_MEASURE(807080.802199914),#16);
 
+/* AP242-only property chains that the interim AP214 loader cannot type, and
+   that used to abort the whole property + spatial-structure build
+   (bldrs-ai/test-models#61). Copied from
+   test-models/step/nist/NIST-PMI-STEP-Files/nist_ctc_01_asme1_ap242-e1.stp
+   at the same express ids.
+
+   1. INTEGER_REPRESENTATION_ITEM has no AP214 class, so resolving #4319's
+      items throws from extractBufferElement(). */
+#4334=PROPERTY_DEFINITION('attribute validation property','',#4368);
+#4304=PROPERTY_DEFINITION_REPRESENTATION(#4334,#4319);
+#4319=REPRESENTATION('',(#4270,#4271,#4272,#4273,#4274),#4351);
+#4270=INTEGER_REPRESENTATION_ITEM('part user attributes',3.);
+#4271=INTEGER_REPRESENTATION_ITEM('text user attributes',3.);
+#4272=INTEGER_REPRESENTATION_ITEM('integer user attributes',0.);
+#4273=INTEGER_REPRESENTATION_ITEM('real user attributes',0.);
+#4274=INTEGER_REPRESENTATION_ITEM('boolean user attributes',0.);
+
+/* 2. #4344's definition is the complex PMI draughting model #13, which is
+      outside AP214's characterized_definition SELECT, so the
+      property_definition.definition getter throws before the items are ever
+      reached. #13 is trimmed: its real items list is 47 PMI entities this
+      fixture does not carry, replaced by one item already present — the
+      complex type is what the SELECT narrowing rejects, not the contents. */
+#4314=PROPERTY_DEFINITION_REPRESENTATION(#4344,#4329);
+#4344=PROPERTY_DEFINITION('pmi validation property','',#13);
+#4329=REPRESENTATION('',(#4281),#4351);
+#4281=INTEGER_REPRESENTATION_ITEM('number of annotations',23.);
+#13=(
+CHARACTERIZED_OBJECT(*,*)
+CHARACTERIZED_REPRESENTATION()
+DRAUGHTING_MODEL()
+REPRESENTATION('MBD_0',(#4346),#4351)
+);
+
 #4351=( GEOMETRIC_REPRESENTATION_CONTEXT(3)
   GLOBAL_UNIT_ASSIGNED_CONTEXT((#16))
   REPRESENTATION_CONTEXT('Context','3D') );

--- a/src/AP214E3_2010/ap214_property_extraction.ts
+++ b/src/AP214E3_2010/ap214_property_extraction.ts
@@ -7,6 +7,7 @@ import { measure_representation_item } from './AP214E3_2010_gen/measure_represen
 import { property_definition } from './AP214E3_2010_gen/property_definition.gen'
 import { property_definition_representation } from './AP214E3_2010_gen/property_definition_representation.gen'
 import { shape_definition_representation } from './AP214E3_2010_gen/shape_definition_representation.gen'
+import Logger from '../logging/logger'
 
 
 /**
@@ -134,6 +135,10 @@ export class AP214PropertyExtraction {
    * Resolve the part owner and value rows for one
    * `property_definition_representation` and append them to the result map.
    *
+   * A `property_definition_representation` whose chain cannot be typed against
+   * the AP214 schema is skipped with a warning rather than propagating — see
+   * the comment on the `try` below.
+   *
    * @param pdr The property-definition representation to walk.
    * @param result The accumulating per-part property map.
    */
@@ -141,47 +146,103 @@ export class AP214PropertyExtraction {
       pdr: property_definition_representation,
       result: ExtractedPropertyMap ): void {
 
-    const propertyDefinition = pdr.definition
+    // Two getters in this chain throw on AP242 files, which route through the
+    // AP214 loader by design (design/new/step-metadata-nist.md §"The AP242
+    // wrinkle"), so AP242-only entities reach here routinely. Both are
+    // observed on the NIST PMI corpus, from bldrs-ai/test-models#61:
+    //
+    // - `representation.items`: `extractBufferElement`
+    //   (src/step/step_entity_base.ts) throws `unresolvedReferenceError_`
+    //   ("Value in STEP was incorrectly typed") when an item names a type the
+    //   schema has no class for — `#4319=REPRESENTATION('',(#4270,…),#4351)`
+    //   over `INTEGER_REPRESENTATION_ITEM` user-attribute counters.
+    // - `property_definition.definition`: the generated `characterized_
+    //   definition` SELECT narrows to AP214's member list and throws
+    //   ("Value in STEP was incorrectly typed for field") otherwise —
+    //   `#4344=PROPERTY_DEFINITION('pmi validation property','',#13)`, where
+    //   `#13` is the complex `CHARACTERIZED_OBJECT | CHARACTERIZED_
+    //   REPRESENTATION | DRAUGHTING_MODEL | REPRESENTATION` PMI model.
+    //
+    // Uncaught, either one took down the whole property map — and with it the
+    // spatial structure built alongside it — for 16 of the 17 NIST AP242 PMI
+    // files. Skipping the offending `pdr` is what the design doc's Phase 0
+    // already promises: structure + properties come through "with unknowns
+    // skipped". Rows accumulate in a local array and are merged only on
+    // success, so a skip is all-or-nothing for one `pdr` and can never leave
+    // half a representation's rows in `result`.
+    //
+    // Nothing this tier would have surfaced is lost, checked over the corpus.
+    // The skips are of exactly two kinds. Either the representation's items
+    // are wholly AP242-only (the INTEGER_REPRESENTATION_ITEM PMI counters —
+    // no mixed typeable/untypeable representation occurs), or the throw is on
+    // the *owner* side, where the `characterized_definition` is an AP242-only
+    // member — `CHARACTERIZED_ITEM_WITHIN_REPRESENTATION` for a PMI linear
+    // size, the complex draughting model above. Those own feature-level PMI,
+    // and `resolveProductDefinitionId` returns `void 0` for anything that is
+    // not a `product_definition` or `product_definition_shape`, so this
+    // (Simplified) tier already dropped them before the fix — see the note on
+    // `extractProperties`.
+    try {
 
-    if ( !( propertyDefinition instanceof property_definition ) ) {
-      return
-    }
+      const propertyDefinition = pdr.definition
 
-    const ownerId =
-      AP214ProductStructureExtraction.resolveProductDefinitionId( propertyDefinition.definition )
-
-    if ( ownerId === void 0 ) {
-      return
-    }
-
-    const definitionId = propertyDefinition.expressID
-    const group = propertyDefinition.name
-    const fallbackKey =
-      ( definitionId !== void 0 ? this.generalPropertyNameByDef_.get( definitionId ) : void 0 ) ??
-      ( group.length > 0 ? group : ( propertyDefinition.description ?? '' ) )
-
-    const representation = pdr.used_representation
-
-    if ( representation === void 0 ) {
-      return
-    }
-
-    for ( const item of representation.items ) {
-
-      const property = AP214PropertyExtraction.toProperty( item, fallbackKey, group )
-
-      if ( property === void 0 ) {
-        continue
+      if ( !( propertyDefinition instanceof property_definition ) ) {
+        return
       }
 
-      let rows = result.get( ownerId )
+      const ownerId =
+        AP214ProductStructureExtraction.resolveProductDefinitionId( propertyDefinition.definition )
 
-      if ( rows === void 0 ) {
-        rows = []
+      if ( ownerId === void 0 ) {
+        return
+      }
+
+      const definitionId = propertyDefinition.expressID
+      const group = propertyDefinition.name
+      const fallbackKey =
+        ( definitionId !== void 0 ? this.generalPropertyNameByDef_.get( definitionId ) : void 0 ) ??
+        ( group.length > 0 ? group : ( propertyDefinition.description ?? '' ) )
+
+      const representation = pdr.used_representation
+
+      if ( representation === void 0 ) {
+        return
+      }
+
+      const rows: ExtractedProperty[] = []
+
+      for ( const item of representation.items ) {
+
+        const property = AP214PropertyExtraction.toProperty( item, fallbackKey, group )
+
+        if ( property === void 0 ) {
+          continue
+        }
+
+        rows.push( property )
+      }
+
+      if ( rows.length === 0 ) {
+        return
+      }
+
+      const existing = result.get( ownerId )
+
+      if ( existing === void 0 ) {
         result.set( ownerId, rows )
+      } else {
+        existing.push( ...rows )
       }
 
-      rows.push( property )
+    } catch ( error ) {
+
+      // toString(), not localID — localID is the dense internal index and
+      // means nothing against the source file; the reference is what a reader
+      // can go look up. Same idiom as populateStyledItemsMap() in
+      // ap214_geometry_extraction.ts.
+      Logger.warning(
+          `Skipping property definition representation that is untypeable in AP214: ${error}`,
+          pdr.toString() )
     }
   }
 

--- a/src/compat/web-ifc/ap214_properties.test.ts
+++ b/src/compat/web-ifc/ap214_properties.test.ts
@@ -174,6 +174,49 @@ describe( 'compat/web-ifc/AP214Properties', () => {
     expect( resolved.get( 'Company' ) ).toBe( 'ACME' )
   } )
 
+  test( 'an AP242-only property representation is skipped, not fatal', async () => {
+
+    // bldrs-ai/test-models#61: the NIST AP242 PMI files route through the
+    // interim AP214 loader, which carries no class for the AP242-only
+    // entities two of their property chains reference — the fixture's
+    // `#4304 → #4319` (INTEGER_REPRESENTATION_ITEM items) and
+    // `#4314 → #4344 → #13` (a complex draughting model outside AP214's
+    // characterized_definition SELECT). Both getters threw out through
+    // AP214PropertyExtraction, so the whole properties + spatial-structure
+    // build died and Share showed "Could not read full model structure."
+    // The two untypeable chains must now be skipped while everything
+    // representable still comes through.
+    const surface = compatSurfaceFor( 'data/nist-ctc-properties.step' )
+
+    // getSpatialStructure is the call Share makes, and buildIndexes() runs the
+    // property walk on its way to the tree — so the untypeable chains killed
+    // the structure too, which is what the issue's screenshot is showing.
+    const root = await surface.getSpatialStructure() as any
+
+    expect( root.type ).toBe( 'product_structure' )
+
+    const psets = await surface.getPropertySets( CTC_PRODUCT_DEFINITION_EXPRESS_ID )
+    const resolved = new Map<string, string | number>()
+
+    for ( const pset of psets ) {
+      for ( const ref of pset.HasProperties ) {
+        const prop = await surface.getItemProperties( ref.value ) as any
+
+        resolved.set( prop.Name.value, prop.NominalValue.value )
+      }
+    }
+
+    expect( resolved.get( 'Modeled By' ) ).toBe( 'Engineer' )
+    expect( resolved.get( 'CAGE Code' ) ).toBe( '64JW1' )
+    expect( resolved.get( 'Company' ) ).toBe( 'ACME' )
+    expect( resolved.get( 'volume measure' ) ).toBe( 14644822.6361138 )
+    expect( resolved.get( 'wetted area measure' ) ).toBe( 807080.802199914 )
+
+    // The untypeable rows are dropped rather than surfacing as blanks.
+    expect( resolved.has( 'part user attributes' ) ).toBe( false )
+    expect( resolved.has( 'number of annotations' ) ).toBe( false )
+  } )
+
   test( 'getPropertySets is empty for an element with no properties', async () => {
 
     const surface = compatSurfaceFor( 'data/as1-assembly.step' )


### PR DESCRIPTION
Fixes the crash behind [bldrs-ai/test-models#61](https://github.com/bldrs-ai/test-models/issues/61): every NIST AP242 PMI STEP model rendered its geometry fine in Share, then died building the spatial structure, surfacing as "Could not read full model structure. Only model geometry will be available."

## Root cause

AP242 files route through the interim AP214 loader by design (`design/new/step-metadata-nist.md` §"The AP242 wrinkle"), so AP242-only PMI entities reach `AP214PropertyExtraction` routinely. Two getters in the per-PDR chain throw on them, and both are hit by the NIST corpus:

- **`representation.items`** — `extractBufferElement` raises `unresolvedReferenceError_` ("Value in STEP was incorrectly typed") for an item whose type has no AP214 class. nist_ctc_01: `#4319=REPRESENTATION('',(#4270,…),#4351)` over `INTEGER_REPRESENTATION_ITEM` user-attribute counters.
- **`property_definition.definition`** — the generated `characterized_definition` SELECT narrows to AP214's member list and throws ("Value in STEP was incorrectly typed for field") otherwise. nist_ctc_01: `#4344=PROPERTY_DEFINITION('pmi validation property','',#13)` where `#13` is the complex `CHARACTERIZED_OBJECT | CHARACTERIZED_REPRESENTATION | DRAUGHTING_MODEL | REPRESENTATION` PMI model.

Either throw escaped `extractProperties` and killed the whole property map — and with it the spatial structure built alongside it in `AP214Properties.buildIndexes`, which is exactly the `getSpatialStructure` call Share makes after geometry is on screen.

## Fix

`collectFromRepresentation` now accumulates rows locally, merges only on success, and skips the offending `property_definition_representation` with a `Logger.warning` keyed on the entity reference (the `populateStyledItemsMap` idiom). This is what the design doc's Phase 0 already specifies: structure + properties come through with unknowns skipped. Adding AP242 entities to the AP214 gen tree is deliberately not the fix — native AP242 is a separate roadmap phase.

Nothing this (Simplified) tier surfaced is lost: the skipped chains are either wholly AP242-only items or feature-owned PMI validation properties that `resolveProductDefinitionId` already dropped.

## Verification

- Sweep over `test-models/step/nist/NIST-PMI-STEP-Files` via the web-ifc compat shim (`OpenModel` → `StreamAllMeshes` → `getSpatialStructure`): **16 of 17 files crashed before, 0 of 17 after**; mesh/placed-geometry counts byte-identical throughout.
- `nist_ctc_01` still yields its Modeled By / CAGE Code / Company / volume / wetted-area rows (pinned in the new test).
- Control `as1-oc-214.stp` (AP214 assembly): unchanged — 7 meshes / 18 placed, full assembly tree, 0 skips.
- `data/nist-ctc-properties.step` gains both crashing chains verbatim from nist_ctc_01 at the same express ids; the new test in `ap214_properties.test.ts` fails against the unfixed source (verified by revert) and passes with the fix.
- Suite: 130 suites / 921 tests green (was 920; +1 new test). No geometry-path file touched, so regression digests are unaffected.

Known remaining gap in the same directory (separate issue, filed as follow-up): `nist_ftc_08_asme1_ap242-e1-tg.stp` produces zero geometry — the tessellated-geometry entities (`TESSELLATED_SOLID`/`TESSELLATED_SHELL`/`COMPLEX_TRIANGULATED_SURFACE_SET`) are not yet supported. Its NavTree now builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPEuMhqtyVjAeGoKJDbGAB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPEuMhqtyVjAeGoKJDbGAB)_