### PR TITLE
Colour models whose styles are only IfcSurfaceStyleShading; bind material-association styles on mapped items

### DIFF
--- a/data/surface_style_shading_mapped.ifc
+++ b/data/surface_style_shading_mapped.ifc
@@ -1,0 +1,124 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('surface_style_shading_mapped.ifc','2026-08-31T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+/* Minimal synthetic model for bldrs-ai/test-models-private#61 — the two
+   colour paths a Renga-style export uses, neither of which index.ifc covers.
+
+   1. Every surface style here is a plain IFCSURFACESTYLESHADING with NO
+      IfcSurfaceStyleRendering. That is legal IFC4 and it is what Renga
+      emits; index.ifc only ever uses IFCSURFACESTYLERENDERING, so the
+      shading branch of extractSurfaceStyle had no fixture at all and
+      shipped without writing CanonicalMaterial.legacyColor. baseColor
+      feeds the GLB/native export, legacyColor feeds the web-ifc compat
+      layer Share consumes, so a model like this exported correct GLB
+      colours while Share saw 0.8 grey everywhere and auto-coloured it.
+
+   2. #1000 and #2000 map ONE shared IfcRepresentationMap (#300) and get
+      their colours only through IfcRelAssociatesMaterial ->
+      IfcMaterialDefinitionRepresentation, whose IfcStyledItem carries
+      `Item = $`. With no Item to bind to, extractMappedItem produced no
+      geometry->material mapping at all and both instances rendered
+      material-less. The two products deliberately carry DIFFERENT
+      materials off the same body: binding the style to the shared
+      mapped geometry would "fix" the missing colour by leaking #1000's
+      red onto #2000, so the assertions demand two distinct colours, not
+      merely two non-default ones.
+
+   3. #3000 is the control: its own, unshared body carries a direct
+      IfcStyledItem (Item = #3012). That binding path already worked and
+      must keep working; it is here so a regression in the direct path
+      cannot hide behind the mapped path's new override.
+
+   All colour components are exact binary fractions (0.75, 0.25, 0.125,
+   ...) so the extracted doubles compare equal to the literals in the
+   test without an epsilon, and none of them is 0.8 — the default the
+   bug produced. */
+#1=IFCPROJECT('0shadingStyleMapped0000',$,'SurfaceStyleShadingMapped',$,$,$,$,(#20),#10);
+#10=IFCUNITASSIGNMENT((#11));
+#11=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#20=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-05,#21,$);
+#21=IFCAXIS2PLACEMENT3D(#22,$,$);
+#22=IFCCARTESIANPOINT((0.,0.,0.));
+#23=IFCDIRECTION((0.,0.,1.));
+
+/* The shared asset: a 1m cube body wrapped in a representation map, so
+   both #1000 and #2000 instance the same IfcExtrudedAreaSolid (#311). */
+#300=IFCREPRESENTATIONMAP(#21,#310);
+#310=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#311));
+#311=IFCEXTRUDEDAREASOLID(#312,#316,#23,1.);
+#312=IFCRECTANGLEPROFILEDEF(.AREA.,$,#313,1.,1.);
+#313=IFCAXIS2PLACEMENT2D(#314,$);
+#314=IFCCARTESIANPOINT((0.5,0.5));
+#316=IFCAXIS2PLACEMENT3D(#22,$,$);
+
+/* Material A: shading-only style, reached only via the material
+   association below. Wiring copied from what Renga emits — note the
+   IfcStyledItem's Item is $. */
+#400=IFCMATERIAL('ShadingRed',$,$);
+#401=IFCCOLOURRGB($,0.75,0.25,0.125);
+#402=IFCSURFACESTYLESHADING(#401,$);
+#403=IFCSURFACESTYLE('ShadingRedStyle',.BOTH.,(#402));
+#404=IFCPRESENTATIONSTYLEASSIGNMENT((#403));
+#405=IFCSTYLEDITEM($,(#404),$);
+#406=IFCSTYLEDREPRESENTATION(#20,$,$,(#405));
+#407=IFCMATERIALDEFINITIONREPRESENTATION($,$,(#406),#400);
+
+/* Material B: same shape, different colour, associated to the OTHER
+   product that maps #300. */
+#500=IFCMATERIAL('ShadingBlue',$,$);
+#501=IFCCOLOURRGB($,0.125,0.375,0.875);
+#502=IFCSURFACESTYLESHADING(#501,$);
+#503=IFCSURFACESTYLE('ShadingBlueStyle',.BOTH.,(#502));
+#504=IFCPRESENTATIONSTYLEASSIGNMENT((#503));
+#505=IFCSTYLEDITEM($,(#504),$);
+#506=IFCSTYLEDREPRESENTATION(#20,$,$,(#505));
+#507=IFCMATERIALDEFINITIONREPRESENTATION($,$,(#506),#500);
+
+/* First user of the shared map, at the origin, material A. */
+#1000=IFCBUILDINGELEMENTPROXY('7777777777shadingA0001',$,'MappedRed',$,$,#1001,#1010,$,$);
+#1001=IFCLOCALPLACEMENT($,#1002);
+#1002=IFCAXIS2PLACEMENT3D(#1003,$,$);
+#1003=IFCCARTESIANPOINT((0.,0.,0.));
+#1010=IFCPRODUCTDEFINITIONSHAPE($,$,(#1011));
+#1011=IFCSHAPEREPRESENTATION(#20,'Body','MappedRepresentation',(#1012));
+#1012=IFCMAPPEDITEM(#300,#1013);
+#1013=IFCCARTESIANTRANSFORMATIONOPERATOR3D($,$,#1014,1.,$);
+#1014=IFCCARTESIANPOINT((0.,0.,0.));
+
+/* Second user of the SAME map, 10m along +X, material B. */
+#2000=IFCBUILDINGELEMENTPROXY('7777777777shadingB0002',$,'MappedBlue',$,$,#2001,#2010,$,$);
+#2001=IFCLOCALPLACEMENT($,#2002);
+#2002=IFCAXIS2PLACEMENT3D(#2003,$,$);
+#2003=IFCCARTESIANPOINT((10.,0.,0.));
+#2010=IFCPRODUCTDEFINITIONSHAPE($,$,(#2011));
+#2011=IFCSHAPEREPRESENTATION(#20,'Body','MappedRepresentation',(#2012));
+#2012=IFCMAPPEDITEM(#300,#2013);
+#2013=IFCCARTESIANTRANSFORMATIONOPERATOR3D($,$,#2014,1.,$);
+#2014=IFCCARTESIANPOINT((0.,0.,0.));
+
+/* Control: unshared body with a DIRECT IfcStyledItem on the solid, still
+   shading-only. Exercises extractStyledItem's `from.Item` binding. */
+#3000=IFCBUILDINGELEMENTPROXY('7777777777shadingC0003',$,'DirectGreen',$,$,#3001,#3010,$,$);
+#3001=IFCLOCALPLACEMENT($,#3002);
+#3002=IFCAXIS2PLACEMENT3D(#3003,$,$);
+#3003=IFCCARTESIANPOINT((20.,0.,0.));
+#3010=IFCPRODUCTDEFINITIONSHAPE($,$,(#3011));
+#3011=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#3012));
+#3012=IFCEXTRUDEDAREASOLID(#3013,#3017,#23,1.);
+#3013=IFCRECTANGLEPROFILEDEF(.AREA.,$,#3014,1.,1.);
+#3014=IFCAXIS2PLACEMENT2D(#3015,$);
+#3015=IFCCARTESIANPOINT((0.5,0.5));
+#3017=IFCAXIS2PLACEMENT3D(#22,$,$);
+#3020=IFCCOLOURRGB($,0.625,0.5,0.25);
+#3021=IFCSURFACESTYLESHADING(#3020,$);
+#3022=IFCSURFACESTYLE('ShadingGreenStyle',.BOTH.,(#3021));
+#3023=IFCSTYLEDITEM(#3012,(#3022),$);
+
+#9000=IFCRELASSOCIATESMATERIAL('0relAssocMaterialRed01',$,$,$,(#1000),#400);
+#9001=IFCRELASSOCIATESMATERIAL('0relAssocMaterialBlu02',$,$,$,(#2000),#500);
+ENDSEC;
+END-ISO-10303-21;

--- a/data/surface_style_shading_mapped.ifc
+++ b/data/surface_style_shading_mapped.ifc
@@ -33,6 +33,9 @@ DATA;
       must keep working; it is here so a regression in the direct path
       cannot hide behind the mapped path's new override.
 
+   4. #4000 is the precedence conflict — a material association AND its own
+      styled item on the IfcMappedItem. See the block beside it below.
+
    All colour components are exact binary fractions (0.75, 0.25, 0.125,
    ...) so the extracted doubles compare equal to the literals in the
    test without an epsilon, and none of them is 0.8 — the default the
@@ -118,7 +121,44 @@ DATA;
 #3022=IFCSURFACESTYLE('ShadingGreenStyle',.BOTH.,(#3021));
 #3023=IFCSTYLEDITEM(#3012,(#3022),$);
 
+/* Precedence conflict (codex finding on bldrs-ai/conway#684). #4000 has BOTH
+   a material association (#600, purple) AND its own IfcStyledItem hung on the
+   IfcMappedItem #4012 (teal). IFC ranks an explicit item style above styling
+   derived from a material, so the teal must win.
+
+   This is the case a `styledItemMap.get(item) ?? extractMaterialStyle(product)`
+   chain gets wrong: the material lookup succeeds, so the branch that looks for
+   a style on the mapped item (or its ancestors) never runs, and the product
+   material paints over an explicit style. #4000 maps the same #300 as #1000
+   and #2000, so all three resolve different styles off one shared body. */
+#600=IFCMATERIAL('ShadingPurple',$,$);
+#601=IFCCOLOURRGB($,0.875,0.125,0.5);
+#602=IFCSURFACESTYLESHADING(#601,$);
+#603=IFCSURFACESTYLE('ShadingPurpleStyle',.BOTH.,(#602));
+#604=IFCPRESENTATIONSTYLEASSIGNMENT((#603));
+#605=IFCSTYLEDITEM($,(#604),$);
+#606=IFCSTYLEDREPRESENTATION(#20,$,$,(#605));
+#607=IFCMATERIALDEFINITIONREPRESENTATION($,$,(#606),#600);
+
+#4000=IFCBUILDINGELEMENTPROXY('7777777777shadingD0004',$,'MappedItemStyled',$,$,#4001,#4010,$,$);
+#4001=IFCLOCALPLACEMENT($,#4002);
+#4002=IFCAXIS2PLACEMENT3D(#4003,$,$);
+#4003=IFCCARTESIANPOINT((30.,0.,0.));
+#4010=IFCPRODUCTDEFINITIONSHAPE($,$,(#4011));
+#4011=IFCSHAPEREPRESENTATION(#20,'Body','MappedRepresentation',(#4012));
+#4012=IFCMAPPEDITEM(#300,#4013);
+#4013=IFCCARTESIANTRANSFORMATIONOPERATOR3D($,$,#4014,1.,$);
+#4014=IFCCARTESIANPOINT((0.,0.,0.));
+/* The style that must win: Item is the IfcMappedItem, not the mapped body —
+   IfcMappedItem is an IfcRepresentationItem, so this is legal and it is the
+   only way to style one instance of a shared map explicitly. */
+#4020=IFCCOLOURRGB($,0.375,0.75,0.625);
+#4021=IFCSURFACESTYLESHADING(#4020,$);
+#4022=IFCSURFACESTYLE('ShadingTealStyle',.BOTH.,(#4021));
+#4023=IFCSTYLEDITEM(#4012,(#4022),$);
+
 #9000=IFCRELASSOCIATESMATERIAL('0relAssocMaterialRed01',$,$,$,(#1000),#400);
 #9001=IFCRELASSOCIATESMATERIAL('0relAssocMaterialBlu02',$,$,$,(#2000),#500);
+#9002=IFCRELASSOCIATESMATERIAL('0relAssocMaterialPur03',$,$,$,(#4000),#600);
 ENDSEC;
 END-ISO-10303-21;

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -4326,49 +4326,54 @@ export class IfcGeometryExtraction {
               isSpace,
               true)
 
-          // Two sources feed styledItemLocalID and they must bind differently.
+          // Three style sources, tried in IFC precedence order: an explicit
+          // IfcStyledItem on geometry outranks anything derived from a
+          // material association, so the material path is the last resort.
+          // They also bind differently, which is why this is a chain of
+          // branches rather than one `??`.
           //
-          // A direct styledItemMap hit is an IfcStyledItem pointing at THIS
-          // representation item, so extractStyledItem's `from.Item` branch binds
-          // it to the mapped body — correct, since the style travels with the
-          // shared geometry and every product mapping it wants that style.
+          // 1. A direct styledItemMap hit is an IfcStyledItem pointing at THIS
+          //    representation item, so extractStyledItem's `from.Item` branch
+          //    binds it to the mapped body — correct, since the style travels
+          //    with the shared geometry and every product mapping it wants it.
           //
-          // The extractMaterialStyle fallback is per-product: it walks
-          // IfcRelAssociatesMaterial -> IfcMaterialDefinitionRepresentation,
-          // whose IfcStyledItem carries `Item = $`. With neither an Item nor a
-          // representationItem argument, extractStyledItem reaches no binding
-          // branch at all and the geometry ended up with no material
-          // (bldrs-ai/test-models-private#61 — mapped doors/windows/MEP). It
-          // must not be bound to representationItem.localID to fix that: a
-          // representation map is shared across products, so that would leak
-          // one product's material onto every other instance of the same body.
-          // It goes through the per-node override instead, keyed on the owning
-          // product — localIDs are unique across entities, so a product's ID
-          // cannot collide with a geometry key, and the parent-styled branch
-          // below already uses non-geometry localIDs as override keys the same
-          // way. IfcSceneBuilder.resolveGeometryNode_ consults the override
-          // ahead of the geometry's own assignment, so each product resolves
-          // its own material off the one shared body.
+          // 2. Otherwise a styled item on the IfcMappedItem itself or on one of
+          //    its mapped ancestors, bound (and overridden) on that mapped
+          //    item's localID. Still an explicit item style, so it must be
+          //    tried before the material association — checking the material
+          //    first silently inverted this precedence
+          //    (codex finding on bldrs-ai/conway#684): for a product that has
+          //    both, the product material won and the mapped item's own style
+          //    was never applied.
+          //
+          // 3. Last, extractMaterialStyle: IfcRelAssociatesMaterial ->
+          //    IfcMaterialDefinitionRepresentation, whose IfcStyledItem carries
+          //    `Item = $`. With neither an Item nor a representationItem
+          //    argument, extractStyledItem reaches no binding branch at all and
+          //    the geometry ended up with no material at all
+          //    (bldrs-ai/test-models-private#61 — mapped doors/windows/MEP). It
+          //    must not be bound to representationItem.localID to fix that: a
+          //    representation map is shared across products, so that would leak
+          //    one product's material onto every other instance of the same
+          //    body. It goes through the per-node override instead, keyed on
+          //    the owning product — localIDs are unique across entities, so a
+          //    product's ID cannot collide with a geometry key, the same way
+          //    case 2 keys its override on a mapped item's localID.
+          //
+          // IfcSceneBuilder.resolveGeometryNode_ consults the override ahead of
+          // the geometry's own assignment, so each product resolves its own
+          // style off the one shared body.
           const directStyledItemLocalID =
             this.materials.styledItemMap.get(representationItem.localID)
 
-          const styledItemLocalID =
-            directStyledItemLocalID ?? this.extractMaterialStyle(owningElement)
-
           let materialOverrideID: number | undefined = void 0
 
-          if (styledItemLocalID !== undefined) {
+          if (directStyledItemLocalID !== void 0) {
 
-            const styledItem = this.model.getElementByLocalID(styledItemLocalID) as IfcStyledItem
+            const styledItem =
+              this.model.getElementByLocalID(directStyledItemLocalID) as IfcStyledItem
 
-            const surfaceStyleID = this.extractStyledItem(styledItem)
-
-            if (directStyledItemLocalID === void 0 && surfaceStyleID !== void 0) {
-
-              this.materials.addGeometryMapping(owningElement.localID, surfaceStyleID)
-
-              materialOverrideID = owningElement.localID
-            }
+            this.extractStyledItem(styledItem)
 
           } else {
             // get material from parent
@@ -4394,6 +4399,25 @@ export class IfcGeometryExtraction {
               this.extractStyledItem(styledItemParent, styleParent)
 
               materialOverrideID = styleParent.localID
+
+            } else {
+
+              const materialStyledItemLocalID = this.extractMaterialStyle(owningElement)
+
+              if (materialStyledItemLocalID !== void 0) {
+
+                const styledItem =
+                  this.model.getElementByLocalID(materialStyledItemLocalID) as IfcStyledItem
+
+                const surfaceStyleID = this.extractStyledItem(styledItem)
+
+                if (surfaceStyleID !== void 0) {
+
+                  this.materials.addGeometryMapping(owningElement.localID, surfaceStyleID)
+
+                  materialOverrideID = owningElement.localID
+                }
+              }
             }
           }
 

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -1881,6 +1881,12 @@ export class IfcGeometryExtraction {
           newMaterial.baseColor = style.DiffuseColour !== null ?
             extractColorOrFactorMultiply(style.DiffuseColour, surfaceColor) : surfaceColor
 
+          // baseColor and legacyColor have different consumers, so both must be
+          // written: the GLB/native export path reads baseColor, while the
+          // web-ifc compat layer builds `PlacedGeometry.color` from legacyColor
+          // (ifc_api_proxy_ifc.ts, streamed_preview_channel.ts) — that is the
+          // API Share consumes. Leaving either at its constructed default hands
+          // that consumer 0.8 grey for a fully styled model.
           newMaterial.legacyColor = surfaceColor
           newMaterial.roughness = extractSpecularHighlight(style.SpecularHighlight)
           newMaterial.specular = style.SpecularColour !== null ?
@@ -1981,8 +1987,22 @@ export class IfcGeometryExtraction {
             // handling)
           }
 
-          newMaterial.baseColor =
+          const surfaceColor =
             extractColorRGBPremultiplied(style.SurfaceColour, 1 - transparency)
+
+          // Both, for the same reason as the rendering branch above: the
+          // native/GLB path reads baseColor and the web-ifc compat layer reads
+          // legacyColor. This branch used to set baseColor alone, so a model
+          // whose styles are all plain IFCSURFACESTYLESHADING (no
+          // IfcSurfaceStyleRendering — legal, and what Renga emits) exported
+          // correct GLB colours while Share rendered every placement at the
+          // 0.8-grey default and auto-coloured the model
+          // (bldrs-ai/test-models-private#61). Shading carries no diffuse
+          // factor, so the two are the same premultiplied surface colour; the
+          // rendering branch keeps legacyColor as the *undiffused* surface
+          // colour, which is the same quantity.
+          newMaterial.baseColor = surfaceColor
+          newMaterial.legacyColor = surfaceColor
 
         }
 
@@ -4306,9 +4326,34 @@ export class IfcGeometryExtraction {
               isSpace,
               true)
 
+          // Two sources feed styledItemLocalID and they must bind differently.
+          //
+          // A direct styledItemMap hit is an IfcStyledItem pointing at THIS
+          // representation item, so extractStyledItem's `from.Item` branch binds
+          // it to the mapped body — correct, since the style travels with the
+          // shared geometry and every product mapping it wants that style.
+          //
+          // The extractMaterialStyle fallback is per-product: it walks
+          // IfcRelAssociatesMaterial -> IfcMaterialDefinitionRepresentation,
+          // whose IfcStyledItem carries `Item = $`. With neither an Item nor a
+          // representationItem argument, extractStyledItem reaches no binding
+          // branch at all and the geometry ended up with no material
+          // (bldrs-ai/test-models-private#61 — mapped doors/windows/MEP). It
+          // must not be bound to representationItem.localID to fix that: a
+          // representation map is shared across products, so that would leak
+          // one product's material onto every other instance of the same body.
+          // It goes through the per-node override instead, keyed on the owning
+          // product — localIDs are unique across entities, so a product's ID
+          // cannot collide with a geometry key, and the parent-styled branch
+          // below already uses non-geometry localIDs as override keys the same
+          // way. IfcSceneBuilder.resolveGeometryNode_ consults the override
+          // ahead of the geometry's own assignment, so each product resolves
+          // its own material off the one shared body.
+          const directStyledItemLocalID =
+            this.materials.styledItemMap.get(representationItem.localID)
+
           const styledItemLocalID =
-            this.materials.styledItemMap.get(representationItem.localID) ??
-            this.extractMaterialStyle(owningElement)
+            directStyledItemLocalID ?? this.extractMaterialStyle(owningElement)
 
           let materialOverrideID: number | undefined = void 0
 
@@ -4316,7 +4361,14 @@ export class IfcGeometryExtraction {
 
             const styledItem = this.model.getElementByLocalID(styledItemLocalID) as IfcStyledItem
 
-            this.extractStyledItem(styledItem)
+            const surfaceStyleID = this.extractStyledItem(styledItem)
+
+            if (directStyledItemLocalID === void 0 && surfaceStyleID !== void 0) {
+
+              this.materials.addGeometryMapping(owningElement.localID, surfaceStyleID)
+
+              materialOverrideID = owningElement.localID
+            }
 
           } else {
             // get material from parent

--- a/src/ifc/ifc_surface_style_shading.test.ts
+++ b/src/ifc/ifc_surface_style_shading.test.ts
@@ -3,7 +3,7 @@
 // Share while its GLB export came out correctly coloured, and the parts it
 // instanced through IfcMappedItem got no material at all.
 //
-// Two independent defects, both covered here against
+// Three defects, all covered here against
 // data/surface_style_shading_mapped.ifc (see that file for the wiring and why
 // each product is shaped the way it is):
 //
@@ -19,6 +19,13 @@
 //      The repair has to be per-product: a representation map is shared, so
 //      binding the style to the mapped body would trade "no colour" for "the
 //      wrong product's colour".
+//
+//   C. The first cut of B consulted the material association before looking
+//      for a styled item on the IfcMappedItem or its ancestors, so for a
+//      product carrying both, the material-derived style won and the explicit
+//      item style was dropped — backwards from IFC's precedence, and a
+//      behaviour change for such models (codex finding on
+//      bldrs-ai/conway#684).
 //
 // Colour components and the wasm-init timeout are literals throughout, the
 // same trade the other fixture-driven suites here make.
@@ -45,14 +52,20 @@ const RED: ColorRGBA = [0.75, 0.25, 0.125, 1]
 const BLUE: ColorRGBA = [0.125, 0.375, 0.875, 1]
 const GREEN: ColorRGBA = [0.625, 0.5, 0.25, 1]
 
+/* #4000's two competing colours: TEAL is on its IfcMappedItem, PURPLE comes
+ * from its material association. IFC says TEAL wins. */
+const TEAL: ColorRGBA = [0.375, 0.75, 0.625, 1]
+const PURPLE: ColorRGBA = [0.875, 0.125, 0.5, 1]
+
 /* What an unwritten CanonicalMaterial field holds — the value every placement
  * of this model's shape used to report to the compat layer. */
 const UNWRITTEN_DEFAULT: ColorRGBA = [0.8, 0.8, 0.8, 1]
 
-/** Express IDs of the three products, and of the body #1000/#2000 share. */
+/** Express IDs of the four products, and of the body #1000/#2000/#4000 share. */
 const MAPPED_RED_EXPRESS_ID = 1000
 const MAPPED_BLUE_EXPRESS_ID = 2000
 const DIRECT_GREEN_EXPRESS_ID = 3000
+const MAPPED_ITEM_STYLED_EXPRESS_ID = 4000
 const SHARED_SOLID_EXPRESS_ID = 311
 
 let extraction: IfcGeometryExtraction
@@ -96,13 +109,14 @@ beforeAll( async () => {
 
 describe( 'shading-only surface styles', () => {
 
-  test( 'the fixture extracts and places all three products', () => {
+  test( 'the fixture extracts and places all four products', () => {
 
     expect( extractResult ).toBe( ExtractResult.COMPLETE )
     expect( [ ...placements.keys() ].sort( ( a, b ) => a - b ) ).toEqual( [
       MAPPED_RED_EXPRESS_ID,
       MAPPED_BLUE_EXPRESS_ID,
       DIRECT_GREEN_EXPRESS_ID,
+      MAPPED_ITEM_STYLED_EXPRESS_ID,
     ] )
   } )
 
@@ -124,7 +138,7 @@ describe( 'shading-only surface styles', () => {
       material.legacyColor.every( ( value, index ) => value === UNWRITTEN_DEFAULT[ index ] ) )
 
     // Guard the guard: this only means anything if styles were extracted at all.
-    expect( extraction.materials.size ).toBe( 3 )
+    expect( extraction.materials.size ).toBe( 4 )
     expect( defaulted ).toEqual( [] )
   } )
 } )
@@ -175,5 +189,43 @@ describe( 'mapped geometry styled only through IfcRelAssociatesMaterial', () => 
     // of the same mapped geometry with whichever product was extracted last.
     expect( extraction.materials.getMaterialByGeometryID( sharedBodyLocalID ) )
         .toBeUndefined()
+  } )
+} )
+
+
+describe( 'style precedence on a mapped item', () => {
+
+  test( 'an IfcStyledItem on the mapped item beats the product material', () => {
+
+    const styled = placements.get( MAPPED_ITEM_STYLED_EXPRESS_ID )
+
+    expect( styled?.material ).toBeDefined()
+
+    // Both colours are reachable for #4000 — the teal is hung on its
+    // IfcMappedItem, the purple on the IfcMaterial associated to the product —
+    // so this only passes if precedence is actually being applied, not because
+    // the purple was never found. Checking the negative too, since a bug that
+    // drops BOTH styles would leave a defined-but-default material.
+    expect( styled!.material!.legacyColor ).toEqual( TEAL )
+    expect( styled!.material!.legacyColor ).not.toEqual( PURPLE )
+    expect( styled!.material!.baseColor ).toEqual( TEAL )
+
+    // It instances the same shared body as the other two mapped products, so
+    // this is per-instance precedence, not a private copy of the geometry.
+    expect( styled!.geometryLocalID )
+        .toBe( placements.get( MAPPED_RED_EXPRESS_ID )!.geometryLocalID )
+  } )
+
+  test( 'the losing product material is never extracted for that instance', () => {
+
+    // The material association is only consulted when no item style was found,
+    // so #4000's purple never becomes a CanonicalMaterial. That is the
+    // observable difference between "material style lost the tie-break" and
+    // "material style was applied and then overwritten".
+    const extracted = [ ...extraction.materials.materials() ].map(
+        ( material ) => material.legacyColor.join( ',' ) )
+
+    expect( extracted ).toContain( TEAL.join( ',' ) )
+    expect( extracted ).not.toContain( PURPLE.join( ',' ) )
   } )
 } )

--- a/src/ifc/ifc_surface_style_shading.test.ts
+++ b/src/ifc/ifc_surface_style_shading.test.ts
@@ -1,0 +1,179 @@
+// bldrs-ai/test-models-private#61 — a model whose surface styles are all plain
+// IFCSURFACESTYLESHADING (no IfcSurfaceStyleRendering) rendered colourless in
+// Share while its GLB export came out correctly coloured, and the parts it
+// instanced through IfcMappedItem got no material at all.
+//
+// Two independent defects, both covered here against
+// data/surface_style_shading_mapped.ifc (see that file for the wiring and why
+// each product is shaped the way it is):
+//
+//   A. extractSurfaceStyle's shading branch wrote only CanonicalMaterial
+//      .baseColor. The GLB/native path reads baseColor, but the web-ifc compat
+//      layer builds PlacedGeometry.color from .legacyColor — which stayed at
+//      its 0.8-grey default, so Share auto-coloured the whole model.
+//
+//   B. extractMappedItem called extractStyledItem with no representation item
+//      for styles arriving via IfcRelAssociatesMaterial ->
+//      IfcMaterialDefinitionRepresentation, whose IfcStyledItem has `Item = $`.
+//      Neither binding branch fired, so mapped geometry stayed material-less.
+//      The repair has to be per-product: a representation map is shared, so
+//      binding the style to the mapped body would trade "no colour" for "the
+//      wrong product's colour".
+//
+// Colour components and the wasm-init timeout are literals throughout, the
+// same trade the other fixture-driven suites here make.
+/* eslint-disable no-magic-numbers */
+import fs from 'fs'
+
+import { beforeAll, describe, expect, test } from '@jest/globals'
+
+import { ConwayGeometry } from '../../dependencies/conway-geom'
+import { CanonicalMaterial, ColorRGBA } from '../core/canonical_material'
+import { ExtractResult } from '../core/shared_constants'
+import { IfcGeometryExtraction } from './ifc_geometry_extraction'
+import IfcStepParser from './ifc_step_parser'
+import ParsingBuffer from '../parsing/parsing_buffer'
+import { ParseResult } from '../step/parsing/step_parser'
+
+
+const FIXTURE = 'data/surface_style_shading_mapped.ifc'
+
+/* The authored colours, as exact binary fractions so no epsilon is needed.
+ * Shading carries no diffuse factor and no transparency here, so the
+ * premultiplied surface colour is the raw IfcColourRgb with alpha 1. */
+const RED: ColorRGBA = [0.75, 0.25, 0.125, 1]
+const BLUE: ColorRGBA = [0.125, 0.375, 0.875, 1]
+const GREEN: ColorRGBA = [0.625, 0.5, 0.25, 1]
+
+/* What an unwritten CanonicalMaterial field holds — the value every placement
+ * of this model's shape used to report to the compat layer. */
+const UNWRITTEN_DEFAULT: ColorRGBA = [0.8, 0.8, 0.8, 1]
+
+/** Express IDs of the three products, and of the body #1000/#2000 share. */
+const MAPPED_RED_EXPRESS_ID = 1000
+const MAPPED_BLUE_EXPRESS_ID = 2000
+const DIRECT_GREEN_EXPRESS_ID = 3000
+const SHARED_SOLID_EXPRESS_ID = 311
+
+let extraction: IfcGeometryExtraction
+let extractResult: ExtractResult
+
+/** Owning product express ID -> the material and geometry its placement resolved. */
+const placements =
+  new Map<number, { material: CanonicalMaterial | undefined, geometryLocalID: number }>()
+
+
+beforeAll( async () => {
+
+  const parser = IfcStepParser.Instance
+  const input = new ParsingBuffer( fs.readFileSync( FIXTURE ) )
+
+  expect( parser.parseHeader( input )[ 1 ] ).toBe( ParseResult.COMPLETE )
+
+  const conwayGeometry = new ConwayGeometry()
+
+  expect( await conwayGeometry.initialize() ).toBe( true )
+
+  const [ , model ] = parser.parseDataToModel( input )
+
+  expect( model ).toBeDefined()
+
+  extraction = new IfcGeometryExtraction( conwayGeometry, model! )
+  extractResult = extraction.extractIFCGeometryData()[ 0 ]
+
+  for ( const [ , , geometry, material, entity ] of extraction.scene.walk() ) {
+
+    if ( entity?.expressID === void 0 ) {
+      continue
+    }
+
+    placements.set(
+        entity.expressID,
+        { material, geometryLocalID: geometry.localID } )
+  }
+}, 120000 )
+
+
+describe( 'shading-only surface styles', () => {
+
+  test( 'the fixture extracts and places all three products', () => {
+
+    expect( extractResult ).toBe( ExtractResult.COMPLETE )
+    expect( [ ...placements.keys() ].sort( ( a, b ) => a - b ) ).toEqual( [
+      MAPPED_RED_EXPRESS_ID,
+      MAPPED_BLUE_EXPRESS_ID,
+      DIRECT_GREEN_EXPRESS_ID,
+    ] )
+  } )
+
+  test( 'a directly styled shading-only item carries its colour in BOTH slots', () => {
+
+    const material = placements.get( DIRECT_GREEN_EXPRESS_ID )?.material
+
+    expect( material ).toBeDefined()
+
+    // baseColor was already correct before the fix; legacyColor is the half the
+    // compat layer reads, and the half that was left at the default.
+    expect( material!.baseColor ).toEqual( GREEN )
+    expect( material!.legacyColor ).toEqual( GREEN )
+  } )
+
+  test( 'no extracted material is left holding the unwritten default', () => {
+
+    const defaulted = [ ...extraction.materials.materials() ].filter( ( material ) =>
+      material.legacyColor.every( ( value, index ) => value === UNWRITTEN_DEFAULT[ index ] ) )
+
+    // Guard the guard: this only means anything if styles were extracted at all.
+    expect( extraction.materials.size ).toBe( 3 )
+    expect( defaulted ).toEqual( [] )
+  } )
+} )
+
+
+describe( 'mapped geometry styled only through IfcRelAssociatesMaterial', () => {
+
+  test( 'both instances of the shared body resolve a material', () => {
+
+    expect( placements.get( MAPPED_RED_EXPRESS_ID )?.material ).toBeDefined()
+    expect( placements.get( MAPPED_BLUE_EXPRESS_ID )?.material ).toBeDefined()
+  } )
+
+  test( 'each instance resolves its OWN product material, not the other\'s', () => {
+
+    const red = placements.get( MAPPED_RED_EXPRESS_ID )!
+    const blue = placements.get( MAPPED_BLUE_EXPRESS_ID )!
+
+    // The distinctness below is only evidence of per-product resolution if the
+    // two placements really do share one body; if extraction ever stopped
+    // instancing the map, they would differ for an uninteresting reason.
+    expect( red.geometryLocalID ).toBe( blue.geometryLocalID )
+    expect( extraction.model.getElementByLocalID( red.geometryLocalID )?.expressID )
+        .toBe( SHARED_SOLID_EXPRESS_ID )
+
+    expect( red.material!.baseColor ).toEqual( RED )
+    expect( red.material!.legacyColor ).toEqual( RED )
+    expect( blue.material!.baseColor ).toEqual( BLUE )
+    expect( blue.material!.legacyColor ).toEqual( BLUE )
+  } )
+
+  test( 'the per-product style is keyed on the product, never on the shared body', () => {
+
+    const sharedBodyLocalID = placements.get( MAPPED_RED_EXPRESS_ID )!.geometryLocalID
+    const redLocalID = extraction.model.getElementByExpressID( MAPPED_RED_EXPRESS_ID )!.localID
+    const blueLocalID = extraction.model.getElementByExpressID( MAPPED_BLUE_EXPRESS_ID )!.localID
+
+    // The override key the scene node carries. Both products must have one, and
+    // they must resolve to different styles.
+    const redStyle = extraction.materials.getMaterialByGeometryID( redLocalID )
+    const blueStyle = extraction.materials.getMaterialByGeometryID( blueLocalID )
+
+    expect( redStyle?.[ 0 ].legacyColor ).toEqual( RED )
+    expect( blueStyle?.[ 0 ].legacyColor ).toEqual( BLUE )
+
+    // And the body itself stays unbound: binding a per-product material there
+    // is the tempting shortcut that would silently paint every other instance
+    // of the same mapped geometry with whichever product was extracted last.
+    expect( extraction.materials.getMaterialByGeometryID( sharedBodyLocalID ) )
+        .toBeUndefined()
+  } )
+} )


### PR DESCRIPTION
Fixes the "no colours found → auto-coloured" regression on [bldrs-ai/test-models-private#61](https://github.com/bldrs-ai/test-models-private/issues/61) (Creoox/Renga `20210215IFC4_RV_Convenience_store_Renga_4.5.ifc`).

## Root causes

**A — `legacyColor` never set for shading-only styles.** `extractSurfaceStyle`'s `IfcSurfaceStyleRendering` branch writes both `baseColor` and `legacyColor`, but the plain `IfcSurfaceStyleShading` branch wrote only `baseColor`, leaving `legacyColor` at the 0.8-grey default. The GLB/native export reads `baseColor` (colours fine), while the web-ifc compat streaming layer — what Share consumes — builds `PlacedGeometry.color` from `legacyColor`, so every placement of a shading-only model (this one has 219 shading styles, zero renderings) arrived default-grey and Share's auto-colour heuristic fired.

**B — material-association styles dropped on mapped items.** In `extractMappedItem`, a style reached via `IfcRelAssociatesMaterial → … → IfcMaterialDefinitionRepresentation` (styled item with `Item = $`) was passed to `extractStyledItem` with no representation item, so neither of its binding branches fired: no geometry→material mapping, no override. Mapped representation items are shared across products, so the fix binds per-product via the existing `materialOverrideID` / `materialOverideLocalID` node-override mechanism keyed on `owningElement.localID`, rather than on the shared geometry (which would leak one product's material onto another's instances).

**B′ — precedence (from Codex review).** The first cut of fix B let the product's material style preempt an explicit `IfcStyledItem` on the mapped item or a mapped ancestor. `537cc62` reorders the dispatch into IFC precedence — direct item style → mapped-item/ancestor style → material-association fallback — so an explicit item style always beats material-derived styling.

## Validation on the issue model

- Streaming `PlacedGeometry.color`: **1 distinct value (0.8-grey × 5,351) → 15 distinct values** matching the authored palette (steel 0.498-grey rebar, concrete 0.827, brick, galvanised steel, red/orange rod markers, whites).
- Placements resolving no material: 663 → 272; GLB true-default triangles 67,477 → 6,965 (−90.7%). Total triangles byte-identical (2,238,466) — purely a material-assignment change.
- The remaining 272 (IfcWindow/IfcDoor/IfcLightFixture/IfcRailing) use materials associated to the **type** object via `IfcRelDefinesByType`, a third, separate inheritance path deliberately left out of scope.

## Tests

New fixture `data/surface_style_shading_mapped.ifc`: three products instancing one `IfcRepresentationMap` — two with *different* material-association colours, one carrying **both** a material association and a direct mapped-item style (the precedence conflict) — plus a direct-styled control; all styles shading-only. `src/ifc/ifc_surface_style_shading.test.ts` has 8 tests. Revert-checked: the suite fails against the unfixed code in all four revert variants, including the leak-shaped wrong fix (binding the shared representation item) and the Codex precedence inversion (product purple painting over mapped-item teal).

## Note for regression baselines

`canonical_material.ts` includes `legacyColor` in the material hash, so digests will shift for shading-styled models (and mapped-geometry material bindings). Per the regression tiering, per-PR digest changes are informational; corpus baselines get re-blessed by the next `rc-*` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSPoDZwutgTofFsHaZ5jpA