### PR TITLE
#682: time the demand-worklist build inside the engine

### DIFF
--- a/design/new/load-performance-ledger.md
+++ b/design/new/load-performance-ledger.md
@@ -1337,6 +1337,21 @@ configuration rather than something averaging removes. Resolving it needs an
 instrument inside `src/` that can time `ensureDemandWorklists_` without
 pumping, and this PR deliberately changes no `src/` file.
 
+**That instrument now exists (conway#682), and the four rows above have not
+been re-measured with it.** `ensureDemandWorklists_` times itself and reports
+through `IfcAPI.GetDemandPrepYield` — `candidatesMs` for the whole-model walk
+every worker replicates, `keysMs` for the dispatch-key pass only a sharded
+worker runs, and the candidate-versus-kept counts that make the replication
+an exact integer rather than an inference. It closes where the build ends, so
+there is no geometry inside it, no per-worker subtraction, and no error bar
+for the product that subtraction stood in for: the two `NOT RESOLVED` rows
+are resolvable by construction rather than by more repetitions.
+`scripts/m3_worker_pool.mjs --prep-probe` prints it beside the differenced
+estimate at every level. **Until a session actually re-runs the four models,
+the numbers in the tables above stand as the differenced ones they are** —
+the ledger does not inherit resolution from an instrument it has not been
+read with.
+
 (A fifth level applies a shard of *one* and must land on the first:
 `setGeometryShard` normalises `count === 1` back to unsharded
 (`ifc_api_proxy_ifc.ts:2680`). It does — 1.00× on D3D, 0.93× on

--- a/scripts/m3_worker_pool.mjs
+++ b/scripts/m3_worker_pool.mjs
@@ -35,6 +35,18 @@
  * product is not the unsharded reference's first product; see `prepProbe`
  * and `runPrepProbe`.
  *
+ * Each level now also prints a `direct (engine)` line, read from
+ * `IfcAPI.GetDemandPrepYield` (conway#682). That figure is timed inside
+ * `ensureDemandWorklists_` itself, so it contains no geometry at all and
+ * needs neither the tail correction nor an error bar for the product that
+ * correction stands in for — which is what lets the candidate/key split
+ * resolve on models where the differenced estimate reported
+ * `NOT RESOLVED` (ledger §11.4: Snowdon and MB-Khaya). The differenced
+ * lines stay: agreement between the two is what says the direct timer
+ * measures the window the sweep's `dupFirstBatch` ratio is about, and
+ * `prepMs` legitimately includes one-time extraction-path warmup that the
+ * direct figure, by construction, excludes.
+ *
  * D3D needs `--max-old-space-size=12288`; nothing here calls `gc()`, so
  * `--expose-gc` buys nothing and is deliberately not in that line.
  */
@@ -179,6 +191,18 @@ function prepProbe( api, modelID, task, openMs ) {
   const tWindow = performance.now()
   const { extracted } = api.ExtractGeometryBatch( modelID, batch, () => {} )
   const windowMs = performance.now() - tWindow
+
+  // The engine's own measurement of the same window, read after the call
+  // that built the worklists. It carries NO geometry — the timer closes
+  // where the build ends, before the pump starts — so it needs neither the
+  // tail correction below nor an error bar for the product the correction
+  // stands in for, and it resolves on every model rather than only the two
+  // whose prep is large against one product's extraction (conway#682,
+  // ledger §11.4). Everything else here is left in place: the differenced
+  // estimate is what says the direct one is measuring the same window, and
+  // `prepMs` still legitimately contains one-time extraction-path warmup
+  // that the direct figure, by construction, does not.
+  const directPrep = api.GetDemandPrepYield( modelID )
   const tailMs = []
 
   for ( let call = 0; call < PROBE_TAIL_CALLS; ++call ) {
@@ -211,6 +235,13 @@ function prepProbe( api, modelID, task, openMs ) {
     prepMs: geometryMs === void 0 ? void 0 : windowMs - geometryMs,
     geometryMs,
     extracted,
+    // Flattened rather than passed whole: this crosses a worker_threads
+    // postMessage boundary, so it has to be plain data.
+    directTotalMs: directPrep?.totalMs,
+    directCandidatesMs: directPrep?.candidatesMs,
+    directKeysMs: directPrep?.keysMs,
+    directCandidateProducts: directPrep?.candidateProducts,
+    directKeptProducts: directPrep?.keptProducts,
   }
 }
 
@@ -333,10 +364,38 @@ async function runPrepProbe( sweep, runPool, runs ) {
             'out of the window and no split of it would mean anything' )
       }
 
+      // Refused for the same reason the tail refusal above is: a level
+      // whose workers did not all report the engine timer would sum a
+      // partial set and print it as if it were the level's, and that is
+      // the "looks measured, is not" shape this probe keeps running into.
+      const untimed = results.filter( ( r ) => r.directTotalMs === void 0 )
+
+      if ( untimed.length > 0 ) {
+
+        throw new Error(
+            `prep probe: ${untimed.length} of ${count} worker(s) reported no ` +
+            'demand-prep yield — GetDemandPrepYield returned undefined, so ' +
+            'either the model was not opened deferred or this build predates ' +
+            'conway#682' )
+      }
+
       samples.push( {
         summed: results.reduce( ( sum, r ) => sum + r.prepMs, 0 ),
         geometry: results.reduce( ( sum, r ) => sum + r.geometryMs, 0 ),
         uncertainty: results.reduce( ( sum, r ) => sum + spread( r.tailMs ), 0 ),
+        // The engine's own split of the same window, summed the same way.
+        // `keysMs` is undefined on every unsharded level — that build
+        // computes no keys — and summing it as 0 there is not a hidden
+        // zero: it is the level's defining property, and it is what the
+        // differenced key-pass term below is measured against.
+        directSummed: results.reduce( ( sum, r ) => sum + r.directTotalMs, 0 ),
+        directCandidates:
+          results.reduce( ( sum, r ) => sum + r.directCandidatesMs, 0 ),
+        directKeys:
+          results.reduce( ( sum, r ) => sum + ( r.directKeysMs ?? 0 ), 0 ),
+        directWalked:
+          results.reduce( ( sum, r ) => sum + r.directCandidateProducts, 0 ),
+        directKept: results.reduce( ( sum, r ) => sum + r.directKeptProducts, 0 ),
         // The uncorrected first-batch window, kept because the two N=1
         // levels below are differenced rather than tail-corrected — see the
         // batch-BATCH_SIZE report.
@@ -400,6 +459,32 @@ async function runPrepProbe( sweep, runPool, runs ) {
         '(NOT RESOLVED: smaller than its own spread)' )
   }
 
+  /**
+   * The engine timer's own reading of a level, printed beside the
+   * differenced one.
+   *
+   * This is the line conway#682 asked for. It needs no error bar and no
+   * `NOT RESOLVED` case: `keysMs` is the dispatch-key pass as the code
+   * measured it, not a difference between two configurations that pump
+   * different products, so a model whose prep is smaller than one product
+   * of geometry still reports it. The walked/kept counts are on the line
+   * because they are the replication itself — a level whose workers walked
+   * four times what they kept has enumerated the model four times.
+   *
+   * @param {object} chosen The median repetition's sample.
+   * @return {string} The direct line.
+   */
+  function directLine( chosen ) {
+
+    const keys = chosen.directKeys > 0 ?
+      `, keys ${toS( chosen.directKeys )}s` : ', keys none (unsharded)'
+
+    return '                   direct (engine)     ' +
+      `${toS( chosen.directSummed )}s summed ` +
+      `(candidates ${toS( chosen.directCandidates )}s${keys}), ` +
+      `walked ${chosen.directWalked} products to keep ${chosen.directKept}`
+  }
+
   const unsharded = await level( 1, () => void 0 )
   const shardOfOne = await level( 1, () => ( { index: 0, count: 1 } ) )
   const withBatch = await level( 1, () => void 0, BATCH_SIZE )
@@ -411,6 +496,7 @@ async function runPrepProbe( sweep, runPool, runs ) {
       'dispatch key computed at all, plus\n                   whatever the ' +
       'first extraction call warms up; the one product of geometry\n' +
       `                   is out — it measured ${toS( unsharded.chosen.geometry )}s)` )
+  console.log( directLine( unsharded.chosen ) )
   console.log(
       `level=shard-of-1   workers=1 batch=0  prep=${toS( shardOfOne.chosen.summed )}s ` +
       `[${toS( shardOfOne.lo )}..${toS( shardOfOne.hi )}] ` +
@@ -486,11 +572,13 @@ async function runPrepProbe( sweep, runPool, runs ) {
         `(${( replicatedAtN.chosen.summed / replicatedLevel.chosen.summed )
           .toFixed( 2 )}x N x the single worker:\n                   ` +
         'contention on the replicated prep alone)' )
+    console.log( directLine( replicatedAtN.chosen ) )
     console.log(
         `level=shards       workers=${count} batch=0  ` +
         `per-shard=${shards.chosen.perWorker.map( toS ).join( '/' )}s ` +
         `summed=${toS( whole )}s [${toS( shards.lo )}..${toS( shards.hi )}] ` +
         `+/-${toS( shards.chosen.uncertainty )}` )
+    console.log( directLine( shards.chosen ) )
     console.log(
         '                   replicated prep     ' +
         `${toS( replicatedLevel.chosen.summed )}s ` +

--- a/scripts/m3_worker_pool.mjs
+++ b/scripts/m3_worker_pool.mjs
@@ -384,15 +384,22 @@ async function runPrepProbe( sweep, runPool, runs ) {
         geometry: results.reduce( ( sum, r ) => sum + r.geometryMs, 0 ),
         uncertainty: results.reduce( ( sum, r ) => sum + spread( r.tailMs ), 0 ),
         // The engine's own split of the same window, summed the same way.
-        // `keysMs` is undefined on every unsharded level — that build
-        // computes no keys — and summing it as 0 there is not a hidden
-        // zero: it is the level's defining property, and it is what the
-        // differenced key-pass term below is measured against.
         directSummed: results.reduce( ( sum, r ) => sum + r.directTotalMs, 0 ),
         directCandidates:
           results.reduce( ( sum, r ) => sum + r.directCandidatesMs, 0 ),
         directKeys:
           results.reduce( ( sum, r ) => sum + ( r.directKeysMs ?? 0 ), 0 ),
+        // Whether the key pass RAN, carried separately from what it cost.
+        // The engine reports `keysMs` absent rather than zero precisely so
+        // that "did not run" and "ran inside one clock tick" stay distinct,
+        // and summing the durations throws that away again: a sharded level
+        // on a small model can sum to 0 ms and is then indistinguishable
+        // from an unsharded one, which would print the sharded branch as
+        // `keys none (unsharded)` (codex round 1). So the flag travels, and
+        // the report branches on it rather than on the duration.
+        directKeyedWorkers:
+          results.filter( ( r ) => r.directKeysMs !== void 0 ).length,
+        directWorkers: results.length,
         directWalked:
           results.reduce( ( sum, r ) => sum + r.directCandidateProducts, 0 ),
         directKept: results.reduce( ( sum, r ) => sum + r.directKeptProducts, 0 ),
@@ -476,8 +483,17 @@ async function runPrepProbe( sweep, runPool, runs ) {
    */
   function directLine( chosen ) {
 
-    const keys = chosen.directKeys > 0 ?
-      `, keys ${toS( chosen.directKeys )}s` : ', keys none (unsharded)'
+    // Branching on whether the pass RAN, never on what it cost — a sharded
+    // level whose key pass fits inside one clock tick sums to 0 ms and must
+    // still read as sharded. A level with SOME keyed workers is not a
+    // configuration this probe can produce (every worker at a level takes
+    // the same shard descriptor), so it is named rather than averaged away.
+    const keys = chosen.directKeyedWorkers === 0 ?
+      ', keys none (unsharded)' :
+      `, keys ${toS( chosen.directKeys )}s` +
+        ( chosen.directKeyedWorkers === chosen.directWorkers ? '' :
+          ` [MIXED: only ${chosen.directKeyedWorkers} of ` +
+          `${chosen.directWorkers} workers ran the key pass]` )
 
     return '                   direct (engine)     ' +
       `${toS( chosen.directSummed )}s summed ` +

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -4,7 +4,7 @@ import { ConwayGeometry, FileHandlerFunction as FileHandlerCallback,
 import {versionString} from '../../version/version'
 import Logger, { LogLevel as ConwayLogLevel } from '../../logging/logger'
 import { ProgressCallback } from '../../core/progress'
-import { ModelInfo } from '../../core/progress_log'
+import { DemandPrepYieldLike, ModelInfo } from '../../core/progress_log'
 import {
   WasmHeapArrayConstructor, wasmHeapView,
 } from '../../core/wasm_heap'
@@ -1168,6 +1168,37 @@ export class IfcAPI {
     result.setGeometryShard(shard)
 
     return true
+  }
+
+  /**
+   * Conway extension (M3): what building this model's demand worklists
+   * cost — the prep window that sits inside the FIRST ExtractGeometryBatch
+   * call, measured directly instead of inferred by differencing two pump
+   * calls (conway#682).
+   *
+   * The distinction the fields carry is what a worker pool needs. Every
+   * worker runs `candidatesMs` in full over the whole model, because a
+   * shard narrows what is BUILT and not what is walked — that is the
+   * replicated term, and `keptProducts` against `candidateProducts` is how
+   * much of the walk this worker had a use for. `keysMs` is its opposite:
+   * the dispatch-key pass runs only when a shard is claimed, so an
+   * unsharded reference never performs it and cannot be the denominator
+   * for it.
+   *
+   * Wall time, and on a windowed source (`windowed: true`) the build awaits
+   * paging, so the number contains I/O rather than only compute.
+   *
+   * Render it with `formatDemandPrepLine` from `core/progress_log`, which
+   * is the canonical text form the CLI, the console and Share share.
+   *
+   * @param modelID handle from a DEFER_GEOMETRY open
+   * @return {DemandPrepYieldLike | undefined} the build's cost, or
+   * undefined for unknown models, for passthroughs with no demand
+   * worklists (AP214/STEP), and for a deferred model that has not pumped
+   * yet — the build is lazy, so there is nothing to report until it runs
+   */
+  GetDemandPrepYield( modelID: number ): DemandPrepYieldLike | undefined {
+    return this.models.get(modelID)?.demandPrepYield
   }
 
   /**

--- a/src/compat/web-ifc/ifc_api_model_passthrough.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough.ts
@@ -1,3 +1,4 @@
+import { DemandPrepYieldLike } from '../../core/progress_log'
 import { StepExternalByteStore } from '../../step/step_buffer_provider'
 import { FlatMesh, IfcGeometry, RawLineData, Vector } from './ifc_api'
 import { PropertiesPassthrough } from './properties_passthrough'
@@ -44,6 +45,14 @@ export interface IfcApiModelPassthrough {
    * deferred pump (AP214/STEP) have no frame to supply.
    */
   setCoordinationFrame?( matrix?: number[] ): void
+
+  /**
+   * What building this model's demand worklists cost (conway extension,
+   * M3) — see IfcAPI.GetDemandPrepYield. Optional and undefined until the
+   * first pump: passthroughs with no demand worklists (AP214/STEP) never
+   * build any, and a deferred model has none before it pumps.
+   */
+  readonly demandPrepYield?: DemandPrepYieldLike
 
   /**
    * Set the resident-geometry budget in bytes (conway extension, M3) —

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -31,7 +31,7 @@ import { IDENTITY_MAT4, LARGE_COORDINATE_BUDGET_M, TRANSLATION_X, TRANSLATION_Y,
 import { IfcProperties } from './ifc_properties'
 import Logger from '../../logging/logger'
 import { ProgressTracker, yieldToEventLoop } from '../../core/progress'
-import { formatModelLine } from '../../core/progress_log'
+import { DemandPrepYieldLike, formatModelLine } from '../../core/progress_log'
 import {
   WasmHeapArrayConstructor, wasmHeapView,
 } from '../../core/wasm_heap'
@@ -234,6 +234,14 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
   /** Deferred-mode product worklist (file order), lazily enumerated. */
   private demandProducts_?: number[]
+
+  /**
+   * What the worklist build cost, recorded by whichever builder installed
+   * the worklists. Undefined until then — a model that never pumps has no
+   * prep to report, and reporting zeros would be indistinguishable from a
+   * build that was instantaneous.
+   */
+  private demandPrepYield_?: DemandPrepYieldLike
 
   /**
    * Deferred capture watermarks: entity localID -> how many of its
@@ -2626,10 +2634,21 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       return
     }
 
+    // Three timestamps for a build that runs once per model and costs
+    // 0.02-1.7 s — the instrument is far below its own resolution, which is
+    // what lets it stay unconditional. See recordDemandPrep_ for why it is
+    // not gated behind a flag.
+    const startedMs = Date.now()
+
     const {products, aggregates} = this.collectDemandCandidates_()
+
+    const candidatesEndedMs = Date.now()
 
     if (this.shard_ === void 0) {
       this.adoptDemandWorklists_(products, aggregates)
+      this.recordDemandPrep_(
+          startedMs, candidatesEndedMs, void 0,
+          products.length, aggregates.length)
       return
     }
 
@@ -2662,8 +2681,14 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
           relatingLocalIDOf(this.model[0], aggregates[where].localID))
     }
 
+    const keysEndedMs = Date.now()
+
     this.adoptShardedWorklists_(
         products, aggregates, productKeys, aggregateKeys)
+
+    this.recordDemandPrep_(
+        startedMs, candidatesEndedMs, keysEndedMs,
+        products.length, aggregates.length)
   }
 
 
@@ -2689,6 +2714,11 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       return
     }
 
+    // Started before the aggregate-target paging below, which is part of
+    // what a windowed build costs — the yield's `windowed` flag is what
+    // says this number contains I/O rather than only compute.
+    const startedMs = Date.now()
+
     // BEFORE collecting: the aggregate-target set is read from the
     // IfcRelAggregates records themselves, and on a windowed source those
     // pages are long gone by the first pump. The sync walk swallows the
@@ -2705,8 +2735,13 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
     const {products, aggregates} = this.collectDemandCandidates_()
 
+    const candidatesEndedMs = Date.now()
+
     if (this.shard_ === void 0) {
       this.adoptDemandWorklists_(products, aggregates)
+      this.recordDemandPrep_(
+          startedMs, candidatesEndedMs, void 0,
+          products.length, aggregates.length)
       return
     }
 
@@ -2717,15 +2752,25 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
         await computeRelatingLocalIDs(
             this.model[0], aggregates.map((aggregate) => aggregate.localID)))
 
+    const keysEndedMs = Date.now()
+
     // Re-checked after the awaits: a concurrent pump could have built the
     // worklists while this one was paging, and adopting a second set would
     // reset the cursors under it, re-extracting everything already pumped.
+    //
+    // Nothing is recorded on this branch either: the yield describes the
+    // build that WON, and overwriting it with a discarded one's timings
+    // would report kept counts against worklists this call never installed.
     if (this.demandProducts_ !== void 0) {
       return
     }
 
     this.adoptShardedWorklists_(
         products, aggregates, productKeys, aggregateKeys)
+
+    this.recordDemandPrep_(
+        startedMs, candidatesEndedMs, keysEndedMs,
+        products.length, aggregates.length)
   }
 
 
@@ -2867,6 +2912,102 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     this.demandAggregatesCursor_ = 0
 
     this.adoptAggregateStepPrefix_()
+  }
+
+
+  /**
+   * Record what the worklist build just cost — the direct measurement of
+   * the window conway#682 is about.
+   *
+   * **Why this lives in the engine.** The build runs lazily inside the
+   * FIRST `ExtractGeometryBatch` call, so from outside it can only be
+   * timed by differencing two pump calls — and `pumpGeometryBatch_` floors
+   * a batch at one product, so every window an external probe can time
+   * carries a product of real geometry inside it. On two of the four
+   * models `scripts/m3_worker_pool.mjs --prep-probe` measured, that
+   * geometry was larger than the term being measured and the split was
+   * reported `NOT RESOLVED` rather than as a number
+   * (`design/new/load-performance-ledger.md` §11.4). This timer has no
+   * geometry inside it at all, so those models resolve by construction
+   * rather than by subtraction.
+   *
+   * **Why it is unconditional rather than flag-gated.** It is three
+   * `Date.now()` calls and four array lengths, once per model, against a
+   * build measured at 21 ms on Schependomlaan and 1.7 s on D3D — the
+   * instrument sits several orders of magnitude below its own subject, so
+   * a flag would buy nothing and add a configuration in which the number
+   * silently does not exist. Nothing is emitted: the value is held for a
+   * caller that asks (`IfcAPI.GetDemandPrepYield`, rendered by
+   * `formatDemandPrepLine`), and a load that never asks logs nothing and
+   * formats nothing. That is the same shape as the preview channels'
+   * `previewYield`, one report per run rather than a stream.
+   *
+   * **`candidatesMs` is the replicated term.** Every worker in a pool runs
+   * `collectDemandCandidates_` over the WHOLE model — a shard narrows what
+   * is built, not what is walked — so this is what N workers duplicate N
+   * times. `keysMs` is its opposite: work that exists only because
+   * sharding exists, which an unsharded reference never performs and so
+   * cannot be divided by.
+   *
+   * **The clock is `Date.now`, so the floor is one millisecond**, matching
+   * the rest of this load-log channel (the preview channels' `firstMeshMs`
+   * is the same clock rendered through the same formatter). That is three
+   * orders of magnitude under the terms it has to separate — the ledger's
+   * smallest per-worker prep is Schependomlaan's ~21 ms, against the
+   * ±0.628 s the external probe could not beat on Snowdon — but it is NOT
+   * under a small fixture's. A few dozen products build their worklists in
+   * well under a millisecond and will report `0.000s` here; that is the
+   * clock, not a measurement, and the counts are the fields to read on a
+   * model that size.
+   *
+   * @param startedMs When the build began.
+   * @param candidatesEndedMs When the whole-model candidate walk finished.
+   * @param keysEndedMs When the dispatch-key pass finished; undefined on an
+   * unsharded build, which runs none.
+   * @param candidateProducts Products the walk produced, before filtering.
+   * @param candidateAggregates Rel-aggregates the walk produced, before
+   * filtering.
+   */
+  private recordDemandPrep_(
+      startedMs: number,
+      candidatesEndedMs: number,
+      keysEndedMs: number | undefined,
+      candidateProducts: number,
+      candidateAggregates: number): void {
+
+    this.demandPrepYield_ = {
+      totalMs: Date.now() - startedMs,
+      candidatesMs: candidatesEndedMs - startedMs,
+      keysMs: keysEndedMs !== void 0 ?
+        keysEndedMs - candidatesEndedMs : void 0,
+      candidateProducts,
+      candidateAggregates,
+      // The ADOPTED lists, not the arguments: on a sharded build these are
+      // the filtered ones, and the gap between the two pairs is the whole
+      // replication claim.
+      keptProducts: (this.demandProducts_ ?? []).length,
+      keptAggregates: (this.demandAggregates_ ?? []).length,
+      shardIndex: this.shard_?.index,
+      shardCount: this.shard_?.count,
+      windowed: this.model[0].isSourceExternal,
+    }
+  }
+
+
+  /**
+   * What building this model's demand worklists cost, once they exist.
+   *
+   * Undefined before the first pump, and on a model opened without
+   * `DEFER_GEOMETRY` (which builds no worklists at all). See
+   * {@link recordDemandPrep_} for what the fields mean and
+   * `core/progress_log.ts`'s `formatDemandPrepLine` for the canonical
+   * rendering.
+   *
+   * @return {DemandPrepYieldLike | undefined} The build's cost, or
+   * undefined if no build has run.
+   */
+  public get demandPrepYield(): DemandPrepYieldLike | undefined {
+    return this.demandPrepYield_
   }
 
 

--- a/src/compat/web-ifc/index.ts
+++ b/src/compat/web-ifc/index.ts
@@ -31,10 +31,12 @@ export {
 // by the conway CLI and Share's status-bar/console output alike — see
 // Share design/new/load-log-format.md.
 export {
+  DemandPrepYieldLike,
   LoadLogAccumulator,
   ModelInfo,
   ProgressEventLike,
   formatBar,
+  formatDemandPrepLine,
   formatMb,
   formatModelLine,
   formatSeconds,

--- a/src/core/progress_log.test.ts
+++ b/src/core/progress_log.test.ts
@@ -3,6 +3,7 @@ import {describe, expect, test} from '@jest/globals'
 import {
   LoadLogAccumulator,
   formatBar,
+  formatDemandPrepLine,
   formatMb,
   formatModelLine,
   formatPreviewLine,
@@ -216,6 +217,76 @@ describe( 'formatPreviewLine', () => {
     } ) ).toBe(
         'Preview: no mesh, 0 meshes from 0 units, ' +
         '532 deferred (531 on placements), 0 retried' )
+  } )
+} )
+
+describe( 'formatDemandPrepLine', () => {
+
+  test( 'a sharded build shows the key pass and how much of the walk it kept',
+      () => {
+
+        // The line conway#682 exists to produce, on D3D-shaped numbers: the
+        // shard walked every one of the model's products and kept a
+        // quarter of them, so `candidates` is work all four workers did in
+        // full and `keys` is work the unsharded reference never did at all.
+        expect( formatDemandPrepLine( {
+          totalMs: 685,
+          candidatesMs: 412,
+          keysMs: 264,
+          candidateProducts: 46166,
+          candidateAggregates: 812,
+          keptProducts: 11542,
+          keptAggregates: 203,
+          shardIndex: 1,
+          shardCount: 4,
+          windowed: false,
+        } ) ).toBe(
+            'Prep: worklists 0.685s (candidates 0.412s, keys 0.264s), ' +
+            'shard 1/4 kept 11542 of 46166 products, 203 of 812 aggregates' )
+      } )
+
+  test( 'an unsharded build reports no key pass at all, rather than zero',
+      () => {
+
+        // `ensureDemandWorklists_` returns at its `shard_ === void 0` guard
+        // before computing a single dispatch key, so an unsharded load's key
+        // time is ABSENT, not zero. Printing "keys 0.000s" would read as a
+        // free pass rather than one that never ran -- and the whole point of
+        // the split is that the unsharded reference cannot be the
+        // denominator for work it does not perform (ledger 11.4).
+        expect( formatDemandPrepLine( {
+          totalMs: 412,
+          candidatesMs: 410,
+          candidateProducts: 46166,
+          candidateAggregates: 812,
+          keptProducts: 46166,
+          keptAggregates: 812,
+          windowed: false,
+        } ) ).toBe(
+            'Prep: worklists 0.412s (candidates 0.410s), ' +
+            '46166 products, 812 aggregates' )
+      } )
+
+  test( 'a windowed build says its wall time contains paging', () => {
+
+    // The async builder awaits `ensureAggregateTargetLocalIDs` and
+    // `computeDispatchKeys`, both of which page. Without the marker the
+    // number reads as compute and would be compared against a resident
+    // worker's, which is a different quantity.
+    expect( formatDemandPrepLine( {
+      totalMs: 1900,
+      candidatesMs: 1100,
+      keysMs: 700,
+      candidateProducts: 24,
+      candidateAggregates: 2,
+      keptProducts: 11,
+      keptAggregates: 1,
+      shardIndex: 0,
+      shardCount: 2,
+      windowed: true,
+    } ) ).toBe(
+        'Prep: worklists 1.900s (candidates 1.100s, keys 0.700s), ' +
+        'shard 0/2 kept 11 of 24 products, 1 of 2 aggregates, windowed' )
   } )
 } )
 

--- a/src/core/progress_log.ts
+++ b/src/core/progress_log.ts
@@ -224,6 +224,90 @@ export function formatPreviewLine( preview: PreviewYieldLike ): string {
     `${preview.retried} retried`
 }
 
+/**
+ * What building a deferred model's demand worklists cost — structurally
+ * typed against `IfcApiProxyIfc.demandPrepYield` so this module stays
+ * import-free, exactly as {@link PreviewYieldLike} is against the preview
+ * channels.
+ *
+ * Wall time, not CPU: on a windowed source the build awaits paging, and
+ * {@link windowed} says so rather than leaving the number to be read as
+ * compute.
+ */
+export interface DemandPrepYieldLike {
+  /** Wall ms for the whole worklist build, end to end. */
+  totalMs: number
+  /**
+   * Wall ms enumerating the whole model's candidates. Every worker in a
+   * pool pays this in full — a shard narrows what is BUILT, not what is
+   * walked (conway#682).
+   */
+  candidatesMs: number
+  /**
+   * Wall ms in the dispatch-key pass. Undefined on an unsharded build,
+   * which computes no keys at all — so this is the shard-only term, and
+   * absent rather than zero because "not run" and "ran instantly" are
+   * different measurements.
+   */
+  keysMs?: number
+  /** Products the whole-model walk produced, before any shard filter. */
+  candidateProducts: number
+  /** Rel-aggregates the whole-model walk produced, before any filter. */
+  candidateAggregates: number
+  /** Products this instance kept — equal to the candidates when unsharded. */
+  keptProducts: number
+  /** Rel-aggregates this instance kept. */
+  keptAggregates: number
+  /** The claimed shard index, when one was claimed. */
+  shardIndex?: number
+  /** The claimed shard count, when one was claimed. */
+  shardCount?: number
+  /** Whether the build paged a windowed source, so its wall time includes I/O. */
+  windowed: boolean
+}
+
+/**
+ * The prep line: what a deferred model's worklist build cost, split into
+ * the part every worker replicates and the part only a shard runs.
+ *
+ * Not a stage, for the same reason the Preview line is not one: the build
+ * happens *inside* the geometry phase, on the first pump call, so feeding
+ * it through onProgress would split Geometry across two lines. It is also
+ * the reason the window needed an in-engine timer at all — an external
+ * probe can only difference two `ExtractGeometryBatch` calls, and the pump
+ * floors a batch at one product, so every window it can time carries a
+ * product of real geometry inside it. On two of four measured models that
+ * geometry was larger than the term being measured
+ * (`design/new/load-performance-ledger.md` §11.4, conway#682).
+ *
+ * The candidate-versus-kept counts are on the line rather than only the
+ * times because they are what makes the replication legible: a shard that
+ * walked 46,166 products to keep 11,542 has done the other three shards'
+ * enumeration as well as its own.
+ *
+ * @param prep The worklist build's reported cost.
+ * @return {string} e.g. "Prep: worklists 0.685s (candidates 0.412s, keys
+ * 0.264s), shard 1/4 kept 11542 of 46166 products, 203 of 812 aggregates"
+ */
+export function formatDemandPrepLine( prep: DemandPrepYieldLike ): string {
+
+  const keys = prep.keysMs !== void 0 ?
+    `, keys ${formatSeconds( prep.keysMs )}` : ''
+
+  const scope = prep.shardCount !== void 0 ?
+    `shard ${prep.shardIndex}/${prep.shardCount} kept ` +
+      `${prep.keptProducts} of ${prep.candidateProducts} products, ` +
+      `${prep.keptAggregates} of ${prep.candidateAggregates} aggregates` :
+    `${prep.candidateProducts} products, ` +
+      `${prep.candidateAggregates} aggregates`
+
+  const windowed = prep.windowed ? ', windowed' : ''
+
+  return `Prep: worklists ${formatSeconds( prep.totalMs )} ` +
+    `(candidates ${formatSeconds( prep.candidatesMs )}${keys}), ` +
+    `${scope}${windowed}`
+}
+
 interface StageState {
   label: string
   startElapsedMs: number

--- a/src/ifc/geometry_dispatch.test.ts
+++ b/src/ifc/geometry_dispatch.test.ts
@@ -365,3 +365,161 @@ describe( 'dispatch keys on a windowed source', () => {
             .toEqual( expectedAggregates.slice().sort( ( a, b ) => a - b ) )
       }, 240000 )
 } )
+
+
+describe( 'demand prep yield', () => {
+
+  test( 'is absent until a build runs, then reports what that build cost',
+      async () => {
+
+        // The build is lazy — it happens inside the FIRST pump call — and
+        // that laziness is exactly why an external probe cannot time it
+        // without a product of geometry riding along. So the yield must be
+        // undefined beforehand rather than zeroed: "not measured" and
+        // "measured as nothing" are different answers, and the ledger's
+        // discipline is to print the first as absent (conway#682).
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const { modelID, passthrough } =
+          await openDeferred( api, 'data/mapped_shared_representation.ifc', false )
+
+        expect( api.GetDemandPrepYield( modelID ) ).toBeUndefined()
+
+        passthrough.ensureDemandWorklists_()
+
+        const prep = api.GetDemandPrepYield( modelID )
+
+        expect( prep ).toBeDefined()
+
+        // An unsharded build takes the `shard_ === void 0` return before a
+        // single dispatch key is computed, so the key term is ABSENT. This
+        // is the asymmetry the ledger's §11.4 turns on: the unsharded
+        // reference does not perform this work, so it cannot be the
+        // denominator for it.
+        expect( prep!.keysMs ).toBeUndefined()
+        expect( prep!.shardCount ).toBeUndefined()
+        expect( prep!.windowed ).toBe( false )
+
+        // Nothing was filtered, so the walk and the worklist agree.
+        expect( prep!.candidateProducts )
+            .toBe( ( passthrough.demandProducts_ ?? [] ).length )
+        expect( prep!.keptProducts ).toBe( prep!.candidateProducts )
+        expect( prep!.keptAggregates ).toBe( prep!.candidateAggregates )
+        expect( prep!.candidateProducts ).toBeGreaterThan( 0 )
+
+        // Wall time is a real interval, and the parts fit inside the whole.
+        // Bounded rather than pinned: Date.now() is millisecond-resolution
+        // and this fixture builds in less than one, so anything stricter
+        // than an ordering would be asserting the clock.
+        expect( prep!.candidatesMs ).toBeGreaterThanOrEqual( 0 )
+        expect( prep!.totalMs ).toBeGreaterThanOrEqual( prep!.candidatesMs )
+
+        api.CloseModel( modelID )
+      }, 240000 )
+
+  test( 'every shard walks the WHOLE model, which is what makes prep replicated',
+      async () => {
+
+        // The measurement conway#682 is filed on, asserted rather than
+        // timed. A shard narrows what is BUILT, not what is walked: each
+        // worker's `candidateProducts` is the whole model's count, while its
+        // `keptProducts` is only its own share. So N workers between them
+        // enumerate the model N times and build it once, and the gap
+        // between the two columns is the replication — visible here without
+        // depending on a clock.
+        const api = new IfcAPI()
+
+        await api.Init()
+
+        const fixture = 'data/mapped_shared_representation.ifc'
+        const shardCount = 2
+
+        const whole = await openDeferred( api, fixture, false )
+
+        whole.passthrough.ensureDemandWorklists_()
+
+        const wholeProducts = ( whole.passthrough.demandProducts_ ?? [] ).length
+        const wholeAggregates =
+          ( whole.passthrough.demandAggregates_ ?? [] ).length
+
+        expect( wholeProducts ).toBeGreaterThan( 1 )
+
+        api.CloseModel( whole.modelID )
+
+        let keptProducts = 0
+        let keptAggregates = 0
+
+        for ( let index = 0; index < shardCount; ++index ) {
+
+          const shardModel = await openDeferred( api, fixture, false )
+
+          expect( api.SetGeometryShard(
+              shardModel.modelID, { index, count: shardCount } ) ).toBe( true )
+
+          shardModel.passthrough.ensureDemandWorklists_()
+
+          const prep = api.GetDemandPrepYield( shardModel.modelID )
+
+          expect( prep ).toBeDefined()
+
+          // Every shard walked the whole model...
+          expect( prep!.candidateProducts ).toBe( wholeProducts )
+          expect( prep!.candidateAggregates ).toBe( wholeAggregates )
+
+          // ...and ran the dispatch-key pass the unsharded build skipped.
+          expect( prep!.keysMs ).toBeDefined()
+          expect( prep!.keysMs ).toBeGreaterThanOrEqual( 0 )
+
+          expect( prep!.shardIndex ).toBe( index )
+          expect( prep!.shardCount ).toBe( shardCount )
+
+          // ...but kept only its own share of it.
+          expect( prep!.keptProducts ).toBeLessThan( prep!.candidateProducts )
+          expect( prep!.keptProducts )
+              .toBe( ( shardModel.passthrough.demandProducts_ ?? [] ).length )
+
+          keptProducts += prep!.keptProducts
+          keptAggregates += prep!.keptAggregates
+
+          api.CloseModel( shardModel.modelID )
+        }
+
+        // The partition closes, so the walk really was N times the build:
+        // shardCount x wholeProducts products enumerated to produce
+        // wholeProducts built.
+        expect( keptProducts ).toBe( wholeProducts )
+        expect( keptAggregates ).toBe( wholeAggregates )
+      }, 240000 )
+
+  test( 'a windowed build marks its wall time as containing paging', async () => {
+
+    // The async builder awaits `ensureAggregateTargetLocalIDs` and
+    // `computeDispatchKeys`, both of which page a windowed source. Its
+    // `totalMs` is therefore not comparable with a resident worker's
+    // without knowing that, so the flag travels with the number rather
+    // than being inferred from the configuration by whoever reads it.
+    const api = new IfcAPI()
+
+    await api.Init()
+
+    const { modelID, passthrough } =
+      await openDeferred( api, 'data/aggregate_master_voids.ifc', true )
+
+    expect( api.SetGeometryShard( modelID, { index: 0, count: 2 } ) ).toBe( true )
+
+    await passthrough.ensureDemandWorklistsAsync_()
+
+    const prep = api.GetDemandPrepYield( modelID )
+
+    expect( prep ).toBeDefined()
+    expect( prep!.windowed ).toBe( true )
+    expect( prep!.keysMs ).toBeDefined()
+    expect( prep!.shardCount ).toBe( 2 )
+    expect( prep!.keptProducts )
+        .toBe( ( passthrough.demandProducts_ ?? [] ).length )
+
+    api.CloseModel( modelID )
+  }, 240000 )
+} )

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,12 @@ export {
 } from './core/progress'
 export { ModelLoadOptions } from './loaders/conway_model_loader'
 export {
+  DemandPrepYieldLike,
   LoadLogAccumulator,
   ModelInfo,
   ProgressEventLike,
   formatBar,
+  formatDemandPrepLine,
   formatMb,
   formatModelLine,
   formatSeconds,


### PR DESCRIPTION
Refs #682, #394. Lands the instrumentation prerequisite. **Does not** land the prep-scoping fix — see "What is deferred, and why", which is the substantive finding here.

Two commits: the timer (`a20d2f1`), and a codex round-1 fix to the probe's reporting (`3dfa926`).

## What this establishes

`ensureDemandWorklists_` and its async twin now time themselves and record a `DemandPrepYieldLike`:

| field | what it is |
|---|---|
| `candidatesMs` | the whole-model candidate walk — the **replicated** term every worker pays in full |
| `keysMs` | the dispatch-key pass — **absent, not zero,** on an unsharded build, which returns before computing a key |
| `candidateProducts` / `keptProducts` | what this worker walked vs. what it kept — the replication as an exact integer rather than an inference |
| `shardIndex` / `shardCount` | the claimed shard |
| `windowed` | whether the build paged, so its wall time contains I/O rather than only compute |

Read it with `IfcAPI.GetDemandPrepYield(modelID)`; render it with `formatDemandPrepLine` in `core/progress_log.ts`.

**Why in the engine.** The build runs lazily inside the *first* `ExtractGeometryBatch` call, and `pumpGeometryBatch_` floors a batch at one product, so every window an external probe can time carries a product of real geometry. On two of the four models `--prep-probe` measured, that geometry was larger than the term, and the split was published as `NOT RESOLVED` (ledger §11.4). This timer closes where the build ends: no geometry inside it, no per-worker subtraction, no error bar for the product that subtraction stood in for.

**Why it matches the existing channel rather than adding one.** It is the `previewYield` shape exactly — a measured sub-window *inside* a phase, exposed as a getter on the model and rendered by a `progress_log` formatter, not a stage (feeding it through `onProgress` would split Geometry across two lines, which is the same reason the Preview line is not a stage).

**Why it is unconditional rather than flag-gated.** Three `Date.now()` calls and four array lengths, once per model, against a build measured at 21 ms – 1.7 s. Nothing is emitted: a load that never asks logs nothing and formats nothing, so a flag would buy no cycles and would add a configuration in which the number silently does not exist. The clock's 1 ms floor is documented at the recorder — comfortably under every term in §11.4 (smallest is Schependomlaan's ~21 ms per worker, against the ±0.628 s the external probe could not beat), and *not* under a few-dozen-product fixture's, which is called out so a `0.000s` is not over-read.

`scripts/m3_worker_pool.mjs --prep-probe` prints the engine's split beside the differenced one at every level. Both are kept deliberately: agreement is what says the direct timer measures the window the sweep's `dupFirstBatch` ratio is about, and `prepMs` legitimately contains one-time extraction-path warmup that the direct figure by construction excludes.

## Measured

No ledger model exists in this container (only baseline CSVs), so **the ledger's four rows are not re-measured** — §11.4 now says so explicitly rather than leaving a reader to assume it, and its tables keep reading as the differenced numbers they are.

What I could run, on a 5.9 MB / 72-product IFC with the probe's batch temporarily shrunk to 8 so it would run at all (at 64 it refuses — its batch-64 reference level cannot find enough products to cancel the geometry, which is the differenced instrument stating its own limitation):

```
level=shards  workers=2  direct (engine) 0.009s (candidates 0.003s, keys 0.005s), walked 144 to keep 72
              shard-only key pass  0.008s [-0.016..0.051] +/-0.103  (NOT RESOLVED)
level=shards  workers=4  direct (engine) 0.031s (candidates 0.010s, keys 0.021s), walked 288 to keep 72
              shard-only key pass -0.015s [-0.051..0.019] +/-0.265  (NOT RESOLVED)
```

The differenced estimate fails to resolve the key pass at both N — at N=4 its point estimate is *negative* — while the direct line reports it. That is the §11.4 failure mode this PR removes, reproduced on a model that was not one of the four. `walked 288 to keep 72` is exact 4× replication. The *times* are near the clock's floor on a model this size and are evidence of plumbing, not a measurement; the counts are exact.

## What is deferred, and why — #682's fix-shape 1 is not available

The issue's cheapest candidate is "scope prep to the shard's own filtered worklist so each worker at least stops walking products it will never build." **The code does not admit that**, and the reason is structural rather than a matter of effort:

- `collectDemandCandidates_` walks every `IfcProduct` and every `IfcRelAggregates` to produce the candidate lists.
- `ensureDemandWorklists_` then computes `geometryDispatchKey` for **every** candidate.
- `adoptShardedWorklists_` filters on `shardOfDispatchKey(key, count) === index`.

The dispatch key *is* the discriminator. A worker cannot know a product is outside its shard until it has computed that product's key, and computing every candidate's key is the prep. There is no whole-model work left over to skip: `aggregateTargetLocalIDs()` is the precondition for the product walk that feeds the keys, and `adoptAggregateStepPrefix_` — the only per-entry pass *after* the filter — already runs on the narrowed `demandAggregates_`.

So the only remaining lever is fix-shape 2 (compute once, ship as transferable columns), which restructures the pool protocol and is explicitly out of scope. **#682 stays open** with that as the precise remainder.

## Digest discipline

Geometry output is byte-identical for every model. The change adds timestamps and counters around the worklist build; it does not touch which products are selected, the order they are selected in, or what is built from them. The `geometry_dispatch` suite's existing exact-partition tests (union of shards ≡ the unsharded worklist, sorted, for both windowed fixtures) still pass unchanged, which is the partition-level statement of the same claim.

## Tests

Six new, each verified to fail against a revert of the source change (AGENTS.md §Traps sequence — committed first, revert undone before resuming, tree confirmed clean after each cycle):

- 3 in `core/progress_log.test.ts` pinning the line format — the sharded split, the **absent** key term on an unsharded build, and the windowed marker. With the formatter body neutralised: 3 failed, 16 passed.
- 3 in `ifc/geometry_dispatch.test.ts` pinning the engine behaviour — undefined before the first pump; every shard's `candidateProducts` equal to the whole model's while its `keptProducts` is a strict subset, and the kept counts summing back to the whole (the replication claim, asserted on integers rather than on a clock); and the windowed async build marking itself. With `ifc_api_proxy_ifc.ts` reverted to `main`: 3 failed, 27 passed, all `expect(received).toBeDefined() / Received: undefined`.

Time assertions are deliberately ordering-only (`totalMs >= candidatesMs`, `keysMs >= 0`) — the fixtures build in under the clock's tick, and anything stricter would be asserting the clock.

**One gap, stated rather than implied:** the `3dfa926` probe fix is not pinned by a test. `scripts/*.mjs` has no test harness here (jest runs over `compiled/`). The engine behaviour it depends on — `keysMs` defined-and-zero on a sharded build, absent on an unsharded one — *is* pinned by two of the six tests above.

## Review

Three rounds; all findings fixed or answered in-thread. Round 1 (codex) found a real P2 in the probe's reporting layer, fixed in `3dfa926`. Round 2 (codex) clean. Round 3 (substitute sub-agent, per AGENTS.md §Review) returned all three named claims HOLD plus one low-severity race — whose prose did not reach me, which is recorded in-thread along with the independent verification I did instead: the async re-entrancy asymmetry is pre-existing on base `575ffaa` and unreachable under `pumpGeometryBatchAsync_`'s pump lock, so it is noted rather than fixed inside a measurement PR.

## Verification

- `yarn precommit` (build → check-compiled-fresh → lint → test): **140 suites / 1051 tests passed**, from main's 140 / 1045. Lint 0 errors.
- `run-ifc-regression` / `visual-diff` run on this PR now that it is ready; `visual_diff_count` must be 0. The change builds no geometry differently.
