### PR TITLE
Share#1634: state the applied-coordination contract, make every path report it, and finish the Normalize() invariant

### DIFF
--- a/design/new/coordination-frame.md
+++ b/design/new/coordination-frame.md
@@ -200,9 +200,18 @@ Two traps the accessor's doc comment states and the tests pin:
   zero — model-zero, above — but whose rotation and scale are still the
   `NormalizeMat` and unit scale the placements were composed under.
   Skipping the inverse on that model reads every point in the wrong axis
-  convention. Identity is returned only when nothing was composed at all:
-  recentring off, a shard with no supplied frame, or no geometry emitted
-  yet.
+  convention. Identity is returned only when nothing was composed *and*
+  nothing was handed in: recentring off, a shard with no supplied frame,
+  or no geometry emitted yet on a model nobody supplied a frame to.
+- **A supplied frame reports before it is applied.**
+  `SetCoordinationFrame` stores its matrix at call time, so
+  `GetAppliedCoordinationMatrix` returns it immediately — before the
+  worker has composed a single placement under it. That is the reading
+  M3's pool wants (which frame *will* this worker apply), and it is
+  sound because a supplied frame is final: the setter refuses to replace
+  a frame the model derived for itself, and refuses one at all after the
+  first batch. The STEP arm has no such case — it implements no
+  `setCoordinationFrame`.
 - **Every walk composes under the same frame, not just the first.** More
   than one classic walk of a live model is legal (`StreamAllMeshes` and
   then `LoadAllGeometry`), and each has its own local. Those locals seed

--- a/design/new/coordination-frame.md
+++ b/design/new/coordination-frame.md
@@ -203,6 +203,15 @@ Two traps the accessor's doc comment states and the tests pin:
   convention. Identity is returned only when nothing was composed at all:
   recentring off, a shard with no supplied frame, or no geometry emitted
   yet.
+- **Every walk composes under the same frame, not just the first.** More
+  than one classic walk of a live model is legal (`StreamAllMeshes` and
+  then `LoadAllGeometry`), and each has its own local. Those locals seed
+  from the persisted frame, because the derivation guard — correctly —
+  stops a second walk re-anchoring, and seeding identity there made it
+  emit raw source coordinates while the accessor went on reporting the
+  real frame (conway#703). Accessor and emission agreeing is what makes
+  the inverse above true of any placement, not just one from the first
+  walk.
 - **The durable walk is the authority.** A deferred open that adopted its
   preview channel's frame reports that adopted frame from the moment it
   opens — truthfully, since the preview payloads were composed under it —
@@ -219,7 +228,8 @@ Two traps the accessor's doc comment states and the tests pin:
 | The cross-format claim — `index.ifc` and `index.step` render in the same world box | Share: `src/Containers/indexStepLogo.spec.ts` |
 | A supplied frame is applied exactly, a different one moves the model, and N shards under one frame union to the single instance's placements | `src/compat/web-ifc/geometry_shard_coordination.test.ts` |
 | `inverse(GetAppliedCoordinationMatrix)` maps a rendered point back to the fixture's authored LV95 coordinates; zero translation but non-identity frame near the origin; exact identity with recentring off; stable across batches; classic and deferred agree | `src/compat/web-ifc/coordination_baked_geometry.test.ts` |
-| The same classic/deferred agreement on the AP214 arm | `src/compat/web-ifc/ap214_streamed_open.test.ts` |
+| A second classic walk of one live model composes under the frame the first derived, and its placements still invert to the authored coordinates (conway#703) | `src/compat/web-ifc/coordination_baked_geometry.test.ts` |
+| The same classic/deferred agreement, and the same second-walk rule, on the AP214 arm | `src/compat/web-ifc/ap214_streamed_open.test.ts` |
 
 The cross-format claim is pinned Share-side rather than here because
 through this surface the AP214 arm reports its placements at the origin

--- a/design/new/coordination-frame.md
+++ b/design/new/coordination-frame.md
@@ -153,6 +153,63 @@ exactly this reason, and
 `src/compat/web-ifc/geometry_shard_coordination.test.ts` asserts that
 span rather than assuming it.
 
+## Reading the applied frame back
+
+`GetCoordinationMatrix` cannot answer "where is this model really".
+It is pinned at identity on purpose: consumers stamp what it returns
+onto the assembled model, so a truthful return there would apply the
+recentre a second time on top of placements that already carry it. That
+left no way to invert the recentre at all — no measurement in source
+coordinates, no georeferenced permalink, no round-tripping export
+(Share#1634).
+
+`GetAppliedCoordinationMatrix(modelID)` is the explicit answer. Write
+`A` for what it returns. Every emitted `flatTransformation` was composed
+as
+
+```
+flatTransformation = A * placement [ * translate(geomCentre) ]
+```
+
+— `placement` the entity's native world placement in authored space, and
+the optional per-leaf `translate(geomCentre)` the IFC path's vertex-buffer
+recentre, which the AP214 path omits. Both sit to the right of `A`, so
+for any uploaded vertex
+
+```
+rendered = A * world       world = inverse(A) * rendered
+```
+
+with `world` in the model's authored space: the file's units, Z-up,
+un-recentred. Inverting the returned matrix is the whole of it, because
+`A` carries all three factors:
+
+```
+A = scale(linearScalingFactor) * NormalizeMat * translate(-anchor)
+```
+
+innermost first — the recentre in source units and pre-rotation, then
+the Z-up → Y-up change of basis, then the scale to metres. A consumer
+therefore needs to know neither the file's unit scale nor the engine's
+axis convention.
+
+Two traps the accessor's doc comment states and the tests pin:
+
+- **"No offset" is not "identity".** A near-origin model under
+  `COORDINATE_TO_ORIGIN` returns a frame whose *translation* is exactly
+  zero — model-zero, above — but whose rotation and scale are still the
+  `NormalizeMat` and unit scale the placements were composed under.
+  Skipping the inverse on that model reads every point in the wrong axis
+  convention. Identity is returned only when nothing was composed at all:
+  recentring off, a shard with no supplied frame, or no geometry emitted
+  yet.
+- **The durable walk is the authority.** A deferred open that adopted its
+  preview channel's frame reports that adopted frame from the moment it
+  opens — truthfully, since the preview payloads were composed under it —
+  and the value can change once, at the first durable batch, if the
+  revalidation above rejects it. From derivation or validation onward it
+  is fixed for the life of the model.
+
 ## What is pinned, and where
 
 | Property | Test |
@@ -161,6 +218,8 @@ span rather than assuming it.
 | Near-origin model keeps authored coordinates; georeferenced model still recentres; classic and streamed opens agree | `src/compat/web-ifc/coordination_export_order.test.ts` |
 | The cross-format claim — `index.ifc` and `index.step` render in the same world box | Share: `src/Containers/indexStepLogo.spec.ts` |
 | A supplied frame is applied exactly, a different one moves the model, and N shards under one frame union to the single instance's placements | `src/compat/web-ifc/geometry_shard_coordination.test.ts` |
+| `inverse(GetAppliedCoordinationMatrix)` maps a rendered point back to the fixture's authored LV95 coordinates; zero translation but non-identity frame near the origin; exact identity with recentring off; stable across batches; classic and deferred agree | `src/compat/web-ifc/coordination_baked_geometry.test.ts` |
+| The same classic/deferred agreement on the AP214 arm | `src/compat/web-ifc/ap214_streamed_open.test.ts` |
 
 The cross-format claim is pinned Share-side rather than here because
 through this surface the AP214 arm reports its placements at the origin

--- a/src/compat/web-ifc/ap214_streamed_open.test.ts
+++ b/src/compat/web-ifc/ap214_streamed_open.test.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs'
 
 import { beforeAll, describe, expect, test } from '@jest/globals'
 
+import { IDENTITY_MAT4, NORMALIZE_MAT_F64 } from './coordination_f64'
 import { FlatMesh, IfcAPI } from './ifc_api'
 
 const SETTINGS = { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true }
@@ -297,4 +298,59 @@ describe( 'OpenModelStreamed on AP214 STEP input', () => {
     }
 
   }, 240000 )
+
+  test( 'classic and deferred report the same applied coordination frame',
+      async () => {
+
+        // The AP214 arm of the Share#1634 accessor. Both walks derive
+        // through deriveCoordinationF64 and both must RECORD what they
+        // derived: the classic walk kept it in a local for a while, so
+        // GetAppliedCoordinationMatrix answered identity for a model it
+        // had in fact composed a frame into, while the deferred pump on
+        // the same file answered the truth. A consumer mapping a
+        // rendered point back to authored coordinates got a different
+        // answer depending on which open it took.
+        const data = new Uint8Array( fs.readFileSync( FIXTURES[ 0 ] ) )
+
+        const classicID = api.OpenModel( data, SETTINGS )
+
+        capture( classicID )
+
+        const classic = api.GetAppliedCoordinationMatrix( classicID )
+
+        const deferredID = await api.OpenModelStreamed(
+            data, { ...SETTINGS, DEFER_GEOMETRY: true } )
+
+        capture( deferredID )
+
+        expect( api.GetAppliedCoordinationMatrix( deferredID ) ).toEqual( classic )
+
+        // Non-vacuous: this fixture sits near the origin, so the frame
+        // carries no recentre — but it still carries the Z-up -> Y-up
+        // basis change and the file's unit scale, which is exactly what
+        // an identity report would lose. Without this the equality above
+        // would hold just as well for two paths that both reported
+        // nothing.
+        expect( classic[ 12 ] ).toBe( 0 )
+        expect( classic[ 13 ] ).toBe( 0 )
+        expect( classic[ 14 ] ).toBe( 0 )
+
+        const scale = Math.hypot( classic[ 0 ], classic[ 1 ], classic[ 2 ] )
+
+        expect( scale ).toBeGreaterThan( 0 )
+
+        for ( let element = 0; element < 16; ++element ) {
+
+          // Bottom row unscaled; the columns above it are NormalizeMat
+          // times the linear scaling factor.
+          const expected = ( element % 4 ) === 3 ?
+            NORMALIZE_MAT_F64[ element ] : NORMALIZE_MAT_F64[ element ] * scale
+
+          expect( classic[ element ] ).toBeCloseTo( expected, 9 )
+        }
+
+        // ...and that is not identity, so an accessor that lost the
+        // classic frame would be caught by the equality above.
+        expect( classic ).not.toEqual( [ ...IDENTITY_MAT4 ] )
+      }, 240000 )
 } )

--- a/src/compat/web-ifc/ap214_streamed_open.test.ts
+++ b/src/compat/web-ifc/ap214_streamed_open.test.ts
@@ -353,4 +353,68 @@ describe( 'OpenModelStreamed on AP214 STEP input', () => {
         // classic frame would be caught by the equality above.
         expect( classic ).not.toEqual( [ ...IDENTITY_MAT4 ] )
       }, 240000 )
+
+  test( 'a second classic walk composes under the frame the first derived',
+      async () => {
+
+        // conway#703 on the AP214 arm. More than one classic walk of one
+        // live model is legal, and the second used to seed its
+        // coordination local from the model tuple's identity while the
+        // `_isCoordinated` guard — correctly — stopped it re-deriving, so
+        // it re-emitted every placement without the frame. On a
+        // near-origin STEP part that is not a 2.6e6 m jump, it is the
+        // Z-up -> Y-up basis change going missing: the second walk's
+        // copies of the model come back in a different axis convention
+        // from the first's, and from what GetAppliedCoordinationMatrix
+        // says they are in.
+        const data = new Uint8Array( fs.readFileSync( FIXTURES[ 0 ] ) )
+
+        const modelID = api.OpenModel( data, SETTINGS )
+
+        const first = capture( modelID )
+
+        expect( first.size ).toBeGreaterThan( 0 )
+
+        const applied = api.GetAppliedCoordinationMatrix( modelID )
+
+        // The per-entity placement vectors are cumulative across walks, so
+        // after the second walk each entity carries both emissions and the
+        // tail of the list is the second walk's.
+        const second = capture( modelID )
+
+        expect( second.size ).toBe( first.size )
+
+        let compared = 0
+
+        for ( const [ expressID, firstList ] of first ) {
+
+          const bothWalks = second.get( expressID )!
+
+          expect( bothWalks.length ).toBe( firstList.length * 2 )
+
+          for ( let where = 0; where < firstList.length; ++where ) {
+
+            const rewalked = bothWalks[ firstList.length + where ]
+
+            expect( rewalked.geometryExpressID )
+                .toBe( firstList[ where ].geometryExpressID )
+
+            // Bit-equality: the same composition over the same inputs, so
+            // any difference at all means the two walks disagreed about
+            // the frame.
+            expect( rewalked.flatTransformation )
+                .toEqual( firstList[ where ].flatTransformation )
+
+            ++compared
+          }
+        }
+
+        expect( compared ).toBeGreaterThan( 0 )
+
+        // The accessor still describes what the SECOND walk emitted, which
+        // is the half that fails on the applied-frame contract rather than
+        // on parity.
+        expect( api.GetAppliedCoordinationMatrix( modelID ) ).toEqual( applied )
+        expect( applied ).not.toEqual( [ ...IDENTITY_MAT4 ] )
+      }, 240000 )
 } )

--- a/src/compat/web-ifc/coordination_baked_geometry.test.ts
+++ b/src/compat/web-ifc/coordination_baked_geometry.test.ts
@@ -640,6 +640,184 @@ describe( 'GetAppliedCoordinationMatrix (Share#1634)', () => {
     expect( api.GetCoordinationMatrix( classicID ) ).toEqual( [ ...IDENTITY_MAT4 ] )
     expect( api.GetCoordinationMatrix( deferredID ) ).toEqual( [ ...IDENTITY_MAT4 ] )
   }, 120000 )
+
+  test( 'a second classic walk composes under the frame the first derived',
+      async () => {
+
+        // conway#703. More than one classic walk of one live model is
+        // legal, and the second used to seed its coordination local from
+        // the model tuple's identity while the `_isCoordinated` guard —
+        // correctly — stopped it re-deriving. So it re-emitted the
+        // fixture's raw LV95 coordinates, ~2.6e6 m out, in the same
+        // session that had just emitted them recentred.
+        //
+        // It belongs in this describe block because of what the accessor
+        // made of it: with the frame persisted,
+        // GetAppliedCoordinationMatrix reports the FIRST walk's real
+        // frame while the second walk's placements carry none, so
+        // `inverse(A) * rendered` — the contract this block exists to
+        // state — silently returns a point 2.6e6 m from the authored one.
+        // Before the accessor the two were accidentally consistent, both
+        // identity, which is why nothing caught it earlier.
+        const modelID = api.OpenModel( buffer, { ...SETTINGS } )
+
+        expect( modelID ).toBeGreaterThanOrEqual( 0 )
+
+        const firstWalk = new Map< number, number[] >()
+
+        api.StreamAllMeshes( modelID, ( mesh ) => {
+          firstWalk.set( mesh.expressID,
+              [ ...mesh.geometries.get( 0 ).flatTransformation ] )
+        } )
+
+        expect( firstWalk.size ).toBe( SOURCE_BOXES.size )
+
+        const applied = api.GetAppliedCoordinationMatrix( modelID )
+
+        expect( applied[ 12 ] ).toBeCloseTo( -GRID_EASTING, 6 )
+
+        // The second walk of the same live model.
+        const secondWalk =
+          new Map< number, { geometryExpressID: number, transform: number[] } >()
+
+        api.StreamAllMeshes( modelID, ( mesh ) => {
+
+          const geometries = mesh.geometries
+
+          // The per-entity vector is CUMULATIVE across walks — each walk
+          // appends its own placement — so the last entry is this walk's.
+          // Asserted rather than assumed: if that accumulation ever
+          // changes shape this test would otherwise quietly start
+          // comparing the first walk with itself.
+          expect( geometries.size() ).toBe( 2 )
+
+          const placed = geometries.get( geometries.size() - 1 )
+
+          secondWalk.set( mesh.expressID, {
+            geometryExpressID: placed.geometryExpressID,
+            transform: [ ...placed.flatTransformation ],
+          } )
+        } )
+
+        expect( secondWalk.size ).toBe( firstWalk.size )
+
+        for ( const [ expressID, first ] of firstWalk ) {
+
+          // Parity over the whole transform, not just its magnitude: the
+          // two walks run the same composition over the same inputs, so
+          // anything short of bit-equality means they disagreed about the
+          // frame.
+          expect( secondWalk.get( expressID )!.transform ).toEqual( first )
+        }
+
+        // ...and the accessor still describes what the SECOND walk
+        // emitted. This is the half that fails on the accessor's own
+        // terms rather than on parity: a placement from walk two, mapped
+        // back through inverse(A), has to land on the authored
+        // coordinates exactly as one from walk one does.
+        const inverse = invertAffine( applied )
+
+        for ( const [ expressID, second ] of secondWalk ) {
+
+          const source = SOURCE_BOXES.get( expressID )!
+
+          const authoredMin = [ Infinity, Infinity, Infinity ]
+          const authoredMax = [ -Infinity, -Infinity, -Infinity ]
+
+          for ( const position of
+            uploadedPositions( modelID, second.geometryExpressID ) ) {
+
+            const authored = transformPoint( inverse,
+                transformPoint( second.transform, position ) )
+
+            for ( let axis = 0; axis < 3; ++axis ) {
+              authoredMin[ axis ] = Math.min( authoredMin[ axis ], authored[ axis ] )
+              authoredMax[ axis ] = Math.max( authoredMax[ axis ], authored[ axis ] )
+            }
+          }
+
+          for ( let axis = 0; axis < 3; ++axis ) {
+            expect( authoredMin[ axis ] ).toBeCloseTo( source.min[ axis ], 3 )
+            expect( authoredMax[ axis ] ).toBeCloseTo( source.max[ axis ], 3 )
+          }
+        }
+      }, 120000 )
+
+  test( 'LoadAllGeometry after StreamAllMeshes composes under the same frame',
+      async () => {
+
+        // conway#703's literal repro, and the second of the three classic
+        // seed sites: `loadAllGeometry` has its own local, so fixing
+        // `streamAllMeshes` alone would leave this path emitting raw LV95
+        // coordinates.
+        //
+        // Two things about this path are pre-existing defects rather than
+        // anything this change introduces, and the assertions below are
+        // shaped around both rather than resting on either:
+        //
+        //  - `loadAllGeometry`'s `return` sits INSIDE its scene walk, so
+        //    it emits one geometry and returns. Only that entity gains a
+        //    second placement today, which is why this asserts over
+        //    whatever gained one and requires at least one, rather than
+        //    over all four.
+        //  - the `Vector<FlatMesh>` it returns cannot be read: the shim's
+        //    `get` bounds-checks against a different (empty) array and so
+        //    always returns the dummy. Hence GetFlatMesh below, which
+        //    reads the model's own mesh map.
+        const modelID = api.OpenModel( buffer, { ...SETTINGS } )
+
+        const firstWalk = new Map< number, number[] >()
+
+        api.StreamAllMeshes( modelID, ( mesh ) => {
+          firstWalk.set( mesh.expressID,
+              [ ...mesh.geometries.get( 0 ).flatTransformation ] )
+        } )
+
+        expect( firstWalk.size ).toBe( SOURCE_BOXES.size )
+
+        const applied = api.GetAppliedCoordinationMatrix( modelID )
+
+        expect( applied[ 12 ] ).toBeCloseTo( -GRID_EASTING, 6 )
+
+        api.LoadAllGeometry( modelID )
+
+        const inverse = invertAffine( applied )
+        let compared = 0
+
+        for ( const [ expressID, first ] of firstWalk ) {
+
+          const geometries = api.GetFlatMesh( modelID, expressID ).geometries
+
+          if ( geometries.size() < 2 ) {
+            continue
+          }
+
+          ++compared
+
+          const placed = geometries.get( geometries.size() - 1 )
+
+          expect( [ ...placed.flatTransformation ] ).toEqual( first )
+
+          const source = SOURCE_BOXES.get( expressID )!
+
+          for ( const position of
+            uploadedPositions( modelID, placed.geometryExpressID ) ) {
+
+            const authored = transformPoint( inverse,
+                transformPoint( [ ...placed.flatTransformation ], position ) )
+
+            for ( let axis = 0; axis < 3; ++axis ) {
+              expect( authored[ axis ] )
+                  .toBeGreaterThanOrEqual( source.min[ axis ] - 1e-3 )
+              expect( authored[ axis ] )
+                  .toBeLessThanOrEqual( source.max[ axis ] + 1e-3 )
+            }
+          }
+        }
+
+        // Nothing re-emitted means nothing was tested.
+        expect( compared ).toBeGreaterThan( 0 )
+      }, 120000 )
 } )
 
 describe( 'normalizeWithCentreF64', () => {

--- a/src/compat/web-ifc/coordination_baked_geometry.test.ts
+++ b/src/compat/web-ifc/coordination_baked_geometry.test.ts
@@ -18,13 +18,23 @@
 // float32 vertex buffer a consumer actually uploads, and the transform it
 // actually applies, and check both against the coordinates the fixture
 // declares.
+//
+// The same fixture is what makes this the home for the
+// GetAppliedCoordinationMatrix contract (Share#1634), in the second
+// describe: a frame is only checkable against authored coordinates on a
+// model whose authored coordinates are known and far enough from the
+// origin that a wrong frame cannot pass by coincidence.
 
 import * as fs from 'fs'
 
 import { beforeAll, describe, expect, test } from '@jest/globals'
 
 import { IfcAPI } from './ifc_api'
-import { LARGE_COORDINATE_BUDGET_M } from './coordination_f64'
+import {
+  IDENTITY_MAT4,
+  LARGE_COORDINATE_BUDGET_M,
+  NORMALIZE_MAT_F64,
+} from './coordination_f64'
 import {
   exceedsLargeCoordinateBudget,
   normalizeWithCentreF64,
@@ -101,6 +111,58 @@ function transformPoint( m: ArrayLike< number >, p: number[] ): number[] {
   ]
 }
 
+/**
+ * Invert a column-major affine 4x4 — the shape every coordination frame
+ * has (`scale * NormalizeMat * translate`, bottom row 0,0,0,1).
+ *
+ * This is the consumer's half of the accessor's contract: what a
+ * measurement or georeferenced-export path has to do with the returned
+ * matrix to get from a rendered point back to authored coordinates. It
+ * is hand-rolled rather than taken from gl-matrix deliberately —
+ * gl-matrix's `mat4` is Float32Array-backed (see coordination_f64), and
+ * float32 at LV95 magnitude quantizes at ~0.25 m, three orders coarser
+ * than the tolerance the round trip below is asserted to.
+ *
+ * @param m The frame to invert.
+ * @return {number[]} Its inverse, column-major.
+ */
+function invertAffine( m: ArrayLike< number > ): number[] {
+
+  // aRC: row R, column C of the 3x3 linear block.
+  const a00 = m[ 0 ], a01 = m[ 4 ], a02 = m[ 8 ]
+  const a10 = m[ 1 ], a11 = m[ 5 ], a12 = m[ 9 ]
+  const a20 = m[ 2 ], a21 = m[ 6 ], a22 = m[ 10 ]
+
+  const det =
+    a00 * ( a11 * a22 - a12 * a21 ) -
+    a01 * ( a10 * a22 - a12 * a20 ) +
+    a02 * ( a10 * a21 - a11 * a20 )
+
+  expect( Math.abs( det ) ).toBeGreaterThan( 0 )
+
+  const i00 = ( a11 * a22 - a12 * a21 ) / det
+  const i01 = ( a02 * a21 - a01 * a22 ) / det
+  const i02 = ( a01 * a12 - a02 * a11 ) / det
+  const i10 = ( a12 * a20 - a10 * a22 ) / det
+  const i11 = ( a00 * a22 - a02 * a20 ) / det
+  const i12 = ( a02 * a10 - a00 * a12 ) / det
+  const i20 = ( a10 * a21 - a11 * a20 ) / det
+  const i21 = ( a01 * a20 - a00 * a21 ) / det
+  const i22 = ( a00 * a11 - a01 * a10 ) / det
+
+  const tx = m[ 12 ], ty = m[ 13 ], tz = m[ 14 ]
+
+  return [
+    i00, i10, i20, 0,
+    i01, i11, i21, 0,
+    i02, i12, i22, 0,
+    -( i00 * tx + i01 * ty + i02 * tz ),
+    -( i10 * tx + i11 * ty + i12 * tz ),
+    -( i20 * tx + i21 * ty + i22 * tz ),
+    1,
+  ]
+}
+
 interface Placement {
   expressID: number
   geometryExpressID: number
@@ -109,12 +171,14 @@ interface Placement {
 
 let api: IfcAPI
 let buffer: Uint8Array
+let nearOrigin: Uint8Array
 
 beforeAll( async () => {
   api = new IfcAPI()
   await api.Init()
 
   buffer = new Uint8Array( fs.readFileSync( 'data/lv95_baked_geometry.ifc' ) )
+  nearOrigin = new Uint8Array( fs.readFileSync( 'data/index.ifc' ) )
 }, 120000 )
 
 /**
@@ -317,6 +381,265 @@ describe( 'COORDINATE_TO_ORIGIN with grid coordinates baked into geometry', () =
         expect( second.flatTransformation[ 14 ] - first.flatTransformation[ 14 ] )
             .toBeCloseTo( -20, 6 )
       }, 120000 )
+} )
+
+/**
+ * Drain a deferred model, discarding the payloads.
+ *
+ * @param modelID The open deferred model.
+ * @return {number} How many batches did work.
+ */
+function drain( modelID: number ): number {
+
+  let batches = 0
+
+  for ( ; ; ) {
+
+    const { extracted, remaining } =
+      api.ExtractGeometryBatch( modelID, 1, () => { /* payload unused */ } )
+
+    if ( remaining === 0 && extracted === 0 ) {
+      return batches
+    }
+
+    ++batches
+  }
+}
+
+describe( 'GetAppliedCoordinationMatrix (Share#1634)', () => {
+
+  // The accessor exists because GetCoordinationMatrix cannot answer this:
+  // it is pinned at identity so consumers can stamp it onto an assembled
+  // model without applying the recentre twice. So every assertion here is
+  // about the OTHER question — what offset did the engine actually apply,
+  // and can a consumer undo it from the return value alone.
+  //
+  // No CloseModel anywhere in this file, deliberately: closing tears down
+  // wasm state the next open in the same IfcAPI still needs, and the
+  // symptom is not an error but a later model whose geometry all arrives
+  // at the origin — which is to say, tests that pass while measuring
+  // nothing.
+
+  test( 'its inverse maps a rendered point back to the authored coordinates',
+      async () => {
+
+        const [ modelID, placements ] = await openAndPump()
+        const applied = api.GetAppliedCoordinationMatrix( modelID )
+
+        // The frame's own contents, against the fixture rather than
+        // against a re-derivation: the recentre is the quantized LV95
+        // anchor, carried through the Z-up -> Y-up change of basis, so
+        // north ends up in +Z and the up axis picks up no offset.
+        expect( applied[ 12 ] ).toBeCloseTo( -GRID_EASTING, 6 )
+        expect( applied[ 13 ] ).toBeCloseTo( 0, 6 )
+        expect( applied[ 14 ] ).toBeCloseTo( GRID_NORTHING, 6 )
+
+        // Non-vacuous: a frame that did nothing would make the round trip
+        // below true for any implementation, including one that returned
+        // identity.
+        expect( Math.max( Math.abs( applied[ 12 ] ), Math.abs( applied[ 14 ] ) ) )
+            .toBeGreaterThan( LARGE_COORDINATE_BUDGET_M )
+
+        const inverse = invertAffine( applied )
+
+        // Guard on the helper itself, so a wrong inverse cannot be read
+        // as a wrong accessor.
+        const probe = [ 3.5, -7.25, 11.125 ]
+        const roundTrip =
+          transformPoint( inverse, transformPoint( applied, probe ) )
+
+        for ( let axis = 0; axis < 3; ++axis ) {
+          expect( roundTrip[ axis ] ).toBeCloseTo( probe[ axis ], 9 )
+        }
+
+        // The acceptance itself: emitted placement x uploaded vertex is
+        // the point on screen; inverse(applied) x that is the coordinate
+        // the file authored. Nothing else about the model is consulted —
+        // not the unit scale, not the axis convention, not the anchor.
+        for ( const placement of placements ) {
+
+          const source = SOURCE_BOXES.get( placement.expressID )!
+
+          const authoredMin = [ Infinity, Infinity, Infinity ]
+          const authoredMax = [ -Infinity, -Infinity, -Infinity ]
+
+          for ( const position of
+            uploadedPositions( modelID, placement.geometryExpressID ) ) {
+
+            const rendered =
+              transformPoint( placement.flatTransformation, position )
+            const authored = transformPoint( inverse, rendered )
+
+            for ( let axis = 0; axis < 3; ++axis ) {
+              authoredMin[ axis ] = Math.min( authoredMin[ axis ], authored[ axis ] )
+              authoredMax[ axis ] = Math.max( authoredMax[ axis ], authored[ axis ] )
+            }
+          }
+
+          for ( let axis = 0; axis < 3; ++axis ) {
+            // 1 mm, the same bound the forward assertion uses: the
+            // uploaded vertices are float32 at ~2 m (ULP ~2e-7 m) and
+            // everything after them is float64, so this is still 250x
+            // tighter than the 0.25 m quantization the recentre removes.
+            expect( authoredMin[ axis ] ).toBeCloseTo( source.min[ axis ], 3 )
+            expect( authoredMax[ axis ] ).toBeCloseTo( source.max[ axis ], 3 )
+          }
+        }
+      }, 120000 )
+
+  test( 'a near-origin model reports a frame with no offset in it', async () => {
+
+    const modelID = await api.OpenModelStreamed(
+        nearOrigin, { ...SETTINGS, DEFER_GEOMETRY: true, STREAMING_CONSUMER: true } )
+
+    expect( drain( modelID ) ).toBeGreaterThan( 0 )
+
+    const applied = api.GetAppliedCoordinationMatrix( modelID )
+
+    // Model-zero: below LARGE_COORDINATE_BUDGET_M the recentre is
+    // skipped entirely so the file keeps the coordinates it authored
+    // (COORDINATION_SNAP_M). Exact zeros, not near-zeros — the
+    // translation was never computed, it was declined.
+    expect( applied[ 12 ] ).toBe( 0 )
+    expect( applied[ 13 ] ).toBe( 0 )
+    expect( applied[ 14 ] ).toBe( 0 )
+
+    // But NOT identity, and this is the trap the doc comment warns about:
+    // the frame still carries the Z-up -> Y-up basis change and the unit
+    // scale that the placements were composed under, so a consumer that
+    // shortcuts on "no offset applied" and skips the inverse reads every
+    // point in the wrong axis convention.
+    const scale = Math.hypot( applied[ 0 ], applied[ 1 ], applied[ 2 ] )
+
+    expect( scale ).toBeGreaterThan( 0 )
+
+    for ( let element = 0; element < 16; ++element ) {
+
+      // Bottom row is unscaled; the three columns above it are the
+      // normalize matrix times the linear scaling factor.
+      const expected = ( element % 4 ) === 3 ?
+        NORMALIZE_MAT_F64[ element ] : NORMALIZE_MAT_F64[ element ] * scale
+
+      expect( applied[ element ] ).toBeCloseTo( expected, 9 )
+    }
+
+  }, 120000 )
+
+  test( 'an open without COORDINATE_TO_ORIGIN reports exact identity',
+      async () => {
+
+        // The other half of "identity when no recentre was applied": with
+        // the setting off nothing is composed at all, the placements come
+        // back in raw authored space, and identity is the truthful report
+        // — inverse(identity) x rendered is the authored point.
+        const modelID = await api.OpenModelStreamed(
+            buffer,
+            {
+              ...SETTINGS,
+              COORDINATE_TO_ORIGIN: false,
+              DEFER_GEOMETRY: true,
+              STREAMING_CONSUMER: true,
+            } )
+
+        const translations: number[][] = []
+
+        for ( ; ; ) {
+
+          const { extracted, remaining } = api.ExtractGeometryBatch(
+              modelID, 2, ( mesh ) => {
+
+                for ( let where = 0; where < mesh.geometries.size(); ++where ) {
+
+                  const t = mesh.geometries.get( where ).flatTransformation
+
+                  translations.push( [ t[ 12 ], t[ 13 ], t[ 14 ] ] )
+                }
+              } )
+
+          if ( remaining === 0 && extracted === 0 ) {
+            break
+          }
+        }
+
+        expect( api.GetAppliedCoordinationMatrix( modelID ) )
+            .toEqual( [ ...IDENTITY_MAT4 ] )
+
+        // Non-vacuous: the fixture really is georeferenced, so identity
+        // here means "nothing was applied" rather than "nothing to apply".
+        expect( translations.length ).toBe( SOURCE_BOXES.size )
+        expect( Math.max( ...translations.flat().map( Math.abs ) ) )
+            .toBeGreaterThan( LARGE_COORDINATE_BUDGET_M )
+
+      }, 120000 )
+
+  test( 'the frame is identical before and after later batches', async () => {
+
+    // Unit batches over a four-product fixture, so the frame is derived
+    // on the first one and re-read three more times. What this pins is
+    // the claim the accessor's doc makes to consumers: the value is
+    // stable for the life of the model once derived, so a measurement
+    // taken against an early read stays valid.
+    const modelID = await api.OpenModelStreamed(
+        buffer, { ...SETTINGS, DEFER_GEOMETRY: true, STREAMING_CONSUMER: true } )
+
+    const reads: number[][] = []
+
+    for ( ; ; ) {
+
+      const { extracted, remaining } =
+        api.ExtractGeometryBatch( modelID, 1, () => { /* payload unused */ } )
+
+      if ( remaining === 0 && extracted === 0 ) {
+        break
+      }
+
+      reads.push( api.GetAppliedCoordinationMatrix( modelID ) )
+    }
+
+    // Fewer than two reads and the comparison below asserts nothing.
+    expect( reads.length ).toBeGreaterThan( 1 )
+
+    for ( const read of reads ) {
+      expect( read ).toEqual( reads[ 0 ] )
+    }
+
+    // ...and what is stable is the real frame, not a stable identity.
+    expect( reads[ 0 ][ 12 ] ).toBeCloseTo( -GRID_EASTING, 6 )
+
+  }, 120000 )
+
+  test( 'the classic and deferred opens report the same frame', async () => {
+
+    // Both derive through deriveCoordinationF64, but from separate
+    // walks in separate proxies, and each records the result at its own
+    // emit site. If one of those sites stops recording, the consumer's
+    // answer to "where is this model really" depends on which open Share
+    // happened to take — which is the defect this accessor exists to
+    // remove, not one it is allowed to introduce.
+    const [ deferredID ] = await openAndPump()
+    const deferred = api.GetAppliedCoordinationMatrix( deferredID )
+
+    const classicID = api.OpenModel( buffer, { ...SETTINGS } )
+
+    expect( classicID ).toBeGreaterThanOrEqual( 0 )
+
+    api.StreamAllMeshes( classicID, () => { /* payload unused */ } )
+
+    const classic = api.GetAppliedCoordinationMatrix( classicID )
+
+    // Bit-identical, not merely close: the same derivation over the same
+    // anchor. (Even a differing anchor would agree here, since both sit
+    // inside one COORDINATION_SNAP_M cell — which is why the assertion
+    // below checks the frame is the georeferenced one rather than
+    // resting on the equality alone.)
+    expect( classic ).toEqual( deferred )
+    expect( classic[ 12 ] ).toBeCloseTo( -GRID_EASTING, 6 )
+    expect( classic[ 14 ] ).toBeCloseTo( GRID_NORTHING, 6 )
+
+    // And the classic identity contract is untouched on both.
+    expect( api.GetCoordinationMatrix( classicID ) ).toEqual( [ ...IDENTITY_MAT4 ] )
+    expect( api.GetCoordinationMatrix( deferredID ) ).toEqual( [ ...IDENTITY_MAT4 ] )
+  }, 120000 )
 } )
 
 describe( 'normalizeWithCentreF64', () => {

--- a/src/compat/web-ifc/coordination_export_order.test.ts
+++ b/src/compat/web-ifc/coordination_export_order.test.ts
@@ -104,9 +104,12 @@ describe( 'COORDINATE_TO_ORIGIN export-order independence (Share#1749)', () => {
     expect( Math.max( ...min.map( Math.abs ), ...max.map( Math.abs ) ) )
         .toBeLessThan( LARGE_COORDINATE_BUDGET_M )
 
-    // The applied-frame report (Share#1634) is not asserted here: only
-    // the deferred pump records it, and
-    // `ifc_api_preview_coordination.test.ts` already covers that path.
+    // The applied-frame report (Share#1634) is not asserted here — it is
+    // pinned against known authored coordinates in
+    // `coordination_baked_geometry.test.ts`, which this fixture cannot
+    // do — but it IS filled in on this classic open, and the note that
+    // used to stand here saying only the deferred pump records it is no
+    // longer true of any IFC emit site.
     api.CloseModel( modelID )
   }, 120000 )
 
@@ -115,10 +118,10 @@ describe( 'COORDINATE_TO_ORIGIN export-order independence (Share#1749)', () => {
     // Both paths derive through deriveCoordinationF64, so the snap has
     // to leave them identical — otherwise one model renders in two
     // places depending on which open Share happened to take. Compared
-    // through the emitted placements rather than
-    // GetAppliedCoordinationMatrix, which only the deferred pump fills
-    // in: on these two opens it reports the identity contract for both,
-    // so comparing it would pass no matter what the frames did.
+    // through the emitted placements, which is the property that
+    // actually matters to a consumer; the narrower claim that the two
+    // opens also AGREE on what GetAppliedCoordinationMatrix reports is
+    // asserted directly in `coordination_baked_geometry.test.ts`.
     const classicID = await api.OpenModel( georeferenced, { ...SETTINGS } )
     const classic = placementBounds( classicID )
     api.CloseModel( classicID )

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -962,6 +962,15 @@ export class IfcAPI {
   }
 
   /**
+   * The CLASSIC web-ifc coordination matrix, which this surface
+   * deliberately keeps at identity: consumers stamp the value they read
+   * here onto the assembled model, and a non-identity return would apply
+   * the recentre a SECOND time on top of the placements that already
+   * carry it.
+   *
+   * It is therefore NOT the answer to "what offset did the engine
+   * apply?" — that is {@link GetAppliedCoordinationMatrix}, and it is
+   * what you want for measurements, georeferenced permalinks and export.
    *
    * @param modelID
    * @return {Array<number>}
@@ -981,16 +990,76 @@ export class IfcAPI {
   }
 
   /**
-   * Conway extension: the coordination frame the open ACTUALLY applied
-   * to emitted placements (the COORDINATE_TO_ORIGIN recenter), identity
-   * when none ran. GetCoordinationMatrix keeps its classic identity
-   * contract (consumers stamp it onto assembled models); this is the
-   * explicit report of the real offset so embedders can map rendered
-   * points back to source-world coordinates (Share#1634 acceptance).
+   * Conway extension: the coordination frame this open ACTUALLY composed
+   * into the placements it emitted — the full float64 column-major mat4,
+   * not {@link GetCoordinationMatrix}'s classic identity (Share#1634).
+   *
+   * **The frame contract.** Write `A` for what this returns. Every
+   * `flatTransformation` the model emits was composed as
+   *
+   * ```
+   *   flatTransformation = A * placement [ * translate(geomCentre) ]
+   * ```
+   *
+   * `placement` is the entity's native world placement in the file's own
+   * authored space — source units, Z-up, un-recentred. The optional
+   * `translate(geomCentre)` is the per-leaf offset the IFC path bakes out
+   * of the shared vertex buffer so the uploaded float32 positions stay
+   * local; the AP214/STEP path omits it (its vertices stay in local
+   * source space and `placement` carries the whole world transform). Both
+   * factors sit to the RIGHT of `A`, which is why neither one is needed
+   * below.
+   *
+   * So for any vertex `v` a consumer uploads and renders,
+   *
+   * ```
+   *   rendered = flatTransformation * v = A * world
+   *   world    = inverse(A) * rendered            <- the inverse you want
+   * ```
+   *
+   * where `world` is the point in the model's AUTHORED world space: the
+   * coordinates the file declares, in the file's units, Z-up. Inverting
+   * the returned matrix is the whole of it — nothing else about the model
+   * is required — because `A` carries all three factors the recentre
+   * composed, in this order (see `deriveCoordinationF64`):
+   *
+   * ```
+   *   A = scale(linearScalingFactor) * NormalizeMat * translate(-anchor)
+   * ```
+   *
+   * innermost first: the recentre translation, in SOURCE units and before
+   * any rotation; then `NormalizeMat`, the Z-up -> Y-up change of basis;
+   * then the scale to metres. `inverse(A)` therefore undoes the unit
+   * scale and the axis convention as well as the offset, so a consumer
+   * recovers authored coordinates without knowing either.
+   *
+   * **When it is identity.** Exactly when nothing was composed: an open
+   * without COORDINATE_TO_ORIGIN, a shard (`SetGeometryShard` suppresses
+   * deriving) with no frame supplied, a model that has emitted no
+   * geometry yet, and an unknown `modelID` or a passthrough that does not
+   * implement it. Note what is NOT in that list: a near-origin model
+   * under COORDINATE_TO_ORIGIN returns a frame whose TRANSLATION is
+   * exactly zero — no recentre was needed, that is the model-zero rule in
+   * `COORDINATION_SNAP_M` — but whose rotation and scale are still the
+   * `NormalizeMat` and unit scale the placements were composed under. Do
+   * not shortcut on "no offset applied"; invert the matrix.
+   *
+   * **Preview-adopted vs. durable.** A deferred open that adopted its
+   * parse-time preview channel's frame reports that adopted frame from
+   * the moment the model opens — truthfully, since the preview payloads
+   * were composed under it. The durable walk is the authority, and it
+   * revalidates that adoption against its own first geometry, so the
+   * value can change ONCE, at the first durable batch, if the adopted
+   * frame is rejected. From the frame's derivation (or validation)
+   * onward it is fixed for the life of the model: later batches place
+   * under the same frame, and {@link SetCoordinationFrame} refuses to
+   * replace a frame the model already derived.
+   *
    * Feature-detect: typeof api.GetAppliedCoordinationMatrix.
    *
    * @param modelID
-   * @return {Array<number>} column-major mat4
+   * @return {Array<number>} column-major mat4, a fresh array the caller
+   * owns
    */
   GetAppliedCoordinationMatrix(modelID: number): Array<number> {
 

--- a/src/compat/web-ifc/ifc_api.ts
+++ b/src/compat/web-ifc/ifc_api.ts
@@ -1033,16 +1033,30 @@ export class IfcAPI {
    * scale and the axis convention as well as the offset, so a consumer
    * recovers authored coordinates without knowing either.
    *
-   * **When it is identity.** Exactly when nothing was composed: an open
-   * without COORDINATE_TO_ORIGIN, a shard (`SetGeometryShard` suppresses
-   * deriving) with no frame supplied, a model that has emitted no
-   * geometry yet, and an unknown `modelID` or a passthrough that does not
-   * implement it. Note what is NOT in that list: a near-origin model
-   * under COORDINATE_TO_ORIGIN returns a frame whose TRANSLATION is
-   * exactly zero — no recentre was needed, that is the model-zero rule in
-   * `COORDINATION_SNAP_M` — but whose rotation and scale are still the
-   * `NormalizeMat` and unit scale the placements were composed under. Do
-   * not shortcut on "no offset applied"; invert the matrix.
+   * **When it is identity.** When nothing has been composed AND nothing
+   * has been handed in: an open without COORDINATE_TO_ORIGIN, a shard
+   * (`SetGeometryShard` suppresses deriving) with no frame supplied, a
+   * model that has emitted no geometry yet and been given no frame, and
+   * an unknown `modelID` or a passthrough that does not implement it.
+   *
+   * Two things are NOT in that list, and both are load-bearing:
+   *
+   *  - A frame handed in by {@link SetCoordinationFrame} is reported
+   *    **immediately**, before a single placement has been composed under
+   *    it. That is what the M3 derive-once-then-distribute workflow needs
+   *    — a worker is asked for the frame it is going to apply, not the
+   *    frame it has finished applying — and it is safe to report early
+   *    precisely because a supplied frame is final: the setter refuses to
+   *    replace a frame the model derived for itself, and refuses to
+   *    accept one at all after the first batch. So "identity" never means
+   *    "ask again later"; on a model you supplied, the answer is right
+   *    from the moment you supplied it.
+   *  - A near-origin model under COORDINATE_TO_ORIGIN returns a frame
+   *    whose TRANSLATION is exactly zero — no recentre was needed, that
+   *    is the model-zero rule in `COORDINATION_SNAP_M` — but whose
+   *    rotation and scale are still the `NormalizeMat` and unit scale the
+   *    placements were composed under. Do not shortcut on "no offset
+   *    applied"; invert the matrix.
    *
    * **Preview-adopted vs. durable.** A deferred open that adopted its
    * parse-time preview channel's frame reports that adopted frame from
@@ -1284,6 +1298,11 @@ export class IfcAPI {
    * Typical use: the coordinator opens once (its parse-time preview channel
    * derives a frame), reads it back with {@link GetAppliedCoordinationMatrix}, and
    * passes it to every worker before their first batch.
+   *
+   * A frame supplied here is readable back from
+   * {@link GetAppliedCoordinationMatrix} straight away, before the worker
+   * has composed anything under it — which is what lets a coordinator
+   * confirm every worker took the frame without first pumping each one.
    *
    * @param modelID handle from a DEFER_GEOMETRY open
    * @param matrix column-major mat4 of 16 finite numbers, or omitted to drop

--- a/src/compat/web-ifc/ifc_api_model_passthrough.ts
+++ b/src/compat/web-ifc/ifc_api_model_passthrough.ts
@@ -76,12 +76,20 @@ export interface IfcApiModelPassthrough {
   getCoordinationMatrix(): number[]
 
   /**
-   * Optional: the coordination frame the open ACTUALLY applied to
-   * emitted placements (COORDINATE_TO_ORIGIN recenter). Unlike
+   * Optional: the coordination frame the open ACTUALLY composed into the
+   * placements it emitted (the COORDINATE_TO_ORIGIN recentre, plus the
+   * Z-up -> Y-up normalize and unit scale that ride with it). Unlike
    * getCoordinationMatrix — whose classic identity contract consumers
-   * stamp onto assembled models — this reports the real offset, so
-   * embedders can map rendered points back to source-world coordinates
+   * stamp onto assembled models — this reports the real frame, so
+   * embedders can map rendered points back to authored world coordinates
    * (Share#1634 acceptance).
+   *
+   * The full contract an implementation must satisfy — the composition
+   * order, the `world = inverse(A) * rendered` inverse it has to make
+   * computable from the return value ALONE, when identity is owed, and
+   * the preview-adopted-versus-durable rule — is stated once on
+   * `IfcAPI.GetAppliedCoordinationMatrix`. Read it before changing an
+   * implementation of this.
    */
   getAppliedCoordination?(): number[]
   getAllLines(): Vector<number>

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -1292,6 +1292,11 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
    * durable walk has since validated; identity while nothing has been
    * composed.
    *
+   * Unlike the IFC proxy there is no supplied-frame case to carve out of
+   * that: this arm implements no `setCoordinationFrame`, so
+   * `IfcAPI.SetCoordinationFrame` returns false for a STEP model and
+   * nothing can populate the frame ahead of the first placement.
+   *
    * Every emit site (classic `streamAllMeshes` / `loadAllGeometry`, and
    * the deferred `streamNewMeshes_`) writes `demandCoordination_` at the
    * moment it derives, which is what makes the classic and deferred

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -1315,6 +1315,40 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
     return [...(this.demandCoordination_ ?? this.identity)]
   }
 
+
+  /**
+   * The frame a classic walk composes under: whatever this model has
+   * already derived, and only failing that the model tuple's identity
+   * seed.
+   *
+   * The classic walks derive a frame only while `_isCoordinated` is
+   * false, which is right — a model must not re-anchor halfway through
+   * its life — but they used to seed their local from `model[5]`'s
+   * identity regardless. So a SECOND walk of one live model
+   * (`streamAllMeshes` and then `loadAllGeometry`, both legal on a
+   * classic open) skipped the derivation AND started from identity,
+   * composing every placement without the recentre while
+   * {@link getAppliedCoordination} went on reporting the real frame:
+   * emitted geometry and accessor answer disagreeing precisely on the
+   * georeferenced models where the difference is large (#703). Before
+   * the accessor existed the two were accidentally consistent, both
+   * identity, which is why this surfaced only now.
+   *
+   * Skipping the re-derivation was never the bug; seeding identity was.
+   * Reading the persisted frame here is what keeps
+   * `world = inverse(A) * rendered` true for every walk rather than only
+   * the first.
+   *
+   * `demandCoordination_` is undefined until something derives, so a
+   * first walk still starts from the identity seed and emits exactly
+   * what it did before this existed.
+   *
+   * @return {ArrayLike<number>} The frame to seed a classic walk with.
+   */
+  private classicCoordinationSeed_(): ArrayLike<number> {
+    return this.demandCoordination_ ?? this.model[5]
+  }
+
   /**
    *
    * @param ptr
@@ -1927,7 +1961,7 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
       geometryMaterialTransformMap,
       vectorFlatMesh] = this.model
 
-    let coordinationMatrix: ArrayLike<number> = this.model[5]
+    let coordinationMatrix: ArrayLike<number> = this.classicCoordinationSeed_()
 
     // eslint-disable-next-line no-unused-vars
     for (const [_, nativeTransform, geometry, material, entity, occurrencePath]
@@ -2111,7 +2145,7 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
       geometryMaterialTransformMap,
       vectorFlatMesh] = this.model
 
-    let coordinationMatrix: ArrayLike<number> = this.model[5]
+    let coordinationMatrix: ArrayLike<number> = this.classicCoordinationSeed_()
 
     // eslint-disable-next-line no-unused-vars
     for (const [_, nativeTransform, geometry, material, entity, occurrencePath]

--- a/src/compat/web-ifc/ifc_api_proxy_ap214.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ap214.ts
@@ -1268,6 +1268,11 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
   }
 
   /**
+   * The classic web-ifc coordination matrix, held at identity on purpose
+   * — consumers stamp it onto the assembled model, so returning the real
+   * recentre here would apply it twice. For the frame this instance
+   * actually composed into its placements, see
+   * {@link getAppliedCoordination}.
    *
    * @param modelID
    * @return {Array<number>}
@@ -1282,11 +1287,29 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
 
 
   /**
-   * The coordination frame actually applied to emitted placements —
-   * the derived (or validated adopted) recenter, identity when no
-   * recenter ran. See ifc_api_model_passthrough.getAppliedCoordination.
+   * The coordination frame this instance actually composed into the
+   * placements it emitted — derived, or an adopted preview frame the
+   * durable walk has since validated; identity while nothing has been
+   * composed.
    *
-   * @return {Array<number>} column-major mat4
+   * Every emit site (classic `streamAllMeshes` / `loadAllGeometry`, and
+   * the deferred `streamNewMeshes_`) writes `demandCoordination_` at the
+   * moment it derives, which is what makes the classic and deferred
+   * opens report the same frame for the same model.
+   *
+   * The AP214 composition omits the per-leaf `translate(geomCentre)` the
+   * IFC path carries — one shared vertex buffer per mapped body, so
+   * nothing is recentred per instance (#308) — but that factor sits to
+   * the right of the frame either way, so the inverse a consumer applies
+   * is the same on both paths.
+   *
+   * The contract this satisfies — composition order, the
+   * `world = inverse(A) * rendered` inverse, and when identity is owed —
+   * is stated on `IfcAPI.GetAppliedCoordinationMatrix`.
+   *
+   * @return {Array<number>} column-major mat4, a fresh array; `identity`
+   * is a mutable field, so the copy is what keeps a caller from editing
+   * this instance's own zero frame.
    */
   getAppliedCoordination(): Array<number> {
     return [...(this.demandCoordination_ ?? this.identity)]
@@ -1942,6 +1965,12 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
         if (!this._isCoordinated && this.settings?.COORDINATE_TO_ORIGIN) {
           coordinationMatrix = deriveCoordinationF64(
               geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)
+          // Persisted for getAppliedCoordination (Share#1634): without
+          // this the classic walk composes under a frame only its local
+          // knows, and the accessor reports identity for a model that
+          // was in fact recentred — while the deferred pump, which does
+          // persist, reports the truth for the same file.
+          this.demandCoordination_ = Array.from(coordinationMatrix)
           this._isCoordinated = true
         }
 
@@ -2121,6 +2150,9 @@ export class IfcApiProxyAP214 implements IfcApiModelPassthrough {
           Logger.info('Setting up coordinationMatrix')
           coordinationMatrix = deriveCoordinationF64(
               geometryTransform, nativePt!, this.NormalizeMat, this.linearScalingFactor)
+          // Persisted for getAppliedCoordination (Share#1634) — see the
+          // sibling site in streamAllMeshes.
+          this.demandCoordination_ = Array.from(coordinationMatrix)
           this._isCoordinated = true
         }
 

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2206,6 +2206,11 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
   }
 
   /**
+   * The classic web-ifc coordination matrix, held at identity on purpose
+   * — consumers stamp it onto the assembled model, so returning the real
+   * recentre here would apply it twice. For the frame this instance
+   * actually composed into its placements, see
+   * {@link getAppliedCoordination}.
    *
    * @param modelID
    * @return {Array<number>}
@@ -2226,11 +2231,24 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
 
 
   /**
-   * The coordination frame actually applied to emitted placements —
-   * the derived (or validated adopted) recenter, identity when no
-   * recenter ran. See ifc_api_model_passthrough.getAppliedCoordination.
+   * The coordination frame this instance actually composed into the
+   * placements it emitted — derived, supplied, or an adopted preview
+   * frame the durable walk has since validated; identity while nothing
+   * has been composed.
    *
-   * @return {Array<number>} column-major mat4
+   * Every emit site (classic `streamAllMeshes` /
+   * `streamAllMeshesWithTypes` / `loadAllGeometry`, and the deferred
+   * `streamNewMeshes_`) writes `demandCoordination_` at the moment it
+   * derives, which is what makes the classic and deferred opens report
+   * the same frame for the same model.
+   *
+   * The contract this satisfies — composition order, the
+   * `world = inverse(A) * rendered` inverse, and when identity is owed —
+   * is stated on `IfcAPI.GetAppliedCoordinationMatrix`.
+   *
+   * @return {Array<number>} column-major mat4, a fresh array; `identity`
+   * is a mutable field, so the copy is what keeps a caller from editing
+   * this instance's own zero frame.
    */
   getAppliedCoordination(): Array<number> {
     return [...(this.demandCoordination_ ?? this.identity)]

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2254,6 +2254,40 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
     return [...(this.demandCoordination_ ?? this.identity)]
   }
 
+
+  /**
+   * The frame a classic walk composes under: whatever this model has
+   * already derived, and only failing that the model tuple's identity
+   * seed.
+   *
+   * The classic walks derive a frame only while `_isCoordinated` is
+   * false, which is right — a model must not re-anchor halfway through
+   * its life — but they used to seed their local from `model[5]`'s
+   * identity regardless. So a SECOND walk of one live model
+   * (`streamAllMeshes` and then `loadAllGeometry`, both legal on a
+   * classic open) skipped the derivation AND started from identity,
+   * composing every placement without the recentre while
+   * {@link getAppliedCoordination} went on reporting the real frame:
+   * emitted geometry and accessor answer disagreeing precisely on the
+   * georeferenced models where the difference is 2.6e6 m (#703). Before
+   * the accessor existed the two were accidentally consistent, both
+   * identity, which is why this surfaced only now.
+   *
+   * Skipping the re-derivation was never the bug; seeding identity was.
+   * Reading the persisted frame here is what keeps
+   * `world = inverse(A) * rendered` true for every walk rather than only
+   * the first.
+   *
+   * `demandCoordination_` is undefined until something derives, so a
+   * first walk still starts from the identity seed and emits exactly
+   * what it did before this existed.
+   *
+   * @return {ArrayLike<number>} The frame to seed a classic walk with.
+   */
+  private classicCoordinationSeed_(): ArrayLike<number> {
+    return this.demandCoordination_ ?? this.model[5]
+  }
+
   /**
    *
    * @param ptr
@@ -4601,7 +4635,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       geometryMaterialTransformMap,
       vectorFlatMesh] = this.model
 
-    let coordinationMatrix: ArrayLike<number> = this.model[5]
+    let coordinationMatrix: ArrayLike<number> = this.classicCoordinationSeed_()
 
     // eslint-disable-next-line no-unused-vars
     for (const [_, nativeTransform, geometry, material, entity] of scene.walk()) {
@@ -4763,7 +4797,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       geometryMaterialTransformMap,
       vectorFlatMesh] = this.model
 
-    let coordinationMatrix: ArrayLike<number> = this.model[5]
+    let coordinationMatrix: ArrayLike<number> = this.classicCoordinationSeed_()
 
     const conwayTypesArray: number[] = []
     types.forEach((type) => {
@@ -4947,7 +4981,7 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
       geometryMaterialTransformMap,
       vectorFlatMesh] = this.model
 
-    let coordinationMatrix: ArrayLike<number> = this.model[5]
+    let coordinationMatrix: ArrayLike<number> = this.classicCoordinationSeed_()
 
     // eslint-disable-next-line no-unused-vars
     for (const [_, nativeTransform, geometry, material, entity] of scene.walk()) {

--- a/src/compat/web-ifc/ifc_api_proxy_ifc.ts
+++ b/src/compat/web-ifc/ifc_api_proxy_ifc.ts
@@ -2234,7 +2234,15 @@ export class IfcApiProxyIfc implements IfcApiModelPassthrough {
    * The coordination frame this instance actually composed into the
    * placements it emitted — derived, supplied, or an adopted preview
    * frame the durable walk has since validated; identity while nothing
-   * has been composed.
+   * has been composed and nothing handed in.
+   *
+   * "Handed in" is the exception to the emitted-placements reading, and
+   * it is deliberate: {@link setCoordinationFrame} stores its matrix at
+   * call time, so a supplied frame reports from that moment rather than
+   * from the first placement composed under it. M3's pool needs exactly
+   * that — a worker is asked which frame it will apply, not which one it
+   * has finished applying — and a supplied frame is final, so the early
+   * answer is never revised.
    *
    * Every emit site (classic `streamAllMeshes` /
    * `streamAllMeshesWithTypes` / `loadAllGeometry`, and the deferred


### PR DESCRIPTION
Closes the surviving acceptance item on bldrs-ai/Share#1634, folds in the last piece of bldrs-ai/conway#680, and **Closes #703**.

Refs bldrs-ai/Share#1634, bldrs-ai/conway#680, bldrs-ai/Share#1633, bldrs-ai/conway-geom#203.

## The problem

The demand/streamed open derives its recentre frame internally (`demandCoordination_`), while `GetCoordinationMatrix()` deliberately returns identity — the classic contract web-ifc consumers stamp onto assembled models, which a truthful return would make apply the recentre twice. `GetAppliedCoordinationMatrix` has existed since M3 as the escape hatch, but only documented as "the real offset, unlike GetCoordinationMatrix".

That is not enough to actually invert. A consumer holding a rendered point and the returned matrix still had to know where `NormalizeMat` and the unit scale sat in the composition before it could get back to authored coordinates — which is the whole of the Share#1634 acceptance: measurements, georeferenced permalinks, round-tripping export.

And two paths did not honour the contract at all (below).

## The contract, stated

The doc comment on `IfcAPI.GetAppliedCoordinationMatrix` now states it rather than gesturing at it. Write `A` for what it returns:

```
flatTransformation = A * placement [ * translate(geomCentre) ]
rendered           = A * world
world              = inverse(A) * rendered
```

with

```
A = scale(linearScalingFactor) * NormalizeMat * translate(-anchor)
```

innermost first — the recentre in **source** units and **pre**-rotation, then the Z-up → Y-up change of basis, then the scale to metres. `placement` is the entity's native world placement in authored space; the optional `translate(geomCentre)` is the IFC path's per-leaf vertex-buffer recentre, which the AP214 path omits. Both sit to the **right** of `A`, which is why inverting the returned matrix is the whole of it: a consumer needs neither the file's unit scale nor the engine's axis convention.

Three traps the comment names, because each is easy to get wrong and none is visible from the signature:

- **Identity is owed only when nothing was composed** — recentring off, a shard with no supplied frame, no geometry emitted yet, unknown model. *Not* on a near-origin model: model-zero means the translation is exactly zero, but the rotation and scale are still live, and a consumer that shortcuts on "no offset applied" reads every point in the wrong axis convention.
- **Every walk composes under the same frame, not just the first** (see #703 below).
- **The durable walk is the authority.** A deferred open that adopted its preview channel's frame reports that frame from the moment it opens — truthfully, since the preview payloads were composed under it — and the value can change **exactly once**, at the first durable batch, if revalidation rejects it. Fixed for the life of the model after that.

`GetCoordinationMatrix` gains a pointer comment saying why it stays identity and where to go instead, on `IfcAPI` and on both proxies.

## Defect 1 — the AP214 classic walks never *recorded* their frame

`streamAllMeshes` and `loadAllGeometry` derived into a local and never persisted it. So `GetAppliedCoordinationMatrix` answered **identity for a STEP model it had in fact composed a frame into**, while the deferred pump on the same file answered the truth — a consumer's "where is this model really" depended on which open it happened to take. Both sites now persist, as the IFC sites already did.

## Defect 2 — later classic walks never *read* it (#703, codex P2)

More than one classic walk of one live model is legal (`StreamAllMeshes` then `LoadAllGeometry`), and each keeps its own local coordination matrix. Every one seeded that local from the model tuple's identity while the `_isCoordinated` guard — correctly — stopped it re-deriving. So the second walk composed every placement with identity: on the LV95 fixture it re-emitted raw ~2.6e6 m coordinates in the same session that had just emitted them recentred.

This is #703, filed during this PR's audit and deliberately deferred — but codex is right that #702 is where it becomes in-scope: the moment this PR promises `world = inverse(A) * rendered`, it owes that promise for every walk. Before the accessor existed, the second walk's placements and the reported frame were accidentally consistent (both identity); after it they disagree exactly when it matters.

Fixed via one new private `classicCoordinationSeed_()` per proxy returning `demandCoordination_ ?? this.model[5]`, used by all five classic seed sites:

| Proxy | Sites |
|---|---|
| `ifc_api_proxy_ifc.ts` | `streamAllMeshes`, `streamAllMeshesWithTypes`, `loadAllGeometry` |
| `ifc_api_proxy_ap214.ts` | `streamAllMeshes`, `loadAllGeometry` |

The `_isCoordinated` guard is left alone — skipping re-derivation is correct, a model must not re-anchor halfway through its life; only the identity seed was wrong. The deferred pumps already read `demandCoordination_` and are untouched, and nothing double-applies because `normalizeWithCentreF64` serves its cached centre on a re-walk rather than shifting the buffer again.

**Digest impact: none on any single-walk load.** `demandCoordination_` is undefined when a first walk seeds, so that walk composes byte-identically to before. Only the walks that were already wrong move.

## Tests

All red-checked against a stubbed accessor or a reverted seed before being taken as green (rubric 6):

| Assertion | Where |
|---|---|
| `inverse(A) × (emitted placement × uploaded float32 vertex)` reproduces the fixture's authored LV95 coordinates to 1mm — and the frame's own contents are checked against the fixture's grid anchor, not against a re-derivation | `coordination_baked_geometry.test.ts` |
| Near-origin model: translation exactly zero, frame still `NormalizeMat × scale` | same |
| `COORDINATE_TO_ORIGIN` off: exact identity, on a fixture whose placements prove there was something to apply | same |
| Frame identical across four unit batches | same |
| Classic and deferred report the same frame (IFC) | same |
| A second classic walk is bit-equal to the first across all four products, **and** a second-walk placement still inverts onto the authored coordinates (#703) | same |
| #703's literal repro: `StreamAllMeshes` then `LoadAllGeometry` | same |
| Classic and deferred report the same frame (AP214) | `ap214_streamed_open.test.ts` |
| A second classic walk on the AP214 arm (#703) | same |

**Red evidence.** Stubbing `getAppliedCoordination` to return identity always turns four of the five accessor tests red; stubbing it to return `NormalizeMat` when nothing was derived turns the fifth (the exact-identity one) red; reverting the two AP214 persistence lines turns the AP214 parity test red; reverting `classicCoordinationSeed_()` to `this.model[5]` turns all three second-walk tests red. Each was rebuilt and run in that state before being restored.

Two stale comments in `coordination_export_order.test.ts` claiming only the deferred pump fills the accessor in are corrected — the IFC classic sites have recorded it since M3.

`design/new/coordination-frame.md` gains a "Reading the applied frame back" section with the same contract, and three rows in its pinned-properties table.

## Pre-existing defects found, not fixed here

Surfaced while writing the `LoadAllGeometry` test; documented in the test rather than fixed, and the assertions are shaped so they neither depend on them nor weaken if they are fixed:

- `loadAllGeometry`'s `return` sits **inside** its scene walk, so it emits one geometry and returns.
- The `Vector<FlatMesh>` it hands back is unreadable: the shim's `get` bounds-checks against a different, empty array and so always returns the dummy. Hence the test reads through `GetFlatMesh`.

## conway-geom gitlink

Second commit bumps `dependencies/conway-geom` to `64c6344` (bldrs-ai/conway-geom#203): `ApplyRescale()` now resets `normalized_`/`normalizedCentre_` in its invalidation tail, matching `ApplyTransform()` and `AppendGeometry()`, so a later `Normalize()` re-derives from the moved vertices instead of short-circuiting to a stale centre. Test-only callers today, so uniformity rather than a live fix — it was the closing note on conway#680. It belongs with this change for the same reason the invariant matters at all: the applied frame is only invertible if the centre baked into a `flatTransformation` is the centre the vertices were actually moved by, and every mutator that can move them has to say so.

## Verification

- `yarn build-codex-MT` on the bumped SHA: `Geometry.cpp` recompiled, MT node module relinked, clean.
- `yarn check-compiled-fresh`: clean.
- Full jest suite: **142 suites, 1090 tests, all passing** — the pre-commit hook's own run agrees.
- `yarn lint`: 0 errors (729 pre-existing warnings, unchanged; the `compat/web-ifc` files are in the eslint ignore set).

Two environment notes rather than code findings:

- CI's wasm cache misses on the new conway-geom SHA, so the `build` job does a **cold emcc compile** rather than a cache hit.
- Three runs in this sandbox reported `1 failed suite / 0 failed tests`, on a different suite each time. Diagnosed, not just observed: `A jest worker process was terminated by another process: signal=SIGKILL` — the box is 16 GB with no swap and jest runs 3 workers, with the heavy AP214/STEP suites peaking ~4.5 GB each. Not reproducible under CI's runners, and the same tree passes 142/1090 when nothing else is resident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fg59i61cnUofhTpnaJHtR
