### PR TITLE
#667: bump conway-geom to eac18067 — analytic shading normals, and normals in the GLB

### DIFF
--- a/src/AP214E3_2010/ap214_analytic_normals.test.ts
+++ b/src/AP214E3_2010/ap214_analytic_normals.test.ts
@@ -1,0 +1,215 @@
+import fs from 'fs'
+import { describe, expect, test, beforeAll } from '@jest/globals'
+import { AP214GeometryExtraction } from './ap214_geometry_extraction'
+import { AP214SceneBuilder } from './ap214_scene_builder'
+import { ParseResult } from '../step/parsing/step_parser'
+import AP214StepParser from './ap214_step_parser'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import { ExtractResult } from '../core/shared_constants'
+
+/* eslint-disable no-magic-numbers -- the reified vertex layout (6 floats) and
+   the axis component indices read more clearly as literals than as names. */
+
+/**
+ * A tube: two coaxial CYLINDRICAL_SURFACE advanced faces (bore and outside)
+ * capped by annular planes. The cylinders take the analytic-normal path added
+ * for https://github.com/bldrs-ai/conway/issues/667, so every emitted normal on
+ * them must be the exact radial direction rather than an average of the
+ * surrounding facets' normals.
+ *
+ * That distinction is the whole point of the change. Reify()'s fallback derives
+ * a shading normal by averaging FACE normals inside a 40-degree smoothing
+ * group; on a curved face those averages are close to the surface but never
+ * equal to it, and near a trimmed boundary — where the triangulator leaves
+ * slivers whose face normals point almost anywhere — they are not even close.
+ * The tolerance below is tight enough that only a genuinely analytic normal
+ * passes: reverting the cylinder call sites to the three-argument
+ * appendMeshToGeometry overload turns this test red.
+ */
+const FIXTURE = 'data/create-a-tube.step'
+
+/**
+ * Angular slack, in radians, between the emitted normal and the analytic one.
+ *
+ * Sized for float32 storage plus the renormalization Reify() does, NOT for
+ * chord error — an averaged face normal on this fixture misses by degrees,
+ * which is four orders of magnitude outside this.
+ */
+const TOLERANCE_RADIANS = 1e-3
+
+let scene: AP214SceneBuilder
+let conwayGeometry: ConwayGeometry
+
+
+beforeAll(async () => {
+  conwayGeometry = new ConwayGeometry()
+
+  await conwayGeometry.initialize()
+
+  const parser = AP214StepParser.Instance
+  const buffer = new ParsingBuffer(fs.readFileSync(FIXTURE))
+
+  // The header has to be consumed before the data section; skipping it leaves
+  // parseDataToModel reading from the wrong offset and returning INCOMPLETE.
+  expect(parser.parseHeader(buffer)[1]).toBe(ParseResult.COMPLETE)
+
+  const [, model] = parser.parseDataToModel(buffer)
+
+  expect(model).not.toBe(void 0)
+
+  const extraction = new AP214GeometryExtraction(conwayGeometry, model!)
+  const [extractResult, sceneBuilder] = extraction.extractAP214GeometryData()
+
+  expect(extractResult).toBe(ExtractResult.COMPLETE)
+
+  scene = sceneBuilder
+})
+
+
+/**
+ * Every emitted vertex of the model as {position, normal}, straight out of the
+ * reified stream the viewer and the GLB writer both consume.
+ *
+ * @return One entry per emitted vertex, in vertex-buffer order.
+ */
+function reifiedVertices(): {position: number[], normal: number[]}[] {
+
+  const wasm =
+    (conwayGeometry as unknown as { wasmModule: { HEAPF32: Float32Array } }).wasmModule
+
+  const out: {position: number[], normal: number[]}[] = []
+
+  for (const [, , mesh] of scene.walk()) {
+
+    const geometry = (mesh as unknown as {
+      geometry: { GetVertexData(): number, GetVertexDataSize(): number }
+    }).geometry
+
+    const floatCount = geometry.GetVertexDataSize()
+
+    // Reified layout: 6 floats per vertex, position xyz then normal xyz. Copied
+    // out immediately — HEAPF32 views detach when the wasm heap grows.
+    const data = wasm.HEAPF32.slice(
+        geometry.GetVertexData() / 4,
+        (geometry.GetVertexData() / 4) + floatCount)
+
+    for (let where = 0; where < floatCount; where += 6) {
+      out.push({
+        position: [data[where], data[where + 1], data[where + 2]],
+        normal: [data[where + 3], data[where + 4], data[where + 5]],
+      })
+    }
+  }
+
+  return out
+}
+
+
+/**
+ * The tube's axis, found from the emitted geometry rather than assumed: the
+ * axis is the coordinate whose spread is largest while the other two describe
+ * a circle of near-constant radius.
+ *
+ * @param vertices Emitted vertices.
+ * @return Index of the axis component (0, 1 or 2).
+ */
+function axisComponent(vertices: {position: number[]}[]): number {
+
+  let best = 0
+  let bestSpread = -Infinity
+
+  for (let component = 0; component < 3; ++component) {
+
+    const values = vertices.map((each) => each.position[component])
+    const spread = Math.max(...values) - Math.min(...values)
+
+    if (spread > bestSpread) {
+      bestSpread = spread
+      best = component
+    }
+  }
+
+  return best
+}
+
+
+describe('AP214 analytic shading normals', () => {
+
+  test('emits unit normals for every vertex', () => {
+
+    const vertices = reifiedVertices()
+
+    expect(vertices.length).toBeGreaterThan(0)
+
+    for (const {normal} of vertices) {
+
+      const length = Math.hypot(normal[0], normal[1], normal[2])
+
+      expect(length).toBeCloseTo(1, 5)
+    }
+  })
+
+  test('cylindrical faces carry the exact radial normal, not an average', () => {
+
+    const vertices = reifiedVertices()
+    const axis = axisComponent(vertices)
+    const radial = [0, 1, 2].filter((component) => component !== axis)
+
+    // The circle centre in the two non-axis components, from the extent rather
+    // than from the file, so the test does not depend on the fixture's
+    // placement.
+    const centre = radial.map((component) => {
+      const values = vertices.map((each) => each.position[component])
+      return (Math.max(...values) + Math.min(...values)) / 2
+    })
+
+    const radii = vertices.map(({position}) =>
+      Math.hypot(position[radial[0]] - centre[0], position[radial[1]] - centre[1]))
+
+    const maxRadius = Math.max(...radii)
+
+    let checked = 0
+
+    for (let where = 0; where < vertices.length; ++where) {
+
+      const {normal} = vertices[where]
+      const radius = radii[where]
+
+      // Only the outer cylinder: the bore's normal points inward and the end
+      // caps are planar, and neither is what this test is about. A vertex on
+      // the outer wall sits at the model's maximum radius.
+      if (radius < maxRadius * 0.999) {
+        continue
+      }
+
+      // A vertex shared with an end cap gets its own split copy whose normal is
+      // the cap's, which is axial. Skip those by requiring the normal to be
+      // predominantly radial before comparing it to the analytic direction.
+      if (Math.abs(normal[axis]) > 0.5) {
+        continue
+      }
+
+      const {position} = vertices[where]
+      const analytic = [
+        (position[radial[0]] - centre[0]) / radius,
+        (position[radial[1]] - centre[1]) / radius,
+      ]
+
+      const dot =
+        (analytic[0] * normal[radial[0]]) + (analytic[1] * normal[radial[1]])
+
+      // Clamped: float32 storage can push a genuinely parallel pair a hair
+      // past 1, where acos() would return NaN.
+      const angle = Math.acos(Math.min(1, Math.max(-1, dot)))
+
+      expect(angle).toBeLessThan(TOLERANCE_RADIANS)
+
+      ++checked
+    }
+
+    // Guard against the filters above quietly excluding everything, which would
+    // leave the assertion loop vacuous.
+    expect(checked).toBeGreaterThan(16)
+  })
+})

--- a/src/AP214E3_2010/ap214_gltf_normals.test.ts
+++ b/src/AP214E3_2010/ap214_gltf_normals.test.ts
@@ -1,0 +1,444 @@
+import fs from 'fs'
+import nodePath from 'path'
+import nodeUrl from 'url'
+import { describe, expect, test, beforeAll } from '@jest/globals'
+import { AP214GeometryExtraction } from './ap214_geometry_extraction'
+import { ParseResult } from '../step/parsing/step_parser'
+import AP214StepParser from './ap214_step_parser'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import { ExtractResult } from '../core/shared_constants'
+import GeometryAggregator from '../core/geometry_aggregator'
+import GeometryConvertor from '../core/geometry_convertor'
+
+/* eslint-disable no-magic-numbers -- GLB header field offsets and glTF
+   component-type constants are clearer as the literals the spec names. */
+
+/**
+ * The GLB writer used to emit POSITION only, on every primitive. glTF says a
+ * primitive without NORMAL is to be flat-shaded, and three.js implements that
+ * literally (GLTFLoader sets `material.flatShading = true`), so every conway
+ * GLB rendered fully faceted in every glTF consumer — and denser, more correct
+ * tessellation made it look WORSE, because the facets got smaller and the
+ * shading noise got higher frequency. See
+ * https://github.com/bldrs-ai/conway/issues/667.
+ *
+ * These tests pin the two halves of that fix: NORMAL is present on every
+ * primitive, and indices narrow to unsigned short when the primitive's vertex
+ * count allows it (which pays for most of the normals' bytes).
+ */
+const FIXTURE = 'data/create-a-tube.step'
+
+/** glTF accessor componentType for unsigned short. */
+const COMPONENT_UNSIGNED_SHORT = 5123
+
+/** glTF accessor componentType for float. */
+const COMPONENT_FLOAT = 5126
+
+/** glTF accessor componentType for unsigned int. */
+const COMPONENT_UNSIGNED_INT = 5125
+
+/**
+ * Where three ships the reference Draco decoder. Used to decode the compressed
+ * output rather than trust its manifest — the manifest cannot tell you whether
+ * the encoded POSITIONs are in the same frame as the uncompressed ones, and
+ * that is exactly where a double-applied position bias hides.
+ */
+const DRACO_DIR = 'node_modules/three/examples/jsm/libs/draco/'
+
+type Manifest = {
+  meshes: {
+    primitives: {
+      attributes: Record<string, number>,
+      indices: number,
+      extensions?: {
+        KHR_draco_mesh_compression?: {
+          bufferView: number,
+          attributes: Record<string, number>,
+        },
+      },
+    }[],
+  }[],
+  accessors: {
+    componentType: number,
+    count: number,
+    type: string,
+    min?: number[],
+    max?: number[],
+  }[],
+  bufferViews: {byteOffset?: number, byteLength: number}[],
+  nodes?: {translation?: number[]}[],
+  extensionsRequired?: string[],
+}
+
+let manifest: Manifest
+
+/**
+ * The same model written with KHR_draco_mesh_compression. The compressed
+ * branch of the writer builds its own draco mesh and its own accessors, so
+ * "NORMAL is emitted" has to be pinned there separately — it shipped
+ * POSITION-only after the uncompressed branch was fixed.
+ */
+let dracoManifest: Manifest
+
+/** The compressed GLB itself, kept so its Draco buffer can be decoded. */
+let dracoGlb: Uint8Array
+
+
+/**
+ * Pull the JSON chunk out of a GLB container.
+ *
+ * @param glb The whole GLB file.
+ * @return The parsed glTF manifest.
+ */
+function parseGlbManifest(glb: Uint8Array): Manifest {
+
+  const view = new DataView(glb.buffer, glb.byteOffset, glb.byteLength)
+
+  expect(String.fromCharCode(...glb.subarray(0, 4))).toBe('glTF')
+
+  // 12-byte header, then length-prefixed chunks; the first is always JSON.
+  const jsonLength = view.getUint32(12, true)
+  const json = new TextDecoder().decode(glb.subarray(20, 20 + jsonLength))
+
+  return JSON.parse(json)
+}
+
+
+/**
+ * The BIN chunk of a GLB, which is where a Draco-compressed primitive's
+ * encoded buffer lives.
+ *
+ * @param glb The whole GLB file.
+ * @return The binary chunk.
+ */
+function glbBinaryChunk(glb: Uint8Array): Uint8Array {
+
+  const view = new DataView(glb.buffer, glb.byteOffset, glb.byteLength)
+  const jsonLength = view.getUint32(12, true)
+
+  // 12-byte header, then each chunk is an 8-byte (length, type) header.
+  return glb.subarray(20 + jsonLength + 8)
+}
+
+
+/**
+ * Decode one Draco-compressed primitive's POSITION attribute.
+ *
+ * @param glb The compressed GLB.
+ * @param manifestIn Its already-parsed manifest.
+ * @param primitiveIndex Which primitive, in mesh-flattened order.
+ * @return One [x, y, z] per decoded point.
+ */
+async function decodeDracoPositions(
+    glb: Uint8Array,
+    manifestIn: Manifest,
+    primitiveIndex: number): Promise<number[][]> {
+
+  // three's decoder is an emscripten UMD bundle living inside a package marked
+  // "type": "module", so require() reads it as ESM and hands back nothing.
+  // Evaluating it in a CommonJS-shaped wrapper is what makes it loadable here.
+  const source = fs.readFileSync(`${DRACO_DIR}draco_decoder.js`, 'utf8')
+  const shim: {exports: unknown} = {exports: {}}
+
+  // The bundle asks for a couple of node builtins at load time. This module is
+  // ESM, so there is no ambient `require` to hand it — these three are all it
+  // wants, and the wasm comes in as a binary below rather than being read from
+  // disk by the bundle itself.
+  const shimRequire = (name: string): unknown => {
+
+    switch (name) {
+      case 'fs': return fs
+      case 'path': return nodePath
+      case 'url': return nodeUrl
+      default: throw new Error(`draco decoder asked for an unexpected module: ${name}`)
+    }
+  }
+
+  // eslint-disable-next-line no-new-func -- see above; the input is a checked-in
+  // vendored file, not anything user-supplied.
+  new Function('module', 'exports', '__filename', '__dirname', 'require', source)(
+      shim, shim.exports, `${DRACO_DIR}draco_decoder.js`, DRACO_DIR, shimRequire)
+
+  const factory = shim.exports as (options: object) => void
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- emscripten module
+  const draco: any = await new Promise((resolve) => {
+    factory({
+      wasmBinary: fs.readFileSync(`${DRACO_DIR}draco_decoder.wasm`),
+      onModuleLoaded: (loaded: unknown) => resolve(loaded),
+    })
+  })
+
+  const primitive = manifestIn.meshes.flatMap((mesh) => mesh.primitives)[primitiveIndex]
+  const extension = primitive.extensions!.KHR_draco_mesh_compression!
+  const bufferView = manifestIn.bufferViews[extension.bufferView]
+  const binary = glbBinaryChunk(glb)
+  const offset = bufferView.byteOffset ?? 0
+  const encoded = binary.subarray(offset, offset + bufferView.byteLength)
+
+  const buffer = new draco.DecoderBuffer()
+
+  buffer.Init(new Int8Array(encoded), encoded.length)
+
+  const decoder = new draco.Decoder()
+  const mesh = new draco.Mesh()
+
+  expect(decoder.DecodeBufferToMesh(buffer, mesh).ok()).toBe(true)
+
+  const attribute = decoder.GetAttributeByUniqueId(mesh, extension.attributes.POSITION)
+  const values = new draco.DracoFloat32Array()
+
+  decoder.GetAttributeFloatForAllPoints(mesh, attribute, values)
+
+  const points: number[][] = []
+
+  for (let point = 0; point < mesh.num_points(); ++point) {
+    points.push([
+      values.GetValue(point * 3),
+      values.GetValue(point * 3 + 1),
+      values.GetValue(point * 3 + 2)])
+  }
+
+  return points
+}
+
+
+beforeAll(async () => {
+
+  const parser = AP214StepParser.Instance
+  const buffer = new ParsingBuffer(fs.readFileSync(FIXTURE))
+
+  expect(parser.parseHeader(buffer)[1]).toBe(ParseResult.COMPLETE)
+
+  const [, model] = parser.parseDataToModel(buffer)
+
+  expect(model).not.toBe(void 0)
+
+  const conwayGeometry = new ConwayGeometry()
+
+  expect(await conwayGeometry.initialize()).toBe(true)
+
+  const [result, scene] =
+    new AP214GeometryExtraction(conwayGeometry, model!).extractAP214GeometryData()
+
+  expect(result).toBe(ExtractResult.COMPLETE)
+
+  const aggregator = new GeometryAggregator(conwayGeometry, {maxGeometrySize: 128})
+
+  aggregator.append(scene)
+
+  const aggregated = aggregator.aggregateNative()
+
+  expect(aggregated.geometry.size()).toBeGreaterThan(0)
+
+  const convertor = new GeometryConvertor(conwayGeometry)
+
+  /**
+   * Write the aggregated geometry out as a GLB and parse its manifest.
+   *
+   * @param outputDraco Whether to take the KHR_draco_mesh_compression branch.
+   * @return The parsed glTF manifest.
+   */
+  function writeManifest(outputDraco: boolean): {manifest: Manifest, glb: Uint8Array} {
+
+    const chunks =
+      Array.from(convertor.toGltfs(
+          aggregated, true, outputDraco, 'conway-667-normals-test'))
+
+    expect(chunks.length).toBeGreaterThan(0)
+    expect(chunks[0].success).toBe(true)
+
+    const buffers = chunks[0].buffers!
+
+    expect(buffers.size()).toBeGreaterThan(0)
+
+    // The native vector is not a typed array; getUint8Array makes a zero-copy
+    // view of it, the same way the CLI does before writing the file.
+    const glb: Uint8Array =
+      (conwayGeometry as unknown as {
+        wasmModule: { getUint8Array(buffer: unknown): Uint8Array }
+      }).wasmModule.getUint8Array(buffers.get(0))
+
+    return {manifest: parseGlbManifest(glb), glb: glb.slice()}
+  }
+
+  const plain = writeManifest(false)
+  const compressed = writeManifest(true)
+
+  manifest = plain.manifest
+  dracoManifest = compressed.manifest
+  dracoGlb = compressed.glb
+})
+
+
+describe('AP214 GLB attributes', () => {
+
+  test('every primitive carries a NORMAL accessor', () => {
+
+    const primitives = manifest.meshes.flatMap((mesh) => mesh.primitives)
+
+    expect(primitives.length).toBeGreaterThan(0)
+
+    for (const primitive of primitives) {
+
+      expect(primitive.attributes.POSITION).not.toBe(void 0)
+      expect(primitive.attributes.NORMAL).not.toBe(void 0)
+
+      const position = manifest.accessors[primitive.attributes.POSITION]
+      const normal = manifest.accessors[primitive.attributes.NORMAL]
+
+      // Same count as POSITION, or the attributes do not line up per vertex.
+      expect(normal.count).toBe(position.count)
+      expect(normal.type).toBe('VEC3')
+      expect(normal.componentType).toBe(COMPONENT_FLOAT)
+    }
+  })
+
+  test('indices narrow to unsigned short when the vertex count allows', () => {
+
+    const primitives = manifest.meshes.flatMap((mesh) => mesh.primitives)
+
+    for (const primitive of primitives) {
+
+      const position = manifest.accessors[primitive.attributes.POSITION]
+      const indices = manifest.accessors[primitive.indices]
+
+      // The rule, not the fixture's own size: a primitive within the unsigned
+      // short range must use it, and one beyond it must not. The bound is
+      // 65535 vertices rather than 65536 so index 65535 is never emitted —
+      // that value is primitive-restart on some drivers.
+      expect(indices.componentType).toBe(
+          position.count <= 65535 ? COMPONENT_UNSIGNED_SHORT : COMPONENT_UNSIGNED_INT)
+    }
+  })
+})
+
+
+describe('AP214 GLB attributes, draco-compressed', () => {
+
+  test('the compressed branch is actually taken', () => {
+
+    expect(dracoManifest.extensionsRequired)
+        .toContain('KHR_draco_mesh_compression')
+
+    const primitives = dracoManifest.meshes.flatMap((mesh) => mesh.primitives)
+
+    expect(primitives.length).toBeGreaterThan(0)
+
+    for (const primitive of primitives) {
+
+      expect(primitive.extensions?.KHR_draco_mesh_compression)
+          .not.toBe(void 0)
+    }
+  })
+
+  test('every compressed primitive carries a NORMAL, in both places', () => {
+
+    const primitives = dracoManifest.meshes.flatMap((mesh) => mesh.primitives)
+
+    for (const primitive of primitives) {
+
+      // Two declarations, and a decoder needs both: the primitive attribute
+      // names the accessor that describes the decompressed data, and the
+      // extension's own attribute map says which draco attribute id supplies
+      // it. Only POSITION was declared in either before this was fixed.
+      expect(primitive.attributes.NORMAL).not.toBe(void 0)
+
+      const dracoAttributes =
+        primitive.extensions!.KHR_draco_mesh_compression!.attributes
+
+      expect(dracoAttributes.POSITION).not.toBe(void 0)
+      expect(dracoAttributes.NORMAL).not.toBe(void 0)
+      expect(dracoAttributes.NORMAL).not.toBe(dracoAttributes.POSITION)
+
+      const position = dracoManifest.accessors[primitive.attributes.POSITION]
+      const normal = dracoManifest.accessors[primitive.attributes.NORMAL]
+
+      expect(normal.count).toBe(position.count)
+      expect(normal.type).toBe('VEC3')
+      expect(normal.componentType).toBe(COMPONENT_FLOAT)
+    }
+  })
+})
+
+describe('AP214 GLB positions, compressed against uncompressed', () => {
+
+  test('the two writers place the geometry in the same frame', () => {
+
+    // Both branches share one `positions` array that is rebased by the chunk's
+    // first placed point, and the node translation adds that offset back once.
+    // The Draco encoder used to subtract it a SECOND time, which displaced the
+    // whole compressed primitive by -bias while its accessor bounds described
+    // the shifted frame — self-consistent, and wrong against every uncompressed
+    // file. Comparing declared bounds catches exactly that.
+    const plainPrimitives = manifest.meshes.flatMap((mesh) => mesh.primitives)
+    const dracoPrimitives = dracoManifest.meshes.flatMap((mesh) => mesh.primitives)
+
+    expect(dracoPrimitives.length).toBe(plainPrimitives.length)
+
+    const plainBounds = manifest.accessors[plainPrimitives[0].attributes.POSITION]
+    const dracoBounds = dracoManifest.accessors[dracoPrimitives[0].attributes.POSITION]
+
+    expect(dracoBounds.min).not.toBe(void 0)
+
+    for (let axis = 0; axis < 3; ++axis) {
+      expect(dracoBounds.min![axis]).toBeCloseTo(plainBounds.min![axis], 3)
+      expect(dracoBounds.max![axis]).toBeCloseTo(plainBounds.max![axis], 3)
+    }
+
+    // And the node offsets agree, so the bounds above are compared in the
+    // same world frame rather than two frames that happen to match.
+    const plainTranslation = manifest.nodes?.[0]?.translation ?? [0, 0, 0]
+    const dracoTranslation = dracoManifest.nodes?.[0]?.translation ?? [0, 0, 0]
+
+    for (let axis = 0; axis < 3; ++axis) {
+      expect(dracoTranslation[axis]).toBeCloseTo(plainTranslation[axis], 3)
+    }
+  })
+
+  test('the decoded positions sit exactly where the accessor says', async () => {
+
+    // The manifest test above compares two declarations. This one decodes what
+    // was actually encoded, which is the only way to catch a shift that the
+    // bounds were adjusted to match — and the double-applied bias was exactly
+    // that: encoder and bounds agreed with each other and with nothing else.
+    const points = await decodeDracoPositions(dracoGlb, dracoManifest, 0)
+
+    expect(points.length).toBeGreaterThan(0)
+
+    const primitive = dracoManifest.meshes.flatMap((mesh) => mesh.primitives)[0]
+    const bounds = dracoManifest.accessors[primitive.attributes.POSITION]
+
+    const decodedMin = [Infinity, Infinity, Infinity]
+    const decodedMax = [-Infinity, -Infinity, -Infinity]
+
+    for (const point of points) {
+      for (let axis = 0; axis < 3; ++axis) {
+        decodedMin[axis] = Math.min(decodedMin[axis], point[axis])
+        decodedMax[axis] = Math.max(decodedMax[axis], point[axis])
+      }
+    }
+
+    // Draco quantizes POSITION to 14 bits over the attribute's range, so a
+    // decoded extreme can miss the declared one by a step. Anything larger is
+    // a frame error, not rounding.
+    const span = Math.max(
+        ...[0, 1, 2].map((axis) => bounds.max![axis] - bounds.min![axis]))
+    const tolerance = (span / 16384) + 1e-6
+
+    for (let axis = 0; axis < 3; ++axis) {
+      expect(Math.abs(decodedMin[axis] - bounds.min![axis])).toBeLessThan(tolerance)
+      expect(Math.abs(decodedMax[axis] - bounds.max![axis])).toBeLessThan(tolerance)
+    }
+
+    // What makes the check above able to fail: the chunk IS rebased, so a
+    // second subtraction has something to shift by. If a future fixture is
+    // authored exactly on the origin this asserts loudly rather than passing
+    // vacuously — the bias must also be big enough to clear the tolerance.
+    const translation = dracoManifest.nodes?.[0]?.translation ?? [0, 0, 0]
+    const bias = Math.hypot(translation[0], translation[1], translation[2])
+
+    expect(bias).toBeGreaterThan(tolerance * 10)
+  }, 60000)
+})


### PR DESCRIPTION
Bumps `dependencies/conway-geom` from `8d1692a` to **`eac18067`**, pulling in bldrs-ai/conway-geom#200. Progress on bldrs-ai/conway#667; part of the epic bldrs-ai/conway#641.

**Gitlink plus the two tests that can only live on this side** — the fixtures and the jest config are here. Three files.

## What this pulls in

Two independent shading defects, one root cause each.

`Geometry::Reify()` derived a shading normal by averaging **face** normals inside a 40-degree smoothing group, comparing every candidate against the **first** triangle's normal rather than the running average — so the grouping depended on triangle order, and a single near-degenerate sliver could capture or exclude a whole fan. Along a trimmed face's boundary the triangulator leaves exactly such slivers. Measured on the fastener dome from conway#667, per triangle corner against the analytic sphere normal, the error cycled through a fixed 7-value pattern once per trim-polyline segment: 176 of 979 boundary corners more than 10° out, worst a full 90°, against 1.65° in the same face's interior. A regular, broken dark line on geometry already proved watertight.

It now takes the normal from the surface the tessellator already evaluates, recorded per triangle **corner** at emission. Corners rather than vertices because the weld merges the coincident vertices of two faces, so a per-vertex array could hold only one of the two — corners survive with their face identity, which is what makes the crease split fall out for free.

| | before | after |
|---|---|---|
| seam-row p50 / p90 / p99 / max | 2.34 / 42.11 / 79.48 / 90.00° | **0.00 / 6.86 / 8.61 / 8.61°** |
| corners &gt; 10° | 176 / 979 | **0** |
| interior max | 1.65° | **0.00°** |
| ring sd, mean \|step\| | 24.9, 16.1 | **2.8, 1.9** |

Separately, the GLB writer built its accessors from the raw welded arrays and emitted **POSITION only, on every primitive**. glTF says a primitive without NORMAL is flat-shaded and three.js implements that literally, so every conway GLB rendered fully faceted in every consumer — and denser, *more correct* tessellation read as **worse**, because the facets got smaller and the shading noise got higher frequency. Both writers now emit the reified stream, Draco included.

| | before | after |
|---|---|---|
| GLB | 11.05 MB | **15.35 MB (+38.9%)** |
| GLB, Draco | 0.91 MB | **1.39 MB (+52.8%)** |
| primitives with NORMAL (plain / Draco) | 0/13, 0/13 | **13/13, 13/13** |
| index type | u32 ×13 | **u16 ×12, u32 ×1** |

## The no-ABI-break claim, verified

`git diff --stat 8d1692a eac18067` is eleven files, and **none of them is a binding**:

```
 conway_geometry/ConwayGeometryProcessor.cpp    | 403 ++++++++++---------
 conway_geometry/operations/gltf_stream.h       | 148 ++++++++
 conway_geometry/operations/mesh_utils.h        |  58 ++-
 conway_geometry/operations/nurbs_utils.h       |  31 ++
 conway_geometry/operations/tesselation_utils.h | 236 +++++++++++-
 conway_geometry/representation/Geometry.cpp    | 285 +++++++++++++--
 conway_geometry/representation/Geometry.h      | 287 ++++++++++++++-
 conway_geometry/structures/vertex_welder.h     |  44 ++-
 test/corner_normals_test.cpp                   | 478 +++++++++++++++++++++++++
 test/gltf_stream_test.cpp                      | 323 +++++++++++++++++
 test/run_native_tests.sh                       |   3 +-
```

No `conway-api.cpp`, no `interface/conway_geometry.ts`. `Geometry` gains members (`corner_normals`, `GetVertexStream`/`GetIndexStream`, `TruncateTriangles`) but every one is additive and none is bound, so there is no wrapper arity to pair and no atomicity constraint beyond this bump.

**The interleaved wasm vertex stream is unchanged**: `[px, py, pz, nx, ny, nz]`, stride 6. Share's conway-direct loader reads the same buffer with the same stride, so this puts better values in the same slots and needs no viewer change.

## Blast radius — measured against the committed baselines, at this exact SHA

The regression digest hashes `SHA1(geometry.dumpToOBJ())`, and `GeometryToObj` writes `vn` lines straight out of the Reify stream. **So the digests hash normals, and this moves them.** Stating that plainly rather than as a surprise: it is bless-scale, and it belongs before an rc-* re-bless rather than after.

Rebuilt at `eac18067` and digested with `ap214_regression_main.js -d`, against `test-models/regression/test_models/`:

| model | digest lines | changed | % | added / removed |
|---|---|---|---|---|
| `create-a-tube.step` | 1 | 1 | 100% | **0 / 0** |
| `supercap.step` | 6 | 2 | 33.3% | **0 / 0** |
| `driver board.step` | 1777 | 194 | 10.9% | **0 / 0** |
| `Right_Hand.step` | 39 | 29 | 74.4% | **0 / 0** |
| | **1823** | **226 (12.4%)** | | **0 / 0** |

**Every movement is hash-only.** On every moved row the ID, type, operand and void columns are identical and the row counts are unchanged, so no geometry moved and no entity appeared or vanished — the same rows carry different content hashes. `driver board`'s 10.9% is of *all* digest lines; curve lines are untouched, so mesh-only it is 194/279 = 69.5%.

A correction to conway-geom#200's own table, which said "all 7 STEP digests in the smoke set move": `regression/smoke_models.txt` carries **six** STEP entries, not seven, and two of them are not measurable here (below). The four measured above all move; the count of seven was wrong.

