### PR TITLE
Inherit type-object materials down onto occurrences

### DIFF
--- a/data/surface_style_shading_mapped.ifc
+++ b/data/surface_style_shading_mapped.ifc
@@ -36,6 +36,12 @@ DATA;
    4. #4000 is the precedence conflict — a material association AND its own
       styled item on the IfcMappedItem. See the block beside it below.
 
+   5. #5000 and #6000 cover type-material inheritance: a material
+      associated to the TYPE object (IfcBuildingElementProxyType) rather
+      than to the occurrence, reached through IfcRelDefinesByType. #5000
+      has ONLY the type's; #6000 has both and must keep its own. See the
+      block beside them below.
+
    All colour components are exact binary fractions (0.75, 0.25, 0.125,
    ...) so the extracted doubles compare equal to the literals in the
    test without an epsilon, and none of them is 0.8 — the default the
@@ -157,8 +163,87 @@ DATA;
 #4022=IFCSURFACESTYLE('ShadingTealStyle',.BOTH.,(#4021));
 #4023=IFCSTYLEDITEM(#4012,(#4022),$);
 
+/* Type-material inheritance (bldrs-ai/test-models-private#61, the path
+   conway#684 left out of scope). In a Renga export the material of a door or
+   window is associated to the TYPE object, never to the occurrence:
+
+     IFCRELASSOCIATESMATERIAL(...,(#5100),#700)   <- names the TYPE
+     IFCRELDEFINESBYTYPE(...,(#5000),#5100)       <- the only link to #5000
+
+   #5000 is that case, reduced: it maps the same #300 as #1000/#2000/#4000,
+   carries no styled item and no association of its own, and must still come
+   out orange. Before the fix its material lookup missed entirely — an
+   IfcTypeObject is not an IfcProduct, so the product filter that builds
+   relMaterialsMap dropped the association at #700 on the floor.
+
+   #6000 is the precedence half: it has BOTH an occurrence association
+   (cyan #800) and a type association (magenta #900) with different colours.
+   IFC makes the type's assignment a default the occurrence overrides, so the
+   cyan must win and the magenta must never be extracted.
+
+   The two IfcRelAssociatesMaterial below are deliberately ordered
+   occurrence-first, type-last: an implementation that pushed type materials
+   into the occurrence map as it swept the associations — rather than in a
+   pass strictly after it — would let #9005 clobber #9004 here, and this
+   fixture is the thing that catches that. */
+#700=IFCMATERIAL('ShadingOrange',$,$);
+#701=IFCCOLOURRGB($,0.875,0.5,0.125);
+#702=IFCSURFACESTYLESHADING(#701,$);
+#703=IFCSURFACESTYLE('ShadingOrangeStyle',.BOTH.,(#702));
+#704=IFCPRESENTATIONSTYLEASSIGNMENT((#703));
+#705=IFCSTYLEDITEM($,(#704),$);
+#706=IFCSTYLEDREPRESENTATION(#20,$,$,(#705));
+#707=IFCMATERIALDEFINITIONREPRESENTATION($,$,(#706),#700);
+
+#800=IFCMATERIAL('ShadingCyan',$,$);
+#801=IFCCOLOURRGB($,0.125,0.75,0.875);
+#802=IFCSURFACESTYLESHADING(#801,$);
+#803=IFCSURFACESTYLE('ShadingCyanStyle',.BOTH.,(#802));
+#804=IFCPRESENTATIONSTYLEASSIGNMENT((#803));
+#805=IFCSTYLEDITEM($,(#804),$);
+#806=IFCSTYLEDREPRESENTATION(#20,$,$,(#805));
+#807=IFCMATERIALDEFINITIONREPRESENTATION($,$,(#806),#800);
+
+#900=IFCMATERIAL('ShadingMagenta',$,$);
+#901=IFCCOLOURRGB($,0.75,0.125,0.625);
+#902=IFCSURFACESTYLESHADING(#901,$);
+#903=IFCSURFACESTYLE('ShadingMagentaStyle',.BOTH.,(#902));
+#904=IFCPRESENTATIONSTYLEASSIGNMENT((#903));
+#905=IFCSTYLEDITEM($,(#904),$);
+#906=IFCSTYLEDREPRESENTATION(#20,$,$,(#905));
+#907=IFCMATERIALDEFINITIONREPRESENTATION($,$,(#906),#900);
+
+/* Inherits orange from its type and nothing else. */
+#5000=IFCBUILDINGELEMENTPROXY('7777777777shadingE0005',$,'TypeInherited',$,$,#5001,#5010,$,$);
+#5001=IFCLOCALPLACEMENT($,#5002);
+#5002=IFCAXIS2PLACEMENT3D(#5003,$,$);
+#5003=IFCCARTESIANPOINT((40.,0.,0.));
+#5010=IFCPRODUCTDEFINITIONSHAPE($,$,(#5011));
+#5011=IFCSHAPEREPRESENTATION(#20,'Body','MappedRepresentation',(#5012));
+#5012=IFCMAPPEDITEM(#300,#5013);
+#5013=IFCCARTESIANTRANSFORMATIONOPERATOR3D($,$,#5014,1.,$);
+#5014=IFCCARTESIANPOINT((0.,0.,0.));
+#5100=IFCBUILDINGELEMENTPROXYTYPE('7777777777proxyType005',$,'OrangeType',$,$,$,$,$,$,.NOTDEFINED.);
+#5101=IFCRELDEFINESBYTYPE('0relDefinesByTypeOra05',$,$,$,(#5000),#5100);
+
+/* Has its own cyan; its type says magenta. Cyan wins. */
+#6000=IFCBUILDINGELEMENTPROXY('7777777777shadingF0006',$,'TypeOverridden',$,$,#6001,#6010,$,$);
+#6001=IFCLOCALPLACEMENT($,#6002);
+#6002=IFCAXIS2PLACEMENT3D(#6003,$,$);
+#6003=IFCCARTESIANPOINT((50.,0.,0.));
+#6010=IFCPRODUCTDEFINITIONSHAPE($,$,(#6011));
+#6011=IFCSHAPEREPRESENTATION(#20,'Body','MappedRepresentation',(#6012));
+#6012=IFCMAPPEDITEM(#300,#6013);
+#6013=IFCCARTESIANTRANSFORMATIONOPERATOR3D($,$,#6014,1.,$);
+#6014=IFCCARTESIANPOINT((0.,0.,0.));
+#6100=IFCBUILDINGELEMENTPROXYTYPE('7777777777proxyType006',$,'MagentaType',$,$,$,$,$,$,.NOTDEFINED.);
+#6101=IFCRELDEFINESBYTYPE('0relDefinesByTypeMag06',$,$,$,(#6000),#6100);
+
 #9000=IFCRELASSOCIATESMATERIAL('0relAssocMaterialRed01',$,$,$,(#1000),#400);
 #9001=IFCRELASSOCIATESMATERIAL('0relAssocMaterialBlu02',$,$,$,(#2000),#500);
 #9002=IFCRELASSOCIATESMATERIAL('0relAssocMaterialPur03',$,$,$,(#4000),#600);
+#9003=IFCRELASSOCIATESMATERIAL('0relAssocMaterialOra04',$,$,$,(#5100),#700);
+#9004=IFCRELASSOCIATESMATERIAL('0relAssocMaterialCya05',$,$,$,(#6000),#800);
+#9005=IFCRELASSOCIATESMATERIAL('0relAssocMaterialMag06',$,$,$,(#6100),#900);
 ENDSEC;
 END-ISO-10303-21;

--- a/src/ifc/ifc_demand_extraction.test.ts
+++ b/src/ifc/ifc_demand_extraction.test.ts
@@ -14,7 +14,12 @@ import IfcStepModel from './ifc_step_model'
 import ParsingBuffer from '../parsing/parsing_buffer'
 import { ConwayGeometry } from '../../dependencies/conway-geom'
 import { ExtractResult } from '../core/shared_constants'
-import { IfcProduct, IfcStyledItem } from './ifc4_gen'
+import {
+  IfcProduct,
+  IfcRelAssociatesMaterial,
+  IfcRelDefinesByType,
+  IfcStyledItem,
+} from './ifc4_gen'
 import EntityTypesIfc from './ifc4_gen/entity_types_ifc.gen'
 import { openStreamedIfcModelFromStore } from './ifc_stream_open'
 import {
@@ -555,6 +560,74 @@ describe( 'concurrent windowed product prefetch (conway#526)', () => {
 
         for ( const span of leafSpans ) {
           model.unpinAddressRange( span.address, span.length )
+        }
+      }, 120000 )
+} )
+
+
+// codex finding on bldrs-ai/conway#704: the map-prep residency contract is a
+// list, and a sweep added to prepareExtractionMaps_ without a matching entry
+// in ensureResidentForDemandPrep's `recordOnlyTypes` fails SILENTLY on a
+// windowed source. Its field reads throw StepBufferNotResidentError,
+// handleMapPrepError_ swallows the throw (MATERIAL_RELATED_OBJECTS_PERMISSIVE
+// is true), and the sweep contributes nothing — while the same model opened
+// classically is correct, so nothing downstream reports a difference.
+//
+// Measured on the Renga convenience-store model
+// (bldrs-ai/test-models-private#61) with IfcRelDefinesByType missing from the
+// list: 0 of its 103 records pinned, and 5 / 11 / 17 swallowed
+// not-resident errors as the window tightened from 4 KiB x 16 to 1 KiB x 2.
+// That model's inheritance survived anyway — a Renga export writes each
+// IfcRelDefinesByType on the line after its type object, so the 1-hop pin of
+// the type dragged in the relationship's chunk — which is precisely why this
+// asserts the pin set rather than a colour: the colour is right by adjacency
+// luck that no other file owes us.
+describe( 'windowed demand-prep residency (conway#704)', () => {
+
+  /** 4 KiB chunks, 2 resident — the cramped window the suite above uses. */
+  const CHUNK = 4 * 1024
+
+  test( 'prep pins every record of every relationship its sweeps read',
+      async () => {
+
+        const store = new InMemoryStepByteStore(
+            new Uint8Array( fs.readFileSync( 'data/surface_style_shading_mapped.ifc' ) ) )
+        const open = await openStreamedIfcModelFromStore( store, { pool: CHUNK } )
+
+        expect( open.model ).toBeDefined()
+
+        const model = new IfcStepModel(
+            void 0,
+            open.columns as any,
+            new WindowedStepBufferProvider( store, CHUNK, 2 ) )
+
+        expect( model.isSourceExternal ).toBe( true )
+
+        const extraction = new IfcGeometryExtraction( conwayGeometry, model )
+        const prepPins = await extraction.ensureResidentForDemandPrep()
+
+        try {
+
+          // IfcRelAssociatesMaterial is the control: it has been in
+          // `recordOnlyTypes` since the map prep existed, so it holds whether
+          // or not the type-material work landed. If it ever stops holding,
+          // the assertion below is measuring the harness, not the list.
+          for ( const type of [ IfcRelAssociatesMaterial, IfcRelDefinesByType ] ) {
+
+            // Materialising to read `.localID` costs no source bytes:
+            // descriptors come from the index columns and the generated
+            // constructors have empty bodies.
+            const localIDs = [ ...model.types( type ) ].map( ( record ) => record.localID )
+
+            // Guard the guard — an empty fixture would satisfy any
+            // "nothing unpinned" claim.
+            expect( localIDs.length ).toBeGreaterThan( 0 )
+            expect( localIDs.filter( ( localID ) => !prepPins.has( localID ) ) ).toEqual( [] )
+          }
+
+        } finally {
+          model.releaseSourceViews( prepPins )
+          model.unpinLocalIDs( prepPins )
         }
       }, 120000 )
 } )

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -7459,8 +7459,19 @@ export class IfcGeometryExtraction {
       }
     }
 
