### PR TITLE
STEP: per-body selection identity for no-NAUO multibody models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,7 @@ Check `scripts/` before building tooling — see
 | CI tiering, cost rationale, rc/re-bless/LFS runbook | [design/new/ci-regression-cost.md](design/new/ci-regression-cost.md) |
 | STEP support: schemas, coverage, known gaps | [design/new/step-support.md](design/new/step-support.md) |
 | STEP product structure and metadata (the AP242 wrinkle, NIST) | [design/new/step-metadata-nist.md](design/new/step-metadata-nist.md) |
+| Why a STEP click selects the wrong thing (or everything): what an occurrence path is made of, the one decision the tree and the scene must agree on, and the inverted-relationship shape that re-places a whole model once per free representation | [design/new/step-nonproduct-semantics.md](design/new/step-nonproduct-semantics.md) |
 | Native GLB export from the CLI | [design/new/glb-native-export.md](design/new/glb-native-export.md) |
 | What the perf bench measures and why: peak vs retention, the three distinct native quantities, why `heapUsed + external` is not a stand-in for RSS, GC settling, the two-pass gc A/B the rc job runs and why a between-run comparison is invalid, and the rule for changing recorded fields | [design/new/perf-measurement.md](design/new/perf-measurement.md) |
 | Memory residency, streaming and federated loading | [design/new/memory-residency.md](design/new/memory-residency.md), [design/new/streaming-federated-loader.md](design/new/streaming-federated-loader.md) |

--- a/data/ap214-inverted-srr-multibody.step
+++ b/data/ap214-inverted-srr-multibody.step
@@ -1,0 +1,58 @@
+ISO-10303-21;
+HEADER;
+/* Reduction of the BLSN_007 hull export (Rhino 7 / ST-DEVELOPER, 281 MB,
+ * test-models-private#98): ONE product with no NEXT_ASSEMBLY_USAGE_OCCURRENCE
+ * and no CONTEXT_DEPENDENT_SHAPE_REPRESENTATION anywhere, all of its bodies
+ * named individually inside one child representation, and the relationships
+ * binding that child written in BOTH argument orders.
+ *
+ * #500 is the (product rep, detail rep) order every other fixture here uses.
+ * #701/#702/#703 are the same kind of relation written the other way round --
+ * the shape that made the whole model 308 walk roots and placed every body
+ * once per root, all of them sharing two occurrence paths. Three inverted
+ * edges is enough: it takes only one to make the SDR-bound representation a
+ * child, and the third proves the multiplier is the count of them. */
+FILE_DESCRIPTION ('AP214 inverted-SRR multibody / occurrence-identity test fixture','2;1');
+FILE_NAME('ap214-inverted-srr-multibody','2026-01-01T00:00:00',('test'),('bldrs'),'','','');
+FILE_SCHEMA(('AUTOMOTIVE_DESIGN { 1 0 10303 214 1 1 1 1 }'));
+ENDSEC;
+DATA;
+#1 = APPLICATION_PROTOCOL_DEFINITION('international standard','automotive_design',2010,#2);
+#2 = APPLICATION_CONTEXT('mechanical design');
+#10 = CARTESIAN_POINT('',(0.,0.,0.));
+#11 = CARTESIAN_POINT('',(1.,0.,0.));
+#20 = DIRECTION('',(0.,0.,1.));
+#21 = DIRECTION('',(1.,0.,0.));
+#30 = AXIS2_PLACEMENT_3D('',#10,#20,#21);
+#100 = ( GEOMETRIC_REPRESENTATION_CONTEXT(3) GLOBAL_UNCERTAINTY_ASSIGNED_CONTEXT((#104)) GLOBAL_UNIT_ASSIGNED_CONTEXT((#101,#102,#103)) REPRESENTATION_CONTEXT('Context','3D') );
+#101 = ( LENGTH_UNIT() NAMED_UNIT(*) SI_UNIT(.MILLI.,.METRE.) );
+#102 = ( NAMED_UNIT(*) PLANE_ANGLE_UNIT() SI_UNIT($,.RADIAN.) );
+#103 = ( NAMED_UNIT(*) SI_UNIT($,.STERADIAN.) SOLID_ANGLE_UNIT() );
+#104 = UNCERTAINTY_MEASURE_WITH_UNIT(LENGTH_MEASURE(1.E-07),#101,'','');
+#201 = PRODUCT_CONTEXT('',#2,'mechanical');
+#202 = PRODUCT_DEFINITION_CONTEXT('part definition',#2,'design');
+#210 = PRODUCT('Document','Document','',(#201));
+#211 = PRODUCT_DEFINITION_FORMATION('','',#210);
+#212 = PRODUCT_DEFINITION('design','',#211,#202);
+#300 = SHAPE_REPRESENTATION('Document',(#30),#100);
+#301 = PRODUCT_DEFINITION_SHAPE('','',#212);
+#302 = SHAPE_DEFINITION_REPRESENTATION(#301,#300);
+#400 = ADVANCED_BREP_SHAPE_REPRESENTATION('brep_rep_0',(#401,#402,#403),#100);
+#401 = MANIFOLD_SOLID_BREP('brep_0',#411);
+#402 = MANIFOLD_SOLID_BREP('brep_1',#412);
+#403 = MANIFOLD_SOLID_BREP('Hauptkoerper',#413);
+#411 = CLOSED_SHELL('',());
+#412 = CLOSED_SHELL('',());
+#413 = CLOSED_SHELL('',());
+#500 = SHAPE_REPRESENTATION_RELATIONSHIP('','',#300,#400);
+#601 = GEOMETRICALLY_BOUNDED_WIREFRAME_SHAPE_REPRESENTATION('wireframe_rep_0',(#611),#100);
+#602 = GEOMETRICALLY_BOUNDED_WIREFRAME_SHAPE_REPRESENTATION('wireframe_rep_1',(#612),#100);
+#603 = GEOMETRICALLY_BOUNDED_WIREFRAME_SHAPE_REPRESENTATION('wireframe_rep_2',(#613),#100);
+#611 = GEOMETRIC_CURVE_SET('curves_0',(#11));
+#612 = GEOMETRIC_CURVE_SET('curves_1',(#11));
+#613 = GEOMETRIC_CURVE_SET('curves_2',(#11));
+#701 = SHAPE_REPRESENTATION_RELATIONSHIP('','',#601,#300);
+#702 = SHAPE_REPRESENTATION_RELATIONSHIP('','',#602,#300);
+#703 = SHAPE_REPRESENTATION_RELATIONSHIP('','',#603,#300);
+ENDSEC;
+END-ISO-10303-21;

--- a/data/ap214-recoverable-scan-records.step
+++ b/data/ap214-recoverable-scan-records.step
@@ -1,0 +1,60 @@
+ISO-10303-21;
+HEADER;
+/* Records that make a reference getter THROW, in the three shapes the
+ * solid-identity scan actually meets. The scan runs on every load (both the
+ * product-structure tree and the geometry walk read it), so a throw it does
+ * not contain fails the whole model instead of skipping one record --
+ * conway#683 review. The geometry walk has always contained these per record;
+ * this fixture holds the scan to the same bar.
+ *
+ *   #502  a dangling relationship reference (#900 is not in the file). This is
+ *         the NORMAL state of a mid-parse prefix model, which the streamed
+ *         preview channel hands to prepareDemandExtraction.
+ *   #452  an item type the AP214 schema has no id for -- the enum carries no
+ *         tessellated entities at all, so reading #450's items throws, the
+ *         case makeThunk documents for #25231 of
+ *         nist_ftc_08_asme1_ap242-e1-tg.stp.
+ *   #403  a mandatory name slot holding `$`, so the name getter throws while
+ *         the body itself is perfectly good.
+ *
+ * The healthy bodies of #400 must still come through addressable. */
+FILE_DESCRIPTION ('AP214 recoverable scan records / conway#683 containment fixture','2;1');
+FILE_NAME('ap214-recoverable-scan-records','2026-01-01T00:00:00',('test'),('bldrs'),'','','');
+FILE_SCHEMA(('AUTOMOTIVE_DESIGN { 1 0 10303 214 1 1 1 1 }'));
+ENDSEC;
+DATA;
+#1 = APPLICATION_PROTOCOL_DEFINITION('international standard','automotive_design',2010,#2);
+#2 = APPLICATION_CONTEXT('mechanical design');
+#10 = CARTESIAN_POINT('',(0.,0.,0.));
+#20 = DIRECTION('',(0.,0.,1.));
+#21 = DIRECTION('',(1.,0.,0.));
+#30 = AXIS2_PLACEMENT_3D('',#10,#20,#21);
+#100 = ( GEOMETRIC_REPRESENTATION_CONTEXT(3) GLOBAL_UNCERTAINTY_ASSIGNED_CONTEXT((#104)) GLOBAL_UNIT_ASSIGNED_CONTEXT((#101,#102,#103)) REPRESENTATION_CONTEXT('Context','3D') );
+#101 = ( LENGTH_UNIT() NAMED_UNIT(*) SI_UNIT(.MILLI.,.METRE.) );
+#102 = ( NAMED_UNIT(*) PLANE_ANGLE_UNIT() SI_UNIT($,.RADIAN.) );
+#103 = ( NAMED_UNIT(*) SI_UNIT($,.STERADIAN.) SOLID_ANGLE_UNIT() );
+#104 = UNCERTAINTY_MEASURE_WITH_UNIT(LENGTH_MEASURE(1.E-07),#101,'','');
+#201 = PRODUCT_CONTEXT('',#2,'mechanical');
+#202 = PRODUCT_DEFINITION_CONTEXT('part definition',#2,'design');
+#210 = PRODUCT('Document','Document','',(#201));
+#211 = PRODUCT_DEFINITION_FORMATION('','',#210);
+#212 = PRODUCT_DEFINITION('design','',#211,#202);
+#300 = SHAPE_REPRESENTATION('Document',(#30),#100);
+#301 = PRODUCT_DEFINITION_SHAPE('','',#212);
+#302 = SHAPE_DEFINITION_REPRESENTATION(#301,#300);
+#400 = ADVANCED_BREP_SHAPE_REPRESENTATION('brep_rep_0',(#401,#402,#403),#100);
+#401 = MANIFOLD_SOLID_BREP('brep_0',#411);
+#402 = MANIFOLD_SOLID_BREP('brep_1',#412);
+#403 = MANIFOLD_SOLID_BREP($,#413);
+#411 = CLOSED_SHELL('',());
+#412 = CLOSED_SHELL('',());
+#413 = CLOSED_SHELL('',());
+#450 = ADVANCED_BREP_SHAPE_REPRESENTATION('tess_rep',(#451,#452),#100);
+#451 = MANIFOLD_SOLID_BREP('tess_body_0',#461);
+#452 = TESSELLATED_SHELL('tess',(),$);
+#461 = CLOSED_SHELL('',());
+#500 = SHAPE_REPRESENTATION_RELATIONSHIP('','',#300,#400);
+#501 = SHAPE_REPRESENTATION_RELATIONSHIP('','',#300,#450);
+#502 = SHAPE_REPRESENTATION_RELATIONSHIP('','',#900,#300);
+ENDSEC;
+END-ISO-10303-21;

--- a/design/new/step-metadata-nist.md
+++ b/design/new/step-metadata-nist.md
@@ -391,6 +391,26 @@ occurrence id must be threaded into the scene's instance map so a
 viewport pick returns the *same* id the tree node carries (bidirectional
 selection).
 
+**Below the product, the path continues with the body** (conway#628). A
+multibody part's bodies share every NAUO segment, so a NAUO-only path
+cannot tell them apart — and there are files with nothing *but* that
+distinction: BLSN_007, a 281 MB Rhino hull export, is one product, zero
+NAUOs and 2,268 individually named `MANIFOLD_SOLID_BREP`s. So an
+individually addressable body appends **its own express id** as the path's
+last segment, on the tree node and on the geometry instance alike. Which
+bodies are addressable is one decision, taken by
+`AP214ProductStructureExtraction.identityBearingSolidExpressIDs` and read by
+both sides — see `design/new/step-nonproduct-semantics.md`.
+
+**What is never a segment: a representation relationship.** A plain
+`shape_representation_relationship` binds a part to its own detail
+representation (the SolidWorks multibody idiom); it is indirection inside
+one part, not an occurrence of anything, and the tree has no node for it.
+Its express id used to appear mid-path, which made every such path
+unresolvable — `[14107, 6611]` on the NEMA motor named a NAUO and then a
+relationship, and matched no node. Paths are NAUOs, optionally ending in a
+body.
+
 **Share generalization flag.** Share's permalink is already a *path*
 (`/1/42/123` = parent chain), but its internal selection key is a scalar
 `expressID`. A scalar cannot distinguish instances; an occurrence **path**

--- a/design/new/step-nonproduct-semantics.md
+++ b/design/new/step-nonproduct-semantics.md
@@ -244,6 +244,15 @@ emits a node for some of a product's bodies and not others makes the
 suppressed bodies' paths unresolvable. `ap214_product_structure_extraction.test.ts`
 pins the two sides against each other directly.
 
+Being read on every load, that scan is also held to the geometry walk's
+containment bar: a record whose getters throw — a dangling reference (the
+normal state of a mid-parse prefix model), or a representation holding an
+item type the AP214 enum has no id for, which is *every* tessellated entity
+— skips, rather than failing the model. `items` is read all-or-nothing per
+representation, so a representation that cannot be enumerated contributes
+to neither side and its bodies simply stay part of the product's selection.
+`data/ap214-recoverable-scan-records.step` carries all three shapes.
+
 **3. An SDR-bound representation is never the child of a plain relationship
 edge.** BLSN_007 writes the same kind of relation both ways round — three
 edges as `(product rep, detail rep)` and 308 as `(detail rep, product rep)`.

--- a/design/new/step-nonproduct-semantics.md
+++ b/design/new/step-nonproduct-semantics.md
@@ -144,9 +144,9 @@ anonymous solid dumps do not.**
 > **one product, zero NAUOs, zero CDSRs and 2,268 individually named
 > bodies** — the multibody pattern as the *entire* model rather than a
 > detail of one part in an assembly. With the layer opt-in, Share got a
-> one-node tree; with a shared path per body, all 1,884 hull solids were one
-> selection; with a 256 cap, seven eighths of them would have had no node
-> even so, while Autodesk's viewer lists every one. See
+> one-node tree; with the path carrying no per-body segment, all 2,268 hull
+> bodies collapsed onto two selections; with a 256 cap, seven eighths of them
+> would have had no node even so, while Autodesk's viewer lists every one. See
 > §"conway#628: identity below the product" below for the resulting rules.
 
 `AP214ProductStructureExtraction.extractProductStructure` and the compat
@@ -258,6 +258,18 @@ geometry, and a duplicated placement is the lesser failure. After the fix:
 2,268 scene nodes, 2,268 distinct paths, 2,268 tree leaves, paths equal.
 `data/ap214-inverted-srr-multibody.step` is that shape reduced to three
 bodies and three inverted edges.
+
+The reorientation is **single-hop**: it asks whether each side of the edge
+is *directly* SDR-bound, not whether it can reach a PDS transitively the
+way `resolvePdsLocalID` (the conway#597 machinery) does. An inverted chain
+two or more edges long is therefore left as written. That is a decision,
+not an oversight — no file in the corpus has that shape (BLSN_007's 308
+edges are all one hop off the product representation), and past one hop
+both sides usually reach *some* PDS, so the question stops being "which
+side is SDR-bound" and becomes a distance comparison carrying the same
+equidistant ambiguity `resolvePdsLocalID` deliberately refuses to guess at.
+If a real file ever needs it, that function is what to build on, and it
+needs a fixture before it needs code.
 
 None of this changes tessellation: the regression digest is one row per
 canonical mesh, so BLSN_007's 2,268-row baseline is byte-identical across

--- a/design/new/step-nonproduct-semantics.md
+++ b/design/new/step-nonproduct-semantics.md
@@ -23,10 +23,12 @@ common enough to justify surfacing ephemeral pickable nodes in the tree?
    different shapes: MCAD multibody parts whose solids carry meaningful *names*
    (the NEMA case), and large *anonymous* solid dumps (ECAD merged-component
    products, tessellated surface soup) that carry no navigable semantics.
-   **Implemented: an opt-in layer of ephemeral solid-level nodes beneath each
-   multibody product** — named solids surface with their file names, small
-   unnamed sets get positional labels, oversized all-unnamed sets are
-   suppressed (with the count reported), and per-face styling stays pick-only.
+   **Implemented: a layer of ephemeral solid-level nodes beneath each
+   multibody product** (on by default since conway#628) — named solids
+   surface with their file names, small unnamed sets get positional labels,
+   oversized all-unnamed sets are suppressed (with the count reported), and
+   per-face styling stays pick-only. Each such node, and the geometry under
+   it, is keyed by an occurrence path ending in the solid's own express id.
 
 ## Q1 — the NEMA file: genuine non-product geometry
 
@@ -135,10 +137,23 @@ anonymous solid dumps do not.**
 
 ## Implemented: the ephemeral solid layer
 
+> **Updated by conway#628 (test-models-private#98).** The layer is now
+> **on by default**, its per-product hard cap is gone, and a solid node's
+> occurrence path ends with the solid's own express id. What forced all
+> three: `BLSN_007.stp`, a 281 MB Rhino 7 / ST-DEVELOPER hull export that is
+> **one product, zero NAUOs, zero CDSRs and 2,268 individually named
+> bodies** — the multibody pattern as the *entire* model rather than a
+> detail of one part in an assembly. With the layer opt-in, Share got a
+> one-node tree; with a shared path per body, all 1,884 hull solids were one
+> selection; with a 256 cap, seven eighths of them would have had no node
+> even so, while Autodesk's viewer lists every one. See
+> §"conway#628: identity below the product" below for the resulting rules.
+
 `AP214ProductStructureExtraction.extractProductStructure` and the compat
-surface's `getSpatialStructure` now take an opt-in
-(`ProductStructureOptions.includeSolids` /
-`SpatialStructureOptions.includeSolids`, default **off**):
+surface's `getSpatialStructure` take a
+`ProductStructureOptions.includeSolids` /
+`SpatialStructureOptions.includeSolids` option (default **true**; pass
+`false` for a products-only outline):
 
 - **What becomes a node**: each solid representation item
   (`manifold_solid_brep` — covering `brep_with_voids` / `faceted_brep` —
@@ -152,23 +167,33 @@ surface's `getSpatialStructure` now take an opt-in
   owning product/occurrence node, so Share can render them lighter-weight
   (selectable-but-not-product). Name from the solid's own name when meaningful
   (`Boss-Extrude7`), else a positional fallback (`Solid 3 of 10`).
-- **Identity**: `(occurrencePath, solid expressID)` — the path (NAUO-only,
-  inherited from the parent occurrence) disambiguates instances of a multibody
-  part used twice; the solid's express id is stable in-file, satisfying the
-  permalink requirement from the occurrence-identity work.
+- **Identity**: the `occurrencePath` alone — the parent occurrence's NAUO
+  chain (which disambiguates instances of a multibody part used twice) plus
+  the solid's own express id as a final segment (which disambiguates the
+  bodies of one instance). The express id is stable in-file, satisfying the
+  permalink requirement from the occurrence-identity work. This was the
+  `(occurrencePath, expressID)` *pair* until conway#628; a pair is not what
+  the scene stamps on a mesh, so a pick could not be resolved by path
+  comparison alone.
 - **Pick ⇄ tree round-trip is nearly free**: the geometry pipeline already
   emits one canonical mesh keyed by the solid's own localID, so an ephemeral
   node maps 1:1 onto an existing pickable scene mesh.
-- **Heuristics** (the survey's two shapes, encoded):
+- **Heuristics** (the survey's two shapes, encoded), all-or-nothing per
+  product:
   - a product with fewer than 2 solids gets no children — the product node
     already maps 1:1 onto its body (as1, jet engine, … are unchanged);
   - an *all-unnamed* set larger than `maxUnnamedSolidsPerProduct`
     (default 32) is suppressed entirely — anonymous dumps carry no navigable
-    semantics (Arty's mega-products, DSA2's shells);
-  - a hard cap `maxSolidsPerProduct` (default 256) bounds any single node's
-    children;
-  - both suppressions report the count via the node's `droppedSolids`, so a
-    consumer can render an "N more…" affordance instead of silently truncating.
+    semantics (Arty's mega-products, DSA2's shells) — and reports the count
+    via the node's `droppedSolids`, so a consumer can render an "N more…"
+    affordance instead of silently truncating;
+  - a *named* set is emitted in full however large it is. The 256-solid
+    `maxSolidsPerProduct` cap that used to bound it is gone: partial
+    emission is not a smaller tree but a broken one, because the geometry
+    walk stamps a per-body path for the same set the tree emits, so the
+    capped-off bodies keep paths that resolve to no node. Either every body
+    of a product is addressable or the product node is what a pick on any of
+    them resolves to.
 - **Not nodes**: per-face styling (254 styled faces on NEMA, 28,674 on DSA2)
   stays hover/pick-only. Named `shape_aspect`s (MBD datums, e.g. `MBD_A` in
   the NIST PMI files) are a worthwhile *future* second ephemeral kind, behind
@@ -181,12 +206,62 @@ Verified against the survey corpus with `includeSolids: true`:
 | NEMA 23 | 6 (unchanged) | 10 named bodies under the motor occurrence | 0 |
 | Arty Z7 | 124 (unchanged) | 13 (small multibody components) | 1,189 across the 2 mega-products |
 | DSA2 | 1 (unchanged) | 0 | 28,674 on the single root |
+| BLSN_007 | 1 (unchanged) | 2,268 named hull bodies (1,884 breps + 384 shells) | 0 |
 
 Hermetic coverage lives in `data/ap214-multibody-part.step` +
 `ap214_product_structure_extraction.test.ts` (named multibody, per-occurrence
 duplication, single-solid gate, transformation-relationship exclusion,
-unnamed-soup suppression, cap overflow) and `ap214_properties.test.ts`
-(compat-surface opt-in and identity-row resolution).
+unnamed-soup suppression, all-or-nothing emission, tree/geometry identity-set
+agreement) and `ap214_properties.test.ts` (compat-surface default + opt-out,
+identity-row resolution, and the arbitrary-entity fallback for a body with no
+node of its own).
+
+
+## conway#628: identity below the product
+
+BLSN_007 broke the layer's two standing assumptions at once — that the
+product tree is the interesting part of a STEP file, and that a body's
+identity is a *pair* the consumer assembles rather than something conway
+emits. Three rules came out of it. They are stated in terms of what a
+consumer can rely on, because that is what makes them testable.
+
+**1. The occurrence path is the whole selection key.** Every geometry
+instance the scene emits carries one, and it equals the path of the tree
+node that instance belongs to. The path is NAUO ids, ending in the body's
+own express id when the body is individually addressable. Nothing else is
+ever a segment — in particular a plain `shape_representation_relationship`
+is not, because it binds a part to its own detail representation and the
+tree has no node for it. (It used to be one: NEMA motor bodies carried
+`[14107, 6611]`, a NAUO followed by a relationship, which resolved to no
+node and was the *same* path for all ten bodies.)
+
+**2. One decision, read by both sides.**
+`identityBearingSolidExpressIDs()` names the bodies that get their own
+segment; `extractProductStructure` emits a node for exactly that set, and
+`AP214GeometryExtraction.prepareDemandExtraction` consults it in its item
+loop. This is why the heuristics above are all-or-nothing: any rule that
+emits a node for some of a product's bodies and not others makes the
+suppressed bodies' paths unresolvable. `ap214_product_structure_extraction.test.ts`
+pins the two sides against each other directly.
+
+**3. An SDR-bound representation is never the child of a plain relationship
+edge.** BLSN_007 writes the same kind of relation both ways round — three
+edges as `(product rep, detail rep)` and 308 as `(detail rep, product rep)`.
+Read literally, those 308 make the product's own representation a child of
+308 free wireframe representations, so it becomes 308 walk roots and the
+whole model is re-walked and re-placed once per root: **698,544 scene nodes
+for 2,268 bodies, sharing 616 paths**. The geometry walk therefore orients
+such an edge by SDR-boundness (the SDR-bound side is the shape *of* a part,
+so it is the parent) — but only when the relationship carries no
+transformation, since reversing a placement without evidence would move
+geometry, and a duplicated placement is the lesser failure. After the fix:
+2,268 scene nodes, 2,268 distinct paths, 2,268 tree leaves, paths equal.
+`data/ap214-inverted-srr-multibody.step` is that shape reduced to three
+bodies and three inverted edges.
+
+None of this changes tessellation: the regression digest is one row per
+canonical mesh, so BLSN_007's 2,268-row baseline is byte-identical across
+the change (verified), as are as1, NEMA and the multibody fixture.
 
 ## Reproducing the survey
 

--- a/scripts/debug/README.md
+++ b/scripts/debug/README.md
@@ -12,6 +12,7 @@ zero, twice attached to the wrong seam, and never survived the session.
 | Tool | Answers |
 |---|---|
 | [`model_report.mjs`](model_report.mjs) | Which entities produced bad geometry, and at which stage of the pipeline |
+| [`occurrence_report.mjs`](occurrence_report.mjs) | Whether a click selects one thing — how many placements each body got, whether their occurrence paths are unique, and whether those paths are the product-structure tree's |
 | [`../render_glb.cjs`](../render_glb.cjs) | What does the output actually look like (zero-dependency software rasterizer, deterministic, pair mode for before/after) |
 | [`../visual_diff_report.cjs`](../visual_diff_report.cjs) | Which regression models changed appearance in this PR |
 | The STEP / IFC CLI mains | Query entities by express ID, and export GLB/GLTF/OBJ to feed the renderer |
@@ -32,7 +33,18 @@ Then:
 node scripts/debug/model_report.mjs Right_Hand.step
 node scripts/debug/model_report.mjs haus.ifc --stage mesh --top 40
 node scripts/debug/model_report.mjs part.step --limit 0.25 --json | jq .
+
+node scripts/debug/occurrence_report.mjs BLSN_007.stp        # STEP selection identity
 ```
+
+`occurrence_report.mjs` answers the *other* "looks wrong": the render is
+right and the selection is not — a click highlights the whole model, or a
+NavTree node highlights nothing. Both halves of that come from conway (the
+scene's per-instance occurrence path, and `getSpatialStructure`'s node
+paths) and neither is checkable alone, which is how BLSN_007 shipped with
+2,268 bodies placed 308 times each under 616 shared paths while its tree
+showed one product and its meshes looked fine
+(test-models-private#98 / conway#628).
 
 To see it, export a GLB and rasterize it. The CLI mains take the model
 directly; `yarn cli` / `yarn step` are the same entry points bundled, and

--- a/scripts/debug/occurrence_report.mjs
+++ b/scripts/debug/occurrence_report.mjs
@@ -9,8 +9,8 @@
  *  2. that path is the path of a node in the product-structure tree.
  *
  * Both halves are emitted by conway and neither is checkable from one of them
- * alone, which is how BLSN_007 shipped with 1,884 hull bodies placed 308 times
- * each under two shared paths (conway#628 / test-models-private#98): the tree
+ * alone, which is how BLSN_007 shipped with 2,268 hull bodies placed 308 times
+ * each under 616 shared paths (conway#628 / test-models-private#98): the tree
  * looked fine (one product), the scene looked fine (real meshes), and only
  * comparing them showed 698,544 placements for 2,268 bodies.
  *

--- a/scripts/debug/occurrence_report.mjs
+++ b/scripts/debug/occurrence_report.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * Occurrence-identity report for a STEP (AP214/AP242) model.
+ *
+ * Answers "does a click select one thing?" — the pair of properties Share's
+ * per-occurrence selection rests on:
+ *
+ *  1. every geometry instance in the scene carries an occurrence path, and
+ *  2. that path is the path of a node in the product-structure tree.
+ *
+ * Both halves are emitted by conway and neither is checkable from one of them
+ * alone, which is how BLSN_007 shipped with 1,884 hull bodies placed 308 times
+ * each under two shared paths (conway#628 / test-models-private#98): the tree
+ * looked fine (one product), the scene looked fine (real meshes), and only
+ * comparing them showed 698,544 placements for 2,268 bodies.
+ *
+ * Usage:
+ *
+ *   node scripts/debug/occurrence_report.mjs model.stp [--paths N] [--json]
+ *
+ * Needs a built tree (`yarn build-incremental`), and the geometry wasm — it
+ * runs the real extraction, so a large model wants
+ * `node --max-old-space-size=8000`.
+ *
+ * Reads, in order:
+ *
+ *   geometry nodes      total scene geometry nodes (a solid plus, when the
+ *                       exporter styles faces individually, that solid's face
+ *                       children — those legitimately share their solid's path)
+ *   distinct paths      how many selections those nodes resolve to; far below
+ *                       the body count means bodies are sharing a selection
+ *   duplicate paths     the worst offenders, with their multiplicity
+ *   tree leaves         leaf nodes of getSpatialStructure
+ *   path equality       leaf paths vs body paths as multisets — the invariant
+ *                       ap214_occurrence_geometry.test.ts pins on as1
+ */
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const HERE = path.dirname( fileURLToPath( import.meta.url ) )
+const COMPILED = path.resolve( HERE, '../../compiled' )
+
+const DEFAULT_PATHS_SHOWN = 10
+
+/**
+ * Parse argv into a small options record.
+ *
+ * @param {string[]} argv Raw arguments after the script name.
+ * @return {{model: string, top: number, json: boolean}} Parsed options.
+ */
+function parseArgs( argv ) {
+
+  const options = { model: void 0, top: DEFAULT_PATHS_SHOWN, json: false }
+
+  for ( let index = 0; index < argv.length; ++index ) {
+
+    const argument = argv[ index ]
+
+    if ( argument === '--json' ) {
+      options.json = true
+    } else if ( argument === '--paths' ) {
+      options.top = Number( argv[ ++index ] )
+    } else {
+      options.model = argument
+    }
+  }
+
+  return options
+}
+
+const options = parseArgs( process.argv.slice( 2 ) )
+
+if ( options.model === void 0 ) {
+  console.error( 'usage: occurrence_report.mjs model.stp [--paths N] [--json]' )
+  process.exit( 1 )
+}
+
+const { default: AP214StepParser } =
+  await import( `${COMPILED}/src/AP214E3_2010/ap214_step_parser.js` )
+const { default: ParsingBuffer } =
+  await import( `${COMPILED}/src/parsing/parsing_buffer.js` )
+const { AP214GeometryExtraction } =
+  await import( `${COMPILED}/src/AP214E3_2010/ap214_geometry_extraction.js` )
+const { AP214Properties } =
+  await import( `${COMPILED}/src/compat/web-ifc/ap214_properties.js` )
+const { ConwayGeometry } =
+  await import( `${COMPILED}/dependencies/conway-geom/index.js` )
+
+const started = Date.now()
+const parser = AP214StepParser.Instance
+const buffer = new ParsingBuffer( fs.readFileSync( options.model ) )
+
+parser.parseHeader( buffer )
+
+const [ , model ] = parser.parseDataToModel( buffer )
+
+if ( model === void 0 ) {
+  console.error( `could not parse ${options.model} as AP214` )
+  process.exit( 1 )
+}
+
+const conwayGeometry = new ConwayGeometry()
+
+await conwayGeometry.initialize()
+
+const [ , scene ] = new AP214GeometryExtraction( conwayGeometry, model ).extractAP214GeometryData()
+
+// A per-face styled export gives each face its own scene node under its
+// solid's node; those inherit the solid's path by design (they ARE that
+// solid), so they are counted but excluded from the body-level comparison.
+const faceChildLocalIDs = new Set()
+
+for ( const [ , node ] of scene.scene_?.entries?.() ?? [] ) {
+  for ( const childLocalID of model.geometry?.getChildrenByLocalID?.( node.localID ) ?? [] ) {
+    faceChildLocalIDs.add( childLocalID )
+  }
+}
+
+let geometryNodes = 0
+const bodyPaths = []
+const pathCounts = new Map()
+
+for ( const node of scene.scene_ ?? [] ) {
+
+  if ( node.occurrencePath === void 0 || model.geometry?.getByLocalID( node.localID ) === void 0 ) {
+    continue
+  }
+
+  ++geometryNodes
+
+  const key = JSON.stringify( node.occurrencePath )
+
+  pathCounts.set( key, ( pathCounts.get( key ) ?? 0 ) + 1 )
+
+  if ( !faceChildLocalIDs.has( node.localID ) ) {
+    bodyPaths.push( key )
+  }
+}
+
+const properties = new AP214Properties( { StepModel: model } )
+const root = await properties.getSpatialStructure()
+
+let treeNodes = 0
+const leafPaths = []
+const walkTree = ( node ) => {
+
+  ++treeNodes
+
+  const children = node.children ?? []
+
+  if ( children.length === 0 ) {
+    leafPaths.push( JSON.stringify( node.occurrencePath ) )
+  }
+
+  children.forEach( walkTree )
+}
+
+walkTree( root )
+
+const duplicates = [ ...pathCounts.entries() ]
+    .filter( ( [ , count ] ) => count > 1 )
+    .sort( ( a, b ) => b[1] - a[1] )
+
+const sortedBodies = bodyPaths.slice().sort()
+const sortedLeaves = leafPaths.slice().sort()
+const pathsMatch = sortedBodies.length === sortedLeaves.length &&
+  sortedBodies.every( ( value, index ) => value === sortedLeaves[ index ] )
+
+const report = {
+  model: options.model,
+  loadMs: Date.now() - started,
+  geometryNodes,
+  bodyNodes: bodyPaths.length,
+  distinctPaths: pathCounts.size,
+  duplicatePaths: duplicates.length,
+  maxPathMultiplicity: duplicates.length > 0 ? duplicates[0][1] : 1,
+  treeNodes,
+  treeLeaves: leafPaths.length,
+  bodyPathsEqualTreeLeafPaths: pathsMatch,
+}
+
+if ( options.json ) {
+  console.log( JSON.stringify( { ...report, topDuplicates: duplicates.slice( 0, options.top ) }, null, 2 ) )
+} else {
+
+  console.log( `# ${options.model}` )
+  console.log( `  loaded in ${report.loadMs} ms` )
+  console.log( `  geometry nodes ${geometryNodes} (${bodyPaths.length} bodies, ` +
+    `${geometryNodes - bodyPaths.length} face children)` )
+  console.log( `  distinct occurrence paths ${pathCounts.size}` )
+  console.log( `  tree nodes ${treeNodes}, leaves ${leafPaths.length}` )
+  console.log( `  body paths == tree leaf paths: ${pathsMatch}` )
+
+  if ( duplicates.length > 0 ) {
+
+    console.log( `\n## paths shared by more than one geometry node (${duplicates.length})` )
+
+    for ( const [ key, count ] of duplicates.slice( 0, options.top ) ) {
+      console.log( `  ${String( count ).padStart( 8 )}x  ${key}` )
+    }
+
+    if ( duplicates.length > options.top ) {
+      console.log( `  ... ${duplicates.length - options.top} more` )
+    }
+  }
+}

--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -163,6 +163,9 @@ import {
 import { AP214MaterialCache } from './ap214_material_cache'
 import AP214ModelCurves from './ap214_model_curves'
 import { AP214ProductShapeMap } from './ap214_product_shape_map'
+import {
+  AP214ProductStructureExtraction,
+} from './ap214_product_structure_extraction'
 import { AP214SceneBuilder, AP214SceneTransform } from './ap214_scene_builder'
 import AP214StepModel from './ap214_step_model'
 
@@ -6330,6 +6333,26 @@ export class AP214GeometryExtraction {
 
     const treeMap = new Map<number, MappedSceneNode>()
 
+    // Local ids of the solid-level bodies that are individually addressable —
+    // the ones whose own express id extends the occurrence path of the
+    // geometry under them, so two bodies of one multibody part are two
+    // selections rather than one (BLSN_007: 1,884 named hull solids under a
+    // single product with no NAUO anywhere in the file). The product-structure
+    // extractor owns the decision and emits a tree node for exactly this set;
+    // reading it from there rather than re-deriving it here is what keeps
+    // "the mesh's path" and "the node's path" the same thing.
+    const solidOccurrenceLocalIDs = new Set<number>()
+
+    for ( const solidExpressID of
+      new AP214ProductStructureExtraction( model ).identityBearingSolidExpressIDs() ) {
+
+      const solidLocalID = model.getElementByExpressID( solidExpressID )?.localID
+
+      if ( solidLocalID !== void 0 ) {
+        solidOccurrenceLocalIDs.add( solidLocalID )
+      }
+    }
+
     // conway#597: representation localID → the PDS a pick under it should
     // report, populated by the plain shape_representation_relationship loop
     // further down and consulted here by makeThunk's item-attribution calls
@@ -6405,8 +6428,28 @@ export class AP214GeometryExtraction {
               // Malformed PDS.definition — fall through to the express-id fallback.
               occurrenceExpressID = void 0
             }
-            occurrenceExpressID ??= this.model.getExpressIDByLocalID( childOwningLocalID )
-            this.scene.pushOccurrence( occurrenceExpressID ?? childOwningLocalID )
+
+            // A plain shape_representation_relationship is NOT an occurrence:
+            // it binds a representation with no SDR of its own (a multibody
+            // advanced_brep_shape_representation, a tessellated rep) to the
+            // SDR-bound representation of the SAME part. This edge used to
+            // contribute its own express id as a path segment, which put an
+            // id the product-structure tree has no node for in the middle of
+            // every such path — so a NEMA motor body's mesh path
+            // ([14107, 6611]) matched no node, and every body of the part
+            // shared the one path. The bodies are told apart by the per-item
+            // segment pushed in the item loop below instead, which is the
+            // segment the tree also emits.
+            if ( occurrenceExpressID === void 0 &&
+                !( owningElement instanceof shape_representation_relationship ) ) {
+
+              occurrenceExpressID =
+                this.model.getExpressIDByLocalID( childOwningLocalID ) ?? childOwningLocalID
+            }
+
+            if ( occurrenceExpressID !== void 0 ) {
+              this.scene.pushOccurrence( occurrenceExpressID )
+            }
 
             try {
               // A sliced unit that reaches deeper than this level supplies
@@ -6425,7 +6468,9 @@ export class AP214GeometryExtraction {
               }
             }
 
-            this.scene.popOccurrence()
+            if ( occurrenceExpressID !== void 0 ) {
+              this.scene.popOccurrence()
+            }
 
             while ( this.scene.stackLength > enterChildStackDepth ) {
               this.scene.popTransform()
@@ -6522,6 +6567,20 @@ export class AP214GeometryExtraction {
             const item = items[ itemIndex ]
             const depthBeforeItem = verifySliceNeutrality ? this.scene.stackLength : 0
 
+            // An individually addressable body (see solidOccurrenceLocalIDs)
+            // ends its geometry's occurrence path with its own express id, so
+            // the path is unique per body and equal to the path of the tree
+            // node the product-structure extractor emits for it. Bodies of a
+            // single-solid part, and the bodies of an anonymous solid dump the
+            // tree deliberately suppresses, are not in the set: their geometry
+            // keeps the owning product's path, which is the node a pick on
+            // them should resolve to.
+            const itemCarriesOccurrence = solidOccurrenceLocalIDs.has( item.localID )
+
+            if ( itemCarriesOccurrence ) {
+              this.scene.pushOccurrence( item.expressID ?? item.localID )
+            }
+
             try {
               if ( item instanceof placement ) {
                 this.extractPlacement( item, mappedItem )
@@ -6564,6 +6623,10 @@ export class AP214GeometryExtraction {
                 }
               }
             } finally {
+
+              if ( itemCarriesOccurrence ) {
+                this.scene.popOccurrence()
+              }
 
               if ( verifySliceNeutrality && !( item instanceof placement ) &&
                   this.scene.stackLength !== depthBeforeItem &&
@@ -7005,7 +7068,35 @@ export class AP214GeometryExtraction {
 
         try {
           sourceShape = shapeRelationship.rep_2
-          targetShape = shapeRelationship.rep_1;
+          targetShape = shapeRelationship.rep_1
+
+          /* An SDR-bound representation is the shape OF a part; a plain
+           * relationship binding it to a representation with no SDR of its own
+           * is that part reaching its own detail geometry, so the SDR-bound
+           * side is the parent whichever way round the exporter wrote the
+           * arguments. BLSN_007 (Rhino 7 / ST-DEVELOPER) writes BOTH: three
+           * edges as (product rep, detail rep) and 308 as (detail rep, product
+           * rep) for the same kind of relation. Read literally, those 308 make
+           * the product's own representation a CHILD of 308 free wireframe
+           * representations, so it becomes 308 walk roots and every solid in
+           * the model is placed 308 times — 698,544 scene nodes for 2,268
+           * bodies, all of them duplicate placements of each other.
+           *
+           * Only reorient a relationship carrying no transformation. A
+           * transformation-bearing one places the child in the parent's frame,
+           * and reversing which side is the parent without evidence about what
+           * the exporter meant would move geometry; there is none of that here
+           * (the 308 are bare relationships), and moving geometry is a much
+           * worse failure than a duplicated placement.
+           */
+          if ( shapeRelationship.findVariant(
+              representation_relationship_with_transformation ) === void 0 &&
+              pdsLocalIDByRep.has( sourceShape.localID ) &&
+              !pdsLocalIDByRep.has( targetShape.localID ) ) {
+
+            sourceShape = shapeRelationship.rep_1
+            targetShape = shapeRelationship.rep_2
+          }
 
           [transform, isContinue] =
             this.doTransforms(shapeRelationship, sourceShape, targetShape, owningLocalID)

--- a/src/AP214E3_2010/ap214_geometry_extraction.ts
+++ b/src/AP214E3_2010/ap214_geometry_extraction.ts
@@ -6336,11 +6336,12 @@ export class AP214GeometryExtraction {
     // Local ids of the solid-level bodies that are individually addressable —
     // the ones whose own express id extends the occurrence path of the
     // geometry under them, so two bodies of one multibody part are two
-    // selections rather than one (BLSN_007: 1,884 named hull solids under a
-    // single product with no NAUO anywhere in the file). The product-structure
-    // extractor owns the decision and emits a tree node for exactly this set;
-    // reading it from there rather than re-deriving it here is what keeps
-    // "the mesh's path" and "the node's path" the same thing.
+    // selections rather than one (BLSN_007: 2,268 named hull bodies — 1,884
+    // breps and 384 shells — under a single product with no NAUO anywhere in
+    // the file). The product-structure extractor owns the decision and emits a
+    // tree node for exactly this set; reading it from there rather than
+    // re-deriving it here is what keeps "the mesh's path" and "the node's
+    // path" the same thing.
     const solidOccurrenceLocalIDs = new Set<number>()
 
     for ( const solidExpressID of
@@ -7088,6 +7089,20 @@ export class AP214GeometryExtraction {
            * the exporter meant would move geometry; there is none of that here
            * (the 308 are bare relationships), and moving geometry is a much
            * worse failure than a duplicated placement.
+           *
+           * SINGLE HOP, DELIBERATELY. The test is `pdsLocalIDByRep` on each
+           * side — is THIS representation directly SDR-bound — not the
+           * transitive reachability `resolvePdsLocalID` (defined just above)
+           * computes over repAdjacency. So an inverted chain two or more edges long is left
+           * as written. No file we have exercises that shape (BLSN_007's 308
+           * are all one hop off the product representation), and a guard for
+           * a state nothing can be shown to produce is a speculative defense.
+           * Transitive orientation is also not a drop-in: past one hop BOTH
+           * sides usually reach some PDS, so "which side is SDR-bound" stops
+           * being a decision and becomes a distance comparison with its own
+           * ambiguity rules — the ones resolvePdsLocalID already refuses to
+           * guess at. If a real file ever needs it, that function is the
+           * machinery to build on, and it needs a fixture first.
            */
           if ( shapeRelationship.findVariant(
               representation_relationship_with_transformation ) === void 0 &&
@@ -7111,18 +7126,20 @@ export class AP214GeometryExtraction {
         }
 
         // conway#597: `owningLocalID` above (the relationship's own
-        // localID) still drives occurrence-path threading exactly as
-        // before — the NEMA multibody fixture's occurrence path
-        // deliberately ends with the SRR's own express id to disambiguate
-        // a multibody solid set from other items under the same NAUO (see
+        // localID) is the edge's identity for the walk, but it is NOT an
+        // occurrence-path segment — conway#628 removed that. A plain
+        // relationship binds a part to its own detail representation, so
+        // it names nothing selectable and the product-structure tree has no
+        // node for it; a multibody solid set is disambiguated by each
+        // body's OWN express id as the path's last segment instead (see
+        // makeThunk's child and item loops, and
         // ap214_occurrence_geometry.test.ts). What conway#597 asks for is
-        // narrower: the express id a *pick* surfaces (relatedElementLocalId)
-        // should be the owning part's PDS, not the relationship's. Record
-        // that resolution separately, keyed by the representation whose
-        // OWN items (sourceShape's) will be attributed — makeThunk applies
-        // it only to item attribution, leaving the occurrence-path seed
-        // (`owningLocalID` above, and everything derived from it for
-        // children) untouched.
+        // narrower and still stands: the express id a *pick* surfaces
+        // (relatedElementLocalId) should be the owning part's PDS, not the
+        // relationship's. Record that resolution separately, keyed by the
+        // representation whose OWN items (sourceShape's) will be
+        // attributed — makeThunk applies it only to item attribution,
+        // leaving occurrence-path threading untouched.
         //
         // Resolved from sourceShape, not targetShape (review finding):
         // targetShape is only THIS edge's one neighbour, so resolving from

--- a/src/AP214E3_2010/ap214_occurrence_geometry.test.ts
+++ b/src/AP214E3_2010/ap214_occurrence_geometry.test.ts
@@ -9,6 +9,7 @@ import { ConwayGeometry } from '../../dependencies/conway-geom'
 import { ExtractResult } from '../core/shared_constants'
 import { AP214Properties } from '../compat/web-ifc/ap214_properties'
 import { IfcApiProxyAP214 } from '../compat/web-ifc/ifc_api_proxy_ap214'
+import { manifold_solid_brep } from './AP214E3_2010_gen/manifold_solid_brep.gen'
 import { product_definition_shape } from './AP214E3_2010_gen/product_definition_shape.gen'
 
 
@@ -253,8 +254,10 @@ describe( 'AP214 NEMA 23 occurrence geometry (parent-first CDSR ordering)', () =
   const SCREW_NAUOS = [ 14108, 14109, 14110, 14111 ]
   const MOTOR_MULTIBODY_SRR = 6611
   const SCREW_MULTIBODY_SRR = 10234
+  const MOTOR_BODY_COUNT = 10
 
   let nemaScene: AP214SceneBuilder
+  let nemaModel: ReturnType<AP214StepParser['parseDataToModel']>[1]
 
   beforeAll( async () => {
 
@@ -266,6 +269,7 @@ describe( 'AP214 NEMA 23 occurrence geometry (parent-first CDSR ordering)', () =
     const [ , parsed ] = parser.parseDataToModel( buffer )
 
     expect( parsed ).not.toBe( void 0 )
+    nemaModel = parsed
 
     const [ result, sceneBuilder ] =
       new AP214GeometryExtraction( conwayGeometry, parsed! ).extractAP214GeometryData()
@@ -290,24 +294,50 @@ describe( 'AP214 NEMA 23 occurrence geometry (parent-first CDSR ordering)', () =
 
   test( 'a part reused across NAUOs instances once per NAUO (the four screws)', () => {
 
+    // The screw is a SINGLE-solid part, so nothing distinguishes its body from
+    // the part: its path is just the NAUO's, one per occurrence.
     const screwPaths = [ ...nemaScene.geometryOccurrences() ]
         .map( ( [ , path ] ) => path )
-        .filter( ( path ) => path[ path.length - 1 ] === SCREW_MULTIBODY_SRR )
+        .filter( ( path ) => SCREW_NAUOS.includes( path[ 0 ] ) )
 
     expect( screwPaths.map( ( p ) => JSON.stringify( p ) ).sort() ).toEqual(
-        SCREW_NAUOS.map( ( nauo ) => JSON.stringify( [ nauo, SCREW_MULTIBODY_SRR ] ) ) )
+        SCREW_NAUOS.map( ( nauo ) => JSON.stringify( [ nauo ] ) ) )
   } )
 
-  test( 'the multibody motor solids all carry the motor occurrence prefix', () => {
+  test( 'each multibody motor body is its own selection under the motor occurrence', () => {
 
+    // Changed by conway#628 (test-models-private#98), deliberately. Every body
+    // of the motor used to carry the SAME path — the NAUO plus the multibody
+    // relationship's own express id (#6611) — so the ten bodies were one
+    // selection, and that path matched no product-structure node either (the
+    // relationship is not an occurrence and has no node). Now each body ends
+    // its path with its own express id, which is exactly what the tree's
+    // solid node for it carries.
     const motorPaths = [ ...nemaScene.geometryOccurrences() ]
         .map( ( [ , path ] ) => path )
         .filter( ( path ) => path[ 0 ] === MOTOR_NAUO )
 
     expect( motorPaths.length ).toBeGreaterThan( 1 )
 
+    const bodyIDs = new Set<number>()
+
     for ( const path of motorPaths ) {
-      expect( path ).toEqual( [ MOTOR_NAUO, MOTOR_MULTIBODY_SRR ] )
+      expect( path.length ).toBe( 2 )
+      expect( path[ 0 ] ).toBe( MOTOR_NAUO )
+      expect( path[ 1 ] ).not.toBe( MOTOR_MULTIBODY_SRR )
+      bodyIDs.add( path[ 1 ] )
+    }
+
+    // Per-face styled geometry (the NEMA export has 254 styled faces) is added
+    // as children of its body's scene node and shares that body's path, so
+    // count DISTINCT bodies rather than nodes.
+    expect( bodyIDs.size ).toBe( MOTOR_BODY_COUNT )
+
+    // ...and every one of them is a manifold_solid_brep in the file — the
+    // segment is the body's own identity, not a synthesised index.
+    for ( const bodyID of bodyIDs ) {
+      expect( nemaModel!.getElementByExpressID( bodyID ) )
+          .toBeInstanceOf( manifold_solid_brep )
     }
   } )
 
@@ -338,7 +368,7 @@ describe( 'AP214 NEMA 23 occurrence geometry (parent-first CDSR ordering)', () =
   test( 'a picked multibody screw solid reports the screw\'s own PDS, not the SRR (conway#597)', () => {
 
     const screwOwners = [ ...nemaScene.geometryOccurrences() ]
-        .filter( ( [ , path ] ) => path[ path.length - 1 ] === SCREW_MULTIBODY_SRR )
+        .filter( ( [ , path ] ) => SCREW_NAUOS.includes( path[ 0 ] ) )
         .map( ( [ owner ] ) => owner )
 
     expect( screwOwners.length ).toBe( SCREW_NAUOS.length )
@@ -347,6 +377,140 @@ describe( 'AP214 NEMA 23 occurrence geometry (parent-first CDSR ordering)', () =
       expect( owner ).toBeInstanceOf( product_definition_shape )
       expect( owner?.expressID ).toBe( SCREW_PDS_EXPRESS_ID )
       expect( owner?.expressID ).not.toBe( SCREW_MULTIBODY_SRR )
+    }
+  } )
+
+  test( 'no multibody relationship id survives in any occurrence path', () => {
+
+    // The other half of conway#628: a plain shape_representation_relationship
+    // binds a part to its own detail representation, so it is not an
+    // occurrence of anything and the product-structure tree has no node for
+    // it. Leaving its id in the path made every such path unresolvable.
+    const relationshipIDs = [ MOTOR_MULTIBODY_SRR, SCREW_MULTIBODY_SRR ]
+
+    for ( const [ , path ] of nemaScene.geometryOccurrences() ) {
+      for ( const segment of path ) {
+        expect( relationshipIDs ).not.toContain( segment )
+      }
+    }
+  } )
+
+  test( 'every geometry path is a tree node\'s path', async () => {
+
+    // The reconciliation the whole scheme exists for, on the multibody shape:
+    // paths as a SET rather than a multiset, because a per-face styled export
+    // (254 styled faces here) adds a scene node per face UNDER its body's
+    // node, sharing that body's path by design.
+    const props =
+      new AP214Properties( { StepModel: nemaModel! } as unknown as IfcApiProxyAP214 )
+    const treePaths = leafOccurrencePaths( await props.getSpatialStructure() as any )
+        .map( ( path ) => JSON.stringify( path ) )
+
+    const geometryPaths = [ ...nemaScene.geometryOccurrences() ]
+        .map( ( [ , path ] ) => JSON.stringify( path ) )
+
+    expect( geometryPaths.length ).toBeGreaterThan( 0 )
+    expect( [ ...new Set( geometryPaths ) ].sort() ).toEqual( treePaths.slice().sort() )
+  } )
+} )
+
+
+/**
+ * The BLSN_007 shape, reduced (test-models-private#98): ONE product, no NAUO
+ * and no context_dependent_shape_representation anywhere, every body named
+ * individually inside one child representation — and the relationships binding
+ * that child written in BOTH argument orders, three of them inverted.
+ *
+ * Read literally, an inverted edge makes the product's own SDR-bound
+ * representation the CHILD of a free wireframe representation, so each one
+ * becomes a separate walk root and the entire model is re-walked and re-placed
+ * once per root. On the real 281 MB export that is 2,268 bodies emitted as
+ * 698,544 scene nodes sharing 616 paths; here it is 3 bodies as 9 nodes
+ * sharing 3. Either way every body of the hull answers to the same path, which
+ * is the defect the issue reports as "all parts a single selection".
+ */
+describe( 'AP214 inverted-SRR multibody occurrence geometry (BLSN_007 shape)', () => {
+
+  const INVERTED_FIXTURE = 'data/ap214-inverted-srr-multibody.step'
+  const BODY_COUNT = 3
+  // eslint-disable-next-line no-magic-numbers
+  const BODY_EXPRESS_IDS = [ 401, 402, 403 ]
+  const BODY_NAMES = [ 'brep_0', 'brep_1', 'Hauptkoerper' ]
+
+  let invertedScene: AP214SceneBuilder
+  let invertedModel: ReturnType<AP214StepParser['parseDataToModel']>[1]
+
+  beforeAll( async () => {
+
+    const parser = AP214StepParser.Instance
+    const buffer = new ParsingBuffer( fs.readFileSync( INVERTED_FIXTURE ) )
+
+    expect( parser.parseHeader( buffer )[1] ).toBe( ParseResult.COMPLETE )
+
+    const [ , parsed ] = parser.parseDataToModel( buffer )
+
+    expect( parsed ).not.toBe( void 0 )
+    invertedModel = parsed
+
+    const [ result, sceneBuilder ] =
+      new AP214GeometryExtraction( conwayGeometry, parsed! ).extractAP214GeometryData()
+
+    expect( result ).toBe( ExtractResult.COMPLETE )
+    invertedScene = sceneBuilder
+  } )
+
+  test( 'each body is placed exactly once, not once per inverted relationship', () => {
+
+    const occurrences = [ ...invertedScene.geometryOccurrences() ]
+
+    // Three inverted edges used to make three walk roots, so every body was
+    // placed three times: 9 nodes for 3 bodies. Counting nodes is the check —
+    // path uniqueness alone would pass a walk that placed one body 3x and
+    // dropped the other two.
+    expect( occurrences.length ).toBe( BODY_COUNT )
+  } )
+
+  test( 'each body carries its own unique occurrence path', () => {
+
+    const paths = [ ...invertedScene.geometryOccurrences() ]
+        .map( ( [ , path ] ) => path )
+
+    // One segment, the body's own express id: there is no NAUO in this file to
+    // prefix it with, and the relationship ids that used to appear here
+    // (`[701,500]`) name nothing selectable.
+    expect( paths.map( ( path ) => JSON.stringify( path ) ).sort() ).toEqual(
+        BODY_EXPRESS_IDS.map( ( id ) => JSON.stringify( [ id ] ) ).sort() )
+  } )
+
+  test( 'the tree names one node per body, and the paths match the scene', async () => {
+
+    const props =
+      new AP214Properties( { StepModel: invertedModel! } as unknown as IfcApiProxyAP214 )
+    const root = await props.getSpatialStructure() as any
+
+    expect( root.Name.value ).toBe( 'Document' )
+    expect( root.children.length ).toBe( BODY_COUNT )
+    expect( root.children.map( ( node: any ) => node.Name.value ) ).toEqual( BODY_NAMES )
+
+    for ( const node of root.children ) {
+      expect( node.type ).toBe( 'solid' )
+      expect( node.ephemeral ).toBe( true )
+    }
+
+    const geometryPaths = [ ...invertedScene.geometryOccurrences() ]
+        .map( ( [ , path ] ) => JSON.stringify( path ) )
+    const treePaths = leafOccurrencePaths( root ).map( ( path ) => JSON.stringify( path ) )
+
+    expect( geometryPaths.slice().sort() ).toEqual( treePaths.slice().sort() )
+  } )
+
+  test( 'a picked body reports the owning product\'s PDS (conway#597 unchanged)', () => {
+
+    const PDS_EXPRESS_ID = 301
+
+    for ( const [ owner ] of invertedScene.geometryOccurrences() ) {
+      expect( owner ).toBeInstanceOf( product_definition_shape )
+      expect( owner?.expressID ).toBe( PDS_EXPRESS_ID )
     }
   } )
 } )

--- a/src/AP214E3_2010/ap214_product_structure_extraction.test.ts
+++ b/src/AP214E3_2010/ap214_product_structure_extraction.test.ts
@@ -39,6 +39,26 @@ function extractStructure(
 }
 
 /**
+ * Parse a hermetic fixture and compute the solid-identity set the tree and the
+ * geometry walk both read.
+ *
+ * @param path The fixture path.
+ * @return {Set<number>} Express ids of the identity-bearing solids.
+ */
+function extractIdentitySet( path: string ): Set<number> {
+
+  const bufferInput = new ParsingBuffer( fs.readFileSync( path ) )
+
+  expect( parser.parseHeader( bufferInput )[1] ).toBe( ParseResult.COMPLETE )
+
+  const [ , model ] = parser.parseDataToModel( bufferInput )
+
+  expect( model ).not.toBe( void 0 )
+
+  return new AP214ProductStructureExtraction( model! ).identityBearingSolidExpressIDs()
+}
+
+/**
  * Parse the hermetic as1 assembly fixture and extract its product structure.
  *
  * @return {ProductStructureNode[]} The extracted assembly forest.
@@ -385,5 +405,70 @@ describe( 'AP214ProductStructureExtraction labels for products with no name', ()
     // '' lets a consumer substitute a type label; '   ' would render as a blank
     // NavTree row. nist_stc_09_asme1_ap242-e3 is this case for real.
     expect( root.name ).toBe( '' )
+  } )
+} )
+
+
+const RECOVERABLE_FIXTURE = 'data/ap214-recoverable-scan-records.step'
+// eslint-disable-next-line no-magic-numbers
+const HEALTHY_BODY_IDS = [ 401, 402, 403 ]
+const HEALTHY_BODY_COUNT = 3
+
+/**
+ * The solid-identity scan runs on EVERY load now (the tree and the geometry
+ * walk both read it), so a reference getter it fails to contain fails the whole
+ * model rather than skipping one record — conway#683 review. The geometry walk
+ * has always contained these per record; without the matching containment in
+ * `indexSolids` this fixture's three bad records each abort
+ * `prepareDemandExtraction`, and `extractProductStructure` throws too.
+ *
+ * Verified against a revert of the containment: `identityBearingSolidExpressIDs`
+ * throws `DanglingReferenceError: Reference to #900 is not in the index`, and
+ * with #502 removed it throws `Value in STEP was incorrectly typed` on #450's
+ * items — i.e. both arms of this suite go red, and so does the whole load.
+ */
+describe( 'AP214ProductStructureExtraction contains bad records in the solid scan', () => {
+
+  test( 'a dangling relationship, an unreadable item list and a bad name do not fail the scan', () => {
+
+    const identity =
+      extractIdentitySet( RECOVERABLE_FIXTURE )
+
+    // #502 (dangling #900) and #450 (holds a TESSELLATED_SHELL, a type the
+    // AP214 enum has no id for) are skipped; #400's bodies still come through.
+    expect( [ ...identity ].sort( ( a, b ) => a - b ) ).toEqual( HEALTHY_BODY_IDS )
+  } )
+
+  test( 'a body whose name getter throws keeps its identity, losing only the label', () => {
+
+    const root = extractStructure( RECOVERABLE_FIXTURE )[0]
+    const solids = solidChildren( root )
+
+    expect( solids.length ).toBe( HEALTHY_BODY_COUNT )
+
+    // #403's name slot is `$` on a mandatory attribute, so the getter throws.
+    // A label is cosmetic and identity is not: it degrades to the positional
+    // name, and its occurrence path is still its own.
+    const unnamed = solids.find( ( solid ) => solid.expressID === HEALTHY_BODY_IDS[2] )!
+
+    expect( unnamed.name ).toBe( 'Solid 3 of 3' )
+    expect( unnamed.occurrencePath ).toEqual( [ HEALTHY_BODY_IDS[2] ] )
+  } )
+
+  test( 'a representation whose items throw contributes to NEITHER side', () => {
+
+    // Coherence: #450's `tess_body_0` is a perfectly good brep, but its
+    // representation's item list cannot be read, so the scan skips the whole
+    // representation. It must therefore get no tree node AND no body path
+    // segment — a body addressable on one side only is a path that resolves to
+    // nothing (or a node that highlights nothing).
+    const identity = extractIdentitySet( RECOVERABLE_FIXTURE )
+    const root = extractStructure( RECOVERABLE_FIXTURE )[0]
+
+    const TESS_REP_BODY_ID = 451
+
+    expect( identity.has( TESS_REP_BODY_ID ) ).toBe( false )
+    expect( solidChildren( root ).map( ( solid ) => solid.expressID ) )
+        .not.toContain( TESS_REP_BODY_ID )
   } )
 } )

--- a/src/AP214E3_2010/ap214_product_structure_extraction.test.ts
+++ b/src/AP214E3_2010/ap214_product_structure_extraction.test.ts
@@ -193,9 +193,14 @@ function solidChildren( node: ProductStructureNode ): ProductStructureNode[] {
 
 describe( 'AP214ProductStructureExtraction ephemeral solid layer', () => {
 
-  test( 'is off by default: no solid nodes anywhere', () => {
+  test( 'is on by default, and opting out drops every solid node', () => {
 
-    const root = extractStructure( MULTIBODY_FIXTURE )[0]
+    const defaulted = extractStructure( MULTIBODY_FIXTURE )[0]
+    const widget = defaulted.children.find( ( node ) => node.name === 'widget' )!
+
+    expect( solidChildren( widget ).length ).toBe( WIDGET_SOLID_COUNT )
+
+    const root = extractStructure( MULTIBODY_FIXTURE, { includeSolids: false } )[0]
 
     const stack = [ root ]
 
@@ -233,10 +238,18 @@ describe( 'AP214ProductStructureExtraction ephemeral solid layer', () => {
         expect( solid.children.length ).toBe( 0 )
         expect( solid.productDefinitionExpressID )
             .toBe( widget.productDefinitionExpressID )
-        // A solid is not an occurrence: it inherits the parent's NAUO-only
-        // path, and (path, expressID) is the selection identity.
-        expect( solid.occurrencePath ).toEqual( widget.occurrencePath )
+        // The solid's own express id is the path's last segment: the NAUO
+        // prefix alone is shared by every body of the part, so a path without
+        // it selects all three bodies at once (the BLSN_007 defect).
+        expect( solid.occurrencePath )
+            .toEqual( [ ...widget.occurrencePath, solid.expressID ] )
       }
+
+      // ...and that makes each body's path unique, which is what a scalar
+      // expressID plus a shared path cannot express.
+      const paths = solids.map( ( solid ) => JSON.stringify( solid.occurrencePath ) )
+
+      expect( new Set( paths ).size ).toBe( solids.length )
     }
 
     // The same part type under two occurrences repeats the same solid ids —
@@ -283,18 +296,53 @@ describe( 'AP214ProductStructureExtraction ephemeral solid layer', () => {
         .toEqual( [ 'Solid 1 of 3', 'Solid 2 of 3', 'Solid 3 of 3' ] )
   } )
 
-  test( 'caps per-product solids and reports the overflow', () => {
+  test( 'suppression is all-or-nothing: a named set is never partly emitted', () => {
 
+    // BLSN_007 is 1,884 named hull bodies under one product, and the layer
+    // used to hard-cap a product at 256 children. A partial emission is not a
+    // smaller tree, it is a broken one: the bodies past the cap keep their own
+    // occurrence paths in the scene (the geometry walk reads the same
+    // identity set) and those paths then resolve to no node at all. So the
+    // only two outcomes are "every body of the product" and "none of them",
+    // and a named set is always the former however large it is.
     const root = extractStructure( MULTIBODY_FIXTURE,
-        { includeSolids: true, maxSolidsPerProduct: 2 } )[0]
+        { includeSolids: true, maxUnnamedSolidsPerProduct: 1 } )[0]
 
     const widget = root.children.find( ( node ) => node.name === 'widget' )!
     const solids = solidChildren( widget )
 
-    expect( solids.length ).toBe( 2 )
-    expect( widget.droppedSolids ).toBe( WIDGET_SOLID_COUNT - 2 )
-    // Truncated, not renumbered: positions stay stable under the cap.
-    expect( solids.map( ( solid ) => solid.name ) ).toEqual( [ 'Body1', 'Body2' ] )
+    // Two named bodies and one unnamed, against a limit of 1 unnamed: the
+    // named ones keep the whole set addressable.
+    expect( solids.length ).toBe( WIDGET_SOLID_COUNT )
+    expect( widget.droppedSolids ).toBe( void 0 )
+  } )
+
+  test( 'the identity set is exactly the emitted solid nodes', () => {
+
+    // The invariant the geometry walk depends on: it stamps a per-body
+    // occurrence segment for precisely the solids this set names, so any
+    // divergence from the emitted nodes is a mesh whose path matches no node.
+    const buffer = new ParsingBuffer( fs.readFileSync( MULTIBODY_FIXTURE ) )
+
+    expect( parser.parseHeader( buffer )[1] ).toBe( ParseResult.COMPLETE )
+
+    const [ , model ] = parser.parseDataToModel( buffer )
+    const identity =
+      new AP214ProductStructureExtraction( model! ).identityBearingSolidExpressIDs()
+
+    const roots = new AP214ProductStructureExtraction( model! ).extractProductStructure()
+    const emitted = new Set<number>()
+    const walk = ( node: ProductStructureNode ) => {
+      if ( node.type === 'solid' ) {
+        emitted.add( node.expressID )
+      }
+      node.children.forEach( walk )
+    }
+
+    roots.forEach( walk )
+
+    expect( emitted.size ).toBeGreaterThan( 0 )
+    expect( [ ...identity ].sort() ).toEqual( [ ...emitted ].sort() )
   } )
 } )
 

--- a/src/AP214E3_2010/ap214_product_structure_extraction.test.ts
+++ b/src/AP214E3_2010/ap214_product_structure_extraction.test.ts
@@ -298,7 +298,7 @@ describe( 'AP214ProductStructureExtraction ephemeral solid layer', () => {
 
   test( 'suppression is all-or-nothing: a named set is never partly emitted', () => {
 
-    // BLSN_007 is 1,884 named hull bodies under one product, and the layer
+    // BLSN_007 is 2,268 named hull bodies under one product, and the layer
     // used to hard-cap a product at 256 children. A partial emission is not a
     // smaller tree, it is a broken one: the bodies past the cap keep their own
     // occurrence paths in the scene (the geometry walk reads the same

--- a/src/AP214E3_2010/ap214_product_structure_extraction.ts
+++ b/src/AP214E3_2010/ap214_product_structure_extraction.ts
@@ -84,7 +84,7 @@ export interface ProductStructureNode {
    */
   shapeRepresentationIds: number[]
 
-  /** Child occurrence nodes (and, when opted in, ephemeral solid nodes). */
+  /** Child occurrence nodes, plus the solid nodes of a multibody part. */
   children: ProductStructureNode[]
 
   /**
@@ -96,8 +96,8 @@ export interface ProductStructureNode {
   ephemeral?: boolean
 
   /**
-   * Number of this node's solids suppressed by the ephemeral-layer limits
-   * (unnamed-soup suppression or the per-product cap), so a consumer can
+   * Number of this node's solids suppressed by the unnamed-soup gate (the
+   * only limit left — see {@link ProductStructureOptions}), so a consumer can
    * render an "N more…" affordance instead of silently truncating.
    */
   droppedSolids?: number
@@ -133,7 +133,7 @@ export interface ProductStructureOptions {
    * suppressed by this limit.
    *
    * The suppression is all-or-nothing on purpose. A partial cap (this layer
-   * carried a 256-solid one until BLSN_007, a 1,884-body Rhino hull export)
+   * carried a 256-solid one until BLSN_007, a 2,268-body Rhino hull export)
    * emits nodes for some of a product's bodies and not others, so the
    * suppressed bodies' geometry carries occurrence paths that resolve to no
    * node at all — and it silently truncates a NavTree an MCAD viewer shows in
@@ -676,7 +676,8 @@ export class AP214ProductStructureExtraction {
         // The solid's own express id extends the parent's NAUO path: two
         // bodies of one multibody part share every NAUO segment, so without
         // this last segment the path cannot tell them apart — which is what
-        // made all 1,884 hull bodies of BLSN_007 one selection. The geometry
+        // collapsed BLSN_007's 2,268 hull bodies onto two selections (one
+        // per child representation). The geometry
         // walk appends the same segment for the same set of solids (see
         // identityBearingSolidExpressIDs), so mesh path == node path.
         occurrencePath: [ ...node.occurrencePath, solid.expressID ],

--- a/src/AP214E3_2010/ap214_product_structure_extraction.ts
+++ b/src/AP214E3_2010/ap214_product_structure_extraction.ts
@@ -442,6 +442,32 @@ export class AP214ProductStructureExtraction {
    * collect the solid items. Transformation-bearing relationship variants are
    * assembly placements (parent rep ↔ child rep), so following them would leak
    * every child part's solids into its parent assembly; they are skipped.
+   *
+   * **Every dereference here is contained per record**, matching the geometry
+   * walk's behavior on the same entities (`prepareDemandExtraction`'s plain-SRR
+   * and SDR loops, and makeThunk's `representation.items` capture): a bad
+   * record skips, and the rest of the model still indexes. This is not
+   * defensive dressing — two concrete shapes reach it and both used to fail
+   * the WHOLE model load once this scan became unconditional:
+   *
+   *  - a dangling reference (`srr.rep_1`, `sdr.definition`, …) throws
+   *    `DanglingReferenceError`. Mid-parse PREFIX models — the streamed
+   *    preview channel calls `prepareDemandExtraction` on one
+   *    (`streamed_preview_channel.ts`) — have a truncated tail by
+   *    construction, so this is their normal state, not corruption.
+   *  - `representation.items` throws `'Value in STEP was incorrectly typed'`
+   *    when a representation holds an item type the AP214 schema has no id for
+   *    (the enum carries no tessellated entities at all): #25231 in
+   *    `nist_ftc_08_asme1_ap242-e1-tg.stp` holds a TESSELLATED_SHELL, the case
+   *    makeThunk documents.
+   *
+   * `items` is read all-or-nothing per representation rather than per item:
+   * a half-enumerated body list is not a smaller answer, it is a wrong one.
+   * Because the tree and the geometry walk both read this one result (see
+   * {@link identityBearingSolidExpressIDs}), a skipped representation
+   * contributes no solids to EITHER side, so its bodies get no node and no
+   * body path segment — they keep the owning product's path, exactly as a
+   * deliberately suppressed set does, and the path-equality invariant holds.
    */
   private indexSolids(): void {
 
@@ -476,12 +502,21 @@ export class AP214ProductStructureExtraction {
 
       const srr = element as shape_representation_relationship
 
-      if ( srr.findVariant( representation_relationship_with_transformation ) !== void 0 ) {
+      let rep1: representation | undefined
+      let rep2: representation | undefined
+
+      try {
+        if ( srr.findVariant( representation_relationship_with_transformation ) !== void 0 ) {
+          continue
+        }
+
+        rep1 = srr.rep_1
+        rep2 = srr.rep_2
+      } catch {
+        // Malformed/dangling relationship record — skip this edge, as the
+        // geometry walk's own plain-SRR loop does.
         continue
       }
-
-      const rep1 = srr.rep_1
-      const rep2 = srr.rep_2
 
       if ( rep1 === void 0 || rep2 === void 0 ) {
         continue
@@ -497,8 +532,17 @@ export class AP214ProductStructureExtraction {
 
       const sdr = element as shape_definition_representation
 
-      const productDefId = AP214ProductStructureExtraction.resolveProductDefinitionId( sdr.definition )
-      const usedRep = sdr.used_representation
+      let productDefId: number | undefined
+      let usedRep: representation | undefined
+
+      try {
+        productDefId = AP214ProductStructureExtraction.resolveProductDefinitionId( sdr.definition )
+        usedRep = sdr.used_representation
+      } catch {
+        // Malformed/dangling SDR record — skip it, as the geometry walk's own
+        // shape_definition_representation loop does.
+        continue
+      }
 
       if ( productDefId === void 0 || usedRep === void 0 ) {
         continue
@@ -507,7 +551,21 @@ export class AP214ProductStructureExtraction {
       const reps = [ usedRep, ...( relatedRepsByRepId.get( usedRep.expressID ?? -1 ) ?? [] ) ]
 
       for ( const rep of reps ) {
-        for ( const item of rep.items ) {
+
+        let items: readonly representation_item[]
+
+        try {
+          items = rep.items
+        } catch {
+          // A representation holding an item type AP214 has no id for, or a
+          // dangling item reference. All-or-nothing per representation: its
+          // bodies get no identity on either side, so they stay part of the
+          // owning product's selection rather than half of them becoming
+          // addressable.
+          continue
+        }
+
+        for ( const item of items ) {
 
           if ( !isSolidItem( item ) || item.expressID === void 0 ) {
             continue
@@ -515,7 +573,12 @@ export class AP214ProductStructureExtraction {
 
           this.addSolid( productDefId, {
             expressID: item.expressID,
-            name: item.name,
+            // `name` is a mandatory STEP string attribute, so the getter
+            // throws on the `$`/mistyped slot exporters do emit. A body's
+            // label is cosmetic and its identity is not: degrade to unnamed
+            // rather than dropping the body, the same trade labelCandidate
+            // makes for node labels.
+            name: AP214ProductStructureExtraction.labelCandidate( () => item.name ),
             representationId: rep.expressID,
           } )
         }

--- a/src/AP214E3_2010/ap214_product_structure_extraction.ts
+++ b/src/AP214E3_2010/ap214_product_structure_extraction.ts
@@ -62,9 +62,18 @@ export interface ProductStructureNode {
   occurrenceExpressID?: number
 
   /**
-   * Ordered occurrence path (NAUO express ids) from the top-level occurrence to
-   * this node. Empty for roots. Disambiguates instances of the same part — e.g.
-   * `[3810, 1921, 1910]` vs `[6217, 1921, 1910]` for the two bolts in `as1`.
+   * Ordered occurrence path from the top-level occurrence to this node: NAUO
+   * express ids, plus — on a `'solid'` node — the solid's own express id as a
+   * final segment. Empty for roots. Disambiguates instances of the same part
+   * (`[3810, 1921, 1910]` vs `[6217, 1921, 1910]` for the two bolts in `as1`)
+   * and the bodies of one multibody part (`[14107, 14084]` vs `[14107, 14085]`
+   * for two NEMA motor bodies).
+   *
+   * The path alone is the selection key: every leaf node's path is unique, and
+   * each geometry instance the scene emits carries the path of the leaf it
+   * belongs to. Representation-relationship ids are never segments — a plain
+   * `shape_representation_relationship` is representation indirection inside
+   * one part, not an occurrence of it.
    */
   occurrencePath: number[]
 
@@ -100,21 +109,21 @@ export interface ProductStructureNode {
 export interface ProductStructureOptions {
 
   /**
-   * Surface an ephemeral layer of solid-level nodes beneath each multibody
-   * product (default false). A product only gets solid children when its shape
-   * representation holds at least two solids — a single-solid product already
-   * maps 1:1 onto its node — and an all-unnamed set larger than
-   * {@link maxUnnamedSolidsPerProduct} is suppressed as meaningless "solid
-   * soup" (the DSA2 case: 28k unnamed single-face shells under one product).
+   * Surface a layer of solid-level nodes beneath each multibody product
+   * (default **true**). A product only gets solid children when it holds at
+   * least two solids — a single-solid product already maps 1:1 onto its node —
+   * and an all-unnamed set larger than {@link maxUnnamedSolidsPerProduct} is
+   * suppressed as meaningless "solid soup" (the DSA2 case: 28k unnamed
+   * single-face shells under one product).
+   *
+   * Passing `false` drops the layer, and with it the per-solid occurrence-path
+   * segments' counterpart in the tree: the scene still stamps them (geometry
+   * extraction reads {@link identityBearingSolidExpressIDs}, which is not
+   * conditioned on this option), so every body of a multibody part resolves to
+   * a path with no node. Turn it off only for a consumer that wants a
+   * products-only outline and does no path→node lookups.
    */
   includeSolids?: boolean
-
-  /**
-   * Hard cap on emitted solid children per product occurrence
-   * (default {@link DEFAULT_MAX_SOLIDS_PER_PRODUCT}); overflow is reported via
-   * {@link ProductStructureNode.droppedSolids}.
-   */
-  maxSolidsPerProduct?: number
 
   /**
    * When a product's solids are *all* unnamed and outnumber this (default
@@ -122,12 +131,18 @@ export interface ProductStructureOptions {
    * large anonymous solid dumps (ECAD merged-component products, tessellated
    * surface soup) carry no navigable semantics. Named solids are never
    * suppressed by this limit.
+   *
+   * The suppression is all-or-nothing on purpose. A partial cap (this layer
+   * carried a 256-solid one until BLSN_007, a 1,884-body Rhino hull export)
+   * emits nodes for some of a product's bodies and not others, so the
+   * suppressed bodies' geometry carries occurrence paths that resolve to no
+   * node at all — and it silently truncates a NavTree an MCAD viewer shows in
+   * full. All-or-nothing keeps the tree and the scene stamping the same
+   * decision: either every body of the product is addressable, or the product
+   * node itself is what a pick on any of them resolves to.
    */
   maxUnnamedSolidsPerProduct?: number
 }
-
-/** Default hard cap on emitted solid children per product occurrence. */
-export const DEFAULT_MAX_SOLIDS_PER_PRODUCT = 256
 
 /** Default suppression threshold for a product whose solids are all unnamed. */
 export const DEFAULT_MAX_UNNAMED_SOLIDS_PER_PRODUCT = 32
@@ -199,8 +214,8 @@ export class AP214ProductStructureExtraction {
   private readonly shapeRepsByProductDef_ = new Map<number, number[]>()
   private readonly solidsByProductDef_ = new Map<number, ProductSolid[]>()
   private readonly solidIdsByProductDef_ = new Map<number, Set<number>>()
-  private includeSolids_ = false
-  private maxSolidsPerProduct_ = DEFAULT_MAX_SOLIDS_PER_PRODUCT
+  private solidsIndexed_ = false
+  private includeSolids_ = true
   private maxUnnamedSolidsPerProduct_ = DEFAULT_MAX_UNNAMED_SOLIDS_PER_PRODUCT
 
   /**
@@ -220,19 +235,15 @@ export class AP214ProductStructureExtraction {
    * Build the product-structure tree.
    *
    * @param options Optional {@link ProductStructureOptions}; pass
-   * `{ includeSolids: true }` to add the ephemeral solid layer beneath
-   * multibody products.
+   * `{ includeSolids: false }` to drop the solid layer beneath multibody
+   * products.
    * @return {ProductStructureNode[]} The roots of the assembly forest. A
    * single-part file yields one root; a multi-level assembly (e.g. `as1`) yields
    * one root whose descendants are the NAUO occurrences.
    */
   public extractProductStructure( options?: ProductStructureOptions ): ProductStructureNode[] {
 
-    this.includeSolids_ = options?.includeSolids ?? false
-    this.maxSolidsPerProduct_ =
-      options?.maxSolidsPerProduct ?? DEFAULT_MAX_SOLIDS_PER_PRODUCT
-    this.maxUnnamedSolidsPerProduct_ =
-      options?.maxUnnamedSolidsPerProduct ?? DEFAULT_MAX_UNNAMED_SOLIDS_PER_PRODUCT
+    this.applyOptions( options )
 
     this.indexProductDefinitions()
     this.indexAssemblyUsages()
@@ -263,6 +274,76 @@ export class AP214ProductStructureExtraction {
     }
 
     return roots
+  }
+
+  /**
+   * The solids that carry their own occurrence-path segment — the express ids
+   * the *geometry* walk stamps onto each body's scene node, and the same set
+   * {@link extractProductStructure} turns into `'solid'` tree nodes.
+   *
+   * This exists so the two sides cannot drift: the tree and the scene must
+   * agree exactly on which bodies are individually addressable, or a picked
+   * mesh's occurrence path resolves to no tree node (and a NavTree node
+   * highlights nothing). `AP214GeometryExtraction.prepareDemandExtraction`
+   * calls this once per model and consults the result in its item loop; see
+   * `design/new/step-nonproduct-semantics.md`.
+   *
+   * Cheap relative to the geometry walk: one pass over the SDRs, the plain
+   * shape-representation relationships and the reached representations' items.
+   *
+   * @param options Optional {@link ProductStructureOptions}; only the solid
+   * limits are read, and they must match whatever the tree is built with.
+   * @return {Set<number>} Express ids of the identity-bearing solids.
+   */
+  public identityBearingSolidExpressIDs( options?: ProductStructureOptions ): Set<number> {
+
+    this.applyOptions( options )
+    this.indexSolids()
+
+    const identityBearing = new Set<number>()
+
+    for ( const solids of this.solidsByProductDef_.values() ) {
+
+      if ( !this.solidsCarryIdentity( solids ) ) {
+        continue
+      }
+
+      for ( const solid of solids ) {
+        identityBearing.add( solid.expressID )
+      }
+    }
+
+    return identityBearing
+  }
+
+  /**
+   * Apply (and default) the extraction options.
+   *
+   * @param options The caller's options, if any.
+   */
+  private applyOptions( options?: ProductStructureOptions ): void {
+
+    this.includeSolids_ = options?.includeSolids ?? true
+    this.maxUnnamedSolidsPerProduct_ =
+      options?.maxUnnamedSolidsPerProduct ?? DEFAULT_MAX_UNNAMED_SOLIDS_PER_PRODUCT
+  }
+
+  /**
+   * Whether one product's solids are individually addressable — the single
+   * decision the tree layer and the geometry stamping both read, so they
+   * cannot disagree about which bodies have identity.
+   *
+   * @param solids The product's solids, in file order.
+   * @return {boolean} True when every one of them gets its own identity.
+   */
+  private solidsCarryIdentity( solids: ProductSolid[] ): boolean {
+
+    if ( solids.length < MIN_SOLIDS_FOR_EPHEMERAL ) {
+      return false
+    }
+
+    return solids.some( ( solid ) => isMeaningfulName( solid.name ) ) ||
+      solids.length <= this.maxUnnamedSolidsPerProduct_
   }
 
   /**
@@ -363,6 +444,15 @@ export class AP214ProductStructureExtraction {
    * every child part's solids into its parent assembly; they are skipped.
    */
   private indexSolids(): void {
+
+    // Both public entry points index solids, and a caller may use one
+    // instance for both; the walk below is a full-model sweep, so make the
+    // second call free rather than merely idempotent (addSolid dedups).
+    if ( this.solidsIndexed_ ) {
+      return
+    }
+
+    this.solidsIndexed_ = true
 
     const relatedRepsByRepId = new Map<number, representation[]>()
 
@@ -553,11 +643,10 @@ export class AP214ProductStructureExtraction {
   }
 
   /**
-   * Append this node's ephemeral solid children, applying the layer's
-   * heuristics (see {@link ProductStructureOptions}): nothing for a
-   * single-solid product, full suppression for oversized all-unnamed sets,
-   * and the hard per-product cap — suppressed/overflow counts are surfaced
-   * via {@link ProductStructureNode.droppedSolids}.
+   * Append this node's solid children, applying the layer's heuristics (see
+   * {@link ProductStructureOptions}): nothing for a single-solid product, full
+   * suppression for oversized all-unnamed sets — the suppressed count is
+   * surfaced via {@link ProductStructureNode.droppedSolids}.
    *
    * @param node The product/occurrence node to attach solid children to.
    */
@@ -569,23 +658,14 @@ export class AP214ProductStructureExtraction {
       return
     }
 
-    const hasNamedSolid = solids.some( ( solid ) => isMeaningfulName( solid.name ) )
-
-    if ( !hasNamedSolid && solids.length > this.maxUnnamedSolidsPerProduct_ ) {
+    if ( !this.solidsCarryIdentity( solids ) ) {
       node.droppedSolids = solids.length
       return
     }
 
-    let emitted = solids
+    for ( let index = 0; index < solids.length; ++index ) {
 
-    if ( solids.length > this.maxSolidsPerProduct_ ) {
-      emitted = solids.slice( 0, this.maxSolidsPerProduct_ )
-      node.droppedSolids = solids.length - emitted.length
-    }
-
-    for ( let index = 0; index < emitted.length; ++index ) {
-
-      const solid = emitted[ index ]
+      const solid = solids[ index ]
 
       node.children.push( {
         expressID: solid.expressID,
@@ -593,9 +673,13 @@ export class AP214ProductStructureExtraction {
         name: isMeaningfulName( solid.name ) ?
           solid.name : `Solid ${index + 1} of ${solids.length}`,
         productDefinitionExpressID: node.productDefinitionExpressID,
-        // A solid is not an occurrence: the path stays NAUO-only, and the
-        // selection identity is the (occurrencePath, expressID) pair.
-        occurrencePath: [ ...node.occurrencePath ],
+        // The solid's own express id extends the parent's NAUO path: two
+        // bodies of one multibody part share every NAUO segment, so without
+        // this last segment the path cannot tell them apart — which is what
+        // made all 1,884 hull bodies of BLSN_007 one selection. The geometry
+        // walk appends the same segment for the same set of solids (see
+        // identityBearingSolidExpressIDs), so mesh path == node path.
+        occurrencePath: [ ...node.occurrencePath, solid.expressID ],
         shapeRepresentationIds:
           solid.representationId !== void 0 ? [ solid.representationId ] : [],
         children: [],

--- a/src/compat/web-ifc/ap214_properties.test.ts
+++ b/src/compat/web-ifc/ap214_properties.test.ts
@@ -59,20 +59,11 @@ describe( 'compat/web-ifc/AP214Properties', () => {
     }
   } )
 
-  test( 'getSpatialStructure surfaces the ephemeral solid layer on opt-in only', async () => {
+  test( 'getSpatialStructure surfaces the solid layer by default, opt-out drops it', async () => {
 
     const surface = compatSurfaceFor( 'data/ap214-multibody-part.step' )
 
-    const plainRoot = await surface.getSpatialStructure() as any
-    const collectTypes = ( node: any, into: Set<string> ): Set<string> => {
-      into.add( node.type )
-      node.children.forEach( ( child: any ) => collectTypes( child, into ) )
-      return into
-    }
-
-    expect( collectTypes( plainRoot, new Set() ).has( 'solid' ) ).toBe( false )
-
-    const root = await surface.getSpatialStructure( void 0, { includeSolids: true } ) as any
+    const root = await surface.getSpatialStructure() as any
     const widget = root.children.find( ( node: any ) => node.Name.value === 'widget' )
     const solids = widget.children.filter( ( node: any ) => node.type === 'solid' )
 
@@ -81,13 +72,27 @@ describe( 'compat/web-ifc/AP214Properties', () => {
     for ( const solid of solids ) {
       expect( solid.ephemeral ).toBe( true )
       expect( solid.Name.type ).toBe( 1 )
-      expect( solid.occurrencePath ).toEqual( widget.occurrencePath )
+      // The body's own express id ends the path, so each body of the part is
+      // its own selection rather than all of them sharing the part's path.
+      expect( solid.occurrencePath )
+          .toEqual( [ ...widget.occurrencePath, solid.expressID ] )
     }
 
     // A solid id resolves to its own identity row, like any tree node.
     const item = await surface.getItemProperties( solids[0].expressID ) as any
 
     expect( item.Name.value ).toBe( solids[0].Name.value )
+
+    // The opt-out is still honoured, for a consumer that wants the outline.
+    const plainRoot =
+      await surface.getSpatialStructure( void 0, { includeSolids: false } ) as any
+    const collectTypes = ( node: any, into: Set<string> ): Set<string> => {
+      into.add( node.type )
+      node.children.forEach( ( child: any ) => collectTypes( child, into ) )
+      return into
+    }
+
+    expect( collectTypes( plainRoot, new Set() ).has( 'solid' ) ).toBe( false )
   } )
 
   test( 'getItemProperties returns a {value}-wrapped identity for a node', async () => {
@@ -231,17 +236,19 @@ describe( 'getItemProperties arbitrary-entity fallback (anonymous geometry)', ()
 
   test( 'resolves a non-tree solid id to its STEP type and body name', async () => {
 
-    // Body1 (#431) is a solid inside the widget product's representation —
-    // never a tree node unless the ephemeral solid layer is requested, so it
-    // exercises the express-id-index fallback a picked anonymous piece takes.
+    // PinBody (#434) is the pin product's ONLY solid, so the solid layer gives
+    // it no node of its own (the pin's product node already maps 1:1 onto it)
+    // — which is exactly the pick with no tree identity this fallback serves.
+    // Body1 (#431) used to stand here; since the layer became the default it
+    // is a tree node, and a tree node resolves to its identity row instead.
     const surface = compatSurfaceFor( 'data/ap214-multibody-part.step' )
-    const solidExpressId = 431
+    const solidExpressId = 434
 
     const item: any = await surface.getItemProperties( solidExpressId )
 
     expect( item.expressID ).toBe( solidExpressId )
     expect( item.type ).toBe( 'MANIFOLD_SOLID_BREP' )
-    expect( item.Name.value ).toBe( 'Body1' )
+    expect( item.Name.value ).toBe( 'PinBody' )
   } )
 
   test( 'resolves an anonymous face id to its STEP type (label seed for #387)', async () => {

--- a/src/compat/web-ifc/ap214_properties.ts
+++ b/src/compat/web-ifc/ap214_properties.ts
@@ -103,8 +103,9 @@ interface AP214Node extends Node {
   children: AP214Node[]
 
   /**
-   * True for ephemeral (non-product) nodes — solid-level bodies surfaced via
-   * `SpatialStructureOptions.includeSolids`. Share should render these
+   * True for ephemeral (non-product) nodes — solid-level bodies of a
+   * multibody part, on by default and dropped by
+   * `SpatialStructureOptions.includeSolids: false`. Share should render these
    * lighter-weight, selectable-but-not-product.
    */
   ephemeral?: boolean
@@ -143,7 +144,7 @@ const SYNTHETIC_ROOT_EXPRESS_ID = 0
 export class AP214Properties {
 
   private structureRoots_?: ProductStructureNode[]
-  private structureRootsWithSolids_?: ProductStructureNode[]
+  private structureRootsWithoutSolids_?: ProductStructureNode[]
   private propertyMap_?: ExtractedPropertyMap
   private ownerByExpressID_?: Map<number, number>
   private nodeNameByExpressID_?: Map<number, string>
@@ -333,9 +334,9 @@ export class AP214Properties {
    *
    * @param includeProperties When true, merge each node's item properties onto
    * the node (mirrors the IFC surface's `includeProperties`).
-   * @param options Optional shaping: `{ includeSolids: true }` adds the
-   * ephemeral solid layer beneath multibody products (`type: 'solid'`,
-   * `ephemeral: true` nodes) — see `design/new/step-nonproduct-semantics.md`.
+   * @param options Optional shaping: `{ includeSolids: false }` drops the
+   * solid layer beneath multibody products (`type: 'solid'`, `ephemeral: true`
+   * nodes) — see `design/new/step-nonproduct-semantics.md`.
    * @return {Promise<Node>} The root node. A single-root file returns its root
    * directly; a multi-root file is wrapped in a synthetic container root.
    */
@@ -343,8 +344,8 @@ export class AP214Properties {
       includeProperties?: IncludeProperties,
       options?: SpatialStructureOptions ): Promise<Node> {
 
-    const roots = options?.includeSolids === true ?
-      this.productStructureWithSolids() : this.productStructure()
+    const roots = options?.includeSolids === false ?
+      this.productStructureWithoutSolids() : this.productStructure()
 
     const nodes = await Promise.all(
         roots.map( ( root ) => this.toSpatialNode( root, includeProperties ) ) )
@@ -538,30 +539,22 @@ export class AP214Properties {
   }
 
   /**
-   * Return (and cache) the product-structure forest with the ephemeral solid
-   * layer included. Built separately from the plain forest so default callers
-   * never pay for the solid walk; the solid nodes are also indexed so
-   * `getItemProperties` resolves a solid id to its identity row and
-   * `getPropertySets` maps it to the owning product's rows.
+   * Return (and cache) the products-only forest, for the
+   * `{ includeSolids: false }` opt-out. Built separately from the default
+   * forest — and never indexed, since its nodes are a subset of the default
+   * one's, already in `ownerByExpressID_` / `nodeNameByExpressID_`.
    *
-   * @return {ProductStructureNode[]} The cached solid-including roots.
+   * @return {ProductStructureNode[]} The cached products-only roots.
    */
-  private productStructureWithSolids(): ProductStructureNode[] {
+  private productStructureWithoutSolids(): ProductStructureNode[] {
 
     this.buildIndexes()
 
-    if ( this.structureRootsWithSolids_ === void 0 ) {
+    this.structureRootsWithoutSolids_ ??=
+      new AP214ProductStructureExtraction( this.api.StepModel )
+          .extractProductStructure( { includeSolids: false } )
 
-      this.structureRootsWithSolids_ =
-        new AP214ProductStructureExtraction( this.api.StepModel )
-            .extractProductStructure( { includeSolids: true } )
-
-      for ( const root of this.structureRootsWithSolids_ ) {
-        this.indexNodes( root )
-      }
-    }
-
-    return this.structureRootsWithSolids_
+    return this.structureRootsWithoutSolids_
   }
 
   /**

--- a/src/compat/web-ifc/properties_passthrough.ts
+++ b/src/compat/web-ifc/properties_passthrough.ts
@@ -36,10 +36,15 @@ export type IncludeProperties = boolean | 'names'
 export interface SpatialStructureOptions {
 
   /**
-   * STEP (AP214/AP242) only: surface ephemeral solid-level nodes beneath
-   * multibody products — pickable bodies that carry identity in the file but
-   * no product semantics (`type: 'solid'`, `ephemeral: true`). Ignored by the
-   * IFC surface. See `design/new/step-nonproduct-semantics.md`.
+   * STEP (AP214/AP242) only, default **true**: surface solid-level nodes
+   * beneath multibody products — pickable bodies that carry identity in the
+   * file but no product semantics (`type: 'solid'`, `ephemeral: true`).
+   * Ignored by the IFC surface.
+   *
+   * Pass `false` for a products-only outline. The scene stamps each such body
+   * with its own occurrence path either way, so with the layer off those paths
+   * resolve to no node — only do it for a consumer that does no path→node
+   * lookup. See `design/new/step-nonproduct-semantics.md`.
    */
   includeSolids?: boolean
 }


### PR DESCRIPTION
Fixes the "all parts are a single selection" behavior on [bldrs-ai/test-models-private#98](https://github.com/bldrs-ai/test-models-private/issues/98) (`BLSN_007.stp`, a Rhino 7 / ST-Developer AP214 export with one product, zero NAUOs, and 2,268 individually named bodies attached through `SHAPE_REPRESENTATION_RELATIONSHIP`s).

## Problem

Two independent defects, both measured on the real 281 MB model with the new `scripts/debug/occurrence_report.mjs`:

- **308× duplicate geometry walk.** 308 of the file's SRRs are written `(wireframe_rep_i, Document)` — the reverse of the other three — so the plain-SRR loop made each wireframe rep a *parent* of the SDR-bound `Document` rep: 308 pending roots each re-walking the whole subtree. 698,544 scene geometry nodes for 2,268 unique meshes.
- **No per-body identity.** Occurrence paths were per-representation (`[SRR_i, 7804]`), the spatial tree had one node with path `[]`, and no geometry path matched any tree path — so a consumer pick can only degrade to the whole product.

## Design

The contract made explicit and enforced by tests: **a mesh's occurrence path equals the path of the tree node it belongs to, and the path alone is the selection key.** Three changes that must land together:

1. **Plain SRR edges are oriented by SDR-boundness** (no-transformation relationships only — reversing a placement without evidence would move geometry; none of the 308 carries one). Mirrors the existing CDSR orientation check. Chosen over dedup-in-`addGeometry` (would break genuine instancing, e.g. the as1 nut) and over dropping the edge (loses the wireframe children).
2. **A body's own express id is the path's last segment** when its representation holds multiple identity-bearing solids; a plain relationship's id is no longer a segment. Paths are now NAUOs, optionally ending in a body.
3. **The solid layer is on by default and uncapped for named sets** (`includeSolids: false` is the new opt-out; `maxSolidsPerProduct` / `DEFAULT_MAX_SOLIDS_PER_PRODUCT` removed — a partial cap is incompatible with path equality). The anonymous-dump gate (>32 unnamed, none named) still suppresses, and then geometry stamps no body segment either, so paths collapse to the product node coherently.

The decision is taken once, by the new `AP214ProductStructureExtraction.identityBearingSolidExpressIDs()`, read by both the tree and the geometry walk, so the two sides cannot drift. `FlatMesh.expressID` stays the PDS (conway#597 preserved); `PlacedGeometry.geometryExpressID` stays per-body.

## Measured results (BLSN_007.stp)

| | before | after |
|---|---:|---:|
| scene geometry nodes | 698,544 | 2,268 |
| distinct occurrence paths | 616 | 2,268 (all unique) |
| tree nodes / leaves | 1 / 1 | 2,269 / 2,268 |
| geometry paths ≡ tree leaf paths | false | true |
| extraction wall clock | 58.8 s | 42.1 s |

- 135 suites / 965 tests pass (958 before); lint clean; `check-compiled-fresh` clean.
- The new tests fail without the source fix (verified by reverting source only: 7/15 occurrence-suite failures). New small fixture `data/ap214-inverted-srr-multibody.step` reproduces the defect at 3-body scale.
- **Zero digest churn, verified:** regression digests run before/after on BLSN_007, as1-oc-214, NEMA and the fixture are byte-identical; BLSN_007's 2,268-row output matches the committed `test-models-private` baseline exactly.

## Deliberate behavior changes

- NEMA multibody: the ten motor bodies are now ten selections with per-body paths (issue #351's intent); single-solid parts keep NAUO-only paths.
- `includeSolids` defaults to true across `extractProductStructure` / `getSpatialStructure`.

## Known limits

- Anonymous dumps (e.g. DSA2's 28,674 unnamed shells) are still suppressed by design; picks there resolve to the product node.
- Transformation-bearing inverted SRRs are deliberately left alone (no file in reach exercises one).
- `GEOMETRIC_CURVE_SET` wireframe reps remain unrendered (out of scope; after the orientation fix they are children of the document rep rather than spurious roots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7JNP4gwujYPEj5kaK74y

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mt7JNP4gwujYPEj5kaK74y)_