**Same environment caveat as #666 and #668:** `nist_ctc_01_asme1_rd.stp` and `nist_ctc_02_asme1_rc.stp` — the two AP203 smoke entries — are unfetched **Git LFS stubs** in this container (131 bytes) and `git lfs` is not installed, so they parse as invalid STEP and digest empty. Environment artifact, not a regression; CI measures them. `nist_ctc_01_asme1_ap242-e1.stp`, a real 396 KB file here and the variant conway-geom#200's table names, was measured instead: **118 lines, 61 changed (51.7%), 0 added / 0 removed** — hash-only like the rest.

Also verified: the digests are **byte-identical** to the same measurement taken before conway-geom main moved to `8d1692a`, so #198's allocation-telemetry work (the only thing between `e18a4dae` and the merge base) is geometry-neutral, as its diff suggests — it touches `alloc_telemetry.{h,cpp}` and its own test and nothing else.

### IFC — a structural prediction, not a measurement

**No IFC digest is measured in this PR.** Structurally, only `IfcAdvancedBrep` faces reach the analytic triangulators; extruded-area-solid, swept, polygonal-face-set and boolean-result geometry all take the no-surface `appendMeshToGeometry` overload, and architectural IFC is overwhelmingly the latter. **So the prediction is that the six IFC smoke models do not move at all**, or move only on stray advanced-BRep content.