+    // Every relationship prepareExtractionMaps_ sweeps has to be listed
+    // here, or its field reads throw StepBufferNotResidentError on a
+    // windowed source and handleMapPrepError_ swallows the throw in
+    // permissive mode — a sweep that silently does nothing rather than a
+    // loud failure. IfcRelDefinesByType is here for inheritTypeMaterials_;
+    // it needs no entry in the 1-hop pass below because that pass exists
+    // for relationship GETTERS, which hydrate their targets, and the
+    // type-inheritance sweep reads only the relationship's own bytes
+    // (extractReferenceLocalID / forEachReferenceInField) plus index
+    // columns (codex finding on bldrs-ai/conway#704).
     const recordOnlyTypes = [
       IfcRelAssociatesMaterial,
+      IfcRelDefinesByType,
       IfcRelVoidsElement,
       IfcStyledItem,
       IfcRelAggregates,

--- a/src/ifc/ifc_geometry_extraction.ts
+++ b/src/ifc/ifc_geometry_extraction.ts
@@ -183,6 +183,8 @@ import {
   IfcTShapeProfileDef,
   IfcZShapeProfileDef,
   IfcRelAggregates,
+  IfcRelDefinesByType,
+  IfcTypeObject,
   IfcObjectDefinition,
   IfcTriangulatedFaceSet,
   IfcPolygonalBoundedHalfSpace,
@@ -381,6 +383,16 @@ const REL_AGGREGATES_RELATING_DEPTH = 3
 const REL_ASSOCIATES_RELATED_OFFSET = 4
 const REL_ASSOCIATES_RELATED_BASE = 4
 const REL_ASSOCIATES_RELATED_DEPTH = 2
+
+/** IfcRelDefinesByType.RelatedObjects — see IfcRelDefinesByType.gen.ts. */
+const REL_DEFINES_BY_TYPE_RELATED_OFFSET = 4
+const REL_DEFINES_BY_TYPE_RELATED_BASE = 4
+const REL_DEFINES_BY_TYPE_RELATED_DEPTH = 3
+
+/** IfcRelDefinesByType.RelatingType — see IfcRelDefinesByType.gen.ts. */
+const REL_DEFINES_BY_TYPE_RELATING_OFFSET = 5
+const REL_DEFINES_BY_TYPE_RELATING_BASE = 4
+const REL_DEFINES_BY_TYPE_RELATING_DEPTH = 3
 const COORD_INDEX_FIELD_OFFSET = 0
 
 const POLYGONAL_INDEX_SINK_CAPACITY = 65536
@@ -7156,6 +7168,17 @@ export class IfcGeometryExtraction {
     // populate relMaterialsMap
     const relAssociatesMaterials = this.model.types(IfcRelAssociatesMaterial)
     const productTypes = new Set< number >( IfcProduct.query )
+    const typeObjectTypes = new Set< number >( IfcTypeObject.query )
+
+    // Material associations whose related object is a TYPE object
+    // (IfcDoorType, IfcWindowType, ...) instead of an occurrence. The
+    // product filter below drops those — correctly, since a type object is
+    // an IfcTypeObject and not an IfcProduct, so it has no geometry of its
+    // own to colour — but the occurrences it defines still inherit its
+    // material. They are collected here keyed by the TYPE's local ID and
+    // pushed down onto occurrences by inheritTypeMaterials_ once the whole
+    // sweep has run; see that method for the precedence rule.
+    const typeMaterialsMap = new Map< number, number >()
 
     for (const relAssociateMaterial of relAssociatesMaterials) {
       try {
@@ -7178,22 +7201,21 @@ export class IfcGeometryExtraction {
                 return true
               }
 
-              const productLocalID = this.model.resolveExpressID( expressID )
+              const relatedLocalID = this.model.resolveExpressID( expressID )
 
-              if ( productLocalID === void 0 ) {
+              if ( relatedLocalID === void 0 ) {
                 return true
               }
 
-              const typeID = this.model.typeIDOf( productLocalID )
+              const typeID = this.model.typeIDOf( relatedLocalID )
 
-              if ( typeID === EntityTypesIfc.IFCOPENINGELEMENT ||
-                  typeID === EntityTypesIfc.IFCSPACE ||
-                  typeID === EntityTypesIfc.IFCOPENINGSTANDARDCASE ) {
+              if ( typeID !== void 0 && typeObjectTypes.has( typeID ) ) {
+                typeMaterialsMap.set( relatedLocalID, materialLocalID )
                 return true
               }
 
-              if ( typeID !== void 0 && productTypes.has( typeID ) ) {
-                this.materials.relMaterialsMap.set( productLocalID, materialLocalID )
+              if ( this.isMaterialTargetProductType_( typeID, productTypes ) ) {
+                this.materials.relMaterialsMap.set( relatedLocalID, materialLocalID )
               }
 
               return true
@@ -7206,6 +7228,10 @@ export class IfcGeometryExtraction {
       }
     }
 
+    // Fill occurrences that got no direct association from their type's,
+    // strictly after the sweep above so direct entries always win.
+    this.inheritTypeMaterials_( typeMaterialsMap, productTypes )
+
     // populate MaterialDefinitionsMap
     this.populateMaterialDefinitionsMap()
 
@@ -7214,6 +7240,135 @@ export class IfcGeometryExtraction {
 
     // populate styled items map
     this.populateStyledItemsMap()
+  }
+
+  /**
+   * Is a related object of an IfcRelAssociatesMaterial one whose geometry
+   * that material may colour?
+   *
+   * Openings and spaces are excluded: they do carry material associations
+   * in real files, but they are subtractive/void volumes rather than
+   * things the scene shows. Shared by the direct-association sweep and the
+   * type-inheritance pass so the two cannot drift apart on which products
+   * count — an occurrence excluded here must stay excluded when the same
+   * material arrives via its type.
+   *
+   * Takes the type ID rather than the local ID because both callers have
+   * already resolved it for their own dispatch.
+   *
+   * @param typeID The related object's entity type ID, or undefined when
+   * the model has no type for it.
+   * @param productTypes The IfcProduct type-ID set, hoisted by the caller.
+   * @return {boolean} True when a material association on this object
+   * should reach relMaterialsMap.
+   */
+  private isMaterialTargetProductType_(
+      typeID: number | undefined,
+      productTypes: ReadonlySet< number > ): boolean {
+
+    if ( typeID === void 0 ||
+        typeID === EntityTypesIfc.IFCOPENINGELEMENT ||
+        typeID === EntityTypesIfc.IFCSPACE ||
+        typeID === EntityTypesIfc.IFCOPENINGSTANDARDCASE ) {
+      return false
+    }
+
+    return productTypes.has( typeID )
+  }
+
+  /**
+   * Push type-level material associations down onto the occurrences that
+   * IfcRelDefinesByType binds to those types.
+   *
+   * A material may be associated with an occurrence (IfcDoor) or with its
+   * type (IfcDoorType); an occurrence without one of its own takes the
+   * type's. Precedence is the load-bearing rule: an occurrence-level
+   * IfcRelAssociatesMaterial ALWAYS overrides the type-level one (IFC4
+   * "Object Typing" — a type's assignments are defaults the occurrence may
+   * override), so this pass only ever fills a hole and never overwrites an
+   * entry the direct sweep wrote. Running it strictly after the WHOLE
+   * IfcRelAssociatesMaterial sweep is what makes that order-independent: a
+   * direct association written later in the file than its type's still
+   * wins, which a fill interleaved with the sweep could not guarantee.
+   *
+   * Without this, an occurrence whose material lives only on its type
+   * resolves no material at all and renders untinted — 272 of 5,351 scene
+   * placements on the Renga convenience-store model
+   * (bldrs-ai/test-models-private#61), all of them windows, doors, light
+   * fixtures and railings whose IfcRelAssociatesMaterial names the
+   * Type entity rather than the occurrence.
+   *
+   * @param typeMaterialsMap Material local ID per TYPE object local ID,
+   * collected by the direct sweep.
+   * @param productTypes The IfcProduct type-ID set, hoisted by the caller.
+   */
+  private inheritTypeMaterials_(
+      typeMaterialsMap: ReadonlyMap< number, number >,
+      productTypes: ReadonlySet< number > ): void {
+
+    if ( typeMaterialsMap.size === 0 ) {
+      // No type carries a material, so no IfcRelDefinesByType in this model
+      // can contribute one. Skip the sweep rather than walk (and, on a
+      // windowed source, page in) every type relationship for nothing.
+      return
+    }
+
+    const relMaterialsMap = this.materials.relMaterialsMap
+
+    for ( const relDefinesByType of this.model.types( IfcRelDefinesByType ) ) {
+
+      try {
+        // RelatingType as a bare local ID: hydrating the type object would
+        // pin its record on a windowed source for no gain, since
+        // typeMaterialsMap is keyed by local ID. Same reason the related
+        // objects go through forEachReferenceInField below.
+        const typeLocalID = relDefinesByType.extractReferenceLocalID(
+            REL_DEFINES_BY_TYPE_RELATING_OFFSET,
+            REL_DEFINES_BY_TYPE_RELATING_BASE,
+            REL_DEFINES_BY_TYPE_RELATING_DEPTH,
+            false )
+
+        if ( typeLocalID === null ) {
+          continue
+        }
+
+        const materialLocalID = typeMaterialsMap.get( typeLocalID )
+
+        if ( materialLocalID === void 0 ) {
+          continue
+        }
+
+        relDefinesByType.forEachReferenceInField(
+            REL_DEFINES_BY_TYPE_RELATED_OFFSET,
+            REL_DEFINES_BY_TYPE_RELATED_BASE,
+            REL_DEFINES_BY_TYPE_RELATED_DEPTH,
+            ( expressID ) => {
+
+              if ( expressID === void 0 ) {
+                return true
+              }
+
+              const productLocalID = this.model.resolveExpressID( expressID )
+
+              if ( productLocalID === void 0 ||
+                  relMaterialsMap.has( productLocalID ) ) {
+                // Occupied entry: the occurrence declared its own material
+                // and that wins over the type's.
+                return true
+              }
+
+              if ( this.isMaterialTargetProductType_(
+                  this.model.typeIDOf( productLocalID ), productTypes ) ) {
+                relMaterialsMap.set( productLocalID, materialLocalID )
+              }
+
+              return true
+            } )
+      } catch ( ex ) {
+        this.handleMapPrepError_(
+            'IfcRelDefinesByType', relDefinesByType.expressID, ex )
+      }
+    }
   }
 
   /**

--- a/src/ifc/ifc_surface_style_shading.test.ts
+++ b/src/ifc/ifc_surface_style_shading.test.ts
@@ -27,6 +27,14 @@
 //      behaviour change for such models (codex finding on
 //      bldrs-ai/conway#684).
 //
+//   D. A material associated to the TYPE object (IfcDoorType, and here
+//      IfcBuildingElementProxyType) instead of the occurrence never reached
+//      the occurrence at all: relMaterialsMap is filtered to IfcProduct, and
+//      a type object is an IfcTypeObject. 272 of the Renga model's 5,351
+//      placements — every window, door, light fixture and railing — resolved
+//      no material because of it. The occurrence must inherit its type's
+//      material, and its OWN association must still override it.
+//
 // Colour components and the wasm-init timeout are literals throughout, the
 // same trade the other fixture-driven suites here make.
 /* eslint-disable no-magic-numbers */
@@ -57,16 +65,31 @@ const GREEN: ColorRGBA = [0.625, 0.5, 0.25, 1]
 const TEAL: ColorRGBA = [0.375, 0.75, 0.625, 1]
 const PURPLE: ColorRGBA = [0.875, 0.125, 0.5, 1]
 
+/* ORANGE reaches #5000 only through its type object. #6000's two competing
+ * colours: CYAN is its own association, MAGENTA its type's. CYAN wins. */
+const ORANGE: ColorRGBA = [0.875, 0.5, 0.125, 1]
+const CYAN: ColorRGBA = [0.125, 0.75, 0.875, 1]
+const MAGENTA: ColorRGBA = [0.75, 0.125, 0.625, 1]
+
 /* What an unwritten CanonicalMaterial field holds — the value every placement
  * of this model's shape used to report to the compat layer. */
 const UNWRITTEN_DEFAULT: ColorRGBA = [0.8, 0.8, 0.8, 1]
 
-/** Express IDs of the four products, and of the body #1000/#2000/#4000 share. */
+/** Express IDs of the six products, and of the body all but #3000 share. */
 const MAPPED_RED_EXPRESS_ID = 1000
 const MAPPED_BLUE_EXPRESS_ID = 2000
 const DIRECT_GREEN_EXPRESS_ID = 3000
 const MAPPED_ITEM_STYLED_EXPRESS_ID = 4000
+const TYPE_INHERITED_EXPRESS_ID = 5000
+const TYPE_OVERRIDDEN_EXPRESS_ID = 6000
 const SHARED_SOLID_EXPRESS_ID = 311
+
+/** #5000's type object and the IfcMaterial that type is associated with. */
+const PROXY_TYPE_ORANGE_EXPRESS_ID = 5100
+const MATERIAL_ORANGE_EXPRESS_ID = 700
+
+/** Distinct colours the fixture expects to reach a placement. */
+const EXTRACTED_MATERIAL_COUNT = 6
 
 let extraction: IfcGeometryExtraction
 let extractResult: ExtractResult
@@ -109,7 +132,7 @@ beforeAll( async () => {
 
 describe( 'shading-only surface styles', () => {
 
-  test( 'the fixture extracts and places all four products', () => {
+  test( 'the fixture extracts and places all six products', () => {
 
     expect( extractResult ).toBe( ExtractResult.COMPLETE )
     expect( [ ...placements.keys() ].sort( ( a, b ) => a - b ) ).toEqual( [
@@ -117,6 +140,8 @@ describe( 'shading-only surface styles', () => {
       MAPPED_BLUE_EXPRESS_ID,
       DIRECT_GREEN_EXPRESS_ID,
       MAPPED_ITEM_STYLED_EXPRESS_ID,
+      TYPE_INHERITED_EXPRESS_ID,
+      TYPE_OVERRIDDEN_EXPRESS_ID,
     ] )
   } )
 
@@ -138,7 +163,7 @@ describe( 'shading-only surface styles', () => {
       material.legacyColor.every( ( value, index ) => value === UNWRITTEN_DEFAULT[ index ] ) )
 
     // Guard the guard: this only means anything if styles were extracted at all.
-    expect( extraction.materials.size ).toBe( 4 )
+    expect( extraction.materials.size ).toBe( EXTRACTED_MATERIAL_COUNT )
     expect( defaulted ).toEqual( [] )
   } )
 } )
@@ -227,5 +252,87 @@ describe( 'style precedence on a mapped item', () => {
 
     expect( extracted ).toContain( TEAL.join( ',' ) )
     expect( extracted ).not.toContain( PURPLE.join( ',' ) )
+  } )
+} )
+
+
+describe( 'material inherited from the type object', () => {
+
+  test( 'a product whose material is only on its type still resolves one', () => {
+
+    const inherited = placements.get( TYPE_INHERITED_EXPRESS_ID )
+
+    // #5000 has no styled item and no association of its own: the ONLY route
+    // to a colour is IfcRelDefinesByType -> IfcBuildingElementProxyType ->
+    // IfcRelAssociatesMaterial. Before the fix this was undefined.
+    expect( inherited?.material ).toBeDefined()
+    expect( inherited!.material!.legacyColor ).toEqual( ORANGE )
+    expect( inherited!.material!.baseColor ).toEqual( ORANGE )
+  } )
+
+  test( 'inheritance goes through the type, not "any unclaimed material"', () => {
+
+    // The type's material has to land on the product's own local ID in
+    // relMaterialsMap, the same slot a direct association fills — that is what
+    // the mapped-item path reads per product. Asserting the map entry as well
+    // as the colour rules out a placement that came out orange because some
+    // fallback painted every unresolved product with the last material seen.
+    const inheritedLocalID =
+      extraction.model.getElementByExpressID( TYPE_INHERITED_EXPRESS_ID )!.localID
+    const typeLocalID =
+      extraction.model.getElementByExpressID( PROXY_TYPE_ORANGE_EXPRESS_ID )!.localID
+    const orangeMaterialLocalID =
+      extraction.model.getElementByExpressID( MATERIAL_ORANGE_EXPRESS_ID )!.localID
+
+    expect( extraction.materials.relMaterialsMap.get( inheritedLocalID ) )
+        .toBe( orangeMaterialLocalID )
+
+    // And the type object itself is never given an entry: it has no geometry,
+    // so an entry there would only be dead weight (and would make the
+    // occurrence's "already claimed" check ambiguous if local IDs collided
+    // with a product's).
+    expect( extraction.materials.relMaterialsMap.has( typeLocalID ) ).toBe( false )
+  } )
+
+  test( 'an occurrence association overrides the type\'s', () => {
+
+    const overridden = placements.get( TYPE_OVERRIDDEN_EXPRESS_ID )
+
+    // #6000 can reach both colours — cyan off its own IfcRelAssociatesMaterial,
+    // magenta off its type's — so this only passes if precedence is applied,
+    // not because the magenta was unreachable. The fixture orders the two
+    // associations occurrence-first/type-last precisely so an implementation
+    // that let the type overwrite as it swept fails here.
+    expect( overridden?.material ).toBeDefined()
+    expect( overridden!.material!.legacyColor ).toEqual( CYAN )
+    expect( overridden!.material!.legacyColor ).not.toEqual( MAGENTA )
+    expect( overridden!.material!.baseColor ).toEqual( CYAN )
+  } )
+
+  test( 'the overridden type material is never extracted', () => {
+
+    // Same reasoning as the mapped-item precedence case: the type's material
+    // is never consulted for #6000, so magenta never becomes a
+    // CanonicalMaterial. Distinguishes "type material lost the tie-break" from
+    // "type material was applied and then overwritten".
+    const extracted = [ ...extraction.materials.materials() ].map(
+        ( material ) => material.legacyColor.join( ',' ) )
+
+    expect( extracted ).toContain( CYAN.join( ',' ) )
+    expect( extracted ).toContain( ORANGE.join( ',' ) )
+    expect( extracted ).not.toContain( MAGENTA.join( ',' ) )
+  } )
+
+  test( 'both type-material products instance the shared body', () => {
+
+    // Neither product has geometry of its own, so a colour here is a colour on
+    // one instance of the map — the same per-instance override the red/blue
+    // pair exercises, reached through a type rather than a direct association.
+    const sharedBodyLocalID = placements.get( MAPPED_RED_EXPRESS_ID )!.geometryLocalID
+
+    expect( placements.get( TYPE_INHERITED_EXPRESS_ID )!.geometryLocalID )
+        .toBe( sharedBodyLocalID )
+    expect( placements.get( TYPE_OVERRIDDEN_EXPRESS_ID )!.geometryLocalID )
+        .toBe( sharedBodyLocalID )
   } )
 } )


### PR DESCRIPTION
The third material path for [bldrs-ai/test-models-private#61](https://github.com/bldrs-ai/test-models-private/issues/61), left out of scope by #684: materials associated to the **type** object (`IfcRelAssociatesMaterial` naming an `IfcDoorType`/`IfcWindowType`), reaching occurrences only through `IfcRelDefinesByType`. `prepareExtractionMaps_`'s sweep filtered related objects to `IfcProduct`, and type objects live in the disjoint `IfcTypeObject` hierarchy — so those associations were silently dropped.

## The fix (map-population time)

- The `IfcRelAssociatesMaterial` sweep now routes an `IfcTypeObject` target into a local `typeMaterialsMap`, an `IfcProduct` into `relMaterialsMap` as before.
- A new `inheritTypeMaterials_()` runs strictly **after** the full sweep, walks `IfcRelDefinesByType`, and fills `relMaterialsMap` only for occurrences with no existing entry — so an occurrence-level association always wins (IFC precedence), independent of file order.
- The opening/space exclusion moved into a shared `isMaterialTargetProductType_()` predicate so the two passes can't drift.
- Cheap on windowed sources: attribute reads via `extractReferenceLocalID`/`forEachReferenceInField` (no entity hydration); an empty `typeMaterialsMap` skips the `IfcRelDefinesByType` sweep entirely; errors flow through the existing map-prep tolerance.
- **Windowed residency (from Codex review):** `IfcRelDefinesByType` added to `ensureResidentForDemandPrep`'s `recordOnlyTypes` — without it, a store-backed open's sweep reads could throw `StepBufferNotResidentError` (swallowed in permissive mode), losing inheritance on files where the relationship records aren't coincidentally resident. Verified empirically: 0/103 records pinned before, 103/103 after; a new windowed demand-prep test asserts the pin set covers every relationship the map prep sweeps.

## Validation on the issue model

Unresolved placements 272 → **89**; exactly two colour buckets move — +147 windows to aluminium grey (0.647³, from the `IfcWindowType` association) and +36 doors to dark wood (0.4, 0.333, 0.333) — and all 12 other buckets are byte-identical. The remaining 89 are legitimately material-less: 68 `IfcLightFixture` (no association names their type anywhere in the file), 12 `IfcRailing` (material reachable only via `IfcRelNests` decomposition — a distinct fourth path, worth its own issue if it matters), 9 `IfcVoidingFeature` (referenced by nothing but `IfcRelVoidsElement`).

## Tests

Fixture gains a type-only-material product and a type+occurrence conflict product; 5 new style tests plus the windowed-residency test (14 new-suite tests total across the two suites). Revert-checked: 4 style tests fail with the inheritance reverted, the occurrence-wins guard is mutation-checked, and the residency test fails with the `recordOnlyTypes` entry removed. Full suite: 142 suites / 1087 tests green.

## Regression note

Digests shift for models with type-associated materials; per-PR digest changes are informational, corpus baselines re-bless on the next `rc-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSPoDZwutgTofFsHaZ5jpA