### PR TITLE
#660: an async whole-model ask, so a windowed deferred model has one

### DIFF
--- a/design/new/streaming-federated-loader.md
+++ b/design/new/streaming-federated-loader.md
@@ -728,13 +728,45 @@ Deliberately small first step; each has a measurable exit.
   as does any whole-model ask after `ReleaseModelGeometry`. A model that
   genuinely has no geometry still returns empty, quietly, as classic does.
 
-    **Scope.** The synchronous whole-model entry points drain through the
-  synchronous pump, which refuses a windowed source outright. So on a
-  model opened over an external store — Share's configuration — the late
-  whole-model ask is not reachable through `StreamAllMeshes` at all. That
-  predates this contract and is identical with and without it; it is noted
-  because the contract's promise about that ask is otherwise easy to read
-  as broader than it is.
+    **Scope: on a windowed source the ask is `StreamAllMeshesAsync`
+  (conway#660).** The synchronous whole-model entry points drain through
+  the synchronous pump, which refuses a windowed source outright, so
+  `StreamAllMeshes` on a model opened over an external store throws before
+  serving anything. That predates this contract, is identical with and
+  without it, and is deliberately left alone. What #660 added is the async
+  entry point beside it: `StreamAllMeshesAsync` drains through
+  `ExtractGeometryBatchAsync` — the pump that pages each batch's product
+  closures — and then runs the *same* post-drain code the sync path runs
+  (`serveDeferredWholeModel_`, single-sourced in both proxies), so the
+  re-walk, the idempotence, the partial-loss warning, the total-loss throw
+  and the post-release throw are the same behaviour reached by a drain
+  that can page. It matters because GitHub/OPFS `File` loads take the
+  windowed open by default, i.e. the large models that motivated this work
+  are exactly the ones the sync ask could not serve.
+
+    **Where the paging does and does not happen — the part worth being
+  precise about.** Only the drain pages. The re-walk resolves each scene
+  node through `IfcSceneBuilder.resolveGeometryNode_`, which reads
+  `node.model.geometry.getByLocalID(...)` — the in-memory geometry store —
+  and never touches the byte source, so windowing is invisible to it. Two
+  consequences, both load-bearing for a consumer deciding whether to keep
+  its own copy: a fully drained windowed model serves *exactly* what a
+  fully drained resident one serves, with no boundary between them; and
+  geometry a `GEOMETRY_BUDGET_MB` eviction already freed is **not** paged
+  back by the ask on either — it is reported missing, by the same parked-
+  node count as above. Re-extracting the evicted product through the
+  window would not fix that: extraction files the result under a fresh
+  localID, so the parked scene node still resolves nothing while a new
+  node re-emits the instance (the measured "21 placements against
+  classic's 16" behind the degraded note). So the contract Share can rely
+  on is *"the same stream the pump delivered, or an exact account of what
+  is missing"* — not recovery.
+
+    AP214 gets the entry point for format parity, and it is synchronous
+  underneath: that proxy has no async pump, and a store-backed open is
+  IFC-only (`IfcApiModelPassthroughFactory.fromStore` refuses every other
+  format), so a windowed AP214 model is not reachable through the public
+  API at all.
 
   **PSB.ifc at batch 8 — the size Share pumps at:**
 

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -108,16 +108,23 @@ export interface Loadersettings {
    * model. A consumer that needs every placement should copy at delivery
    * from the pump, which is what the budget's own contract already says.
    *
-   * **Scope: the sync `StreamAllMeshes` cannot serve a windowed source.**
-   * On a model opened over an external store (`OpenModelStream`), the
-   * synchronous whole-model entry points drain through the synchronous pump,
-   * which refuses a windowed source outright — *"ExtractGeometryBatch is
-   * synchronous and cannot page a windowed source"*. That predates this
-   * setting and is identical with and without it, but it means the late
-   * whole-model ask described above is reachable on a resident source only.
-   * Share pumps `ExtractGeometryBatchAsync` over a store, so on Share's
-   * configuration the ask is not available at all — which is consistent with
-   * this setting, whose premise is that the consumer already has the stream.
+   * **Scope: on a windowed source the ask is async
+   * ({@link StreamAllMeshesAsync}).** The synchronous whole-model entry
+   * points drain through the synchronous pump, which refuses an external
+   * source outright — *"ExtractGeometryBatch is synchronous and cannot page
+   * a windowed source"*. That predates this setting, is identical with and
+   * without it, and is unchanged: `StreamAllMeshes` on a model opened with
+   * `OpenModelStream` still throws. `StreamAllMeshesAsync` (conway#660) is
+   * the entry point that serves such a model — it drains through
+   * `ExtractGeometryBatchAsync`, which pages each batch's product closures
+   * in, and then serves the identical re-walk with the identical accounting.
+   * Share pumps the async pump over a store, so that is the entry point a
+   * windowed Share load reaches for.
+   *
+   * The re-walk itself is unaffected by windowing either way: it resolves
+   * scene nodes against the model's geometry STORE, never against the byte
+   * source, so what a fully drained windowed model can serve is exactly what
+   * a fully drained resident one can. Paging is a property of the drain.
    *
    * Ignored on a non-deferred open, which has no pump and no accumulation to
    * suppress.
@@ -1226,6 +1233,59 @@ export class IfcAPI {
     if (result !== void 0) {
 
       result.streamAllMeshes(meshCallback)
+    }
+
+    Logger.displayLogs()
+    Logger.clearLogs()
+    Logger.printStatistics(modelID)
+  }
+
+  /**
+   * Conway extension (conway#660): async twin of {@link StreamAllMeshes},
+   * and the ONLY whole-model ask a **windowed** deferred model can answer.
+   *
+   * `StreamAllMeshes` drains a deferred model through the synchronous pump,
+   * which refuses an external source — *"ExtractGeometryBatch is synchronous
+   * and cannot page a windowed source"* — so on a model opened with
+   * {@link OpenModelStream} it throws before serving anything. This drains
+   * through {@link ExtractGeometryBatchAsync} instead, paging each batch's
+   * product closures in, and then serves exactly what the sync entry point
+   * would have served on the same model: the same placements, the same
+   * `STREAMING_CONSUMER` re-walk, the same budget accounting (partial loss
+   * warns with the unresolved count, total loss throws), and the same loud
+   * throw once `ReleaseModelGeometry` has freed the natives.
+   *
+   * **What it does not do is recover geometry.** The re-walk that serves the
+   * ask reads the model's geometry store, not the byte source, so paging is
+   * a property of the DRAIN only — anything a `GEOMETRY_BUDGET_MB` eviction
+   * already freed is reported as missing rather than fetched back, exactly
+   * as on a resident source. A consumer that needs every placement copies at
+   * delivery from the pump.
+   *
+   * Safe on a resident source and on a non-deferred model, both of which are
+   * served by the synchronous path internally. Feature-detect with
+   * `typeof api.StreamAllMeshesAsync === 'function'`.
+   *
+   * @param modelID handle retrieved by OpenModelStream / OpenModelStreamed
+   * @param meshCallback receives one whole-model FlatMesh per entity
+   * @return {Promise<void>} resolves once every entity has been delivered
+   */
+  async StreamAllMeshesAsync(
+      modelID: number,
+      meshCallback: (mesh: FlatMesh) => void ): Promise<void> {
+
+    const result = this.models.get(modelID)
+
+    if (result !== void 0) {
+
+      // Passthroughs predating conway#660 (and any future non-conway one)
+      // have no async twin; the sync entry point is the whole of what they
+      // can do, and on a resident source it is equivalent.
+      if (result.streamAllMeshesAsync !== void 0) {
+        await result.streamAllMeshesAsync(meshCallback)
+      } else {
+        result.streamAllMeshes(meshCallback)
+      }
     }
 
     Logger.displayLogs()

--- a/src/compat/web-ifc/ifc_api_model_passthrough.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough.ts
@@ -11,6 +11,15 @@ export interface IfcApiModelPassthrough {
   loadAllGeometry(): Vector<FlatMesh>
   streamAllMeshesWithTypes(types: number[], meshCallback: (mesh: FlatMesh) => void): void
   streamAllMeshes(meshCallback: (mesh: FlatMesh) => void): void
+
+  /**
+   * Async twin of streamAllMeshes (conway#660) — drains a deferred model's
+   * pump through the ASYNC pump before serving, so a windowed source can be
+   * paged. Optional, and feature-detected with typeof: the sync entry point
+   * refuses a windowed source outright, so this is the only whole-model ask
+   * such a model can answer. See IfcApiProxyIfc.streamAllMeshesAsync.
+   */
+  streamAllMeshesAsync?(meshCallback: (mesh: FlatMesh) => void): Promise<void>
   /**
    * Deferred-mode batch pump (IFC proxies opened with DEFER_GEOMETRY) —
    * see IfcApiProxyIfc.extractGeometryBatch.

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -1734,6 +1734,90 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
   }
 
   /**
+   * Serve a whole-model ask on a deferred model whose pump has just been
+   * drained to completion. The AP214 twin of the IFC proxy's method of the
+   * same name, and shorter for the same reason its `recaptureWholeModel_`
+   * is: this proxy has no geometry residency, so there is no eviction to
+   * account for and no partial-loss warning to emit — the only way the
+   * natives go missing is `ReleaseModelGeometry`, which the re-walk throws
+   * on.
+   *
+   * Shared verbatim by {@link streamAllMeshes} and
+   * {@link streamAllMeshesAsync} so the two cannot drift; see the IFC twin
+   * for why that matters.
+   *
+   * @param meshCallback Receives one whole-model FlatMesh per entity.
+   * @param entryPoint The public method being served, for the messages.
+   */
+  private serveDeferredWholeModel_(
+      meshCallback: (mesh: FlatMesh) => void,
+      entryPoint: string ): void {
+
+    if (this.streamingConsumer_) {
+      // Nothing was accumulated to absorb stragglers into: this open
+      // declared the caller the owner of the stream. Rebuild the whole
+      // model from the live scene instead — same placements, one walk,
+      // and it throws rather than serving an empty model when the natives
+      // are gone.
+      this.recaptureWholeModel_(entryPoint)
+    } else {
+      this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
+    }
+
+    const [, , meshMap, , vectorFlatMesh] = this.model
+
+    meshMap.forEach((mesh) => {
+      vectorFlatMesh.push(mesh[1])
+      meshCallback(mesh[1])
+    })
+  }
+
+  /**
+   * Async twin of {@link streamAllMeshes} (conway#660), for format parity
+   * with the IFC proxy's entry point of the same name: a consumer that
+   * feature-detects `StreamAllMeshesAsync` and drives it must get the same
+   * answer on a STEP model as on an IFC one, rather than finding the method
+   * absent and silently falling back.
+   *
+   * **It cannot page a windowed source, and on this format nothing needs
+   * it to.** AP214 geometry runs off a thunk tree with no async pump —
+   * `extractGeometryBatch` here has no async twin — and a store-backed open
+   * is IFC-only (`IfcApiModelPassthroughFactory.fromStore` logs
+   * *"Store-backed open is IFC-only"* and returns undefined for every other
+   * format), so a windowed AP214 model is not reachable through the public
+   * API at all. The drain below is therefore the same synchronous one
+   * {@link streamAllMeshes} runs, awaited only so the signature matches.
+   * The asymmetry is stated here rather than hidden because the IFC twin's
+   * whole point is the windowed drain.
+   *
+   * @param meshCallback Receives one whole-model FlatMesh per entity.
+   * @return {Promise<void>} Resolves once every entity has been delivered.
+   */
+  async streamAllMeshesAsync(
+      meshCallback: (mesh: FlatMesh) => void ): Promise<void> {
+
+    if (!this.deferredMode_) {
+
+      this.streamAllMeshes(meshCallback)
+      return
+    }
+
+    const noCallback = void 0
+    const unbudgeted = void 0
+
+    // Unbudgeted for the same reason the sync drain is: this loop runs to
+    // completion before anything can be served, so yielding mid-drain would
+    // be pure overhead. The public extractGeometryBatch keeps its frame
+    // budget.
+    while (this.pumpDemandUnits_(
+        DEFERRED_DRAIN_BATCH_AP214, noCallback, unbudgeted).remaining > 0) {
+      // draining
+    }
+
+    this.serveDeferredWholeModel_(meshCallback, 'StreamAllMeshesAsync')
+  }
+
+  /**
    *
    * @param meshCallback
    */
@@ -1774,23 +1858,7 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
         // draining
       }
 
-      if (this.streamingConsumer_) {
-        // Nothing was accumulated to absorb stragglers into: this open
-        // declared the caller the owner of the stream. Rebuild the whole
-        // model from the live scene instead — same placements, one walk,
-        // and it throws rather than serving an empty model when the natives
-        // are gone.
-        this.recaptureWholeModel_('StreamAllMeshes')
-      } else {
-        this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
-      }
-
-      const [, , meshMap, , vectorFlatMesh] = this.model
-
-      meshMap.forEach((mesh) => {
-        vectorFlatMesh.push(mesh[1])
-        meshCallback(mesh[1])
-      })
+      this.serveDeferredWholeModel_(meshCallback, 'StreamAllMeshes')
 
       return
     }

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -30,7 +30,7 @@ import { AP214GeometryExtraction } from '../../AP214E3_2010/ap214_geometry_extra
 import AP214StepParser from '../../AP214E3_2010/ap214_step_parser'
 import { AP214Properties } from './ap214_properties'
 import { EntityTypesAP214Count } from '../../AP214E3_2010/AP214E3_2010_gen/entity_types_ap214.gen'
-import { ProgressTracker } from '../../core/progress'
+import { ProgressTracker, yieldToEventLoop } from '../../core/progress'
 import { formatModelLine } from '../../core/progress_log'
 import {
   WasmHeapArrayConstructor, wasmHeapView,
@@ -1805,13 +1805,44 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
     const noCallback = void 0
     const unbudgeted = void 0
 
-    // Unbudgeted for the same reason the sync drain is: this loop runs to
-    // completion before anything can be served, so yielding mid-drain would
-    // be pure overhead. The public extractGeometryBatch keeps its frame
-    // budget.
-    while (this.pumpDemandUnits_(
-        DEFERRED_DRAIN_BATCH_AP214, noCallback, unbudgeted).remaining > 0) {
-      // draining
+    // Bounded batches with an event-loop yield between them, so the `async`
+    // on this method means something. An async function runs synchronously
+    // until its first await, so a drain with no awaits in it would not even
+    // hand the caller a promise until the whole model was extracted — an
+    // awaiting consumer would be starved exactly as it is by the sync
+    // StreamAllMeshes, while being told otherwise by the signature.
+    //
+    // Each call stays UNBUDGETED, matching the sync drain rather than the
+    // public extractGeometryBatch, and that is deliberate on two counts.
+    // The output has to be identical to the sync drain's — the parity tests
+    // compare them placement for placement — and passing a wall-clock
+    // budget also switches the pump to flushing staged faces per unit
+    // instead of keeping one staged batch (see extractDemandUnitBatch),
+    // which is where staging's throughput actually comes from. So the bound
+    // is the batch COUNT, the same DEFERRED_DRAIN_BATCH_AP214 the sync
+    // drain uses and the same size the IFC async pump drains at.
+    //
+    // What that buys, stated exactly: the block is bounded to one drain
+    // batch rather than to the whole model. It is not frame-bounded — a
+    // batch of expensive units still overruns a frame — and a consumer that
+    // needs frame-level responsiveness pumps extractGeometryBatch itself,
+    // which carries AP214_PUMP_BATCH_BUDGET_MS.
+    //
+    // The yield goes BEFORE each batch rather than between them, which is
+    // what makes the first one matter: it returns the promise to the caller
+    // before any extraction runs at all, instead of after the first 256
+    // units. It also means a model small enough to drain in a single batch
+    // still yields once, so the guarantee does not depend on model size.
+    for ( ; ; ) {
+
+      await yieldToEventLoop()
+
+      const { remaining } = this.pumpDemandUnits_(
+          DEFERRED_DRAIN_BATCH_AP214, noCallback, unbudgeted)
+
+      if (remaining === 0) {
+        break
+      }
     }
 
     this.serveDeferredWholeModel_(meshCallback, 'StreamAllMeshesAsync')

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -3608,6 +3608,240 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   }
 
   /**
+   * Serve a whole-model ask on a deferred model whose pump has just been
+   * drained to completion: rebuild the per-entity cache (or absorb the
+   * stragglers into it), hand every entity to the callback, and account
+   * for whatever a `GEOMETRY_BUDGET_MB` eviction took out from under the
+   * walk.
+   *
+   * Shared verbatim by the synchronous {@link streamAllMeshes} and the
+   * async {@link streamAllMeshesAsync}. Those two differ in exactly one
+   * thing — which pump they drain through, and so whether they can page a
+   * windowed source — and single-sourcing everything after the drain is
+   * deliberate: the throw/warn accounting here is the part of #638's
+   * contract a second copy would drift from silently, and a consumer that
+   * feature-detects its way onto the async entry point must get the same
+   * semantics for the same model, not a second implementation of them.
+   *
+   * The caller owns the budget suspension around the drain and this call;
+   * see the reasoning at each call site.
+   *
+   * @param meshCallback Receives one whole-model FlatMesh per entity.
+   * @param degraded Whether this model has ever evicted under a budget,
+   * sampled by the caller BEFORE it suspended that budget.
+   * @param entryPoint The public method being served, for the messages.
+   */
+  private serveDeferredWholeModel_(
+      meshCallback: (mesh: FlatMesh) => void,
+      degraded: boolean,
+      entryPoint: string ): void {
+
+    // Placed instances the re-walk could not resolve, which on this path
+    // is the ONLY signal that anything was lost: evicted geometry is
+    // deleted from the store, so those placements never reach the
+    // rebuilt map and the livePlacements filter below cannot see them.
+    // Zero on the retaining path, where that filter is the signal.
+    let unresolvedInstances = 0
+
+    if (this.streamingConsumer_) {
+      // Nothing was accumulated to absorb stragglers into: this open
+      // declared the caller the owner of the stream. Rebuild the whole
+      // model from the live scene instead — same placements, one walk,
+      // and it throws rather than serving an empty model when the
+      // natives are gone.
+      unresolvedInstances = this.recaptureWholeModel_(entryPoint)
+    } else {
+      this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
+    }
+
+    const [, , meshMap, geometryMaterialTransformMap, vectorFlatMesh] =
+      this.model
+
+    let droppedInstances = 0
+    let droppedEntities = 0
+    let servedEntities = 0
+
+    meshMap.forEach((mesh) => {
+
+      if (degraded) {
+
+        const live = livePlacements(mesh[1], geometryMaterialTransformMap)
+
+        droppedInstances += mesh[1].geometries.size() - live.length
+
+        if (live.length === 0) {
+          ++droppedEntities
+          return
+        }
+      }
+
+      ++servedEntities
+      vectorFlatMesh.push(mesh[1])
+      meshCallback(mesh[1])
+    })
+
+    if (this.streamingConsumer_) {
+
+      // Served nothing, and the re-walk found instances it could not
+      // resolve: the geometry behind them is gone. What must NOT throw is
+      // a model that genuinely has no geometry — nothing parked, nothing
+      // to serve — where empty is the right answer and classic returns it
+      // too.
+      //
+      // `unresolvedInstances` is the whole signal today; `degraded` is a
+      // failsafe that is NOT independently reachable, and saying so is
+      // the point of this paragraph. Eviction removes geometry from the
+      // store and never touches the scene, which is append-only
+      // (IfcSceneBuilder.nodeCount's contract) — so every instance an
+      // eviction costs us is an instance the walk parks, and there is no
+      // state today in which the model evicted but the walk parked
+      // nothing. It is kept because it costs a boolean read and it fails
+      // in the safe direction: any future path that removes geometry
+      // WITHOUT leaving a parked node behind would otherwise reintroduce
+      // exactly the silent empty model this guard exists to prevent. No
+      // test pins it, and none can, because the state cannot be
+      // constructed through the public API.
+      //
+      // What this deliberately does NOT key on is droppedEntities, the
+      // way the retaining path below does. That counter is fed by the
+      // livePlacements filter, which can only ever see placements that
+      // reached the rebuilt map — and evicted ones never do, because
+      // eviction deletes the mesh from the store rather than leaving a
+      // dead handle in it. Keying on it made this throw unreachable and
+      // let a fully-evicted model return silently empty: measured at a
+      // 1-byte budget on mapped_shared_representation.ifc as 0 placements
+      // served, "0 instance(s) across 0 entit(ies)" logged, no throw.
+      if (servedEntities === 0 && (unresolvedInstances > 0 || degraded)) {
+
+        throw new Error(
+            `${entryPoint}: this model was opened with ` +
+            `STREAMING_CONSUMER, so conway kept no reference to the ` +
+            `meshes the pump delivered — the caller owns them — and the ` +
+            `re-walk that serves a late whole-model ask resolved none of ` +
+            `the model (${unresolvedInstances} placed instance(s) ` +
+            `unresolved), because a GEOMETRY_BUDGET_MB eviction has ` +
+            `already freed the geometry behind them. Nothing can be ` +
+            `served. Copy at delivery, raise the budget, or open without ` +
+            `STREAMING_CONSUMER.` )
+      }
+
+      // Partial loss is a warning, matching the retaining path, but the
+      // number comes from the re-walk rather than the filter — see above
+      // for why the filter reads zero here however much was lost.
+      if (unresolvedInstances > 0) {
+        Logger.warning(
+            `[geometry budget] ${entryPoint} re-walked a ` +
+            `STREAMING_CONSUMER model that evicted under a budget: ` +
+            `${unresolvedInstances} placed instance(s) could not be ` +
+            `resolved because their geometry was freed, and are missing ` +
+            `from the ${servedEntities} entit(ies) this call served. ` +
+            `Pump ExtractGeometryBatch and copy at delivery to receive ` +
+            `everything.`)
+      }
+
+    } else if (degraded) {
+
+      // One line for the whole call, not one per dropped instance: this
+      // fires on a path that may drop thousands, and a per-instance log
+      // would bury the fact that anything was dropped at all.
+      Logger.warning(
+          `[geometry budget] ${entryPoint} served a model that evicted ` +
+          `under a budget: ${droppedInstances} instance(s) across ` +
+          `${droppedEntities} entit(ies) were dropped because their ` +
+          `geometry was freed. Pump ExtractGeometryBatch and copy at ` +
+          `delivery to receive everything.`)
+    }
+  }
+
+  /**
+   * Async twin of {@link streamAllMeshes} (conway#660): the whole-model ask
+   * for a model whose source is **windowed**, where the synchronous one
+   * cannot go.
+   *
+   * The sync entry point drains through `extractGeometryBatch`, which
+   * refuses an external source outright — *"ExtractGeometryBatch is
+   * synchronous and cannot page a windowed source"* — so on a model opened
+   * through {@link IfcApiProxyIfc.createFromStore} the late whole-model ask
+   * was unreachable however the model was opened, flag or no flag. That is
+   * the gap this closes, and it closes it in the one place it existed: the
+   * DRAIN. Everything after the drain is
+   * {@link serveDeferredWholeModel_}, shared with the sync path.
+   *
+   * **What the re-walk does for geometry a window would have to page back,
+   * verified rather than assumed.** It does not page anything, and it does
+   * not need to. The walk resolves each scene node through
+   * `IfcSceneBuilder.resolveGeometryNode_`, which reads
+   * `node.model.geometry.getByLocalID(...)` — the in-memory geometry store —
+   * and never touches the byte source. So the source being windowed is
+   * irrelevant to the re-walk: what a fully drained windowed model can serve
+   * is exactly what a fully drained buffered one can, and the only thing
+   * that removes geometry from under either is `GEOMETRY_BUDGET_MB`
+   * eviction, which is reported here identically for both. Re-extracting an
+   * evicted product through the window would NOT help: extraction files the
+   * result under a fresh localID, so the scene node that parked still
+   * resolves nothing while a new node emits the same instance again — the
+   * measured "21 placements against classic's 16" in
+   * {@link streamAllMeshes}' degraded note is that path.
+   *
+   * Safe on a resident source (the async pump's prefetch is a no-op there)
+   * and on a non-deferred model, which has no pump and is delegated to the
+   * sync entry point.
+   *
+   * @param meshCallback Receives one whole-model FlatMesh per entity.
+   * @return {Promise<void>} Resolves once every entity has been delivered.
+   */
+  async streamAllMeshesAsync(
+      meshCallback: (mesh: FlatMesh) => void ): Promise<void> {
+
+    // No pump to drain, so nothing here can page anything: the classic walk
+    // and the released-model replay are already whole-model answers, and
+    // both read the geometry store rather than the source.
+    if (!this.deferredMode_) {
+
+      this.streamAllMeshes(meshCallback)
+      return
+    }
+
+    // The budget cannot hold across a whole-model ask, for the reasons the
+    // sync entry point sets out at length — the peak during this call is the
+    // unbudgeted peak, which is what asking for every mesh at once means.
+    // Sampled before the suspension, because everEvicted is what tells the
+    // accounting below whether anything was already lost.
+    const residency = this.model[0].geometryResidency
+    const suspendedBudgetBytes = residency.budgetBytes
+    const degraded = residency.everEvicted
+
+    residency.setBudgetBytes(0)
+
+    try {
+
+      const noCallback = void 0
+
+      // The one line that differs from the sync path. Each call pages the
+      // batch's product closures in before extracting them, so a source that
+      // is a moving window over an external store is drained the same way
+      // Share drains it.
+      while ((await this.extractGeometryBatchAsync(
+          DEFERRED_DRAIN_BATCH, noCallback)).remaining > 0) {
+        // draining
+      }
+
+      this.serveDeferredWholeModel_(
+          meshCallback, degraded, 'StreamAllMeshesAsync')
+
+    } finally {
+
+      // In a finally for the same reason as the sync path: meshCallback is
+      // the CALLER's code, and an early return through it would leave the
+      // model permanently unbudgeted with nothing to signal it.
+      if (Number.isFinite(suspendedBudgetBytes)) {
+        residency.setBudgetBytes(suspendedBudgetBytes)
+        residency.evictToBudget()
+      }
+    }
+  }
+
+  /**
    *
    * @param modelID
    * @param meshCallback
@@ -3666,7 +3900,8 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       // emits the same instances again (21 placements against classic's 16
       // on the shared-representation fixture). Rather than hand out dangling
       // handles, this delivers what is still resident and drops the rest —
-      // see the filter below. Properly serving this combination needs the
+      // see the livePlacements filter in serveDeferredWholeModel_, which is
+      // what this flag feeds. Properly serving this combination needs the
       // meshes re-keyed onto re-extracted geometry, which is follow-up work.
       const degraded = residency.everEvicted
 
@@ -3681,121 +3916,10 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
           // draining
         }
 
-        // Placed instances the re-walk could not resolve, which on this path
-        // is the ONLY signal that anything was lost: evicted geometry is
-        // deleted from the store, so those placements never reach the
-        // rebuilt map and the livePlacements filter below cannot see them.
-        // Zero on the retaining path, where that filter is the signal.
-        let unresolvedInstances = 0
-
-        if (this.streamingConsumer_) {
-          // Nothing was accumulated to absorb stragglers into: this open
-          // declared the caller the owner of the stream. Rebuild the whole
-          // model from the live scene instead — same placements, one walk,
-          // and it throws rather than serving an empty model when the
-          // natives are gone.
-          unresolvedInstances = this.recaptureWholeModel_('StreamAllMeshes')
-        } else {
-          this.streamNewMeshes_(() => { /* absorb stragglers into meshMap */ })
-        }
-
-        const [, , meshMap, geometryMaterialTransformMap, vectorFlatMesh] =
-          this.model
-
-        let droppedInstances = 0
-        let droppedEntities = 0
-        let servedEntities = 0
-
-        meshMap.forEach((mesh) => {
-
-          if (degraded) {
-
-            const live = livePlacements(mesh[1], geometryMaterialTransformMap)
-
-            droppedInstances += mesh[1].geometries.size() - live.length
-
-            if (live.length === 0) {
-              ++droppedEntities
-              return
-            }
-          }
-
-          ++servedEntities
-          vectorFlatMesh.push(mesh[1])
-          meshCallback(mesh[1])
-        })
-
-        if (this.streamingConsumer_) {
-
-          // Served nothing, and the re-walk found instances it could not
-          // resolve: the geometry behind them is gone. What must NOT throw is
-          // a model that genuinely has no geometry — nothing parked, nothing
-          // to serve — where empty is the right answer and classic returns it
-          // too.
-          //
-          // `unresolvedInstances` is the whole signal today; `degraded` is a
-          // failsafe that is NOT independently reachable, and saying so is
-          // the point of this paragraph. Eviction removes geometry from the
-          // store and never touches the scene, which is append-only
-          // (IfcSceneBuilder.nodeCount's contract) — so every instance an
-          // eviction costs us is an instance the walk parks, and there is no
-          // state today in which the model evicted but the walk parked
-          // nothing. It is kept because it costs a boolean read and it fails
-          // in the safe direction: any future path that removes geometry
-          // WITHOUT leaving a parked node behind would otherwise reintroduce
-          // exactly the silent empty model this guard exists to prevent. No
-          // test pins it, and none can, because the state cannot be
-          // constructed through the public API.
-          //
-          // What this deliberately does NOT key on is droppedEntities, the
-          // way the retaining path below does. That counter is fed by the
-          // livePlacements filter, which can only ever see placements that
-          // reached the rebuilt map — and evicted ones never do, because
-          // eviction deletes the mesh from the store rather than leaving a
-          // dead handle in it. Keying on it made this throw unreachable and
-          // let a fully-evicted model return silently empty: measured at a
-          // 1-byte budget on mapped_shared_representation.ifc as 0 placements
-          // served, "0 instance(s) across 0 entit(ies)" logged, no throw.
-          if (servedEntities === 0 && (unresolvedInstances > 0 || degraded)) {
-
-            throw new Error(
-                `StreamAllMeshes: this model was opened with ` +
-                `STREAMING_CONSUMER, so conway kept no reference to the ` +
-                `meshes the pump delivered — the caller owns them — and the ` +
-                `re-walk that serves a late whole-model ask resolved none of ` +
-                `the model (${unresolvedInstances} placed instance(s) ` +
-                `unresolved), because a GEOMETRY_BUDGET_MB eviction has ` +
-                `already freed the geometry behind them. Nothing can be ` +
-                `served. Copy at delivery, raise the budget, or open without ` +
-                `STREAMING_CONSUMER.` )
-          }
-
-          // Partial loss is a warning, matching the retaining path, but the
-          // number comes from the re-walk rather than the filter — see above
-          // for why the filter reads zero here however much was lost.
-          if (unresolvedInstances > 0) {
-            Logger.warning(
-                `[geometry budget] StreamAllMeshes re-walked a ` +
-                `STREAMING_CONSUMER model that evicted under a budget: ` +
-                `${unresolvedInstances} placed instance(s) could not be ` +
-                `resolved because their geometry was freed, and are missing ` +
-                `from the ${servedEntities} entit(ies) this call served. ` +
-                `Pump ExtractGeometryBatch and copy at delivery to receive ` +
-                `everything.`)
-          }
-
-        } else if (degraded) {
-
-          // One line for the whole call, not one per dropped instance: this
-          // fires on a path that may drop thousands, and a per-instance log
-          // would bury the fact that anything was dropped at all.
-          Logger.warning(
-              `[geometry budget] StreamAllMeshes served a model that evicted ` +
-              `under a budget: ${droppedInstances} instance(s) across ` +
-              `${droppedEntities} entit(ies) were dropped because their ` +
-              `geometry was freed. Pump ExtractGeometryBatch and copy at ` +
-              `delivery to receive everything.`)
-        }
+        // Everything past the drain is shared with streamAllMeshesAsync —
+        // see serveDeferredWholeModel_ for why the two entry points must not
+        // grow separate copies of this accounting.
+        this.serveDeferredWholeModel_(meshCallback, degraded, 'StreamAllMeshes')
 
       } finally {
 

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -30,7 +30,7 @@ import { IDENTITY_MAT4, LARGE_COORDINATE_BUDGET_M, TRANSLATION_X, TRANSLATION_Y,
   TRANSLATION_Z, composeTransformF64, deriveCoordinationF64 } from './coordination_f64'
 import { IfcProperties } from './ifc_properties'
 import Logger from '../../logging/logger'
-import { ProgressTracker } from '../../core/progress'
+import { ProgressTracker, yieldToEventLoop } from '../../core/progress'
 import { formatModelLine } from '../../core/progress_log'
 import {
   WasmHeapArrayConstructor, wasmHeapView,
@@ -282,6 +282,18 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   private shard_?: { index: number, count: number }
 
   private demandCursor_ = 0
+
+  /**
+   * Tail of the async pump's serialisation chain — resolved when no pump
+   * call holds the lock, otherwise pending until the current one releases.
+   *
+   * The pump body reads `demandCursor_`, awaits a prefetch, and only then
+   * writes the cursor back, so two overlapping calls would select the same
+   * batch and could write the cursor backward. Every entry into that body
+   * queues behind this. See extractGeometryBatchAsync for the full account
+   * and for why conway#660 is what made it reachable.
+   */
+  private pumpChain_: Promise<void> = Promise.resolve()
 
   /** Wall-clock split of the store-backed batch pump (profile script). */
   private readonly extractProfile_ = {
@@ -2155,6 +2167,66 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       meshCallback?: (mesh: FlatMesh) => void ):
       Promise<{extracted: number, remaining: number}> {
 
+    // Serialised, because the pump body below is NOT re-entrant across its
+    // awaits and this is the only place that can enforce it.
+    //
+    // The body selects its batch — `productEnd` and `batchIDs` off
+    // `demandCursor_` — synchronously, then awaits the prefetch, and only
+    // assigns `this.demandCursor_ = productEnd` after extracting. Two calls
+    // in flight therefore both read the SAME un-advanced cursor and extract
+    // the same products, duplicating scene nodes so that a later whole-model
+    // re-walk serves each of them twice; and each then writes its own saved
+    // `productEnd`, so the later finisher can move the cursor BACKWARD over
+    // ground a call that started after it already covered, leaving those
+    // products to be extracted a second time as well. Measured unlocked on
+    // data/mapped_shared_representation.ifc with two overlapping calls: both
+    // returned `{extracted: 4, remaining: 12}` for the SAME four products,
+    // and the whole-model ask afterwards served 20 placements against the
+    // model's true 16.
+    //
+    // That was latent while `ExtractGeometryBatchAsync` was the only door
+    // into this body and a consumer awaited each call before the next.
+    // conway#660 adds a second door — `streamAllMeshesAsync` drains through
+    // this same pump — and a consumer reaching for a whole-model ask while
+    // its own batch pump is still in flight is an ordinary thing to do
+    // (Share's degraded end-of-load fires from an error handler, not from
+    // inside the pump loop). So overlapping calls QUEUE here rather than
+    // interleave: each waits for the previous to finish before it reads the
+    // cursor, which is what makes the cursor monotonic.
+    //
+    // `previous` only ever resolves — the release is in a `finally` — so one
+    // call's rejection cannot wedge the chain for every later call.
+    const previous = this.pumpChain_
+
+    let release: () => void = () => { /* replaced below, before any await */ }
+
+    this.pumpChain_ = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    await previous
+
+    try {
+      return await this.pumpGeometryBatchAsync_(batchSize, meshCallback)
+    } finally {
+      release()
+    }
+  }
+
+  /**
+   * The body behind {@link extractGeometryBatchAsync}, which holds the pump
+   * lock across this whole call. Never call it directly: it reads and writes
+   * `demandCursor_` across an await and is not safe to re-enter.
+   *
+   * @param batchSize Max products to extract this call (min 1).
+   * @param meshCallback Receives each newly-extracted product's mesh.
+   * @return {Promise<object>} `{extracted, remaining}`.
+   */
+  private async pumpGeometryBatchAsync_(
+      batchSize: number,
+      meshCallback?: (mesh: FlatMesh) => void ):
+      Promise<{extracted: number, remaining: number}> {
+
     if (!this.deferredMode_) {
       return {extracted: 0, remaining: 0}
     }
@@ -3817,13 +3889,29 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
       const noCallback = void 0
 
-      // The one line that differs from the sync path. Each call pages the
+      // The line that differs from the sync path. Each call pages the
       // batch's product closures in before extracting them, so a source that
       // is a moving window over an external store is drained the same way
       // Share drains it.
-      while ((await this.extractGeometryBatchAsync(
-          DEFERRED_DRAIN_BATCH, noCallback)).remaining > 0) {
-        // draining
+      //
+      // The yield before each batch is what makes the `async` on this method
+      // mean something on a RESIDENT deferred source, where the pump has no
+      // real I/O to await: it would otherwise reach only microtasks (the
+      // pump lock, the worklist check), which do not let timers or I/O run,
+      // so an awaiting consumer would be starved exactly as the sync entry
+      // point starves it. Placed before the batch rather than after, so the
+      // caller gets the promise back before any extraction runs, and so a
+      // single-batch model still yields once.
+      for ( ; ; ) {
+
+        await yieldToEventLoop()
+
+        const { remaining } = await this.extractGeometryBatchAsync(
+            DEFERRED_DRAIN_BATCH, noCallback)
+
+        if (remaining === 0) {
+          break
+        }
       }
 
       this.serveDeferredWholeModel_(

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -295,6 +295,34 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    */
   private pumpChain_: Promise<void> = Promise.resolve()
 
+  /**
+   * Tail of the whole-model ask's serialisation chain — the same shape as
+   * pumpChain_, one level up.
+   *
+   * An ask suspends the geometry budget for its whole duration and captures
+   * a `degraded` snapshot alongside it, so exactly one ask may own that
+   * suspension at a time. Two overlapping asks would each snapshot the
+   * other's suspended (infinite) budget as the value to restore, and the
+   * first to finish would re-enable eviction underneath the second — whose
+   * snapshot then says "nothing was ever evicted" while its geometry is
+   * being freed. See streamAllMeshesAsync.
+   */
+  private askChain_: Promise<void> = Promise.resolve()
+
+  /**
+   * True while a whole-model ask holds the geometry budget suspended, which
+   * is what makes {@link setGeometryBudget} defer instead of applying.
+   */
+  private budgetSuspendedForAsk_ = false
+
+  /**
+   * The budget a caller asked for while an ask held the suspension, already
+   * normalised the way GeometryResidency.setBudgetBytes normalises it.
+   * Undefined when nothing was requested; applied by the ask on its way out
+   * in place of the value it suspended.
+   */
+  private pendingBudgetBytes_?: number
+
   /** Wall-clock split of the store-backed batch pump (profile script). */
   private readonly extractProfile_ = {
     prefetchMs: 0,
@@ -3330,13 +3358,54 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * Takes effect at the next pump batch, so lowering it mid-load does not
    * stall the current one freeing memory.
    *
+   * **Deferred while a whole-model ask is running** (`StreamAllMeshesAsync`).
+   * That ask suspends the budget for its whole duration — asking for every
+   * mesh at once means accepting the unbudgeted peak — and decides, from a
+   * snapshot taken before the drain, whether it must filter freed placements
+   * out of what it serves. A budget arriving mid-drain would break both
+   * halves at once: eviction would resume at the next pump batch's head and
+   * free geometry EARLIER batches already captured, while the snapshot still
+   * said nothing had ever been evicted, so the filter would be skipped and
+   * FlatMeshes pointing at freed natives would reach the callback — the
+   * embind abort SHARE-1NK was (`isNativeDeleted`'s doc comment has the
+   * mechanism). Reproduced before this coordination existed: a mid-drain
+   * `SetGeometryBudget( 1 byte )` on a partially pumped retaining model
+   * delivered 16 placements of which 1 carried a freed handle.
+   *
+   * So the request is remembered and applied when the ask finishes, in place
+   * of the value it suspended — the caller's latest request wins, and it
+   * takes effect a moment later than usual rather than being dropped. The
+   * returned `budgetBytes` is therefore what WILL be in force, not what is
+   * in force this instant; `liveBytes` is current.
+   *
+   * The synchronous entry points need no such coordination: they cannot
+   * yield, so nothing can call this between their drain and their serving.
+   *
    * @param bytes The ceiling; non-finite or non-positive disables eviction.
    * @return {{budgetBytes: number, liveBytes: number}} The budget now in
-   * force and what is currently accounted resident.
+   * force — or, during a whole-model ask, the one that will be — and what is
+   * currently accounted resident.
    */
   public setGeometryBudget( bytes: number ): { budgetBytes: number, liveBytes: number } {
 
     const residency = this.model[0].geometryResidency
+
+    if ( this.budgetSuspendedForAsk_ ) {
+
+      // Normalised here rather than at application, so the value reported
+      // back is the one that will actually be in force and the ask's own
+      // `Number.isFinite` resume test reads the caller's intent. Mirrors
+      // GeometryResidency.setBudgetBytes' own rule: non-finite or
+      // non-positive means "no budget".
+      this.pendingBudgetBytes_ =
+        Number.isFinite( bytes ) && bytes > 0 ?
+          bytes : Number.POSITIVE_INFINITY
+
+      return {
+        budgetBytes: this.pendingBudgetBytes_,
+        liveBytes: residency.liveBytes,
+      }
+    }
 
     residency.setBudgetBytes( bytes )
 
@@ -3874,6 +3943,24 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       return
     }
 
+    // Serialised against other asks, so exactly one owner holds the budget
+    // suspension below. Two overlapping asks would each snapshot the other's
+    // suspended (infinite) budget as the value to restore, and whichever
+    // finished first would re-enable eviction underneath the one still
+    // draining — whose own snapshot says nothing was ever evicted. Same
+    // chain shape as the pump lock, one level up; the two cannot deadlock
+    // because they are different chains and the pump lock is only ever taken
+    // inside a call this one has already admitted.
+    const previousAsk = this.askChain_
+
+    let releaseAsk: () => void = () => { /* replaced before any await */ }
+
+    this.askChain_ = new Promise<void>((resolve) => {
+      releaseAsk = resolve
+    })
+
+    await previousAsk
+
     // The budget cannot hold across a whole-model ask, for the reasons the
     // sync entry point sets out at length — the peak during this call is the
     // unbudgeted peak, which is what asking for every mesh at once means.
@@ -3882,6 +3969,12 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     const residency = this.model[0].geometryResidency
     const suspendedBudgetBytes = residency.budgetBytes
     const degraded = residency.everEvicted
+
+    // From here until serving completes, budget state and that snapshot must
+    // stay coherent, so setGeometryBudget defers instead of applying — see
+    // there for what a mid-drain budget change did before this existed.
+    this.budgetSuspendedForAsk_ = true
+    this.pendingBudgetBytes_ = void 0
 
     residency.setBudgetBytes(0)
 
@@ -3914,18 +4007,52 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         }
       }
 
+      // Re-read rather than reusing the pre-drain snapshot alone, so the
+      // filter decision is made on POST-drain state.
+      //
+      // Defence in depth behind the deferral above, and the two were
+      // measured separately rather than assumed to overlap. With the
+      // deferral in place this cannot fire: the budget stays suspended for
+      // the whole drain, `evictToBudget` is a no-op while disabled, and
+      // eviction is the only thing that sets `everEvicted`. Revert the
+      // deferral alone and it becomes live — a mid-drain
+      // `SetGeometryBudget( 1 byte )` on a partially pumped retaining model
+      // then evicts, and this re-read is what runs the live-placement filter
+      // so the freed placement is dropped instead of delivered (measured: 15
+      // placements served rather than 16, and no freed handle). Revert both
+      // and the freed handle reaches the callback (measured: 16 served, 1
+      // with a deleted native) — the embind abort of SHARE-1NK.
+      //
+      // So the deferral is what keeps the answer COMPLETE, and this is what
+      // keeps it SAFE if anything ever evicts during a drain anyway. OR-ed,
+      // never replaced, so a model already degraded on entry stays degraded.
+      const degradedNow = degraded || residency.everEvicted
+
       this.serveDeferredWholeModel_(
-          meshCallback, degraded, 'StreamAllMeshesAsync')
+          meshCallback, degradedNow, 'StreamAllMeshesAsync')
 
     } finally {
 
       // In a finally for the same reason as the sync path: meshCallback is
       // the CALLER's code, and an early return through it would leave the
       // model permanently unbudgeted with nothing to signal it.
-      if (Number.isFinite(suspendedBudgetBytes)) {
-        residency.setBudgetBytes(suspendedBudgetBytes)
+      this.budgetSuspendedForAsk_ = false
+
+      // A budget requested during the ask wins over the one suspended on the
+      // way in — it is the caller's latest word, and deferring it was this
+      // method's doing, not the caller's. `resume` carries the normalised
+      // value either way, so the finite test below reads "is there a budget
+      // to put back" for both.
+      const resume = this.pendingBudgetBytes_ ?? suspendedBudgetBytes
+
+      this.pendingBudgetBytes_ = void 0
+
+      if (Number.isFinite(resume)) {
+        residency.setBudgetBytes(resume)
         residency.evictToBudget()
       }
+
+      releaseAsk()
     }
   }
 

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -3358,6 +3358,17 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * Takes effect at the next pump batch, so lowering it mid-load does not
    * stall the current one freeing memory.
    *
+   * **Where "the next pump batch" is, precisely.** Each pump call evicts
+   * exactly once, and that eviction precedes all of the call's extraction
+   * and delivery — on the resident path it is the first thing the call does,
+   * and on the async path it follows the pump lock and the worklist build
+   * but still runs before any product is extracted or any mesh handed over.
+   * So a budget landing while a pump call is suspended on either of those
+   * awaits is honoured by that same call's eviction, and a consumer never
+   * receives geometry from a batch that was evicted after it was delivered:
+   * #654's copy window — everything call N delivers stays resident until
+   * call N+1 begins — holds on both source types.
+   *
    * **Deferred while a whole-model ask is running** (`StreamAllMeshesAsync`).
    * That ask suspends the budget for its whole duration — asking for every
    * mesh at once means accepting the unbudgeted peak — and decides, from a
@@ -3376,7 +3387,15 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * of the value it suspended — the caller's latest request wins, and it
    * takes effect a moment later than usual rather than being dropped. The
    * returned `budgetBytes` is therefore what WILL be in force, not what is
-   * in force this instant; `liveBytes` is current.
+   * in force this instant.
+   *
+   * **And `liveBytes` reads 0 for the duration of an ask**, which is not a
+   * measurement of anything. Suspending the budget goes through
+   * `setBudgetBytes( 0 )`, and that clears the residency's bookkeeping
+   * outright — with no budget the accounting can only go stale, and a stale
+   * eviction order would free the wrong things if a budget were set later.
+   * The real resident figure comes back after the ask, when restoring a
+   * finite budget reseeds from the stores.
    *
    * The synchronous entry points need no such coordination: they cannot
    * yield, so nothing can call this between their drain and their serving.
@@ -3384,7 +3403,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * @param bytes The ceiling; non-finite or non-positive disables eviction.
    * @return {{budgetBytes: number, liveBytes: number}} The budget now in
    * force — or, during a whole-model ask, the one that will be — and what is
-   * currently accounted resident.
+   * currently accounted resident, which is 0 during an ask (see above).
    */
   public setGeometryBudget( bytes: number ): { budgetBytes: number, liveBytes: number } {
 
@@ -3961,97 +3980,119 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     await previousAsk
 
-    // The budget cannot hold across a whole-model ask, for the reasons the
-    // sync entry point sets out at length — the peak during this call is the
-    // unbudgeted peak, which is what asking for every mesh at once means.
-    // Sampled before the suspension, because everEvicted is what tells the
-    // accounting below whether anything was already lost.
-    const residency = this.model[0].geometryResidency
-    const suspendedBudgetBytes = residency.budgetBytes
-    const degraded = residency.everEvicted
-
-    // From here until serving completes, budget state and that snapshot must
-    // stay coherent, so setGeometryBudget defers instead of applying — see
-    // there for what a mid-drain budget change did before this existed.
-    this.budgetSuspendedForAsk_ = true
-    this.pendingBudgetBytes_ = void 0
-
-    residency.setBudgetBytes(0)
-
+    // Nothing between registering on the chain and this `try`, and nothing
+    // in its `finally` but the release — the same shape as the pump lock, and
+    // for the same reason. Everything the ask does to shared state happens
+    // inside, so any throw still reaches releaseAsk(). Get this wrong and the
+    // failure is not a lost call but a wedged proxy: an unresolved chain
+    // hangs every later ask, and a `budgetSuspendedForAsk_` stuck true makes
+    // setGeometryBudget defer forever while REPORTING the value as applied.
     try {
 
-      const noCallback = void 0
+      // The budget cannot hold across a whole-model ask, for the reasons the
+      // sync entry point sets out at length — the peak during this call is
+      // the unbudgeted peak, which is what asking for every mesh at once
+      // means. Sampled before the suspension, because everEvicted is what
+      // tells the accounting below whether anything was already lost.
+      const residency = this.model[0].geometryResidency
+      const suspendedBudgetBytes = residency.budgetBytes
+      const degraded = residency.everEvicted
 
-      // The line that differs from the sync path. Each call pages the
-      // batch's product closures in before extracting them, so a source that
-      // is a moving window over an external store is drained the same way
-      // Share drains it.
-      //
-      // The yield before each batch is what makes the `async` on this method
-      // mean something on a RESIDENT deferred source, where the pump has no
-      // real I/O to await: it would otherwise reach only microtasks (the
-      // pump lock, the worklist check), which do not let timers or I/O run,
-      // so an awaiting consumer would be starved exactly as the sync entry
-      // point starves it. Placed before the batch rather than after, so the
-      // caller gets the promise back before any extraction runs, and so a
-      // single-batch model still yields once.
-      for ( ; ; ) {
+      // From here until serving completes, budget state and that snapshot
+      // must stay coherent, so setGeometryBudget defers instead of applying
+      // — see there for what a mid-drain budget change did before this
+      // existed. Inside the inner try/finally below, so the deferral window
+      // is closed and the budget put back however this call leaves.
+      this.budgetSuspendedForAsk_ = true
+      this.pendingBudgetBytes_ = void 0
 
-        await yieldToEventLoop()
+      residency.setBudgetBytes(0)
 
-        const { remaining } = await this.extractGeometryBatchAsync(
-            DEFERRED_DRAIN_BATCH, noCallback)
+      try {
 
-        if (remaining === 0) {
-          break
+        const noCallback = void 0
+
+        // The line that differs from the sync path. Each call pages the
+        // batch's product closures in before extracting them, so a source
+        // that is a moving window over an external store is drained the same
+        // way Share drains it.
+        //
+        // The yield before each batch is what makes the `async` on this
+        // method mean something on a RESIDENT deferred source, where the
+        // pump has no real I/O to await: it would otherwise reach only
+        // microtasks (the pump lock, the worklist check), which do not let
+        // timers or I/O run, so an awaiting consumer would be starved
+        // exactly as the sync entry point starves it. Placed before the
+        // batch rather than after, so the caller gets the promise back
+        // before any extraction runs, and so a single-batch model still
+        // yields once.
+        for ( ; ; ) {
+
+          await yieldToEventLoop()
+
+          const { remaining } = await this.extractGeometryBatchAsync(
+              DEFERRED_DRAIN_BATCH, noCallback)
+
+          if (remaining === 0) {
+            break
+          }
+        }
+
+        // Re-read rather than reusing the pre-drain snapshot alone, so the
+        // filter decision is made on POST-drain state.
+        //
+        // Defence in depth behind the deferral above, and the two were
+        // measured separately rather than assumed to overlap. With the
+        // deferral in place this cannot fire: the budget stays suspended for
+        // the whole drain, `evictToBudget` is a no-op while disabled, and
+        // eviction is the only thing that sets `everEvicted`. Revert the
+        // deferral alone and it becomes live — a mid-drain
+        // `SetGeometryBudget( 1 byte )` on a partially pumped retaining
+        // model then evicts, and this re-read is what runs the
+        // live-placement filter so the freed placement is dropped instead of
+        // delivered (measured: 15 placements served rather than 16, and no
+        // freed handle). Revert both and the freed handle reaches the
+        // callback (measured: 16 served, 1 with a deleted native) — the
+        // embind abort of SHARE-1NK.
+        //
+        // So the deferral is what keeps the answer COMPLETE, and this is
+        // what keeps it SAFE if anything ever evicts during a drain anyway.
+        // OR-ed, never replaced, so a model already degraded on entry stays
+        // degraded.
+        const degradedNow = degraded || residency.everEvicted
+
+        this.serveDeferredWholeModel_(
+            meshCallback, degradedNow, 'StreamAllMeshesAsync')
+
+      } finally {
+
+        // In a finally for the same reason as the sync path: meshCallback is
+        // the CALLER's code, and an early return through it would leave the
+        // model permanently unbudgeted with nothing to signal it.
+        //
+        // Cleared FIRST, so that even if putting the budget back throws the
+        // deferral window is shut — a stuck-true flag would make every later
+        // setGeometryBudget defer forever while reporting the value as
+        // applied. This whole block sits inside the ask lock's try, so a
+        // throw here still reaches releaseAsk().
+        this.budgetSuspendedForAsk_ = false
+
+        // A budget requested during the ask wins over the one suspended on
+        // the way in — it is the caller's latest word, and deferring it was
+        // this method's doing, not the caller's. `resume` carries the
+        // normalised value either way, so the finite test below reads "is
+        // there a budget to put back" for both.
+        const resume = this.pendingBudgetBytes_ ?? suspendedBudgetBytes
+
+        this.pendingBudgetBytes_ = void 0
+
+        if (Number.isFinite(resume)) {
+          residency.setBudgetBytes(resume)
+          residency.evictToBudget()
         }
       }
 
-      // Re-read rather than reusing the pre-drain snapshot alone, so the
-      // filter decision is made on POST-drain state.
-      //
-      // Defence in depth behind the deferral above, and the two were
-      // measured separately rather than assumed to overlap. With the
-      // deferral in place this cannot fire: the budget stays suspended for
-      // the whole drain, `evictToBudget` is a no-op while disabled, and
-      // eviction is the only thing that sets `everEvicted`. Revert the
-      // deferral alone and it becomes live — a mid-drain
-      // `SetGeometryBudget( 1 byte )` on a partially pumped retaining model
-      // then evicts, and this re-read is what runs the live-placement filter
-      // so the freed placement is dropped instead of delivered (measured: 15
-      // placements served rather than 16, and no freed handle). Revert both
-      // and the freed handle reaches the callback (measured: 16 served, 1
-      // with a deleted native) — the embind abort of SHARE-1NK.
-      //
-      // So the deferral is what keeps the answer COMPLETE, and this is what
-      // keeps it SAFE if anything ever evicts during a drain anyway. OR-ed,
-      // never replaced, so a model already degraded on entry stays degraded.
-      const degradedNow = degraded || residency.everEvicted
-
-      this.serveDeferredWholeModel_(
-          meshCallback, degradedNow, 'StreamAllMeshesAsync')
-
     } finally {
-
-      // In a finally for the same reason as the sync path: meshCallback is
-      // the CALLER's code, and an early return through it would leave the
-      // model permanently unbudgeted with nothing to signal it.
-      this.budgetSuspendedForAsk_ = false
-
-      // A budget requested during the ask wins over the one suspended on the
-      // way in — it is the caller's latest word, and deferring it was this
-      // method's doing, not the caller's. `resume` carries the normalised
-      // value either way, so the finite test below reads "is there a budget
-      // to put back" for both.
-      const resume = this.pendingBudgetBytes_ ?? suspendedBudgetBytes
-
-      this.pendingBudgetBytes_ = void 0
-
-      if (Number.isFinite(resume)) {
-        residency.setBudgetBytes(resume)
-        residency.evictToBudget()
-      }
-
       releaseAsk()
     }
   }

--- a/src/compat/web-ifc/streaming_consumer_async_whole_model.test.ts
+++ b/src/compat/web-ifc/streaming_consumer_async_whole_model.test.ts
@@ -32,6 +32,8 @@ import { beforeAll, describe, expect, test } from '@jest/globals'
 import Logger, { LogLevel } from '../../logging/logger'
 import { InMemoryStepByteStore } from '../../step/step_buffer_provider'
 import { FlatMesh, IfcAPI } from './ifc_api'
+import { IfcApiProxyIfc } from './ifc_api_proxy_ifc'
+import { isNativeDeleted } from './native_geometry_liveness'
 
 
 const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
@@ -273,6 +275,63 @@ async function bufferedRetainingReference(
 }
 
 
+/**
+ * The live geometry residency behind an open IFC model.
+ *
+ * Reached through the proxy because the budget's *effective* state — as
+ * against what `SetGeometryBudget` reports — is what the coordination tests
+ * below are about, and only the residency has it.
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The open model.
+ * @return {object} The model's GeometryResidency.
+ */
+function residencyOf( api: IfcAPI, modelID: number ):
+  { budgetBytes: number, everEvicted: boolean } {
+
+  const passthrough = api.getPassthrough( modelID )
+
+  if ( !( passthrough instanceof IfcApiProxyIfc ) ) {
+    throw new Error( 'expected the IFC proxy for the open model' )
+  }
+
+  return passthrough.model[ 0 ].geometryResidency
+}
+
+
+/**
+ * Whether any placement on a mesh points at a native that has been freed.
+ *
+ * This is the failure the budget coordination exists to prevent: a FlatMesh
+ * whose geometry the consumer cannot touch, because reading it aborts inside
+ * embind (see isNativeDeleted's doc comment, and Sentry SHARE-1NK).
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The open model.
+ * @param mesh The mesh as delivered to a callback.
+ * @return {number} How many of its placements have a freed native.
+ */
+function freedPlacements(
+    api: IfcAPI, modelID: number, mesh: FlatMesh ): number {
+
+  const passthrough = api.getPassthrough( modelID ) as IfcApiProxyIfc
+
+  let freed = 0
+
+  for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+
+    const entry = passthrough.model[ 3 ].get(
+        mesh.geometries.get( where ).geometryExpressID )
+
+    if ( isNativeDeleted( entry?.[ 0 ] ) ) {
+      ++freed
+    }
+  }
+
+  return freed
+}
+
+
 beforeAll( () => {
   ifcFixture = new Uint8Array( fs.readFileSync( IFC_FIXTURE ) )
   stepFixture = new Uint8Array( fs.readFileSync( STEP_FIXTURE ) )
@@ -388,6 +447,245 @@ describe.each( [
 
         expect( crossedATask ).toBe( true )
       }, 240000 )
+} )
+
+
+describe( 'StreamAllMeshesAsync coordinates budget changes (IFC only — ' +
+  'AP214 has no geometry residency)', () => {
+
+  // A whole-model ask suspends the geometry budget for its whole duration
+  // and decides, from a snapshot taken before the drain, whether it must
+  // filter freed placements out of what it serves. Those two pieces of state
+  // have to stay coherent from drain start until serving completes, and the
+  // drain now yields to the event loop, so a handler CAN run in between and
+  // call SetGeometryBudget.
+  //
+  // Measured across three builds, on a partially pumped retaining model with
+  // a 1-byte budget set mid-drain, against this fixture's true 16 placements:
+  //
+  //   coordination + failsafe : budget Infinity during serving, 16 served, 0 freed
+  //   failsafe only           : budget 1 during serving, 15 served, 0 freed
+  //   neither                 : budget 1 during serving, 16 served, 1 FREED
+  //
+  // So the deferral is what keeps the answer complete, and the post-drain
+  // re-read of everEvicted is what keeps it safe if anything evicts anyway.
+
+  /**
+   * Run the ask with a budget change forced into the middle of its drain.
+   *
+   * The scheduling is what makes this deterministic. The ask suspends on its
+   * serialisation chain and then on its per-batch event-loop yield, so a
+   * `setImmediate` scheduled at call time lands after the suspension is in
+   * force and before the drain finishes — which the returned
+   * `budgetAtChange` confirms rather than assumes: Infinity there means the
+   * change really did land inside the ask's suspension window.
+   *
+   * @param api The API instance owning the model.
+   * @param modelID The partially pumped retaining model.
+   * @param bytes The budget to request mid-drain.
+   * @return {Promise<object>} What the ask saw and served.
+   */
+  async function askWithBudgetChangeMidDrain(
+      api: IfcAPI, modelID: number, bytes: number ): Promise< {
+        budgetAtChange: number,
+        budgetDuringServing: number,
+        evictedDuringServing: boolean,
+        served: Placement[],
+        freedAtDelivery: number,
+      } > {
+
+    const residency = residencyOf( api, modelID )
+    const served: Placement[] = []
+
+    let budgetAtChange = Number.NaN
+    let budgetDuringServing = Number.NaN
+    let evictedDuringServing = false
+    let sampled = false
+    let freedAtDelivery = 0
+
+    const asked = api.StreamAllMeshesAsync( modelID, ( mesh ) => {
+
+      // Sampled inside the callback: that runs during serving, before the
+      // ask's `finally` puts any budget back, so it is the only place the
+      // in-flight state is observable.
+      if ( !sampled ) {
+        sampled = true
+        budgetDuringServing = residency.budgetBytes
+        evictedDuringServing = residency.everEvicted
+      }
+
+      freedAtDelivery += freedPlacements( api, modelID, mesh )
+      served.push( ...placements( mesh ) )
+    } )
+
+    setImmediate( () => {
+      budgetAtChange = residency.budgetBytes
+      api.SetGeometryBudget( modelID, bytes )
+    } )
+
+    await asked
+
+    return {
+      budgetAtChange,
+      budgetDuringServing,
+      evictedDuringServing,
+      served,
+      freedAtDelivery,
+    }
+  }
+
+  test( 'a budget set mid-drain is deferred, and the ask still serves the ' +
+    'whole model with live handles',
+  async () => {
+
+    const api = new IfcAPI()
+
+    await api.Init()
+
+    const reference = await bufferedRetainingReference( api, ifcFixture )
+
+    expect( reference.length ).toBeGreaterThan( 0 )
+
+    const modelID = await api.OpenModelStreamed( ifcFixture, DEFERRED )
+
+    // Partially pumped, so geometry from EARLIER batches is resident and in
+    // the cumulative cache when the mid-drain budget arrives. That is the
+    // geometry a resumed eviction frees out from under the ask.
+    await api.ExtractGeometryBatchAsync(
+        modelID, 2, () => { /* delivery is not what this pins */ } )
+
+    const outcome =
+      await askWithBudgetChangeMidDrain( api, modelID, 1 / BYTES_PER_MIB )
+
+    // The change really did land inside the suspension window — otherwise
+    // everything below would be pinning nothing.
+    expect( outcome.budgetAtChange ).toBe( Number.POSITIVE_INFINITY )
+
+    // The invariant: budget state and the degraded snapshot are stable from
+    // drain start until serving completes.
+    expect( outcome.budgetDuringServing ).toBe( Number.POSITIVE_INFINITY )
+    expect( outcome.evictedDuringServing ).toBe( false )
+
+    // Nothing freed reached the callback...
+    expect( outcome.freedAtDelivery ).toBe( 0 )
+
+    // ...and nothing was lost either: the ask still answers for the whole
+    // model, which is what the suspension is FOR. Without the deferral this
+    // serves one placement fewer.
+    expect( asSortedKeys( outcome.served ) )
+        .toEqual( asSortedKeys( reference ) )
+  }, 240000 )
+
+  test( 'the deferred budget takes effect once the ask completes, and the ' +
+    'next ask reports the loss with exact counts',
+  async () => {
+
+    // Deferring must not mean dropping: the caller asked for a budget and
+    // has to get one, a moment later than usual.
+    const api = new IfcAPI()
+
+    await api.Init()
+
+    const modelID = await api.OpenModelStreamed( ifcFixture, DEFERRED )
+
+    await api.ExtractGeometryBatchAsync(
+        modelID, 2, () => { /* delivery is not what this pins */ } )
+
+    const whole =
+      ( await askWithBudgetChangeMidDrain( api, modelID, 1 / BYTES_PER_MIB ) )
+          .served
+
+    expect( whole.length ).toBeGreaterThan( 0 )
+
+    const residency = residencyOf( api, modelID )
+
+    // Applied on the way out, and it bit.
+    expect( residency.budgetBytes ).toBe( 1 )
+    expect( residency.everEvicted ).toBe( true )
+
+    // The next ask therefore sees a genuinely degraded model and must say
+    // so, with the real numbers rather than a silent short answer.
+    const logged: string[] = []
+
+    Logger.clearLogs()
+    Logger.setLogLevel( LogLevel.WARNING )
+    Logger.setSink( ( _level, message ) => {
+      logged.push( message )
+    } )
+
+    let after: Placement[]
+
+    try {
+      after = await streamAllAsync( api, modelID )
+    } finally {
+      Logger.setSink()
+      Logger.setLogLevel( LogLevel.INFO )
+      Logger.clearLogs()
+    }
+
+    const warned = logged.find( ( line ) =>
+      line.includes( 'StreamAllMeshesAsync served a model that evicted' ) )
+
+    expect( warned ).toBeDefined()
+
+    const reported = /: (\d+) instance\(s\) across/.exec( warned! )
+
+    expect( reported ).not.toBeNull()
+
+    const dropped = Number( reported![ 1 ] )
+
+    expect( dropped ).toBeGreaterThan( 0 )
+
+    // The identity, not merely "fewer": what it served plus what it says it
+    // dropped is the whole model.
+    expect( after.length ).toBe( whole.length - dropped )
+  }, 240000 )
+
+  test( 'overlapping whole-model asks each answer for the whole model and ' +
+    'leave the budget intact',
+  async () => {
+
+    // Each ask snapshots the budget to restore on its way out, and sets the
+    // instance-level deferral state the tests above depend on. Two running
+    // at once would each snapshot the OTHER's suspended (infinite) value and
+    // share one `pendingBudgetBytes_`, so the first to finish could
+    // re-enable eviction underneath the one still draining — whose own
+    // snapshot says nothing was ever evicted. `askChain_` serialises them
+    // so exactly one owns that state at a time.
+    //
+    // Pinned vs reasoned, stated plainly: this pins the OUTCOME — both asks
+    // answer for the whole model, and the budget in force before them is in
+    // force after. It does NOT distinguish the serialisation itself, and
+    // reverting `askChain_` leaves it green, because which ask finishes last
+    // decides whether the wrong snapshot is the one that gets restored and
+    // this fixture happens to finish them in the safe order. The lock's
+    // ordering guarantee is therefore reasoned from the field lifetimes
+    // above, not pinned here.
+    const api = new IfcAPI()
+
+    await api.Init()
+
+    const reference = await bufferedRetainingReference( api, ifcFixture )
+
+    const modelID = await api.OpenModelStreamed( ifcFixture, DEFERRED )
+
+    expect( api.SetGeometryBudget( modelID, 4 )?.budgetBytes )
+        .toBe( 4 * BYTES_PER_MIB )
+
+    const [ first, second ] = await Promise.all( [
+      streamAllAsync( api, modelID ),
+      streamAllAsync( api, modelID ),
+    ] )
+
+    // Both answered for the whole model...
+    expect( asSortedKeys( first ) ).toEqual( asSortedKeys( reference ) )
+    expect( asSortedKeys( second ) ).toEqual( asSortedKeys( reference ) )
+
+    // ...and the budget that was in force before them is in force after,
+    // rather than one ask having restored the other's suspension.
+    expect( residencyOf( api, modelID ).budgetBytes )
+        .toBe( 4 * BYTES_PER_MIB )
+  }, 240000 )
 } )
 
 

--- a/src/compat/web-ifc/streaming_consumer_async_whole_model.test.ts
+++ b/src/compat/web-ifc/streaming_consumer_async_whole_model.test.ts
@@ -1,0 +1,538 @@
+/* eslint-disable no-magic-numbers */
+// The ASYNC whole-model ask (conway#660), and specifically the one case that
+// had no answer before it: a deferred model whose source is WINDOWED.
+//
+// conway#657 gave a STREAMING_CONSUMER model a late whole-model ask served by
+// re-walking the live scene. That ask drains the pump first, and the
+// synchronous entry point drains through the synchronous pump, which refuses
+// an external source outright — "ExtractGeometryBatch is synchronous and
+// cannot page a windowed source". So on a model opened with OpenModelStream
+// the ask threw before serving anything, flag or no flag. GitHub/OPFS File
+// loads take that open by default, i.e. the large models the memory work is
+// aimed at are exactly the ones it could not serve.
+//
+// StreamAllMeshesAsync closes that in the one place the gap existed — the
+// DRAIN — and shares everything after it with the sync path. What each test
+// below pins:
+//
+//   1. the async ask agrees with the sync one on a model both can serve, so
+//      "async" is a way of draining and not a second set of semantics;
+//   2. on a windowed model it serves the whole model, matching an
+//      independently-produced buffered reference placement for placement,
+//      and repeats exactly;
+//   3. the budget accounting survives the move: partial loss warns with the
+//      exact count, total loss throws, on the windowed path;
+//   4. a released model throws, loudly, through the new entry point too;
+//   5. the SYNC entry point still refuses a windowed source with the same
+//      message it always did — this change must not quietly relax it.
+import * as fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import Logger, { LogLevel } from '../../logging/logger'
+import { InMemoryStepByteStore } from '../../step/step_buffer_provider'
+import { FlatMesh, IfcAPI } from './ifc_api'
+
+
+const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
+
+const DEFERRED = { ...SETTINGS, DEFER_GEOMETRY: true }
+
+const DEFERRED_OWNED = { ...DEFERRED, STREAMING_CONSUMER: true }
+
+/* Same fixtures as the #657 suite, and for the same reasons: the IFC one has
+ * shared/mapped representations, so an entity's instance set grows across
+ * batches; the STEP one actually serves geometry (as1-assembly has none even
+ * classically). Sharing them also makes the two suites' counts comparable. */
+const IFC_FIXTURE = 'data/mapped_shared_representation.ifc'
+
+const STEP_FIXTURE = 'data/nema-23-76mm.step'
+
+/** Products (IFC) / scaled units (AP214) per pump call. */
+const BATCH = 4
+
+/* MB is the API's unit and bytes are the engine's, so a budget small enough
+ * to bind on a fixture this size has to be expressed as a fraction. */
+const BYTES_PER_MIB = 1024 * 1024
+
+/* The message the SYNCHRONOUS pump has always refused a windowed source
+ * with. Spelled out rather than matched loosely because pinning it is the
+ * whole point of the test that uses it: this work adds an entry point beside
+ * that refusal and must not soften it. */
+const SYNC_WINDOWED_REFUSAL =
+  'ExtractGeometryBatch is synchronous and cannot page a windowed source'
+
+let ifcFixture: Uint8Array
+let stepFixture: Uint8Array
+
+
+/** One delivered placement, flattened to something comparable by value. */
+interface Placement {
+  expressID: number
+  geometryExpressID: number
+  flatTransformation: number[]
+  color: number[]
+  occurrencePath?: readonly number[]
+}
+
+
+/**
+ * Flatten a delivered FlatMesh into comparable placement records.
+ *
+ * Colour and occurrencePath are included, not just the identifying fields:
+ * colour comes off the material and occurrencePath off the AP214 scene walk,
+ * so both are things a differently-drained re-walk could plausibly get wrong
+ * while still agreeing on which geometry goes where.
+ *
+ * @param mesh The mesh handed to a callback.
+ * @return {Placement[]} One record per placed instance on it.
+ */
+function placements( mesh: FlatMesh ): Placement[] {
+
+  const out: Placement[] = []
+
+  for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+
+    const placed = mesh.geometries.get( where )
+
+    out.push( {
+      expressID: mesh.expressID,
+      geometryExpressID: placed.geometryExpressID,
+      flatTransformation: [ ...placed.flatTransformation ],
+      color: [ placed.color.x, placed.color.y, placed.color.z, placed.color.w ],
+      occurrencePath: placed.occurrencePath === void 0 ?
+        void 0 : [ ...placed.occurrencePath ],
+    } )
+  }
+
+  return out
+}
+
+
+/**
+ * Order-independent comparison key for a set of placements. The pump
+ * delivers per batch and a whole-model walk delivers per entity, so the two
+ * agree on content, not on sequence.
+ *
+ * @param all The placements to key.
+ * @return {string[]} Sorted, one string per placement.
+ */
+function asSortedKeys( all: Placement[] ): string[] {
+
+  return all.map( ( placement ) =>
+    `${placement.expressID}/${placement.geometryExpressID}/` +
+    `${placement.flatTransformation.join( ',' )}/` +
+    `${placement.color.join( ',' )}/` +
+    `${placement.occurrencePath?.join( '.' ) ?? '-'}` ).sort()
+}
+
+
+/**
+ * Drain a deferred model through the SYNC pump.
+ *
+ * Stops on `remaining === 0 && extracted === 0`, the documented consumer
+ * stopping condition rather than a test convenience: the final zero-work call
+ * is what runs the geometry budget's head eviction (conway#654's copy window).
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The deferred model to drain.
+ */
+function drain( api: IfcAPI, modelID: number ): void {
+
+  for ( ; ; ) {
+
+    const { extracted, remaining } = api.ExtractGeometryBatch(
+        modelID, BATCH, () => { /* delivery is not what this pins */ } )
+
+    if ( remaining === 0 && extracted === 0 ) {
+      break
+    }
+  }
+}
+
+
+/**
+ * Drain a deferred model through the ASYNC pump — the only one that can page
+ * a windowed source, and the one Share drives.
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The deferred model to drain.
+ * @return {Promise<Placement[]>} Every placement the pump delivered.
+ */
+async function drainAsync(
+    api: IfcAPI, modelID: number ): Promise< Placement[] > {
+
+  const delivered: Placement[] = []
+
+  for ( ; ; ) {
+
+    const { extracted, remaining } = await api.ExtractGeometryBatchAsync(
+        modelID, BATCH, ( mesh ) => {
+          delivered.push( ...placements( mesh ) )
+        } )
+
+    if ( remaining === 0 && extracted === 0 ) {
+      break
+    }
+  }
+
+  return delivered
+}
+
+
+/**
+ * Collect a whole-model StreamAllMeshes into placement records.
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The open model.
+ * @return {Placement[]} Every placement served.
+ */
+function streamAll( api: IfcAPI, modelID: number ): Placement[] {
+
+  const served: Placement[] = []
+
+  api.StreamAllMeshes( modelID, ( mesh ) => {
+    served.push( ...placements( mesh ) )
+  } )
+
+  return served
+}
+
+
+/**
+ * Collect a whole-model StreamAllMeshesAsync into placement records.
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The open model.
+ * @return {Promise<Placement[]>} Every placement served.
+ */
+async function streamAllAsync(
+    api: IfcAPI, modelID: number ): Promise< Placement[] > {
+
+  const served: Placement[] = []
+
+  await api.StreamAllMeshesAsync( modelID, ( mesh ) => {
+    served.push( ...placements( mesh ) )
+  } )
+
+  return served
+}
+
+
+/**
+ * Run an async whole-model ask with the log sink captured.
+ *
+ * The partial-loss path's ONLY output to a consumer is a warning line — the
+ * placements it lost are simply not in what it returns — so the line has to
+ * be asserted on directly rather than inferred from a count.
+ *
+ * @param api The API instance owning the model.
+ * @param modelID The open model.
+ * @return {Promise<object>} What was served, and every line the call logged.
+ */
+async function streamAllAsyncCapturingLogs( api: IfcAPI, modelID: number ):
+  Promise< { served: Placement[], logged: string[] } > {
+
+  const logged: string[] = []
+
+  Logger.clearLogs()
+  Logger.setLogLevel( LogLevel.WARNING )
+  Logger.setSink( ( _level, message ) => {
+    logged.push( message )
+  } )
+
+  try {
+    return { served: await streamAllAsync( api, modelID ), logged }
+  } finally {
+    Logger.setSink()
+    Logger.setLogLevel( LogLevel.INFO )
+    Logger.clearLogs()
+  }
+}
+
+
+/**
+ * The whole-model answer of an ordinary retaining deferred open, produced
+ * entirely through pre-#660 machinery: buffered source, synchronous pump,
+ * synchronous ask, cumulative cache. Every windowed expectation below is
+ * anchored to this rather than to a hand-written count, so a test can only
+ * pass by agreeing with the path production already trusts.
+ *
+ * @param api The API instance to open the reference model on.
+ * @param fixture The source bytes.
+ * @return {Promise<Placement[]>} The reference placements.
+ */
+async function bufferedRetainingReference(
+    api: IfcAPI, fixture: Uint8Array ): Promise< Placement[] > {
+
+  const retainingID = await api.OpenModelStreamed( fixture, DEFERRED )
+
+  drain( api, retainingID )
+
+  return streamAll( api, retainingID )
+}
+
+
+beforeAll( () => {
+  ifcFixture = new Uint8Array( fs.readFileSync( IFC_FIXTURE ) )
+  stepFixture = new Uint8Array( fs.readFileSync( STEP_FIXTURE ) )
+} )
+
+
+describe.each( [
+  [ 'IFC', () => ifcFixture ],
+  [ 'AP214/STEP', () => stepFixture ],
+] )( 'StreamAllMeshesAsync on %s', ( _format, fixture ) => {
+
+  test( 'the async whole-model ask serves what the sync one serves, and ' +
+    'repeats exactly',
+  async () => {
+
+    // Format parity for the entry point itself, on a source both entry
+    // points can serve. If the async one is a second implementation of the
+    // semantics rather than a second way of draining into them, this is
+    // where the two diverge.
+    const api = new IfcAPI()
+
+    await api.Init()
+
+    const reference = await bufferedRetainingReference( api, fixture() )
+
+    expect( reference.length ).toBeGreaterThan( 0 )
+
+    const ownedID = await api.OpenModelStreamed( fixture(), DEFERRED_OWNED )
+
+    drain( api, ownedID )
+
+    const first = await streamAllAsync( api, ownedID )
+
+    expect( asSortedKeys( first ) ).toEqual( asSortedKeys( reference ) )
+
+    // Idempotent, as the sync ask is and the retaining path is not: each
+    // call clears the rebuilt cache and re-walks from instance zero.
+    const second = await streamAllAsync( api, ownedID )
+
+    expect( asSortedKeys( second ) ).toEqual( asSortedKeys( first ) )
+  }, 240000 )
+
+  test( 'an async whole-model ask after the natives are released throws by ' +
+    'contract',
+  async () => {
+
+    const api = new IfcAPI()
+
+    await api.Init()
+
+    const ownedID = await api.OpenModelStreamed( fixture(), DEFERRED_OWNED )
+
+    drain( api, ownedID )
+
+    expect( api.ReleaseModelGeometry( ownedID ) ).toBe( true )
+
+    // Never a silent empty model, on this entry point either: the cache is
+    // gone by contract and the natives a re-walk needs are gone by request.
+    await expect( streamAllAsync( api, ownedID ) )
+        .rejects.toThrow( /STREAMING_CONSUMER/ )
+
+    // ...and it names the entry point that was actually asked, so a
+    // consumer driving both can tell which one failed.
+    await expect( streamAllAsync( api, ownedID ) )
+        .rejects.toThrow( /StreamAllMeshesAsync/ )
+  }, 240000 )
+} )
+
+
+describe( 'StreamAllMeshesAsync on a WINDOWED source (IFC only — ' +
+  'store-backed opens are IFC-only)', () => {
+
+  // The case conway#660 exists for. OpenModelStream keeps the model windowed
+  // from birth, which is what a GitHub/OPFS File load takes by default in
+  // Share, and it is exactly where the whole-model ask had no answer.
+
+  test( 'the sync whole-model ask still refuses a windowed source',
+      async () => {
+
+        // Pinned FIRST and separately, because it is the pre-existing
+        // behaviour this change is most likely to relax by accident: adding
+        // an async drain beside the sync one must not turn the sync one into
+        // something that quietly half-works on a source it cannot page.
+        // Asserted with and without the flag, since the refusal is the sync
+        // PUMP's and has nothing to do with the ownership contract.
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        for ( const settings of [ DEFERRED, DEFERRED_OWNED ] ) {
+
+          const windowedID = await api.OpenModelStream(
+              new InMemoryStepByteStore( ifcFixture ), settings )
+
+          expect( api.getPassthrough( windowedID )!.sourceIsExternal )
+              .toBe( true )
+
+          await drainAsync( api, windowedID )
+
+          expect( () => streamAll( api, windowedID ) )
+              .toThrow( SYNC_WINDOWED_REFUSAL )
+        }
+      }, 240000 )
+
+  test( 'a windowed streaming-consumer model serves its whole model, and ' +
+    'repeats exactly',
+  async () => {
+
+    const api = new IfcAPI()
+
+    await api.Init()
+
+    // Produced through pre-#660 machinery end to end — buffered, sync pump,
+    // sync ask, retaining — so agreement below is a cross-check against the
+    // path production already trusts, not a comparison of the new code with
+    // itself.
+    const reference = await bufferedRetainingReference( api, ifcFixture )
+
+    expect( reference.length ).toBeGreaterThan( 0 )
+
+    const ownedID = await api.OpenModelStream(
+        new InMemoryStepByteStore( ifcFixture ), DEFERRED_OWNED )
+
+    expect( api.getPassthrough( ownedID )!.sourceIsExternal ).toBe( true )
+
+    const delivered = await drainAsync( api, ownedID )
+
+    // The pump delivered normally, so what follows is about the late ask
+    // rather than about a load that never worked.
+    expect( asSortedKeys( delivered ) ).toEqual( asSortedKeys( reference ) )
+
+    // Nothing retained to replay: this is a fresh walk of the live scene on
+    // a model whose bytes are a moving window, reached through a drain that
+    // paged them.
+    const first = await streamAllAsync( api, ownedID )
+
+    expect( asSortedKeys( first ) ).toEqual( asSortedKeys( reference ) )
+
+    const second = await streamAllAsync( api, ownedID )
+
+    expect( asSortedKeys( second ) ).toEqual( asSortedKeys( first ) )
+  }, 240000 )
+
+  test( 'a windowed RETAINING model is served by the async ask too',
+      async () => {
+
+        // The leak guard for the test above: the windowed ask must work
+        // because the drain can page, not because STREAMING_CONSUMER routes
+        // it somewhere special. An unflagged windowed model has no sync
+        // whole-model ask either, and gets one here.
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const reference = await bufferedRetainingReference( api, ifcFixture )
+
+        const windowedID = await api.OpenModelStream(
+            new InMemoryStepByteStore( ifcFixture ), DEFERRED )
+
+        await drainAsync( api, windowedID )
+
+        expect( asSortedKeys( await streamAllAsync( api, windowedID ) ) )
+            .toEqual( asSortedKeys( reference ) )
+      }, 240000 )
+
+  test( 'total eviction throws rather than serving an empty model',
+      async () => {
+
+        // conway#657's budget tests, moved onto the windowed path: eviction
+        // DELETES the mesh from the store, so the re-walk resolves nothing
+        // for that scene node, parks it, and the placement is absent from
+        // the rebuilt map rather than sitting in it with a dead handle.
+        // Nothing about that is different when the SOURCE is windowed — the
+        // walk reads the geometry store, never the source — and these two
+        // tests are what makes "nothing different" a checked claim.
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const ownedID = await api.OpenModelStream(
+            new InMemoryStepByteStore( ifcFixture ), DEFERRED_OWNED )
+
+        // One byte: nothing survives a pump call, so by the end of the drain
+        // the model's whole geometry store has been evicted.
+        expect( api.SetGeometryBudget( ownedID, 1 / BYTES_PER_MIB )
+            ?.budgetBytes ).toBe( 1 )
+
+        const delivered = await drainAsync( api, ownedID )
+
+        // The pump still DELIVERED — the copy window is intact, this is a
+        // model that streamed correctly and then lost its natives — so the
+        // rejection below is about the late ask, not a broken load.
+        expect( delivered.length ).toBeGreaterThan( 0 )
+
+        await expect( streamAllAsync( api, ownedID ) )
+            .rejects.toThrow( /STREAMING_CONSUMER/ )
+
+        // ...and it names what it could not resolve, rather than reporting
+        // the "0 instance(s) across 0 entit(ies)" a filter-based count did.
+        await expect( streamAllAsync( api, ownedID ) )
+            .rejects.toThrow( /[1-9][0-9]* placed instance\(s\) unresolved/ )
+      }, 240000 )
+
+  test( 'partial eviction serves what survived and reports the exact loss',
+      async () => {
+
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        // The unevicted anchor: what the same windowed ask returns when
+        // nothing was evicted. Without it "served fewer" is unanchored.
+        const wholeID = await api.OpenModelStream(
+            new InMemoryStepByteStore( ifcFixture ), DEFERRED_OWNED )
+
+        await drainAsync( api, wholeID )
+
+        const whole = await streamAllAsync( api, wholeID )
+
+        expect( whole.length ).toBeGreaterThan( 0 )
+
+        const ownedID = await api.OpenModelStream(
+            new InMemoryStepByteStore( ifcFixture ), DEFERRED_OWNED )
+
+        // 2 KiB binds on this fixture without evicting everything.
+        expect( api.SetGeometryBudget( ownedID, 2048 / BYTES_PER_MIB )
+            ?.budgetBytes ).toBe( 2048 )
+
+        await drainAsync( api, ownedID )
+
+        const { served: partial, logged } =
+          await streamAllAsyncCapturingLogs( api, ownedID )
+
+        // Partial loss is a warning, not a throw: something is still there
+        // to hand back, and refusing to hand it back would be worse than the
+        // silence this contract is fixing.
+        expect( partial.length ).toBeGreaterThan( 0 )
+        expect( partial.length ).toBeLessThan( whole.length )
+
+        // The warning is the ONLY thing that tells a consumer it received a
+        // partial model, so assert both that the line exists and that the
+        // number in it is the REAL loss. `served === whole - unresolved` is
+        // an identity: a warning that reported any other number would fail
+        // here even though the served set is unchanged, which is what makes
+        // this pin the reporting rather than the serving. It also pins that
+        // the async entry point names ITSELF in the line, not the sync one.
+        const warned = logged.find( ( line ) =>
+          line.includes(
+              'StreamAllMeshesAsync re-walked a STREAMING_CONSUMER' ) )
+
+        expect( warned ).toBeDefined()
+
+        const reported =
+          /(\d+) placed instance\(s\) could not be resolved/.exec( warned! )
+
+        expect( reported ).not.toBeNull()
+
+        const unresolved = Number( reported![ 1 ] )
+
+        expect( unresolved ).toBeGreaterThan( 0 )
+        expect( partial.length ).toBe( whole.length - unresolved )
+      }, 240000 )
+} )

--- a/src/compat/web-ifc/streaming_consumer_async_whole_model.test.ts
+++ b/src/compat/web-ifc/streaming_consumer_async_whole_model.test.ts
@@ -276,6 +276,28 @@ async function bufferedRetainingReference(
 
 
 /**
+ * Let the event loop turn over a couple of times.
+ *
+ * `setImmediate` rather than a timer, for the reason the yield test spells
+ * out: `yieldToEventLoop` posts through `MessageChannel`, and those tasks
+ * cycle without the timers phase getting a turn, so a timer can sit
+ * unserviced through an entire drain.
+ *
+ * @return {Promise<void>} Resolved after two event-loop turns.
+ */
+async function settle(): Promise< void > {
+
+  await new Promise< void >( ( resolve ) => {
+    setImmediate( resolve )
+  } )
+
+  await new Promise< void >( ( resolve ) => {
+    setImmediate( resolve )
+  } )
+}
+
+
+/**
  * The live geometry residency behind an open IFC model.
  *
  * Reached through the proxy because the budget's *effective* state — as
@@ -641,6 +663,79 @@ describe( 'StreamAllMeshesAsync coordinates budget changes (IFC only — ' +
     expect( after.length ).toBe( whole.length - dropped )
   }, 240000 )
 
+  test( 'a second ask cannot discard a budget the first one already ' +
+    'acknowledged',
+  async () => {
+
+    // The ask chain's real guarantee, pinned rather than reasoned about.
+    //
+    // `budgetSuspendedForAsk_` and `pendingBudgetBytes_` are instance
+    // fields, so they have exactly one owner only because asks are
+    // serialised. Without that, a second ask starting while the first is
+    // still draining runs its own `pendingBudgetBytes_ = void 0` and
+    // **throws away a budget the first ask already told the caller it would
+    // apply** — SetGeometryBudget returned that value as "what will be in
+    // force", and then it silently is not.
+    //
+    // Made deterministic by holding the first ask's drain open: the pump is
+    // stubbed to block on its first call, which parks ask1 inside its
+    // suspension window with the field set, exactly where a second ask does
+    // the damage. White-box, in keeping with the rest of this suite.
+    const api = new IfcAPI()
+
+    await api.Init()
+
+    const modelID = await api.OpenModelStreamed( ifcFixture, DEFERRED )
+    const passthrough = api.getPassthrough( modelID ) as IfcApiProxyIfc
+
+    let releaseHold: () => void = () => { /* replaced below */ }
+
+    const held = new Promise< void >( ( resolve ) => {
+      releaseHold = resolve
+    } )
+
+    const realPump =
+      passthrough.extractGeometryBatchAsync.bind( passthrough )
+
+    let firstPumpCall = true
+
+    passthrough.extractGeometryBatchAsync = async (
+        batchSize: number, callback?: ( mesh: FlatMesh ) => void ) => {
+
+      if ( firstPumpCall ) {
+        firstPumpCall = false
+        await held
+      }
+
+      return realPump( batchSize, callback )
+    }
+
+    const ask1 = streamAllAsync( api, modelID )
+
+    // Let ask1 reach the held pump call, so it is parked mid-drain with the
+    // deferral window open.
+    await settle()
+
+    // Deferred and acknowledged: the caller is told 1 byte will be in force.
+    expect( api.SetGeometryBudget( modelID, 1 / BYTES_PER_MIB )?.budgetBytes )
+        .toBe( 1 )
+
+    // The second ask, issued while the first is still holding.
+    const ask2 = streamAllAsync( api, modelID )
+
+    await settle()
+
+    releaseHold()
+
+    await Promise.all( [ ask1, ask2 ] )
+
+    // The acknowledged value survived and took effect. Without the ask
+    // chain, ask2 clears the pending field on its way in, both asks restore
+    // their own (infinite) snapshots, and this reads Infinity — the budget
+    // the caller was promised never arrives.
+    expect( residencyOf( api, modelID ).budgetBytes ).toBe( 1 )
+  }, 240000 )
+
   test( 'overlapping whole-model asks each answer for the whole model and ' +
     'leave the budget intact',
   async () => {
@@ -653,14 +748,16 @@ describe( 'StreamAllMeshesAsync coordinates budget changes (IFC only — ' +
     // snapshot says nothing was ever evicted. `askChain_` serialises them
     // so exactly one owns that state at a time.
     //
-    // Pinned vs reasoned, stated plainly: this pins the OUTCOME — both asks
-    // answer for the whole model, and the budget in force before them is in
-    // force after. It does NOT distinguish the serialisation itself, and
-    // reverting `askChain_` leaves it green, because which ask finishes last
-    // decides whether the wrong snapshot is the one that gets restored and
-    // this fixture happens to finish them in the safe order. The lock's
-    // ordering guarantee is therefore reasoned from the field lifetimes
-    // above, not pinned here.
+    // What THIS test pins is the outcome under natural scheduling — both
+    // asks answer for the whole model, and the budget in force before them
+    // is in force after. It does not by itself distinguish the
+    // serialisation: reverting `askChain_` leaves it green, because which
+    // ask finishes last decides whether the wrong snapshot is restored and
+    // this fixture happens to finish them in the safe order.
+    //
+    // The discriminator lives in the test above, which holds the first ask's
+    // drain open so the ordering is forced rather than hoped for. Keep both:
+    // that one pins the guarantee, this one covers the ordinary path.
     const api = new IfcAPI()
 
     await api.Init()

--- a/src/compat/web-ifc/streaming_consumer_async_whole_model.test.ts
+++ b/src/compat/web-ifc/streaming_consumer_async_whole_model.test.ts
@@ -342,6 +342,55 @@ describe.each( [
 } )
 
 
+describe.each( [
+  [ 'IFC', () => ifcFixture ],
+  [ 'AP214/STEP', () => stepFixture ],
+] )( 'StreamAllMeshesAsync yields to the event loop on %s',
+( _format, fixture ) => {
+
+  test( 'the drain yields before it extracts, so the signature is not a lie',
+      async () => {
+
+        // An async function runs SYNCHRONOUSLY until its first await, so a
+        // drain containing no event-loop yield would not hand the caller a
+        // promise until the whole model had been extracted — an awaiting
+        // consumer starved exactly as the sync StreamAllMeshes starves it,
+        // while the signature said otherwise. Microtasks do not fix that:
+        // the pump lock and the worklist check are microtask awaits, and a
+        // microtask checkpoint does not let timers or I/O run.
+        //
+        // The probe is a setImmediate scheduled BEFORE the ask: it is a
+        // macrotask, so it can only run ahead of the ask's resolution if the
+        // drain actually crossed an event-loop task boundary. A drain that
+        // awaited nothing, or only microtasks, settles during the current
+        // task's microtask drain and leaves this false.
+        //
+        // A timer is the WRONG probe here and was tried first: `setInterval`
+        // at 0 ms recorded zero ticks across a measured 74 ms drain, because
+        // yieldToEventLoop posts through MessageChannel — deliberately, so
+        // background tabs do not clamp it — and those tasks keep cycling
+        // without the timers phase getting a turn. Zero ticks there means
+        // "timers were starved", not "nothing yielded", which is exactly the
+        // wrong conclusion.
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const ownedID = await api.OpenModelStreamed( fixture(), DEFERRED_OWNED )
+
+        let crossedATask = false
+
+        setImmediate( () => {
+          crossedATask = true
+        } )
+
+        await streamAllAsync( api, ownedID )
+
+        expect( crossedATask ).toBe( true )
+      }, 240000 )
+} )
+
+
 describe( 'StreamAllMeshesAsync on a WINDOWED source (IFC only — ' +
   'store-backed opens are IFC-only)', () => {
 
@@ -437,6 +486,83 @@ describe( 'StreamAllMeshesAsync on a WINDOWED source (IFC only — ' +
         expect( asSortedKeys( await streamAllAsync( api, windowedID ) ) )
             .toEqual( asSortedKeys( reference ) )
       }, 240000 )
+
+  test( 'overlapping async pump calls queue instead of extracting the same ' +
+    'products twice',
+  async () => {
+
+    // The pump body selects its batch — productEnd and batchIDs off
+    // demandCursor_ — synchronously, awaits the prefetch, and only then
+    // writes the cursor back. Two calls in flight therefore read the SAME
+    // un-advanced cursor and extract the same products, duplicating scene
+    // nodes so a later whole-model re-walk serves each twice; and each
+    // writes its own saved productEnd, so the later finisher can move the
+    // cursor BACKWARD over ground a call that started after it already
+    // covered.
+    //
+    // conway#660 is what makes this reachable: streamAllMeshesAsync is a
+    // second door into this same pump, and asking for the whole model while
+    // a batch pump is still in flight is an ordinary thing for a consumer
+    // to do (Share's degraded end-of-load fires from an error handler, not
+    // from inside its pump loop).
+    //
+    // Two concurrent pump calls are the direct, deterministic form of that
+    // hazard, and what this pins. Measured against a build with the lock
+    // removed: both calls returned {extracted: 4, remaining: 12} for the
+    // SAME four products, 8 placements were delivered of which only 4 were
+    // distinct, and the whole-model ask afterwards served 20 against this
+    // model's true 16.
+    //
+    // What is pinned vs reasoned, stated plainly: this pins the pump's
+    // serialisation, which is where the corruption lives. It does NOT force
+    // the specific interleaving of a pump call against a whole-model ask —
+    // that composes with the same lock, but it cannot be forced here
+    // because InMemoryStepByteStore resolves its reads within a microtask,
+    // so an in-test pump call finishes before the ask's leading
+    // event-loop yield returns. Against a real store, whose prefetch spans
+    // many tasks, that overlap is ordinary.
+    const api = new IfcAPI()
+
+    await api.Init()
+
+    const reference = await bufferedRetainingReference( api, ifcFixture )
+
+    expect( reference.length ).toBeGreaterThan( 0 )
+
+    const ownedID = await api.OpenModelStream(
+        new InMemoryStepByteStore( ifcFixture ), DEFERRED_OWNED )
+
+    const delivered: Placement[] = []
+
+    const collect = ( mesh: FlatMesh ): void => {
+      delivered.push( ...placements( mesh ) )
+    }
+
+    // Both issued before either is awaited: the second enters while the
+    // first is suspended on its prefetch.
+    const [ firstCall, secondCall ] = await Promise.all( [
+      api.ExtractGeometryBatchAsync( ownedID, BATCH, collect ),
+      api.ExtractGeometryBatchAsync( ownedID, BATCH, collect ),
+    ] )
+
+    // The second call must have advanced PAST the first rather than
+    // repeating it, so the two together cover twice one batch's work.
+    expect( secondCall.remaining )
+        .toBeLessThan( firstCall.remaining )
+
+    // ...and nothing was delivered twice.
+    const deliveredKeys = asSortedKeys( delivered )
+
+    expect( deliveredKeys.length ).toBe( new Set( deliveredKeys ).size )
+
+    // Finish the drain and ask for the whole model: a duplicated extraction
+    // or a cursor that moved backward both show up here as a served set
+    // that no longer matches the model's true content.
+    await drainAsync( api, ownedID )
+
+    expect( asSortedKeys( await streamAllAsync( api, ownedID ) ) )
+        .toEqual( asSortedKeys( reference ) )
+  }, 240000 )
 
   test( 'total eviction throws rather than serving an empty model',
       async () => {


### PR DESCRIPTION
Part of #660 (and so of #635). **conway half only** — the Share half (dropping windowed retention through the new API, feature-detected) and the PSB before/after the issue's A/B comment sets up are both still owed, so this carries no closing keyword.

## What this establishes

`StreamAllMeshes` drains a deferred model through the **synchronous** pump, which refuses an external source outright — *"ExtractGeometryBatch is synchronous and cannot page a windowed source"* — so on a model opened with `OpenModelStream` the late whole-model ask #657 added threw before serving anything, flagged or unflagged. GitHub/OPFS `File` loads take that open by default, i.e. the large models the epic is aimed at are exactly the ones it could not serve, which is what #660's PSB A/B measured as ~zero bytes reclaimed on the windowed path.

`StreamAllMeshesAsync(modelID, meshCallback)` closes that gap **in the one place it existed: the drain.** It pumps `ExtractGeometryBatchAsync`, which pages each batch's product closures, and then runs the same post-drain code the sync path runs.

Measured on `data/mapped_shared_representation.ifc` opened through `OpenModelStream` + `DEFER_GEOMETRY` + `STREAMING_CONSUMER`, against the buffered retaining model's whole-model answer of **16 placements**:

| ask | before | after |
|---|---|---|
| `StreamAllMeshes` (sync) | throws *"cannot page a windowed source"* | **unchanged** — still throws |
| `StreamAllMeshesAsync` | did not exist | serves **16**, matching placement-for-placement (identity, full transform, colour, `occurrencePath`); second call identical |
| …at a 2 KiB budget | — | serves **3**, warns *"13 placed instance(s) could not be resolved"* (3 + 13 = 16) |
| …at a 1-byte budget | — | **throws**, naming a non-zero unresolved count |

Both proxies, per the epic's standing rule. The post-drain logic is extracted to `serveDeferredWholeModel_` in each and called by **both** entry points, so the re-walk, the idempotence, the partial-loss warning, the total-loss throw and the post-release throw cannot drift between sync and async — a consumer that feature-detects its way onto the async one gets the same semantics, not a second implementation of them.

## The paging crux, answered by reading the code rather than assuming

The brief for this work flagged one thing as the crux: on a windowed source, does the re-walk need to re-extract through the pager, and can it?

**It does not page anything, and it does not need to.** The re-walk resolves each scene node through `IfcSceneBuilder.resolveGeometryNode_`, whose entire geometry lookup is:

```ts
const geometry = node.model.geometry?.getByLocalID(node.localID)
```

— the in-memory geometry **store**, never the byte source. So windowing is invisible to the walk. Two consequences, both checked rather than reasoned to:

1. **A fully drained windowed model serves exactly what a fully drained resident one serves.** There is no windowed/buffered boundary in the answer at all; the two are compared directly in the tests, and the windowed ask is anchored to a reference produced entirely through pre-#660 machinery (buffered source, sync pump, sync ask, retaining cache).
2. **Geometry a `GEOMETRY_BUDGET_MB` eviction already freed is not paged back — on either.** It is reported missing, by the same parked-node count #657 built.

**Re-extraction through the window would not have helped, so it was deliberately not attempted.** Extraction files its result under a fresh localID, so the parked scene node still resolves nothing while a new node re-emits the same instance — the measured "21 placements against classic's 16" already documented in `streamAllMeshes`' degraded note. The contract Share can rely on is *"the same stream the pump delivered, or an exact account of what is missing"*, and explicitly **not** recovery.

## The concurrency contract (rounds 1–3)

Adding a second door into the pump surfaced two re-entrancy problems in the machinery around it. Both are coordinated, and the contract is one sentence: **from the moment a whole-model ask starts draining until it finishes serving, the pump cursor, the geometry budget and the `degraded` snapshot are stable.**

### 1. The async pump serialises (round 1)

The pump body selects its batch — `productEnd` and `batchIDs` off `demandCursor_` — **synchronously**, awaits the prefetch, and only then writes the cursor back. Two calls in flight both read the same un-advanced cursor and extract the same products; each then writes its own saved `productEnd`, so the later finisher can move the cursor *backward*.

Measured with the lock removed, two overlapping calls:

| observable | unlocked | locked |
|---|---|---|
| the two calls' results | both `{extracted: 4, remaining: 12}` — the **same four products** | `{4, 12}` then `{4, 8}` |
| placements delivered / distinct | 8 / **4** | 8 / 8 |
| whole-model ask afterwards | **20** placements | **16** — the model's true content |

Latent while `ExtractGeometryBatchAsync` was the only door and consumers awaited each call; `streamAllMeshesAsync` is a second one, and asking for the whole model during an in-flight pump is ordinary (Share's degraded end-of-load fires from an error handler, not from inside its pump loop). Overlapping calls now queue on a chained promise whose release is in a `finally`.

### 2. Budget updates defer across an ask (round 2)

An ask suspends the budget for its duration — asking for every mesh at once means accepting the unbudgeted peak — and snapshots `everEvicted` to decide whether it must filter freed placements out of what it serves. The round-1 yields let a handler call `SetGeometryBudget` in between, which re-enabled eviction at the next pump batch's head, freeing geometry **earlier batches had already captured**, while the snapshot still said nothing had been evicted so the filter was skipped.

Measured three ways on a partially pumped retaining model with a 1-byte budget set mid-drain, against the fixture's true **16** placements:

| build | budget during serving | `everEvicted` during serving | served | freed handles delivered |
|---|---|---|---|---|
| **both layers (this PR)** | Infinity | false | **16** | **0** |
| deferral off, re-read on | 1 | true | **15** — one silently lost | 0 |
| **neither** | 1 | true | 16 | **1 — the embind abort of SHARE-1NK** |

`SetGeometryBudget` now **defers while an ask holds the suspension**, keeping the caller's latest requested value and applying it on the way out in place of the suspended one. The `everEvicted` snapshot is additionally **re-read after the drain**; the table is why that is defence in depth rather than dead code — with the deferral in place it cannot fire, but revert the deferral alone and it is the thing that runs the live-placement filter instead of delivering a freed handle.

Asks are serialised on their own chain (`askChain_`) so exactly one owns that instance-level state — **and that is now pinned, not merely reasoned** (see round 3). It cannot deadlock against the pump lock: different chains, and the pump lock is only ever taken inside a call the ask chain has already admitted.

### 3. Where "the next pump batch" is, precisely

Each pump call evicts **exactly once**, and that eviction **precedes all of the call's extraction and delivery** — on the resident path it is the first thing the call does; on the async path it follows the pump lock and the worklist build, but still runs before any product is extracted or any mesh handed over. So a budget landing while a pump call is suspended on either of those awaits is honoured by that same call's eviction, and a consumer never receives geometry from a batch that was evicted after it was delivered: #654's copy window holds on both source types.

(An earlier revision of this section said "both sites are before any await". That was imprecise — round 3 caught it — and is corrected above; the claim that actually holds is the ordering against extraction and delivery, not against every await.)

**The synchronous entry points need no coordination at all.** They cannot yield, so nothing can run between their drain and their serving. This is also why their behaviour is unchanged.

## What this only hopes

- **The bytes.** No memory number is claimed. This makes the ask *reachable* on windowed opens; whether dropping Share's third spine there pays out is the PSB before/after, owed by the Share half.
- **That Share will use it.** Nothing consumes it yet. It is additive and feature-detectable (`typeof api.StreamAllMeshesAsync === 'function'`).
- **That the ask is cheap.** It is a full drain plus a full scene walk — the price of asking for the whole model after the fact, paid at the ask instead of on every load against the chance of one.

## Scope notes

- **The sync path is untouched behaviourally.** It keeps its own drain, its own budget suspend/restore and its own `'StreamAllMeshes'` messages verbatim; only the post-drain block moved into a method it calls. Its windowed refusal is unchanged and **pinned by a test**, flagged and unflagged, re-run after each review round.
- **AP214 gets the entry point for parity, and it is synchronous underneath.** No async pump, and store-backed opens are IFC-only (`IfcApiModelPassthroughFactory.fromStore` logs *"Store-backed open is IFC-only"*), so a windowed AP214 model is unreachable through the public API. It also has **no geometry residency at all**, which is why the budget coordination is IFC-only.
- **`loadAllGeometry` / `streamAllMeshesWithTypes` get no async twins.** #660 names them as the entry points that don't throw and are worse for it (they seed coordination from `model[5]`, which a deferred open never writes). Async twins would extend that mis-framing; `StreamAllMeshes`' deferred branch already routes around it via `demandCoordination_`.
- **`SetGeometryBudget`'s `liveBytes` reads 0 during an ask**, and that is not a measurement: suspending goes through `setBudgetBytes( 0 )`, which clears the residency's bookkeeping outright (a stale eviction order would free the wrong things if a budget were set later). The real figure returns after the ask, when restoring a finite budget reseeds from the stores. Documented at the return.

## Merged with main at `12d12550` (#673)

`origin/main` moved to #673 ("Render AP242 tessellated part geometry via a hand-written shadow schema") while this was in review, and it touches `ifc_api_proxy_ap214.ts` — which this PR also edits. Merged (not rebased), one conflict, resolved by taking **both** sides:

```
-import { EntityTypesAP214Count } from '.../entity_types_ap214.gen'   <- #673 replaced this
-import { ProgressTracker } from '../../core/progress'                <- this PR extended this
+import { EntityTypesAP214ExtendedCount } from '.../ap214_tessellated_types'
+import { ProgressTracker, yieldToEventLoop } from '../../core/progress'
```

Two adjacent import lines, each side changing a different one — git merged them as a block, and nothing is lost either way. #673's other change to that file is the `EntityTypesAP214ExtendedCount` loop bound in `getAllLines` (~line 1237); this PR's changes are `serveDeferredWholeModel_` / `streamAllMeshesAsync` (~line 1750+). Disjoint hunks, disjoint logic, no behaviour to pick between.

**Interaction worth naming, deliberately not acted on:** #673's changes sit in the AP214 *geometry-extraction walk* (which items reach the scene), not in the demand-unit pump — `extractDemandUnitBatch`, `demandUnitCursor` and `pumpDemandUnits_` are untouched. So a model with AP242 tessellated solids now puts those in the scene, and this PR's whole-model ask serves them for free by the same mechanism it serves everything else: the ask re-walks the scene, so more in the scene means more served, with no change needed here. Nothing about that widens this PR.

## Review history

**Round 1 (codex) — two findings, both verified and both real.**

- **P1, the async pump body is not re-entrant across its awaits.** Fixed by queueing. Codex offered "or reject a concurrent drain"; queueing was taken because rejecting would make a legitimate consumer pattern an error it has to code around, when the ask can simply wait.
- **P2, the async drain had no event-loop yield** — an async function runs synchronously to its first await, so the caller did not get the promise until the whole model was extracted. Extended beyond codex's finding to the IFC proxy, where a *resident*-source drain has the same problem; revert G shows the IFC test red without it.

**Round 2 (codex) — one finding, verified and reproduced before fixing:** the budget re-entrancy above. Both mirrored surfaces codex asked me to re-check were checked and are reported in §3 — the pump path was already correct, and the `degraded` re-read was added as asked.

**Round 3 (sub-agent) — clean to merge, no P1/P2.** The reviewer independently verified the ordering claim this PR rested on, with a held drain: a second ask cannot begin draining until the first finishes applying. Four P3s, all taken in one pass:

- **P3-1 (exception safety).** The ask chain's registration and release were not exception-shaped like the pump lock: six statements sat between the registration and the `try` (including `setBudgetBytes(0)` *after* `budgetSuspendedForAsk_ = true`), and the budget restore preceded `releaseAsk()` in the `finally`. Not reachable today — `setBudgetBytes` is pure JS and embind aborts do not throw — but the failure mode is a **wedged proxy rather than a lost call**: an unresolved chain hangs every later ask, and a stuck-true flag makes every `SetGeometryBudget` defer forever *while reporting the value as applied* (the reviewer measured both). Now register → await previous → `try { everything } finally { release() }`, with the budget restore as an inner `finally` inside that try and the flag cleared before it.
- **P3-3 (converts an acknowledged gap into a pin).** The previous revision said the `askChain_` guarantee was reasoned, not pinned. The reviewer showed it *is* deterministically pinnable, and it now is — see test 6 below.
- **P3-2 (doc).** The "before any await" claim was imprecise; corrected in §3.
- **P3-4 (doc).** `liveBytes` reads 0 during an ask; documented at the return.

**Three test-methodology corrections worth recording, because each first produced a green test that proved nothing.**

1. **A timer is the wrong probe for "did it yield".** The first P2 test counted `setInterval(…, 0)` ticks and recorded **zero across a measured 74 ms drain** — not because nothing yielded, but because `yieldToEventLoop` posts through `MessageChannel` (deliberately: `setTimeout` is clamped to ≥1 s in background tabs) and those tasks cycle without the timers phase getting a turn. Zero ticks read as "nothing yielded" when it meant "timers were starved". Replaced with a `setImmediate` scheduled before the ask and asserted to have run before it resolved.
2. **The first P1 test was vacuous.** It issued an un-awaited pump then a concurrent ask, but **passed against the unlocked build**, because `InMemoryStepByteStore` resolves reads within a microtask so the pump finished before the ask's leading yield returned. Now pinned directly with two concurrent pump calls.
3. **The first round-2 probe measured the wrong moment.** It checked handle liveness *after* the ask resolved, which catches the ask's own `finally` correctly applying the deferred budget — a false positive. The invariant is liveness **at delivery**, inside the callback; the three-build table is measured that way.

## Falsifiability evidence

Each revert was applied, rebuilt, run against both the new suite and #657's, and restored. All 28 tests across the two suites pass with none applied.

| revert | what it removes | result |
|---|---|---|
| **A** | the async drain (`streamAllMeshesAsync` pumps `extractGeometryBatch`) | **4 failed / 17 passed** |
| **B** | the API-level dispatch (`StreamAllMeshesAsync` always calls `streamAllMeshes`) | **6 failed / 15 passed** |
| **C** | the parameterised entry-point name (messages hardcode `'StreamAllMeshes'`) | **3 failed / 18 passed** |
| **D** | the sync pump's windowed refusal | **1 failed / 26 passed** |
| **E** | the re-walk routing in the shared `serveDeferredWholeModel_` | **14 failed / 7 passed** |
| **F** | the pump serialization lock (round 1) | **1 failed / 23 passed** |
| **G** | the drain's event-loop yields, both proxies (round 1) | **2 failed / 22 passed** |
| **H** | the budget deferral (round 2) | **2 failed / 25 passed** |
| **I** | the budget deferral **and** the post-drain `everEvicted` re-read | **1 failed / 26 passed** |
| **K** | the ask serialization chain (round 3) | **1 failed / 27 passed** |

(Each was measured against the suite size current when it was run; D was re-run after each round.)

- **A** fails exactly the four windowed tests, each on *"ExtractGeometryBatch is synchronous and cannot page a windowed source"*. The buffered parity tests and the sync-refusal pin still pass, which is the right shape.
- **B** fails those four plus **both formats'** release tests, which assert the message names `StreamAllMeshesAsync`. The buffered parity tests still pass, honestly — on a buffered model the sync fallback *is* equivalent, which is why the windowed tests carry the claim.
- **C** fails both release tests and the partial-eviction test, and nothing else.
- **D** fails only `the sync whole-model ask still refuses a windowed source` — that pre-existing behaviour pinned independently, unchanged across all three rounds.
- **E** fails 14 across **both** suites, including #657's existing whole-model, release, budget and `GetFlatMesh` tests — the evidence that `serveDeferredWholeModel_` is genuinely shared and not a copy.
- **F** fails only the concurrency test, at `expect(secondCall.remaining).toBeLessThan(firstCall.remaining)` with *"Expected: < 12, Received: 12"*.
- **G** fails the yield test on **both** formats, establishing that the IFC drain needed the fix too.
- **H** fails both budget-coordination tests, the first at `expect(budgetDuringServing).toBe(Infinity)` with *"Received: 1"*.
- **I** fails one, short-circuiting at that same earlier assertion; the freed-handle assertion behind it is what the three-build table measures directly.
- **K** fails only the new ask-chain test, at `expect(residencyOf(...).budgetBytes).toBe(1)` with *"Received: Infinity"* — the acknowledged budget silently dropped. Applied by disabling the chain in the compiled output, since the source shape is what the test is about.

## Numbers

- **Baseline, measured on the untouched tree at `1997609f`** (with `compiled/dependencies/conway-geom/Dist` force-refreshed from the published build first — a previous session had left a locally-built telemetry wasm there and `yarn wasm-prebuilt` skips when files exist): `yarn lint` 0 errors / **725** warnings; `yarn test` **130 suites / 926 tests**, green, 102.4 s.
- **Before merging main:** `yarn test` **131 suites / 942 tests** green — `+1 suite, +16 tests` against that baseline.
- **On the merged tree (this head):** `yarn lint` 0 errors / **725** warnings (unchanged throughout); `yarn test` **133 suites / 950 tests**, green. The extra `+2 suites / +8 tests` over the pre-merge figure are #673's own (`ap214_tessellated_geometry.test.ts`, `ap214_tessellated_compat.test.ts`).
- The husky `pre-commit` gate passed on all four development commits, and the full gate (`build-incremental` + `check-compiled-fresh` + `lint` + `test`) was run explicitly on the merged tree — the conflict meant the merge was completed with `git commit`, which fires the hook, rather than landing ungated as an auto-committed merge would have.
- Post-merge spot-check of the suites the conflict put at risk: this PR's 16 tests, #657's 12, `geometry_budget_copy_window`, and all 26 AP214 suites (including #673's two new ones) — **33 suites / 187 tests, all green**. All three `AP214/STEP` parity blocks present and passing.

## Tests

`src/compat/web-ifc/streaming_consumer_async_whole_model.test.ts` — 16 tests. A new file rather than additions to #657's, so that suite stays byte-identical and its 12 tests keep meaning what they meant.

Both formats (3 × 2):

1. **the async whole-model ask serves what the sync one serves, and repeats exactly**.
2. **an async whole-model ask after the natives are released throws by contract** — `/STREAMING_CONSUMER/` **and** `/StreamAllMeshesAsync/`.
3. **the drain yields before it extracts, so the signature is not a lie** *(round 1)*.

IFC only, budget coordination (4) — AP214 has no residency:

4. **a budget set mid-drain is deferred, and the ask still serves the whole model with live handles** *(round 2)* — confirms the change landed inside the suspension window, then asserts the invariant, zero freed handles at delivery, and the full placement set.
5. **the deferred budget takes effect once the ask completes, and the next ask reports the loss with exact counts** *(round 2)* — `served === whole − dropped` as an identity.
6. **a second ask cannot discard a budget the first one already acknowledged** *(round 3)* — the first ask's drain is held open by stubbing the pump, a budget is set and acknowledged mid-hold, and a second ask starts before release. This is the ask chain's discriminator.
7. **overlapping whole-model asks each answer for the whole model and leave the budget intact** — the ordinary-scheduling companion to (6).

IFC only, windowed (`OpenModelStream` over `InMemoryStepByteStore`) — 6:

8. **the sync whole-model ask still refuses a windowed source**, flagged and unflagged, against the literal message.
9. **a windowed streaming-consumer model serves its whole model, and repeats exactly**.
10. **a windowed RETAINING model is served by the async ask too** — the leak guard for (9).
11. **overlapping async pump calls queue instead of extracting the same products twice** *(round 1)*.
12. **total eviction throws rather than serving an empty model**.
13. **partial eviction serves what survived and reports the exact loss**.

`geometry_budget_copy_window.test.ts` is **unmodified** and green, as is the whole of #657's suite. Both drain helpers stop on `remaining === 0 && extracted === 0`, preserving #654's trailing head-eviction call.

## Sequencing

conway publishes first; then Share's feature-detected switch to `StreamAllMeshesAsync` and the drop of windowed retention; then the PSB before/after on the trace #660's comment already captured. #660 and #635 stay open.