That is a prediction, written down here so it can be scored rather than quietly dropped.

**On the ordering, stated plainly because it cannot be otherwise:** `run-ifc-regression` is gated on `draft == false` (build.yml, and deliberately so — it is the longest job and draft pushes would saturate the concurrency cap). So the smoke comment that carries the IFC measurement **does not exist while this is a draft; the ready-flip is what starts it.** Reconciling prediction against measurement therefore happens in this section **after the flip and before merge**, not before the flip. If IFC moves more than predicted, that is a stop-and-report, not a bless.

## Verification on this commit

- `yarn build-codex-MT` — clean
- `yarn test` — **132 suites, 934 tests, all passing**
- `yarn eslint src` — **0 errors** (726 pre-existing warnings, unchanged)
- `yarn check-compiled-fresh` — clean
- conway-geom native suite at the bumped SHA — all six self-contained suites pass, including #198's `alloc_telemetry_test` and this change's two new ones
- seam decision gate re-measured on the merge commit: **unchanged to the digit**
- husky pre-commit gate passed on the commit

## The tests this PR adds

`ap214_analytic_normals` — a cylindrical face's shading normal is exactly radial, to within 1e-3 rad. That tolerance is four orders of magnitude tighter than an averaged face normal reaches on the fixture, which is what makes it a test about analytic normals rather than about tessellation being fine. **Red-proven at 2.34e-3 rad with the analytic path disabled.**

`ap214_gltf_normals` — six cases over the writer: NORMAL on every primitive with a count matching POSITION; indices narrowed to u16 where the vertex count allows; the Draco branch actually taken; NORMAL declared in **both** places on that branch (the primitive attribute and `KHR_draco_mesh_compression`'s own attribute map — a decoder needs both); the two writers agreeing on the frame; and the decoded positions landing on the declared accessor bounds within one quantization step, checked by decoding the Draco buffer with three's reference decoder. That last one is red at **0.025 against a 7.1e-6 tolerance** on a build where the encoder double-applies the position bias, and it asserts the chunk's bias exceeds its own tolerance so a fixture authored on the origin fails loudly instead of passing vacuously.

## Review history carried by this bump

conway-geom#200 ran **three codex rounds**, the third clean. Round 1 found four defects (Draco emitting no normals; the per-face rollback leaving corner normals stale; smoothing groups mixing unit analytic with area-weighted face normals, measurably scale-dependent at 11.5° between scale 1 and scale 10; `ReverseFace` not negating). Round 2 found four more, all in the writer the round-1 fix had relocated — including a double-applied position bias that round 1 introduced — and the response was to extract the per-component half into `operations/gltf_stream.h` behind typed vectors, which gave that code its first native coverage and made the 32-bit-address class of bug unrepresentable in it. Every fix in both rounds ships with a pinning test verified red by reverting that fix alone.

Branch note: `claude/issue-641-fix-5xzvrk`'s previous PR (#668) merged, so the branch was restarted from `origin/main` and force-pushed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEbApNYfjEPWeGAYjXVhcT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEbApNYfjEPWeGAYjXVhcT)_