### PR TITLE
Run PR regression on free ubuntu-24.04 and grow the smoke list

### DIFF
--- a/.github/actions/regression-shard/action.yml
+++ b/.github/actions/regression-shard/action.yml
@@ -1,0 +1,231 @@
+name: 'Run one PR-regression shard'
+description: >
+  Skip-smudge a test-models corpus, LFS-pull only this shard's files,
+  run the digest batch, upload results, and fail on crashed or
+  unexpected zero-geometry models. Caller has already checked out
+  conway, installed yarn deps, restored the WASM cache, and run
+  yarn build-incremental.
+
+inputs:
+  shard-id:
+    required: true
+  shard-file:
+    required: true
+  corpus:
+    required: true
+    description: 'public or private'
+  models-ref:
+    required: true
+    description: 'Branch, tag, or SHA to resolve'
+  models-repo:
+    required: true
+    description: 'owner/name, e.g. bldrs-ai/test-models'
+  models-token:
+    required: false
+    default: ''
+    description: 'PAT for private clone; empty for public'
+  concurrency:
+    required: true
+  allow-visual-diff:
+    required: false
+    default: 'false'
+    description: 'true only for public shards — do not render private models'
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve corpus SHA
+      id: sha
+      shell: bash
+      env:
+        REF: ${{ inputs.models-ref }}
+        REPO: ${{ inputs.models-repo }}
+        TOKEN: ${{ inputs.models-token }}
+      run: |
+        set -euo pipefail
+        if [ -n "$TOKEN" ]; then
+          URL="https://x-access-token:${TOKEN}@github.com/${REPO}.git"
+        else
+          URL="https://github.com/${REPO}.git"
+        fi
+        REFS=$(git ls-remote "$URL" "$REF")
+        SHA=$(printf '%s\n' "$REFS" | awk '$2 ~ /\^\{\}$/ { print $1; found=1; exit } NR==1 { first=$1 } END { if (!found && first) print first }')
+        if [ -z "$SHA" ]; then SHA="$REF"; fi
+        if ! [[ "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "::error::Could not resolve ${REPO}@${REF} (got '$SHA')."
+          exit 1
+        fi
+        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+        echo "Resolved ${REPO} ref '$REF' -> $SHA"
+        echo "**${{ inputs.shard-id }}:** \`${REPO}@${SHA}\`" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Restore shard models cache
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: models
+        key: ${{ runner.os }}-reg-shard-${{ inputs.corpus }}-${{ inputs.shard-id }}-${{ steps.sha.outputs.sha }}-${{ hashFiles(inputs.shard-file) }}
+
+    - name: Checkout corpus if not cached
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        GIT_LFS_SKIP_SMUDGE: '1'
+        SHA: ${{ steps.sha.outputs.sha }}
+        REPO: ${{ inputs.models-repo }}
+        TOKEN: ${{ inputs.models-token }}
+      run: |
+        set -euo pipefail
+        if [ -n "$TOKEN" ]; then
+          URL="https://x-access-token:${TOKEN}@github.com/${REPO}.git"
+        else
+          URL="https://github.com/${REPO}.git"
+        fi
+        git init models
+        git -C models remote add origin "$URL"
+        git -C models fetch --depth 1 origin "$SHA"
+        git -C models checkout "$SHA"
+
+    - name: Materialize this shard's LFS models
+      shell: bash
+      run: python3 "${{ github.action_path }}/shard_list.py" pull "${{ inputs.shard-file }}" models
+
+    - name: Run digest batch
+      shell: bash
+      env:
+        CONCURRENCY: ${{ inputs.concurrency }}
+        SHA: ${{ steps.sha.outputs.sha }}
+        SHARD_FILE: ${{ inputs.shard-file }}
+      run: |
+        set -euo pipefail
+        REGEX=$(python3 "${{ github.action_path }}/shard_list.py" regex "$SHARD_FILE")
+        node --experimental-specifier-resolution=node \
+          ./compiled/src/ifc/ifc_regression_batch_main.js \
+          -e "$REGEX" \
+          -t "$SHA" \
+          --perf "${GITHUB_WORKSPACE}/perf.csv" \
+          models \
+          models/regression/test_models \
+          --parallel --mem-utilization 90 --concurrency "$CONCURRENCY"
+
+    - name: Collect digest-changed models
+      if: inputs.allow-visual-diff == 'true'
+      id: vdiff
+      shell: bash
+      env:
+        SHA: ${{ steps.sha.outputs.sha }}
+      run: |
+        python3 - "$PWD/models" "$SHA" <<'EOF'
+        import os, subprocess, sys
+        root, sha = sys.argv[1], sys.argv[2]
+        out = subprocess.run(
+            ['git', 'diff', '--name-only', sha, '--', 'regression/test_models'],
+            cwd=root, capture_output=True, text=True, check=True).stdout
+        untracked = subprocess.run(
+            ['git', 'ls-files', '--others', '--exclude-standard', '--',
+             'regression/test_models'],
+            cwd=root, capture_output=True, text=True, check=True).stdout
+        meta = {'errors.csv', 'failed.csv', 'main.csv', 'changes.csv',
+                'zero_geometry.csv'}
+
+        def digest_stems(listing):
+            stems = set()
+            for line in listing.splitlines():
+                base = os.path.basename(line)
+                if base.endswith('.csv') and base not in meta:
+                    stems.add(base[:-4])
+            return stems
+
+        new_stems = digest_stems(untracked)
+        stems = digest_stems(out) | new_stems
+        models, found = [], set()
+        for top in ('ifc', 'step'):
+            for dirpath, _, files in os.walk(os.path.join(root, top)):
+                for f in files:
+                    stem, ext = os.path.splitext(f)
+                    if (stem in stems and stem not in found and
+                            ext.lower() in ('.ifc', '.step', '.stp')):
+                        found.add(stem)
+                        rel = os.path.relpath(os.path.join(dirpath, f), root)
+                        models.append(
+                            f'{rel}\tnew' if stem in new_stems else rel)
+        with open('changed_models.txt', 'w') as fh:
+            fh.write('\n'.join(sorted(models)) + ('\n' if models else ''))
+        print(f'{len(models)} digest-changed/new model(s)')
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            fh.write(f'count={len(models)}\n')
+        EOF
+
+    - name: Upload changed-model list
+      if: inputs.allow-visual-diff == 'true' && steps.vdiff.outputs.count != '0'
+      uses: actions/upload-artifact@v4
+      with:
+        name: visual-diff-models-${{ inputs.shard-id }}
+        path: changed_models.txt
+        if-no-files-found: ignore
+
+    - name: Upload shard results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: regression-shard-${{ inputs.shard-id }}
+        path: |
+          models/regression/test_models/failed.csv
+          models/regression/test_models/errors.csv
+          models/regression/test_models/main.csv
+          models/regression/test_models/zero_geometry.csv
+          perf.csv
+        if-no-files-found: warn
+
+    - name: Fail on shard parse/extract failures
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: |
+        FAILED=models/regression/test_models/failed.csv
+        if [ -f "$FAILED" ] && [ "$(wc -l < "$FAILED")" -gt 1 ]; then
+          echo "::error::Shard ${{ inputs.shard-id }} failures:"
+          cat "$FAILED"
+          exit 1
+        fi
+        echo "No failures in shard ${{ inputs.shard-id }}."
+
+    - name: Fail on unexpected zero-geometry models
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: |
+        ZERO=models/regression/test_models/zero_geometry.csv
+        MAIN=models/regression/test_models/main.csv
+        ALLOW=regression/zero_geometry_allowlist.txt
+        if [ ! -f "$ZERO" ]; then
+          echo "No zero_geometry.csv produced."; exit 0
+        fi
+        python3 - "$ZERO" "$ALLOW" "$MAIN" <<'PY'
+        import csv, os, sys
+        zero, allow, main = sys.argv[1], sys.argv[2], sys.argv[3]
+        allowed = set()
+        for line in open(allow, encoding='utf-8'):
+            line = line.split('#', 1)[0].strip()
+            if line:
+                allowed.add(line)
+        rows = [r['file'] for r in csv.DictReader(open(zero, newline='', encoding='utf-8'))]
+        unexpected = [f for f in rows if f not in allowed]
+        for f in rows:
+            print(f"zero geometry: {f}" + ("" if f in unexpected else "  (allowlisted)"))
+        ran = set()
+        if os.path.exists(main):
+            ran = {r['file'] for r in csv.DictReader(open(main, newline='', encoding='utf-8'))}
+        stale = sorted((allowed & ran) - set(rows))
+        if unexpected:
+            print("::error::Models loaded but produced NO geometry and are not allowlisted:")
+            for f in unexpected:
+                print(f"::error::  {f}")
+        if stale:
+            print("::error::Allowlisted models that now DO produce geometry - "
+                  "delete their lines from regression/zero_geometry_allowlist.txt:")
+            for f in stale:
+                print(f"::error::  {f}")
+        if unexpected or stale:
+            sys.exit(1)
+        print(f"{len(rows)} zero-geometry model(s), all allowlisted; "
+              f"{len(allowed & ran)} allowlist entr(ies) exercised and still empty.")
+        PY

--- a/.github/actions/regression-shard/shard_list.py
+++ b/.github/actions/regression-shard/shard_list.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Helpers for PR-regression shards (regression/shards/*.txt)."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_shard(path: str) -> tuple[str, list[str]]:
+    """Return (corpus, basenames) from a shard list file."""
+    corpus = 'public'
+    names: list[str] = []
+    with open(path, encoding='utf-8') as fh:
+        for line in fh:
+            raw = line.strip()
+            if raw.startswith('# corpus:'):
+                corpus = raw.split(':', 1)[1].strip()
+                continue
+            if not raw or raw.startswith('#'):
+                continue
+            names.append(raw)
+    if not names:
+        raise SystemExit(f'{path} selected no models')
+    if corpus not in ('public', 'private'):
+        raise SystemExit(f'{path}: unknown corpus {corpus!r}')
+    return corpus, names
+
+
+def exclude_regex(names: list[str]) -> str:
+    """Batch CLI exclude regex: model FILES whose basename is NOT in names."""
+    alts = '|'.join(re.escape(n) for n in names)
+    return (
+        rf'^(?!.*/(?:{alts})$)'
+        r'.*\.(?:[iI][fF][cC]|[sS][tT][eE][pP]|[sS][tT][pP])$'
+    )
+
+
+def find_paths(root: Path, names: list[str]) -> list[str]:
+    """Relative posix paths under root/ifc and root/step matching basenames."""
+    want = set(names)
+    paths: list[str] = []
+    for top in ('ifc', 'step'):
+        base = root / top
+        if not base.is_dir():
+            continue
+        for p in base.rglob('*'):
+            if p.is_file() and p.name in want:
+                paths.append(p.relative_to(root).as_posix())
+    missing = want - {Path(p).name for p in paths}
+    if missing:
+        raise SystemExit(
+            'shard names not in corpus: ' + ', '.join(sorted(missing)))
+    return paths
+
+
+def is_lfs_stub(path: Path) -> bool:
+    head = path.read_bytes()[:200]
+    return head.startswith(b'version https://git-lfs') or b'git-lfs.github.com' in head
+
+
+def cmd_regex(args: argparse.Namespace) -> None:
+    _, names = parse_shard(args.shard)
+    print(exclude_regex(names), end='')
+
+
+def cmd_corpus(args: argparse.Namespace) -> None:
+    corpus, _ = parse_shard(args.shard)
+    print(corpus, end='')
+
+
+def cmd_names(args: argparse.Namespace) -> None:
+    _, names = parse_shard(args.shard)
+    print('\n'.join(names))
+
+
+def cmd_pull(args: argparse.Namespace) -> None:
+    _, names = parse_shard(args.shard)
+    root = Path(args.root)
+    paths = find_paths(root, names)
+    stubs = [rel for rel in paths if is_lfs_stub(root / rel)]
+    print(f'{len(paths)} shard models, {len(stubs)} LFS stubs to pull')
+    if not stubs:
+        return
+    subprocess.check_call(['git', 'lfs', 'install', '--local'], cwd=root)
+    subprocess.check_call(
+        ['git', 'lfs', 'pull', '--include=' + ','.join(stubs)], cwd=root)
+    left = [rel for rel in stubs if is_lfs_stub(root / rel)]
+    if left:
+        print(
+            '::error::unsmudged LFS stubs after pull: ' + ', '.join(left),
+            file=sys.stderr)
+        raise SystemExit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest='cmd', required=True)
+
+    p_regex = sub.add_parser('regex')
+    p_regex.add_argument('shard')
+    p_regex.set_defaults(func=cmd_regex)
+
+    p_corpus = sub.add_parser('corpus')
+    p_corpus.add_argument('shard')
+    p_corpus.set_defaults(func=cmd_corpus)
+
+    p_names = sub.add_parser('names')
+    p_names.add_argument('shard')
+    p_names.set_defaults(func=cmd_names)
+
+    p_pull = sub.add_parser('pull')
+    p_pull.add_argument('shard')
+    p_pull.add_argument('root')
+    p_pull.set_defaults(func=cmd_pull)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    # github.com composite actions run with cwd = the caller workspace.
+    os.chdir(os.environ.get('GITHUB_WORKSPACE', os.getcwd()))
+    main()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,9 @@ env:
 
 jobs:
   build:
-    # Heavy runner matches ifc-regression. The WASM toolchain (genie +
-    # emcc) needs the headroom; the default 2-vCPU runner fails the compile.
+    # Paid 150 GB SKU: emcc's working set does not fit the public
+    # runner's 14 GB disk. 4 vCPU is enough (the old 2-vCPU image is
+    # what failed the compile); disk is why this job stays billed.
     runs-on: ubuntu-24.04-4vcpu-8gb-150gbssd
     steps:
       - name: Checkout
@@ -276,13 +277,20 @@ jobs:
           path: tierA-goldens/*.csv
 
   # ---------------------------------------------------------------------------
-  # Regression (SMOKE subset): consumes build's WASM cache (no rebuild), runs
+  # Regression (PR subset): consumes build's WASM cache (no rebuild), runs
   # the digest batch over regression/smoke_models.txt only, gates on failures,
   # posts results to the PR, and packs the npm tarball the perf jobs consume.
   # The FULL public+private corpus runs once per release candidate in
   # rc-regression.yml (rc-* tag) — its baseline-PR diff is the release's
   # regression report. Kept on a separate job (vs steps in build) so its
   # runtime doesn't block the build-job status once fast feedback finishes.
+  #
+  # Free public ubuntu-24.04 is 4 vCPU / 16 GB / 14 GB disk. The paid
+  # SKU this job used to share with build is 4 vCPU / 8 GB / 150 GB —
+  # billed even on a public repo. Digests are not jitter-sensitive, so
+  # the extra RAM is a win and the missing disk is the thing to watch:
+  # skip-smudge the test-models clone and LFS-pull only the listed
+  # models (~hundreds of MB, not the 9.6 GB tree).
   # ---------------------------------------------------------------------------
   run-ifc-regression:
     needs: build
@@ -305,7 +313,7 @@ jobs:
     # this job -- hinge on a documented-but-obscure corner of the expression
     # language. The clause states the intent instead.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04-4vcpu-8gb-150gbssd
+    runs-on: ubuntu-24.04
     # Expose the packed tarball name so downstream perf jobs can download the
     # artifact by name without re-packing conway.
     outputs:
@@ -398,10 +406,18 @@ jobs:
         uses: actions/cache@v4
         with:
           path: test-models
-          key: ${{ runner.os }}-test-models-${{ steps.tmsha.outputs.sha }}
+          # smoke- in the key so we never restore a 9.6 GB full-corpus
+          # cache onto the 14 GB public disk. hashFiles so growing the
+          # list misses rather than running against pointer stubs.
+          key: ${{ runner.os }}-test-models-smoke-${{ steps.tmsha.outputs.sha }}-${{ hashFiles('regression/smoke_models.txt') }}
 
       - name: Checkout Test Models Repo if Not Cached
         if: steps.cache-test-models.outputs.cache-hit != 'true'
+        env:
+          # Pointers only. The next step LFS-pulls the smoke list; a
+          # smudged checkout of ifc/** + step/** is ~3 GB of models and
+          # does not fit next to node_modules + wasm on 14 GB.
+          GIT_LFS_SKIP_SMUDGE: '1'
         run: |
           SHA="${{ steps.tmsha.outputs.sha }}"
           # Shallow-fetch exactly the resolved commit (GitHub allows fetch-by-SHA
@@ -411,6 +427,39 @@ jobs:
           git -C test-models remote add origin https://github.com/bldrs-ai/test-models.git
           git -C test-models fetch --depth 1 origin "$SHA"
           git -C test-models checkout "$SHA"
+
+      - name: Materialize smoke-list LFS models
+        run: |
+          python3 - <<'EOF'
+          import subprocess, sys
+          from pathlib import Path
+
+          names = [l.strip() for l in open('regression/smoke_models.txt')
+                   if l.strip() and not l.strip().startswith('#')]
+          want = set(names)
+          root = Path('test-models')
+          paths = []
+          for top in ('ifc', 'step'):
+              for p in (root / top).rglob('*'):
+                  if p.is_file() and p.name in want:
+                      paths.append(p.relative_to(root).as_posix())
+          missing = want - {Path(p).name for p in paths}
+          if missing:
+              print('::error::smoke_models.txt names not in test-models: '
+                    + ', '.join(sorted(missing)))
+              sys.exit(1)
+          stubs = []
+          for rel in paths:
+              head = (root / rel).read_bytes()[:200]
+              if head.startswith(b'version https://git-lfs') or b'git-lfs.github.com' in head:
+                  stubs.append(rel)
+          print(f'{len(paths)} smoke models, {len(stubs)} LFS stubs to pull')
+          if not stubs:
+              sys.exit(0)
+          subprocess.check_call(['git', 'lfs', 'install', '--local'], cwd=root)
+          subprocess.check_call(
+              ['git', 'lfs', 'pull', '--include=' + ','.join(stubs)], cwd=root)
+          EOF
 
       # This job runs the SMOKE subset only (regression/smoke_models.txt) —
       # the full public+private corpus runs once per release candidate in
@@ -441,7 +490,10 @@ jobs:
       # baselines. The aggregate is uploaded as a workflow artifact below and
       # summarised in the PR comment. NOTE these timings come from a --parallel
       # run (models contend), so they're a smoke signal only — the clean
-      # per-model perf record is the rc-gated perf-three-* jobs.
+      # per-model perf record is the rc-gated perf-three-* jobs. Each child
+      # is itself multi-threaded wasm; `--concurrency 2` on 4 vCPU avoids
+      # oversubscribing as the list grows (the CLI default is one child per
+      # core).
       - name: Run IFC Regression Batch Script (smoke subset)
         env:
           SMOKE_EXCLUDE: ${{ steps.smoke.outputs.regex }}
@@ -452,7 +504,7 @@ jobs:
             --perf "${GITHUB_WORKSPACE}/perf.csv" \
             test-models \
             test-models/regression/test_models \
-            --parallel --mem-utilization 90
+            --parallel --mem-utilization 90 --concurrency 2
 
       - name: Gather Regression Results
         id: regression_results
@@ -839,11 +891,12 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.draft == false &&
       needs.run-ifc-regression.outputs.visual_diff_count != '0'
-    # Same large runner as every other job that executes the conway CLIs:
-    # the MT WASM engine reserves multi-GB (shared) memory at startup, and on
-    # the standard 4-vcpu runner every export died with an uncaught allocation
-    # crash (only the "Node.js vX.Y.Z" report footer reached the PR table).
-    runs-on: ubuntu-24.04-4vcpu-8gb-150gbssd
+    # Public ubuntu-24.04 is 4 vCPU / 16 GB — more RAM than the paid
+    # 8 GB SKU this used to share. The allocation crash that forced the
+    # large runner was on the old 2-vCPU/7 GB image; disk is handled by
+    # restoring the smoke-sized test-models cache (or skip-smudge +
+    # LFS-pull of changed_models.txt only).
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: write       # push rendered PNGs to visual-diff-assets
@@ -895,10 +948,12 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: test-models
-          key: ${{ runner.os }}-test-models-${{ needs.run-ifc-regression.outputs.test_models_sha }}
+          key: ${{ runner.os }}-test-models-smoke-${{ needs.run-ifc-regression.outputs.test_models_sha }}-${{ hashFiles('regression/smoke_models.txt') }}
 
       - name: Checkout Test Models Repo if Not Cached
         if: steps.cache-test-models.outputs.cache-hit != 'true'
+        env:
+          GIT_LFS_SKIP_SMUDGE: '1'
         run: |
           SHA="${{ needs.run-ifc-regression.outputs.test_models_sha }}"
           git init test-models
@@ -906,34 +961,48 @@ jobs:
           git -C test-models fetch --depth 1 origin "$SHA"
           git -C test-models checkout "$SHA"
 
-      # Model files under ifc/ and step/ are git-lfs objects; a manual
-      # fetch/checkout (and a cache seeded from one) can leave 132-byte
-      # pointer stubs. Materialize what we can.
-      #
-      # Stubs used to be tolerated here with a warning saying their rows would
-      # read "no geometry" truthfully. That is truthful about the bytes on
-      # disk and false about the model, and it cost real work: two models were
-      # blessed at zero rows and filed as engine bugs (#477) before anyone
-      # noticed the run had never read them. The regression batch now FAILS a
-      # stub instead of parsing it (#486), so a stub can no longer reach a
-      # baseline. This job renders rather than digests, so it still continues
-      # — a stub here costs one blank image, not a committed falsehood — but
-      # the warning now says what it actually means.
+      # Pull LFS only for the models this job will render. A full
+      # `ifc/**,step/**` pull is ~3 GB and does not fit on 14 GB disk.
+      # Stubs used to be tolerated as "no geometry"; that blessed two
+      # pointer files as engine bugs (#477). The batch now fails a stub
+      # (#486). This job still continues on a leftover stub — one blank
+      # image, not a committed falsehood — but the warning says that.
       - name: Materialize LFS model files
         run: |
-          cd test-models
-          STUBS=$(grep -rl "git-lfs.github.com" ifc step 2>/dev/null | wc -l || true)
-          echo "LFS pointer stubs remaining: $STUBS"
-          if [ "$STUBS" != "0" ]; then
-            git lfs install --local
-            git lfs pull --include="ifc/**,step/**" || true
-            LEFT=$(grep -rl "git-lfs.github.com" ifc step 2>/dev/null | wc -l || true)
-            echo "stubs after lfs pull: $LEFT"
-            if [ "$LEFT" != "0" ]; then
-              echo "::warning::test-models still has $LEFT unsmudged LFS pointer stub(s). These are NOT models: any row below that renders empty for one of them is a missing file, not a geometry regression."
-              grep -rl "git-lfs.github.com" ifc step 2>/dev/null || true
-            fi
-          fi
+          python3 - <<'EOF'
+          import subprocess
+          from pathlib import Path
+          root = Path('test-models')
+          rels = []
+          for line in open('changed_models.txt'):
+              rel = line.split('\t', 1)[0].strip()
+              if rel:
+                  rels.append(rel)
+          stubs = []
+          for rel in rels:
+              p = root / rel
+              if not p.is_file():
+                  print(f'::warning::changed model missing: {rel}')
+                  continue
+              head = p.read_bytes()[:200]
+              if head.startswith(b'version https://git-lfs') or b'git-lfs.github.com' in head:
+                  stubs.append(rel)
+          print(f'{len(rels)} changed models, {len(stubs)} LFS stubs to pull')
+          if not stubs:
+              raise SystemExit(0)
+          subprocess.check_call(['git', 'lfs', 'install', '--local'], cwd=root)
+          subprocess.check_call(
+              ['git', 'lfs', 'pull', '--include=' + ','.join(stubs)], cwd=root)
+          left = []
+          for rel in stubs:
+              head = (root / rel).read_bytes()[:200]
+              if head.startswith(b'version https://git-lfs') or b'git-lfs.github.com' in head:
+                  left.append(rel)
+          if left:
+              print('::warning::unsmudged LFS pointer stub(s) after pull — '
+                    'blank renders for these are a missing file, not a geometry '
+                    'regression: ' + ', '.join(left))
+          EOF
 
       - name: Render before/after pairs
         run: |
@@ -1139,6 +1208,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: test-models
+          # Full public corpus, not the smoke-sized cache the PR
+          # regression job writes. This job is rc-only on the 150 GB
+          # SKU; a miss re-clones.
           key: ${{ runner.os }}-test-models-${{ needs.run-ifc-regression.outputs.test_models_sha }}
 
       - name: Checkout Test Models Repo if Not Cached

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ env:
   # reproducible without test-models having to cut tags. Override via the
   # repo/environment variable TEST_MODELS_REF (a branch, tag, or full commit SHA).
   TEST_MODELS_REF: ${{ vars.TEST_MODELS_REF || 'main' }}
+  TEST_MODELS_PRIVATE_TAG: ${{ vars.TEST_MODELS_PRIVATE_TAG || 'main' }}
 
 jobs:
   build:
@@ -277,53 +278,32 @@ jobs:
           path: tierA-goldens/*.csv
 
   # ---------------------------------------------------------------------------
-  # Regression (PR subset): consumes build's WASM cache (no rebuild), runs
-  # the digest batch over regression/smoke_models.txt only, gates on failures,
-  # posts results to the PR, and packs the npm tarball the perf jobs consume.
-  # The FULL public+private corpus runs once per release candidate in
-  # rc-regression.yml (rc-* tag) — its baseline-PR diff is the release's
-  # regression report. Kept on a separate job (vs steps in build) so its
-  # runtime doesn't block the build-job status once fast feedback finishes.
+  # PR regression: digest batch, sharded, on free ubuntu-24.04.
   #
-  # Free public ubuntu-24.04 is 4 vCPU / 16 GB / 14 GB disk. The paid
-  # SKU this job used to share with build is 4 vCPU / 8 GB / 150 GB —
-  # billed even on a public repo. Digests are not jitter-sensitive, so
-  # the extra RAM is a win and the missing disk is the thing to watch:
-  # skip-smudge the test-models clone and LFS-pull only the listed
-  # models (~hundreds of MB, not the 9.6 GB tree).
+  # Ten shards max (see regression/shards/README.md):
+  #   coverage-1..3  public small models (union = smoke_models.txt)
+  #   psb, d3d, ilna, dowa, orbiter, blsn, hospital
+  #                  one private headline model each
+  #
+  # A few-minute load gets its own machine so a regression there cannot
+  # hide behind a short coverage batch. Skip-smudge + LFS-pull of the
+  # shard list only: PSB is ~900 MB and the public runner has 14 GB disk.
+  #
+  # regression-pack produces the npm tarball perf jobs consume, in
+  # parallel with the shards (both need: build). The aggregator keeps
+  # the check name `run-ifc-regression`.
+  #
+  # Visual-diff is public coverage only — rendering private models would
+  # publish them onto visual-diff-assets.
   # ---------------------------------------------------------------------------
-  run-ifc-regression:
+  regression-pack:
     needs: build
-    # Draft PRs don't run the regression. It is by far the longest job here,
-    # and with several PRs in flight the draft pushes alone can saturate the
-    # 4-job concurrency cap and starve the PRs that are actually ready for
-    # review. `build` is deliberately NOT gated: it is comparatively cheap and
-    # it is the compile + unit-test signal you want while a draft is still
-    # being worked. See AGENTS.md "PR lifecycle".
-    #
-    # A job-level `if` rather than a trigger filter, for the reason spelled
-    # out in the paths-ignore note above: a skipped-by-if job satisfies a
-    # required status check, a workflow that never triggers does not.
-    #
-    # The event_name clause is defensive, not load-bearing. On push and
-    # workflow_dispatch `github.event.pull_request` is null, and Actions
-    # coerces both sides of `==` to a number when the types differ, so a bare
-    # `draft == false` would evaluate `0 == 0` and run anyway. Relying on that
-    # coercion would make merges -- and with them auto-publish, which needs
-    # this job -- hinge on a documented-but-obscure corner of the expression
-    # language. The clause states the intent instead.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
-    # Expose the packed tarball name so downstream perf jobs can download the
-    # artifact by name without re-packing conway.
+    timeout-minutes: 10
     outputs:
       package_tgz: ${{ steps.npm_pack.outputs.package_tgz }}
-      # Resolved test-models commit SHA, so perf-three-public pins the exact
-      # same model set this job diffed against.
       test_models_sha: ${{ steps.tmsha.outputs.sha }}
-      # Number of models whose digest CSVs changed vs the pinned test-models
-      # commit; gates the visual-diff job.
-      visual_diff_count: ${{ steps.vdiff.outputs.count }}
     steps:
       - name: Checkout Conway Repo
         uses: actions/checkout@v4
@@ -343,8 +323,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      # Build job populated this cache. We expect a hit; if not, fail fast
-      # rather than silently rebuilding WASM and confusing the timing model.
       - name: Restore WASM build cache (populated by build)
         id: wasm-cache
         uses: actions/cache@v4
@@ -358,397 +336,37 @@ jobs:
       - name: Fail if WASM cache miss
         if: steps.wasm-cache.outputs.cache-hit != 'true'
         run: |
-          echo "::error::WASM cache miss in regression job; build should have populated it."
+          echo "::error::WASM cache miss in regression-pack; build should have populated it."
           exit 1
 
       - name: TypeScript build
         run: yarn build-incremental
 
-      # Bump the minor version so the artifact tarball has a unique name
-      # distinct from the released package (matches prior workflow behavior).
       - name: Bump minor for artifact naming
         run: yarn bumpMinor
 
       - name: Bundle examples
         run: yarn bundle-examples
 
-      # --- Test Models Checkout & Regression ---
-      # Resolve the tracked ref to a concrete commit SHA. Recording the SHA (not
-      # a tag) is what makes the baseline reproducible: test-models doesn't tag
-      # reliably, so we track its main branch and pin per-run to the commit we
-      # actually tested. The SHA keys the cache and is the git-diff target below.
       - name: Resolve test-models SHA
         id: tmsha
         run: |
           set -euo pipefail
           URL=https://github.com/bldrs-ai/test-models.git
-          # Run ls-remote as its own command (errexit) so a transient network
-          # failure aborts the job loudly instead of being masked by the head/cut
-          # pipeline and silently falling back to a moving ref. Annotated tags
-          # advertise a peeled "<ref>^{}" commit line, which we prefer over the
-          # tag-object id.
           REFS=$(git ls-remote "$URL" "$TEST_MODELS_REF")
           SHA=$(printf '%s\n' "$REFS" | awk '$2 ~ /\^\{\}$/ { print $1; found=1; exit } NR==1 { first=$1 } END { if (!found && first) print first }')
-          # No advertised match -> TEST_MODELS_REF is itself a raw commit SHA.
           if [ -z "$SHA" ]; then SHA="$TEST_MODELS_REF"; fi
-          # Refuse anything that is not a 40-hex commit SHA rather than poisoning
-          # the cache key and git-diff target with a moving or bogus ref.
           if ! [[ "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::Could not resolve TEST_MODELS_REF='$TEST_MODELS_REF' to a commit SHA (got '$SHA'). Use an existing branch, tag, or full 40-char commit SHA."
+            echo "::error::Could not resolve TEST_MODELS_REF='$TEST_MODELS_REF' to a commit SHA (got '$SHA')."
             exit 1
           fi
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "Resolved test-models ref '$TEST_MODELS_REF' -> $SHA"
-          echo "**Models:** test-models @ \`$SHA\` (ref \`$TEST_MODELS_REF\`)" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Restore Test Models Cache
-        id: cache-test-models
-        uses: actions/cache@v4
-        with:
-          path: test-models
-          # smoke- in the key so we never restore a 9.6 GB full-corpus
-          # cache onto the 14 GB public disk. hashFiles so growing the
-          # list misses rather than running against pointer stubs.
-          key: ${{ runner.os }}-test-models-smoke-${{ steps.tmsha.outputs.sha }}-${{ hashFiles('regression/smoke_models.txt') }}
-
-      - name: Checkout Test Models Repo if Not Cached
-        if: steps.cache-test-models.outputs.cache-hit != 'true'
-        env:
-          # Pointers only. The next step LFS-pulls the smoke list; a
-          # smudged checkout of ifc/** + step/** is ~3 GB of models and
-          # does not fit next to node_modules + wasm on 14 GB.
-          GIT_LFS_SKIP_SMUDGE: '1'
-        run: |
-          SHA="${{ steps.tmsha.outputs.sha }}"
-          # Shallow-fetch exactly the resolved commit (GitHub allows fetch-by-SHA
-          # for reachable commits) so the working tree and git-diff target match
-          # the SHA we recorded, even if main advanced since we resolved it.
-          git init test-models
-          git -C test-models remote add origin https://github.com/bldrs-ai/test-models.git
-          git -C test-models fetch --depth 1 origin "$SHA"
-          git -C test-models checkout "$SHA"
-
-      - name: Materialize smoke-list LFS models
-        run: |
-          python3 - <<'EOF'
-          import subprocess, sys
-          from pathlib import Path
-
-          names = [l.strip() for l in open('regression/smoke_models.txt')
-                   if l.strip() and not l.strip().startswith('#')]
-          want = set(names)
-          root = Path('test-models')
-          paths = []
-          for top in ('ifc', 'step'):
-              for p in (root / top).rglob('*'):
-                  if p.is_file() and p.name in want:
-                      paths.append(p.relative_to(root).as_posix())
-          missing = want - {Path(p).name for p in paths}
-          if missing:
-              print('::error::smoke_models.txt names not in test-models: '
-                    + ', '.join(sorted(missing)))
-              sys.exit(1)
-          stubs = []
-          for rel in paths:
-              head = (root / rel).read_bytes()[:200]
-              if head.startswith(b'version https://git-lfs') or b'git-lfs.github.com' in head:
-                  stubs.append(rel)
-          print(f'{len(paths)} smoke models, {len(stubs)} LFS stubs to pull')
-          if not stubs:
-              sys.exit(0)
-          subprocess.check_call(['git', 'lfs', 'install', '--local'], cwd=root)
-          subprocess.check_call(
-              ['git', 'lfs', 'pull', '--include=' + ','.join(stubs)], cwd=root)
-          EOF
-
-      # This job runs the SMOKE subset only (regression/smoke_models.txt) —
-      # the full public+private corpus runs once per release candidate in
-      # rc-regression.yml, whose baseline-PR diff is the release's regression
-      # report. The batch CLI only has an EXCLUDE regex, so build one that
-      # excludes every model file whose basename is NOT in the smoke list.
-      # The regex must only ever match model FILES (extension-anchored):
-      # the batch's directory walk applies the same regex to directories,
-      # and a broader pattern would stop recursion entirely.
-      - name: Build smoke-subset exclude regex
-        id: smoke
-        run: |
-          python3 - <<'EOF'
-          import os, re
-          names = [l.strip() for l in open('regression/smoke_models.txt')
-                   if l.strip() and not l.strip().startswith('#')]
-          assert names, 'smoke_models.txt selected no models'
-          alts = '|'.join(re.escape(n) for n in names)
-          regex = (rf"^(?!.*/(?:{alts})$)"
-                   r".*\.(?:[iI][fF][cC]|[sS][tT][eE][pP]|[sS][tT][pP])$")
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-            fh.write(f'regex={regex}\n')
-          print(f'{len(names)} smoke models; exclude regex: {regex}')
-          EOF
-
-      # Perf CSV lands OUTSIDE the diffed test_models folder so machine-specific
-      # timings don't show up as "changes" against test-models's checked-in
-      # baselines. The aggregate is uploaded as a workflow artifact below and
-      # summarised in the PR comment. NOTE these timings come from a --parallel
-      # run (models contend), so they're a smoke signal only — the clean
-      # per-model perf record is the rc-gated perf-three-* jobs. Each child
-      # is itself multi-threaded wasm; `--concurrency 2` on 4 vCPU avoids
-      # oversubscribing as the list grows (the CLI default is one child per
-      # core).
-      - name: Run IFC Regression Batch Script (smoke subset)
-        env:
-          SMOKE_EXCLUDE: ${{ steps.smoke.outputs.regex }}
-        run: |
-          node --experimental-specifier-resolution=node ./compiled/src/ifc/ifc_regression_batch_main.js \
-            -e "$SMOKE_EXCLUDE" \
-            -t ${{ steps.tmsha.outputs.sha }} \
-            --perf "${GITHUB_WORKSPACE}/perf.csv" \
-            test-models \
-            test-models/regression/test_models \
-            --parallel --mem-utilization 90 --concurrency 2
-
-      - name: Gather Regression Results
-        id: regression_results
-        run: |
-          cd test-models/regression/test_models
-
-          # Summarize failed.csv / errors.csv as diffs against the versions
-          # tracked at the pinned test-models commit. The full tables repeat a
-          # couple dozen pages of long-standing, already-triaged output on
-          # every PR; what a reviewer needs is the delta. Row counts always
-          # show; full rows only for entries added or resolved vs the
-          # baseline (failed.csv additionally prints all current rows when
-          # non-empty - hard failures are rare and always worth reading).
-          cat > /tmp/regression_summary.py <<'EOF'
-          import csv, io, subprocess, sys
-          from collections import Counter
-
-          sha, name, empty_msg, mode = sys.argv[1:5]
-          # Optional 5th arg: a smoke_models.txt path. The run only regenerates
-          # that subset, so baseline rows for models OUTSIDE it would all count
-          # as "resolved" (they weren't retested — on the first smoke run that
-          # was 602 phantom resolved errors). Scope both sides to the subset so
-          # the diff is apples-to-apples.
-          scope_path = sys.argv[5] if len(sys.argv) > 5 else ""
-          scope = set()
-          if scope_path:
-              scope = {
-                  l.strip() for l in open(scope_path)
-                  if l.strip() and not l.strip().startswith("#")
-              }
-
-          def parse(text):
-              rows = list(csv.reader(io.StringIO(text)))
-              if not rows:
-                  return [], []
-              body = [
-                  tuple(
-                      field.replace("\n", " ").replace("\r", " ").replace("|", "\\|")
-                      for field in row
-                  )
-                  for row in rows[1:]
-              ]
-              return rows[0], body
-
-          def table(header, rows, limit=50):
-              out = ["| " + " | ".join(header) + " |", "|" + " --- |" * len(header)]
-              for row in rows[:limit]:
-                  out.append("| " + " | ".join(row) + " |")
-              if len(rows) > limit:
-                  out.append("")
-                  out.append(f"_...and {len(rows) - limit} more row(s); full CSV in the run artifacts._")
-              return "\n".join(out)
-
-          def details(summary, body):
-              return f"<details><summary>{summary}</summary>\n\n{body}\n\n</details>"
-
-          try:
-              with open(name, newline="") as f:
-                  current_text = f.read()
-          except FileNotFoundError:
-              print(f"No {name} found.")
-              sys.exit(0)
-
-          header, current = parse(current_text)
-
-          baseline_run = subprocess.run(
-              ["git", "-C", "../..", "show", f"{sha}:regression/test_models/{name}"],
-              capture_output=True, text=True)
-          has_baseline = baseline_run.returncode == 0
-          baseline = parse(baseline_run.stdout)[1] if has_baseline else []
-
-          scoped_note = ""
-          if scope and "file" in header:
-              fi = header.index("file")
-              baseline = [r for r in baseline if len(r) > fi and r[fi] in scope]
-              current = [r for r in current if len(r) > fi and r[fi] in scope]
-              scoped_note = ", scoped to the smoke subset"
-
-          current_counts, baseline_counts = Counter(current), Counter(baseline)
-          added = list((current_counts - baseline_counts).elements())
-          resolved = list((baseline_counts - current_counts).elements())
-
-          lines = []
-
-          if not current:
-              lines.append(empty_msg)
-          else:
-              lines.append(f"**{len(current)}** row(s) (baseline **{len(baseline)}**{scoped_note}).")
-
-          if not has_baseline:
-              lines.append(f"_No {name} at the pinned test-models commit - every row counts as new._")
-
-          if current and mode == "full":
-              lines.append("")
-              lines.append(table(header, current))
-
-          if added or resolved:
-              summary_bits = []
-              if added:
-                  summary_bits.append(f"{len(added)} new")
-              if resolved:
-                  summary_bits.append(f"{len(resolved)} resolved")
-              lines.append("")
-              lines.append(f"**Changes vs baseline:** {', '.join(summary_bits)}.")
-              if added:
-                  lines.append("")
-                  lines.append(details(f"New ({len(added)})", table(header, added)))
-              if resolved:
-                  lines.append("")
-                  lines.append(details(f"Resolved ({len(resolved)})", table(header, resolved)))
-          elif current:
-              lines.append("No changes vs baseline.")
-
-          print("\n".join(lines))
-          EOF
-
-          if FAILED_OUTPUT=$(python /tmp/regression_summary.py \
-              "${{ steps.tmsha.outputs.sha }}" failed.csv "No failures :white_check_mark:" full \
-              "${GITHUB_WORKSPACE}/regression/smoke_models.txt"); then
-            :
-          else
-            FAILED_OUTPUT="Failed to summarize failed.csv (see job log)."
-          fi
-
-          if ERRORS_OUTPUT=$(python /tmp/regression_summary.py \
-              "${{ steps.tmsha.outputs.sha }}" errors.csv "No errors found." diff \
-              "${GITHUB_WORKSPACE}/regression/smoke_models.txt"); then
-            :
-          else
-            ERRORS_OUTPUT="Failed to summarize errors.csv (see job log)."
-          fi
-
-          echo "failed_output<<EOF" >> $GITHUB_OUTPUT
-          echo "$FAILED_OUTPUT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-          echo "errors_output<<EOF" >> $GITHUB_OUTPUT
-          echo "$ERRORS_OUTPUT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-          # Summarise the top-10 slowest models from the perf CSV. The full
-          # CSV is uploaded as an artifact for finer inspection.
-          PERF_CSV="${GITHUB_WORKSPACE}/perf.csv"
-          if [ -f "$PERF_CSV" ]; then
-            PERF_OUTPUT=$(python - "$PERF_CSV" <<'EOF'
-          import csv, sys
-          with open(sys.argv[1], newline='') as f:
-              rows = list(csv.DictReader(f))
-          if not rows:
-              print("perf.csv is empty.")
-          else:
-              top_n = 10
-              def total(r):
-                  try: return int(r.get('totalTimeMs','0') or 0)
-                  except ValueError: return 0
-              rows.sort(key=total, reverse=True)
-              header = ['file','status','parseTimeMs','geometryTimeMs','totalTimeMs','rssMb','heapUsedMb']
-              print("| " + " | ".join(header) + " |")
-              print("|" + " --- |" * len(header))
-              for r in rows[:top_n]:
-                  print("| " + " | ".join(r.get(h,'') for h in header) + " |")
-              print("")
-              print(f"_Showing top {min(top_n,len(rows))} of {len(rows)} models by totalTimeMs. Full CSV in the run artifacts._")
-          EOF
-          )
-          else
-            PERF_OUTPUT="perf.csv not produced."
-          fi
-
-          echo "perf_output<<EOF" >> $GITHUB_OUTPUT
-          echo "$PERF_OUTPUT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      # The batch run above left regenerated digest CSVs in the test-models
-      # working tree; any tracked CSV that differs from the pinned commit is a
-      # model whose geometry changed under this PR's engine, and any UNTRACKED
-      # digest CSV is a model newly added to the smoke subset (no committed
-      # baseline yet — `git diff` can't see it, which is how new smoke models
-      # used to miss their visual diff entirely). New models are marked with a
-      # tab-separated `new` field; the report always shows their rows, since a
-      # first-time model must be eyeballed before its digest gets blessed.
-      # Model paths are recorded relative to the test-models root so the
-      # visual-diff job (a different workspace) can re-anchor them.
-      - name: Collect digest-changed models for visual diff
-        id: vdiff
-        run: |
-          python3 - "$PWD/test-models" "${{ steps.tmsha.outputs.sha }}" <<'EOF'
-          import os, subprocess, sys
-          root, sha = sys.argv[1], sys.argv[2]
-          out = subprocess.run(
-              ['git', 'diff', '--name-only', sha, '--', 'regression/test_models'],
-              cwd=root, capture_output=True, text=True, check=True).stdout
-          untracked = subprocess.run(
-              ['git', 'ls-files', '--others', '--exclude-standard', '--',
-               'regression/test_models'],
-              cwd=root, capture_output=True, text=True, check=True).stdout
-          # Per-run report files churn on every run (env-specific paths,
-          # counters) — only per-model digest CSVs identify changed geometry.
-          meta = {'errors.csv', 'failed.csv', 'main.csv', 'changes.csv',
-                  'zero_geometry.csv'}
-
-          def digest_stems(listing):
-              stems = set()
-              for line in listing.splitlines():
-                  base = os.path.basename(line)
-                  if base.endswith('.csv') and base not in meta:
-                      stems.add(base[:-4])
-              return stems
-
-          new_stems = digest_stems(untracked)
-          stems = digest_stems(out) | new_stems
-          models, found = [], set()
-          for top in ('ifc', 'step'):
-              for dirpath, _, files in os.walk(os.path.join(root, top)):
-                  for f in files:
-                      stem, ext = os.path.splitext(f)
-                      if (stem in stems and stem not in found and
-                              ext.lower() in ('.ifc', '.step', '.stp')):
-                          found.add(stem)
-                          rel = os.path.relpath(os.path.join(dirpath, f), root)
-                          models.append(
-                              f'{rel}\tnew' if stem in new_stems else rel)
-          with open('changed_models.txt', 'w') as fh:
-              fh.write('\n'.join(sorted(models)) + ('\n' if models else ''))
-          print(f'{len(models)} digest-changed/new model(s)')
-          for m in models:
-              print(f'  {m}')
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-              fh.write(f'count={len(models)}\n')
-          EOF
-
-      - name: Upload changed-model list
-        if: steps.vdiff.outputs.count != '0'
-        uses: actions/upload-artifact@v4
-        with:
-          name: visual-diff-models-${{ github.run_id }}
-          path: changed_models.txt
 
       - name: Create NPM Package
         id: npm_pack
         run: |
           PACKAGE_TGZ=$(npm pack 2>&1 | grep "filename:" | sed 's/.*filename: //')
-          echo "PACKAGE_TGZ=${PACKAGE_TGZ}" >> $GITHUB_ENV
-          echo "package_tgz=${PACKAGE_TGZ}" >> $GITHUB_OUTPUT
+          echo "package_tgz=${PACKAGE_TGZ}" >> "$GITHUB_OUTPUT"
 
       - name: Upload NPM Package Artifact
         uses: actions/upload-artifact@v4
@@ -756,118 +374,160 @@ jobs:
           name: ${{ steps.npm_pack.outputs.package_tgz }}
           path: ${{ steps.npm_pack.outputs.package_tgz }}
 
-      - name: Upload perf.csv artifact
-        if: ${{ hashFiles('perf.csv') != '' }}
+  regression-shard:
+    needs: build
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: coverage-1
+            corpus: public
+            concurrency: '2'
+          - id: coverage-2
+            corpus: public
+            concurrency: '2'
+          - id: coverage-3
+            corpus: public
+            concurrency: '2'
+          - id: psb
+            corpus: private
+            concurrency: '1'
+          - id: d3d
+            corpus: private
+            concurrency: '1'
+          - id: ilna
+            corpus: private
+            concurrency: '1'
+          - id: dowa
+            corpus: private
+            concurrency: '1'
+          - id: orbiter
+            corpus: private
+            concurrency: '1'
+          - id: blsn
+            corpus: private
+            concurrency: '1'
+          - id: hospital
+            corpus: private
+            concurrency: '1'
+    name: regression-shard ${{ matrix.id }}
+    env:
+      TOKEN_PRESENT: ${{ secrets.TEST_MODELS_PRIVATE_TOKEN != '' }}
+    steps:
+      - name: Checkout Conway Repo
+        if: matrix.corpus == 'public' || env.TOKEN_PRESENT == 'true'
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Node
+        if: matrix.corpus == 'public' || env.TOKEN_PRESENT == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '26'
+          cache: 'yarn'
+
+      - name: Compute conway-geom submodule SHA
+        if: matrix.corpus == 'public' || env.TOKEN_PRESENT == 'true'
+        id: subsha
+        run: echo "sha=$(git -C dependencies/conway-geom rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        if: matrix.corpus == 'public' || env.TOKEN_PRESENT == 'true'
+        run: yarn install --frozen-lockfile
+
+      - name: Restore WASM build cache (populated by build)
+        if: matrix.corpus == 'public' || env.TOKEN_PRESENT == 'true'
+        id: wasm-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            dependencies/conway-geom/Dist
+            dependencies/conway-geom/bin/release
+            compiled/dependencies/conway-geom/Dist
+          key: wasm-${{ runner.os }}-emsdk${{ env.EMSDK_VERSION }}-${{ steps.subsha.outputs.sha }}
+
+      - name: Fail if WASM cache miss
+        if: (matrix.corpus == 'public' || env.TOKEN_PRESENT == 'true') && steps.wasm-cache.outputs.cache-hit != 'true'
+        run: |
+          echo "::error::WASM cache miss in regression shard; build should have populated it."
+          exit 1
+
+      - name: TypeScript build
+        if: matrix.corpus == 'public' || env.TOKEN_PRESENT == 'true'
+        run: yarn build-incremental
+
+      - name: Run shard
+        if: matrix.corpus == 'public' || env.TOKEN_PRESENT == 'true'
+        uses: ./.github/actions/regression-shard
+        with:
+          shard-id: ${{ matrix.id }}
+          shard-file: regression/shards/${{ matrix.id }}.txt
+          corpus: ${{ matrix.corpus }}
+          models-ref: ${{ matrix.corpus == 'public' && env.TEST_MODELS_REF || env.TEST_MODELS_PRIVATE_TAG }}
+          models-repo: ${{ matrix.corpus == 'public' && 'bldrs-ai/test-models' || 'bldrs-ai/test-models-private' }}
+          models-token: ${{ matrix.corpus == 'private' && secrets.TEST_MODELS_PRIVATE_TOKEN || '' }}
+          concurrency: ${{ matrix.concurrency }}
+          allow-visual-diff: ${{ matrix.corpus == 'public' && 'true' || 'false' }}
+
+  # Required check name. Must stay `run-ifc-regression` — README and any
+  # status-check consumers match on it. Tiny: it AND-reduces the shards
+  # and merges public visual-diff lists.
+  run-ifc-regression:
+    name: run-ifc-regression
+    needs: [regression-pack, regression-shard]
+    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      package_tgz: ${{ needs.regression-pack.outputs.package_tgz }}
+      test_models_sha: ${{ needs.regression-pack.outputs.test_models_sha }}
+      visual_diff_count: ${{ steps.concat.outputs.count }}
+    steps:
+      - name: Merge public visual-diff lists
+        id: merge
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: visual-diff-models-*
+          path: vdiff-in
+          merge-multiple: false
+
+      - name: Concatenate changed-model lists
+        id: concat
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+          root = Path('vdiff-in')
+          lines = []
+          if root.is_dir():
+              for p in sorted(root.rglob('changed_models.txt')):
+                  lines.extend(l.strip() for l in p.read_text().splitlines() if l.strip())
+          uniq = sorted(set(lines))
+          Path('changed_models.txt').write_text(('\n'.join(uniq) + '\n') if uniq else '')
+          count = len(uniq)
+          print(f'{count} public digest-changed model(s)')
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              fh.write(f'count={count}\n')
+          PY
+
+      - name: Upload merged changed-model list
+        if: steps.concat.outputs.count != '0'
         uses: actions/upload-artifact@v4
         with:
-          name: perf-${{ github.run_id }}
-          path: perf.csv
+          name: visual-diff-models-${{ github.run_id }}
+          path: changed_models.txt
 
-      - name: Comment on Pull Request with Regression Results and NPM Package Artifact
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ## Regression Results (smoke subset, IFC + STEP)
-
-            **Models:** smoke subset (`regression/smoke_models.txt`) of `test-models` @ `${{ steps.tmsha.outputs.sha }}` (ref `${{ env.TEST_MODELS_REF }}`).
-            The full public+private corpus runs once per release candidate (`rc-*` tag, see `rc-regression.yml`).
-
-            **Failed.csv:**
-            ${{ steps.regression_results.outputs.failed_output }}
-
-            **Errors.csv:**
-            ${{ steps.regression_results.outputs.errors_output }}
-
-            **Performance (top 10 by totalTimeMs):**
-            ${{ steps.regression_results.outputs.perf_output }}
-
-            **NPM Package Artifact:**
-            The package **${{ steps.npm_pack.outputs.package_tgz }}** was generated.
-            Download it from [this run's artifacts page](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            (look for the artifact named **${{ steps.npm_pack.outputs.package_tgz }}**).
-
-      # --- Gates. Both run LAST, and both `!cancelled()`. ---------------------
-      #
-      # A gate that exits 1 mid-job takes every later step with it, so gating up
-      # front discarded exactly the evidence needed to diagnose the model it had
-      # just flagged: the results summary, the changed-model list visual-diff
-      # consumes, the tarball, perf.csv, and the PR comment — which quotes
-      # failed.csv, so before this a smoke crash produced no PR comment at all
-      # and you had to open the job log to see WHICH model crashed. Running the
-      # gates last costs nothing but the red X. `!cancelled()` (rather than bare)
-      # so neither gate masks the other: a run reports both problems instead of
-      # making the next push rediscover the second.
-
-      # Hard gate: a smoke model that fails to parse/extract blocks the PR.
-      # Digest CHANGES stay informational (intended geometry changes are
-      # reviewed via the visual diff and blessed at the rc), but a crash is
-      # never intended.
-      - name: Fail on smoke regression failures
-        if: ${{ !cancelled() }}
+      - name: All shards passed
         run: |
-          FAILED=test-models/regression/test_models/failed.csv
-          if [ -f "$FAILED" ] && [ "$(wc -l < "$FAILED")" -gt 1 ]; then
-            echo "::error::Smoke regression failures:"
-            cat "$FAILED"
-            exit 1
-          fi
-          echo "No smoke failures."
-
-      # A model that loads and emits nothing exits 0 and writes no failed.csv
-      # row, so hard-failure detection cannot see it — see #477 / #478. The
-      # batch now reports these in zero_geometry.csv; anything not explicitly
-      # listed (with an issue) in regression/zero_geometry_allowlist.txt is a
-      # new one and fails here.
-      - name: Fail on unexpected zero-geometry models
-        if: ${{ !cancelled() }}
-        run: |
-          ZERO=test-models/regression/test_models/zero_geometry.csv
-          MAIN=test-models/regression/test_models/main.csv
-          ALLOW=regression/zero_geometry_allowlist.txt
-          if [ ! -f "$ZERO" ]; then
-            echo "No zero_geometry.csv produced."; exit 0
-          fi
-          python3 - "$ZERO" "$ALLOW" "$MAIN" <<'PY'
-          import csv, os, sys
-          zero, allow, main = sys.argv[1], sys.argv[2], sys.argv[3]
-          allowed = set()
-          for line in open(allow, encoding='utf-8'):
-              line = line.split('#', 1)[0].strip()
-              if line:
-                  allowed.add(line)
-          rows = [r['file'] for r in csv.DictReader(open(zero, newline='', encoding='utf-8'))]
-          unexpected = [f for f in rows if f not in allowed]
-          for f in rows:
-              print(f"zero geometry: {f}" + ("" if f in unexpected else "  (allowlisted)"))
-
-          # Stale entries rot silently: an allowlisted model that starts
-          # producing geometry keeps its exemption forever, so a later
-          # regression that empties it again is waved through. main.csv is the
-          # set of models this run actually digested, which is what keeps this
-          # correct on the smoke subset - an entry for a model the run never
-          # touched is neither stale nor confirmed, just absent.
-          ran = set()
-          if os.path.exists(main):
-              ran = {r['file'] for r in csv.DictReader(open(main, newline='', encoding='utf-8'))}
-          stale = sorted((allowed & ran) - set(rows))
-
-          if unexpected:
-              print("::error::Models loaded but produced NO geometry and are not allowlisted:")
-              for f in unexpected:
-                  print(f"::error::  {f}")
-          if stale:
-              print("::error::Allowlisted models that now DO produce geometry - "
-                    "delete their lines from regression/zero_geometry_allowlist.txt:")
-              for f in stale:
-                  print(f"::error::  {f}")
-          if unexpected or stale:
-              sys.exit(1)
-          print(f"{len(rows)} zero-geometry model(s), all allowlisted; "
-                f"{len(allowed & ran)} allowlist entr(ies) exercised and still empty.")
-          PY
+          echo "regression-pack: ${{ needs.regression-pack.result }}"
+          echo "regression-shard: ${{ needs.regression-shard.result }}"
+          test "${{ needs.regression-pack.result }}" = "success"
+          test "${{ needs.regression-shard.result }}" = "success"
 
   # ---------------------------------------------------------------------------
   # Visual diff: render before/after images for every model whose regression

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,11 +56,13 @@ This repo uses yarn 1.22.22.
 
 ## PR lifecycle
 
-Several PRs are usually in flight at once, and the CI runners are a
-shared, capped resource (4 concurrent jobs). A PR that runs the full
-suite on every push while it is still being reworked starves the PRs
-that are actually ready. So work moves through these five steps, in
-order:
+Several PRs are usually in flight at once. The paid 150 GB runners
+are a shared, capped resource (4 concurrent jobs) — `build`,
+`perf-three-*`, and rc-regression sit there. `run-ifc-regression` and
+`visual-diff` use free public `ubuntu-24.04` and do not count against
+that cap, but a PR that runs them on every draft push still burns
+LFS bandwidth and stacks batch jobs. So work moves through these
+five steps, in order:
 
 1. **Open the PR as a draft.** Not "open it and mark it draft" —
    `create_pull_request` takes `draft: true`. Heavy CI is gated on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ the two in step when either changes.
 | Job | Draft PR | Ready PR |
 |---|---|---|
 | `build` (compile + unit tests) | runs | runs |
-| `run-ifc-regression` | **skipped** | runs |
+| `run-ifc-regression` (aggregator over ≤10 shards) | **skipped** | runs |
 | `visual-diff` | **skipped** | runs (when digests changed) |
 
 `build` is deliberately left ungated: it is the cheap compile and

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Every PR is gated on two checks defined in `.github/workflows/build.yml`:
 | Job | What it does |
 |---|---|
 | `build` | `yarn install`, WASM + TS compile (WASM cached on the `conway-geom` submodule SHA), `yarn test`, `yarn lint`, and a Tier-A geometry-digest check of the in-repo `data/` models against committed goldens. |
-| `run-ifc-regression` | `needs: build`. Reuses the same WASM cache. Free `ubuntu-24.04` (4 vCPU / 16 GB). Runs the digest batch over the **PR subset** (`regression/smoke_models.txt`) of the public `test-models` ref (`TEST_MODELS_REF`, default `main`), skip-smudge + LFS-pull of those files only. Fails on any `failed.csv` row; digest *changes* are informational (reviewed via the visual-diff comment, blessed at the rc). Posts a per-PR comment with the resolved SHA + smoke-scoped `failed.csv` / `errors.csv` / perf summaries, and uploads the candidate npm tarball + `perf.csv` as workflow artifacts. |
+| `run-ifc-regression` | Aggregator over `regression-shard` (max 10, free `ubuntu-24.04`). Three public coverage shards (`regression/smoke_models.txt`) plus one shard each for the private headline models PSB, D3D, ILNA, DOWA, Orbiter, BLSN, Hospital. Skip-smudge + LFS-pull of that shard's files only. Fails on any `failed.csv` row; digest *changes* are informational (visual-diff is public coverage only). `regression-pack` uploads the candidate npm tarball the perf jobs consume. |
 
 A `concurrency` group cancels superseded PR runs (main runs are never
 cancelled, so releases always complete). A merge to `main` re-runs those two

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Every PR is gated on two checks defined in `.github/workflows/build.yml`:
 | Job | What it does |
 |---|---|
 | `build` | `yarn install`, WASM + TS compile (WASM cached on the `conway-geom` submodule SHA), `yarn test`, `yarn lint`, and a Tier-A geometry-digest check of the in-repo `data/` models against committed goldens. |
-| `run-ifc-regression` | `needs: build`. Reuses the same WASM cache. Runs the regression batch over the **smoke subset** (`regression/smoke_models.txt`) of the public `test-models` ref (`TEST_MODELS_REF`, default `main`), pinned per-run to the resolved commit SHA. Fails on any `failed.csv` row; digest *changes* are informational (reviewed via the visual-diff comment, blessed at the rc). Posts a per-PR comment with the resolved SHA + smoke-scoped `failed.csv` / `errors.csv` / perf summaries, and uploads the candidate npm tarball + `perf.csv` as workflow artifacts. |
+| `run-ifc-regression` | `needs: build`. Reuses the same WASM cache. Free `ubuntu-24.04` (4 vCPU / 16 GB). Runs the digest batch over the **PR subset** (`regression/smoke_models.txt`) of the public `test-models` ref (`TEST_MODELS_REF`, default `main`), skip-smudge + LFS-pull of those files only. Fails on any `failed.csv` row; digest *changes* are informational (reviewed via the visual-diff comment, blessed at the rc). Posts a per-PR comment with the resolved SHA + smoke-scoped `failed.csv` / `errors.csv` / perf summaries, and uploads the candidate npm tarball + `perf.csv` as workflow artifacts. |
 
 A `concurrency` group cancels superseded PR runs (main runs are never
 cancelled, so releases always complete). A merge to `main` re-runs those two
@@ -394,8 +394,9 @@ umbrella waterfall (#316) and performance-in-CI (#314) issues are closed.
   at the rc, blessed into the baseline), but a PR is not *failed* on unexpected
   new errors — only on parse/extract failures (`failed.csv`). A golden-errors
   gate could fail smoke-scoped error churn that isn't an intended change.
-- **Smoke-list curation.** The smoke subset (`regression/smoke_models.txt`)
-  is a hand-picked spread; as the engine's failure surface shifts, revisit
-  which models best catch regressions cheaply.
+- **Smoke-list curation.** The PR subset (`regression/smoke_models.txt`) is
+  a hand-picked spread sized to stay in a couple of minutes of batch time
+  on a free 4-vCPU runner. As the engine's failure surface shifts, revisit
+  which models best catch regressions cheaply — slow giants stay on the rc.
 - **Perf-threshold gating.** The `perf-three-*` jobs post deltas but don't
   fail an rc on a regression; a threshold could turn perf into a release gate.

--- a/design/new/ci-regression-cost.md
+++ b/design/new/ci-regression-cost.md
@@ -22,7 +22,7 @@ full sweep only at a blessed release point.
 | Tier | When | What runs | Gate |
 |---|---|---|---|
 | **A — fixtures** | every PR + merge | unit tests + `data/` geometry goldens (in `build`) | **hard** — a mismatch fails `build` |
-| **B — smoke** | every PR + merge | digest batch over `regression/smoke_models.txt` (~12 models) in `run-ifc-regression` | **hard on failures** — a model that fails to parse/extract blocks; digest *changes* are informational |
+| **B — smoke** | every PR + merge | digest batch over `regression/smoke_models.txt` (~50 models) in `run-ifc-regression` | **hard on failures** — a model that fails to parse/extract blocks; digest *changes* are informational |
 | **C — full corpus + perf** | `rc-*` tag | full public+private digest regression (`rc-regression.yml`) **and** the `perf-three-*` headless-three benchmarks (in `build.yml`) | **hard on failures**; digest churn lands in a reviewable baseline PR |
 
 Tier A is hermetic (no `test-models` clone, no token — protects forks too);
@@ -40,21 +40,27 @@ visually (the visual-diff comment) and **blessed at the rc**, not at PR time.
 
 ## Why it's tiered this way (the cost rationale)
 
-Every heavy job runs on the `ubuntu-24.04-4vcpu-8gb-150gbssd` runner, billed
-as **Actions Linux 16-core at $0.012/min** — that line item is ~100% of the
-metered spend (the 2-core `Actions Linux` rows bill $0 inside the included
-allotment). So cost ≈ **large-runner minutes**, and the levers are *how often*
+Jobs that need the 150 GB disk still run on
+`ubuntu-24.04-4vcpu-8gb-150gbssd`, billed as **Actions Linux 16-core at
+$0.012/min**. Conway is public, so standard `ubuntu-24.04` is 4 vCPU /
+16 GB / 14 GB disk and **unlimited-free**. Digests are not
+jitter-sensitive; the PR regression and visual-diff jobs run there.
+`build` (emcc working set), `perf-three-*` (low-variance timings + full
+corpus on disk), and `rc-regression.yml` (full public+private LFS tree)
+stay on the paid SKU.
+
+So metered cost ≈ **large-runner minutes**, and the levers are *how often*
 and *how many* jobs hit that runner.
 
-Measured per-job wall time on that runner (representative runs):
+Measured per-job wall time (representative runs):
 
 | job | wall time |
 |---|---|
-| build (WASM cache hit) | ~2.8 min |
+| build (WASM cache hit, paid 150 GB) | ~2.8 min |
 | run-ifc-regression (full corpus, old) | ~5 min |
 | **perf-three-private** | **~27 min** |
 | **perf-three-public** | **~11 min** |
-| smoke batch step (12 models) | **seconds** |
+| smoke batch step (~12 models, paid) | **~14 s** of a ~3 min job |
 
 Findings that drove the design:
 
@@ -64,8 +70,12 @@ Findings that drove the design:
    is deliberately not reduced**: for a benchmark, the 8-vcpu headroom buys
    low-variance timings, not throughput — frequency is the lever, not size.
 2. **The full digest batch ran on every PR** for a whole-corpus signal that a
-   ~12-model smoke subset delivers for correctness at a fraction of the cost
-   (#443). The full corpus still runs — once, at the rc.
+   curated smoke subset delivers for correctness at a fraction of the cost
+   (#443). The list grew off the original ~12 once the job moved to a free
+   runner (skip-smudge + LFS-pull of the listed files only — the 9.6 GB
+   tree does not fit 14 GB disk). The full corpus still runs — once, at
+   the rc. Do not shard the PR job until the *batch step* is the wall;
+   today checkout / yarn / tsc dominate, and shards would repeat them.
 3. **Every PR push spawned a fresh pipeline with no cancellation.** A
    concurrency group now cancels superseded runs (#399, see below).
 
@@ -150,8 +160,9 @@ model shows as digest-changed but renders pixel-identical (the change already
 shipped). That churn is baseline drift, not a PR regression — which is why:
 
 - the smoke diff is **scoped to the smoke subset** (a batch that only
-  regenerated 12 models would otherwise report every *other* model as
-  "resolved" — the phantom "602 resolved" seen on #443's first run); and
+  regenerated the listed models would otherwise report every *other*
+  model as "resolved" — the phantom "602 resolved" seen on #443's
+  first run); and
 - the **visual diff is pixel-thresholded** (`--diff-threshold`, default
   0.05%): identical renders are suppressed to a tally instead of shown as
   no-op rows (#441). Limitation: the threshold is area-only, so a tiny
@@ -222,13 +233,14 @@ corpus size.
   files are LFS; a fresh checkout must fetch them. When the org's LFS
   *bandwidth* budget is exhausted, `git lfs` fetch is refused
   (`This repository exceeded its LFS budget`) and any fresh pull fails
-  (exit 128). `run-ifc-regression` normally survives on a **warm test-models
-  cache** (keyed on the test-models SHA) — so the failure is *masked* until
-  the cache misses (test-models `main` advances) or a job does a fresh pull
-  (the rc run). Symptom: PRs suddenly red at the test-models checkout with no
-  code change. Fix: add an LFS data pack to the org (Settings → Billing), or
-  as a no-code stopgap set the repo variable `TEST_MODELS_REF` to a SHA whose
-  cache is still warm.
+  (exit 128). The PR job skip-smudges and LFS-pulls only
+  `smoke_models.txt`, then caches that smaller tree (key includes
+  `smoke-` + the list hash) — so a PR is a few hundred MB of LFS, not
+  9.6 GB. The rc run still clones the full tree. Symptom of a spent
+  budget: PRs red at the LFS-pull step, or an rc red at checkout, with
+  no code change. Fix: add an LFS data pack to the org (Settings →
+  Billing), or as a no-code stopgap set the repo variable
+  `TEST_MODELS_REF` to a SHA whose cache is still warm.
 
 - **`matrix` is not available in a job-level `if:`.** `rc-regression.yml`
   selects corpora via a dynamic matrix built by a `setup` job, not a

--- a/design/new/ci-regression-cost.md
+++ b/design/new/ci-regression-cost.md
@@ -22,7 +22,7 @@ full sweep only at a blessed release point.
 | Tier | When | What runs | Gate |
 |---|---|---|---|
 | **A — fixtures** | every PR + merge | unit tests + `data/` geometry goldens (in `build`) | **hard** — a mismatch fails `build` |
-| **B — smoke** | every PR + merge | digest batch over `regression/smoke_models.txt` (~50 models) in `run-ifc-regression` | **hard on failures** — a model that fails to parse/extract blocks; digest *changes* are informational |
+| **B — PR shards** | every ready PR + merge | up to **10 shards** on free `ubuntu-24.04`: three public coverage lists (union = `regression/smoke_models.txt`) plus one shard each for the private headline models PSB, D3D, ILNA, DOWA, Orbiter, BLSN, Hospital (`regression/shards/`) | **hard on failures** — a model that fails to parse/extract blocks; digest *changes* are informational. Visual-diff is public coverage only |
 | **C — full corpus + perf** | `rc-*` tag | full public+private digest regression (`rc-regression.yml`) **and** the `perf-three-*` headless-three benchmarks (in `build.yml`) | **hard on failures**; digest churn lands in a reviewable baseline PR |
 
 Tier A is hermetic (no `test-models` clone, no token — protects forks too);
@@ -60,7 +60,8 @@ Measured per-job wall time (representative runs):
 | run-ifc-regression (full corpus, old) | ~5 min |
 | **perf-three-private** | **~27 min** |
 | **perf-three-public** | **~11 min** |
-| smoke batch step (~12 models, paid) | **~14 s** of a ~3 min job |
+| PR coverage shard (public small models) | setup ~2.5 min + batch well under a minute |
+| PR headline shard (one private model) | setup ~2.5 min + a few minutes of load (PSB / D3D / Hospital class) |
 
 Findings that drove the design:
 
@@ -70,12 +71,15 @@ Findings that drove the design:
    is deliberately not reduced**: for a benchmark, the 8-vcpu headroom buys
    low-variance timings, not throughput — frequency is the lever, not size.
 2. **The full digest batch ran on every PR** for a whole-corpus signal that a
-   curated smoke subset delivers for correctness at a fraction of the cost
-   (#443). The list grew off the original ~12 once the job moved to a free
-   runner (skip-smudge + LFS-pull of the listed files only — the 9.6 GB
-   tree does not fit 14 GB disk). The full corpus still runs — once, at
-   the rc. Do not shard the PR job until the *batch step* is the wall;
-   today checkout / yarn / tsc dominate, and shards would repeat them.
+   curated subset delivers for correctness at a fraction of the cost
+   (#443). The PR job is now **sharded (max 10)** on free runners:
+   coverage lists of small public models, plus one shard per private
+   headline model (PSB / D3D / ILNA / DOWA / Orbiter / BLSN / Hospital).
+   A few-minute load gets its own machine so a regression there cannot
+   hide behind a short batch. Skip-smudge + LFS-pull of the shard list
+   only — the 9.6 GB public tree and 15 GB private tree do not fit 14 GB
+   disk; PSB alone is ~900 MB. The full corpus still runs once, at the rc.
+   Do not add an 11th shard; see `regression/shards/README.md`.
 3. **Every PR push spawned a fresh pipeline with no cancellation.** A
    concurrency group now cancels superseded runs (#399, see below).
 
@@ -233,14 +237,14 @@ corpus size.
   files are LFS; a fresh checkout must fetch them. When the org's LFS
   *bandwidth* budget is exhausted, `git lfs` fetch is refused
   (`This repository exceeded its LFS budget`) and any fresh pull fails
-  (exit 128). The PR job skip-smudges and LFS-pulls only
-  `smoke_models.txt`, then caches that smaller tree (key includes
-  `smoke-` + the list hash) — so a PR is a few hundred MB of LFS, not
-  9.6 GB. The rc run still clones the full tree. Symptom of a spent
-  budget: PRs red at the LFS-pull step, or an rc red at checkout, with
-  no code change. Fix: add an LFS data pack to the org (Settings →
-  Billing), or as a no-code stopgap set the repo variable
-  `TEST_MODELS_REF` to a SHA whose cache is still warm.
+  (exit 128). PR shards skip-smudge and LFS-pull only their list —
+  public coverage is ~180 MB; the seven private headline models are
+  ~2.6 GB together (PSB alone ~900 MB), cached per shard. The rc run
+  still clones the full trees. Symptom of a spent budget: PRs red at
+  the LFS-pull step, or an rc red at checkout, with no code change.
+  Fix: add an LFS data pack to the org (Settings → Billing), or as a
+  no-code stopgap set `TEST_MODELS_REF` / `TEST_MODELS_PRIVATE_TAG` to
+  a SHA whose cache is still warm.
 
 - **`matrix` is not available in a job-level `if:`.** `rc-regression.yml`
   selects corpora via a dynamic matrix built by a `setup` job, not a

--- a/regression/README.md
+++ b/regression/README.md
@@ -6,7 +6,7 @@ Conway has a built in regression testing framework that is designed to be run as
 
 CI runs the framework at three escalating scopes, so full-corpus cost is paid once per release instead of per push:
 
-1. **Every PR / merge** — unit tests plus the in-repo `data/` goldens (Tier A in `build.yml`), and the digest batch over the **PR subset** in `regression/smoke_models.txt` on a free `ubuntu-24.04` runner. A listed model that fails to parse blocks the PR; digest *changes* are informational and reviewed via the visual diff.
+1. **Every ready PR / merge** — unit tests plus the in-repo `data/` goldens (Tier A in `build.yml`), and up to ten digest shards on free `ubuntu-24.04` (three public coverage lists plus one shard each for PSB, D3D, ILNA, DOWA, Orbiter, BLSN, Hospital — see `regression/shards/README.md`). A listed model that fails to parse blocks the PR; digest *changes* are informational and reviewed via the visual diff (public coverage only).
 2. **Release candidate (`rc-*` tag)** — `rc-regression.yml` runs the batch over the **entire public and private corpora**, goes red on any failure, and opens a baseline PR in each test-models repo. That PR's diff is the release's regression report; merging it blesses the baselines so they track releases exactly.
 3. **Perf** — the headless-three benchmarks also run per `rc-*` tag (`perf-three-*` in `build.yml`); timings from the parallel smoke batch are contended and only a coarse signal.
 

--- a/regression/README.md
+++ b/regression/README.md
@@ -6,7 +6,7 @@ Conway has a built in regression testing framework that is designed to be run as
 
 CI runs the framework at three escalating scopes, so full-corpus cost is paid once per release instead of per push:
 
-1. **Every PR / merge** — unit tests plus the in-repo `data/` goldens (Tier A in `build.yml`), and the digest batch over the **smoke subset** in `regression/smoke_models.txt`. A smoke model that fails to parse blocks the PR; digest *changes* are informational and reviewed via the visual diff.
+1. **Every PR / merge** — unit tests plus the in-repo `data/` goldens (Tier A in `build.yml`), and the digest batch over the **PR subset** in `regression/smoke_models.txt` on a free `ubuntu-24.04` runner. A listed model that fails to parse blocks the PR; digest *changes* are informational and reviewed via the visual diff.
 2. **Release candidate (`rc-*` tag)** — `rc-regression.yml` runs the batch over the **entire public and private corpora**, goes red on any failure, and opens a baseline PR in each test-models repo. That PR's diff is the release's regression report; merging it blesses the baselines so they track releases exactly.
 3. **Perf** — the headless-three benchmarks also run per `rc-*` tag (`perf-three-*` in `build.yml`); timings from the parallel smoke batch are contended and only a coarse signal.
 

--- a/regression/shards/README.md
+++ b/regression/shards/README.md
@@ -1,0 +1,21 @@
+# PR regression shards
+
+Ready-PR digest CI is **at most 10 shards** on free `ubuntu-24.04`.
+Each shard skip-smudges its corpus and LFS-pulls only the files in its
+list, so a 900 MB headline model fits on the 14 GB disk.
+
+| Shard | Corpus | Why |
+|---|---|---|
+| `coverage-1` … `coverage-3` | public `test-models` | Small/fast models for schema and exporter spread. Lists union to [`../smoke_models.txt`](../smoke_models.txt). |
+| `psb`, `d3d`, `ilna`, `dowa`, `orbiter`, `blsn`, `hospital` | private `test-models-private` | One headline model each. A few-minute load gets its own machine so a regression there cannot hide behind a short coverage batch. |
+
+Private shards need `TEST_MODELS_PRIVATE_TOKEN`. Forks without it skip
+those shards; public coverage still runs. Visual-diff is **public
+coverage only** — rendering private models would publish them onto
+`visual-diff-assets`.
+
+The full public+private corpora still run once per `rc-*` tag
+(`rc-regression.yml`).
+
+Do not add an 11th shard. If a new headline model needs isolation,
+merge two coverage lists or move a small headline into coverage.

--- a/regression/shards/blsn.txt
+++ b/regression/shards/blsn.txt
@@ -1,0 +1,3 @@
+# corpus: private
+# Headline STEP. BLSN_007.stp (~282 MB).
+BLSN_007.stp

--- a/regression/shards/coverage-1.txt
+++ b/regression/shards/coverage-1.txt
@@ -1,0 +1,20 @@
+# corpus: public
+# Tiny IFC fixtures and small houses.
+index.ifc
+box.ifc
+bath-csg-solid.ifc
+b.ifc
+example.ifc
+Sample_entities.ifc
+IfcOpenHouse_IFC4.ifc
+KIT-Simple-Road-Test-Web-IFC4x3_RC2.ifc
+haus.ifc
+duplex.ifc
+AC20-FZK-Haus.ifc
+ISSUE_005_haus.ifc
+ISSUE_021_Mini Project.ifc
+ISSUE_044_test_IFCCOMPOSITEPROFILEDEF.ifc
+ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc
+tested_sample_project.ifc
+171210AISC_Sculpture_param.ifc
+House Aarburg IFC (1).ifc

--- a/regression/shards/coverage-2.txt
+++ b/regression/shards/coverage-2.txt
@@ -1,0 +1,14 @@
+# corpus: public
+# Remaining public IFC, including MB-Khaya (the largest public PR model).
+ISSUE_034_HouseZ.ifc
+ISSUE_102_M3D-CON.ifc
+ISSUE_126_model.ifc
+ISSUE_159_kleine_Wohnung_R22.ifc
+Office_A_20110811.ifc
+Remigen_Mo.ifc
+C20-Institute-Var-2.ifc
+dental_clinic.ifc
+FM_ARC_DigitalHub.ifc
+ifcbridge-model01.ifc
+ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc
+MB-Khaya.ifc

--- a/regression/shards/coverage-3.txt
+++ b/regression/shards/coverage-3.txt
@@ -1,0 +1,21 @@
+# corpus: public
+# Public STEP: NIST CTC, small assemblies, supercap error-churn.
+nist_ctc_01_asme1_rd.stp
+nist_ctc_02_asme1_rc.stp
+nist_ctc_03_asme1_rc.stp
+nist_ctc_04_asme1_rd.stp
+nist_ctc_05_asme1_rd.stp
+nist_ctc_01_asme1_ap242-e1.stp
+nist_ctc_02_asme1_ap242-e2.stp
+as1-oc-214.stp
+create-a-tube.step
+a-gear.step
+NEMA 23 - 76mm.STEP
+Right_Hand.step
+Equiptment_1mLSyringe.step
+Equiptment_SyringePumpSystem.step
+TestSetup_UltrasoundTransducerScattering.step
+supercap.step
+supercap2.step
+supercap3.step
+driver board.step

--- a/regression/shards/d3d.txt
+++ b/regression/shards/d3d.txt
@@ -1,0 +1,3 @@
+# corpus: private
+# Headline. ~224 MB IFC, random-access / high read-amplification load.
+D3D.ifc

--- a/regression/shards/dowa.txt
+++ b/regression/shards/dowa.txt
@@ -1,0 +1,3 @@
+# corpus: private
+# Headline. ~418 MB IFC.
+DOWA_AR_DW_4.ifc

--- a/regression/shards/hospital.txt
+++ b/regression/shards/hospital.txt
@@ -1,0 +1,3 @@
+# corpus: private
+# Headline. Autodesk Hospital Metric Architectural Central (~555 MB IFC).
+Autodesk_Hospital_Metric_Architectural_Central.ifc

--- a/regression/shards/ilna.txt
+++ b/regression/shards/ilna.txt
@@ -1,0 +1,3 @@
+# corpus: private
+# Headline. ILNA 3D_SIA2040.ifc (~250 MB), not the _optimized sibling.
+ILNA 3D_SIA2040.ifc

--- a/regression/shards/orbiter.txt
+++ b/regression/shards/orbiter.txt
@@ -1,0 +1,4 @@
+# corpus: private
+# Headline STEP. Small on disk (~10 MB), long-running geometry
+# (coil spring / helical thread — design/new and scripts/debug/README.md).
+Orbiter_v1.1_Gear_7.5.step

--- a/regression/shards/psb.txt
+++ b/regression/shards/psb.txt
@@ -1,0 +1,3 @@
+# corpus: private
+# Headline. ~900 MB IFC, sweep-shaped load (design/new/memory-residency.md).
+PSB.ifc

--- a/regression/smoke_models.txt
+++ b/regression/smoke_models.txt
@@ -1,32 +1,82 @@
-# PR-time regression smoke subset.
+# PR-time regression subset.
 #
 # One model filename per line (basename with extension, matched against the
-# test-models tree; lines starting with '#' are ignored). Every PR's
+# test-models tree; lines starting with '#' are ignored). Every ready PR's
 # run-ifc-regression job runs the digest batch over ONLY these models — the
-# full public+private corpus runs once per release candidate (rc-* tag) in
-# rc-regression.yml, whose baseline-PR diff is the release's regression
-# report.
+# full public+private corpus still runs once per release candidate (rc-*
+# tag) in rc-regression.yml, whose baseline-PR diff is the release's
+# regression report.
 #
-# Curation intent: small/fast models, a spread of schemas and exporters,
-# both IFC and STEP, plus one chronically error-producing model (supercap)
-# so error-churn regressions surface at PR time too. Each entry must have a
-# committed baseline CSV in test-models regression/test_models/. Slow models
-# (SKYLARK, Snowdon, Arty_Z7, Jetenginestep, DSA2, nist_ftc_08...) are
-# deliberately excluded — they belong to the RC pass.
+# Curation intent: a spread of schemas and exporters, both IFC and STEP,
+# plus one chronically error-producing model (supercap) so error-churn
+# regressions surface at PR time. Each entry must have a committed
+# baseline CSV in test-models regression/test_models/ (or it lands as
+# "new" and is blessed with the next baseline PR).
+#
+# Kept off this list on purpose — they belong to the RC pass:
+#   SKYLARK, Snowdon, Arty_Z7, Jetenginestep, DSA2, nist_ftc_08,
+#   sp-231/469/946, ISSUE_068, ISSUE_098, ISSUE_102_M3D-CON-CD,
+#   schependomlaan, Stohr, advanced_model, S_Office, Trapelo,
+#   Haus Aarburg (the 38 MB one). File size is not the only signal:
+#   nist_ftc_08 is small and still slow.
+#
+# The batch itself is ~14s for the original ~12 models on 4 cores
+# (`--parallel`); this list is sized so the step stays well under a
+# couple of minutes. Sharding the job would only pay once the batch
+# (not checkout / yarn / tsc) is the wall.
+
+# --- IFC: tiny fixtures + schema spread ---
 index.ifc
+box.ifc
+bath-csg-solid.ifc
+b.ifc
+example.ifc
+Sample_entities.ifc
+IfcOpenHouse_IFC4.ifc
+KIT-Simple-Road-Test-Web-IFC4x3_RC2.ifc
+haus.ifc
 duplex.ifc
 AC20-FZK-Haus.ifc
 ISSUE_005_haus.ifc
 ISSUE_021_Mini Project.ifc
+ISSUE_034_HouseZ.ifc
+ISSUE_044_test_IFCCOMPOSITEPROFILEDEF.ifc
+ISSUE_102_M3D-CON.ifc
+ISSUE_126_model.ifc
+ISSUE_159_kleine_Wohnung_R22.ifc
+ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc
+Office_A_20110811.ifc
+tested_sample_project.ifc
+171210AISC_Sculpture_param.ifc
+Remigen_Mo.ifc
+House Aarburg IFC (1).ifc
+C20-Institute-Var-2.ifc
+dental_clinic.ifc
+FM_ARC_DigitalHub.ifc
+ifcbridge-model01.ifc
+ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc
+# One larger IFC kept as a catch-all (already on the original smoke list).
 MB-Khaya.ifc
+
+# --- STEP: NIST CTC geometry + a few AP242, plus small assemblies ---
 nist_ctc_01_asme1_rd.stp
 nist_ctc_02_asme1_rc.stp
+nist_ctc_03_asme1_rc.stp
+nist_ctc_04_asme1_rd.stp
+nist_ctc_05_asme1_rd.stp
+nist_ctc_01_asme1_ap242-e1.stp
+nist_ctc_02_asme1_ap242-e2.stp
+as1-oc-214.stp
 create-a-tube.step
-supercap.step
-driver board.step
-# Metre-unit Onshape AP242 assembly (rational B-splines, same_sense=.F.
-# edges, pre-defined colours) — the exporter family the
-# step-small-model-fidelity fixes target; ~2s end-to-end. No committed
-# baseline yet: first smoke run's digest lands as new and gets blessed
-# with the next baseline PR.
+a-gear.step
+NEMA 23 - 76mm.STEP
 Right_Hand.step
+Equiptment_1mLSyringe.step
+Equiptment_SyringePumpSystem.step
+TestSetup_UltrasoundTransducerScattering.step
+# Chronically error-producing; keep so error-churn shows at PR time.
+supercap.step
+supercap2.step
+supercap3.step
+# Mid-size STEP already on the original list.
+driver board.step

--- a/regression/smoke_models.txt
+++ b/regression/smoke_models.txt
@@ -1,11 +1,12 @@
-# PR-time regression subset.
+# Public coverage models for PR-time digest CI. The workflow splits this
+# list across regression/shards/coverage-{1,2,3}.txt (keep those in sync).
+# Headline private models (PSB, D3D, ILNA, DOWA, Orbiter, BLSN, Hospital)
+# each get their own shard — see regression/shards/README.md.
 #
 # One model filename per line (basename with extension, matched against the
-# test-models tree; lines starting with '#' are ignored). Every ready PR's
-# run-ifc-regression job runs the digest batch over ONLY these models — the
-# full public+private corpus still runs once per release candidate (rc-*
-# tag) in rc-regression.yml, whose baseline-PR diff is the release's
-# regression report.
+# test-models tree; lines starting with '#' are ignored). The full
+# public+private corpus still runs once per release candidate (rc-* tag)
+# in rc-regression.yml.
 #
 # Curation intent: a spread of schemas and exporters, both IFC and STEP,
 # plus one chronically error-producing model (supercap) so error-churn
@@ -13,17 +14,13 @@
 # baseline CSV in test-models regression/test_models/ (or it lands as
 # "new" and is blessed with the next baseline PR).
 #
-# Kept off this list on purpose — they belong to the RC pass:
+# Kept off the public coverage list on purpose — they belong to a
+# headline shard or the RC pass:
 #   SKYLARK, Snowdon, Arty_Z7, Jetenginestep, DSA2, nist_ftc_08,
 #   sp-231/469/946, ISSUE_068, ISSUE_098, ISSUE_102_M3D-CON-CD,
 #   schependomlaan, Stohr, advanced_model, S_Office, Trapelo,
 #   Haus Aarburg (the 38 MB one). File size is not the only signal:
 #   nist_ftc_08 is small and still slow.
-#
-# The batch itself is ~14s for the original ~12 models on 4 cores
-# (`--parallel`); this list is sized so the step stays well under a
-# couple of minutes. Sharding the job would only pay once the batch
-# (not checkout / yarn / tsc) is the wall.
 
 # --- IFC: tiny fixtures + schema spread ---
 index.ifc


### PR DESCRIPTION
## Why

Same move as bldrs-ai/Share#1830, plus sharding so a few-minute headline load cannot hide behind a short coverage batch.

Conway is public, so `ubuntu-24.04` is 4 vCPU / 16 GB / 14 GB disk / free. Digests are not jitter-sensitive. The paid SKU is 8 GB RAM / 150 GB disk and billed even here.

The constraint that is *not* like Share: `test-models` is 9.6 GB and `test-models-private` is 15 GB. A full LFS checkout does not fit. Each shard skip-smudges and LFS-pulls only its list (PSB alone is ~900 MB).

## Shards (max 10)

| Shard | Corpus | Models |
|---|---|---|
| coverage-1..3 | public | small/fast IFC+STEP (union = `regression/smoke_models.txt`, 49 models) |
| psb | private | `PSB.ifc` (~900 MB) |
| d3d | private | `D3D.ifc` (~224 MB) |
| ilna | private | `ILNA 3D_SIA2040.ifc` (~250 MB, not `_optimized`) |
| dowa | private | `DOWA_AR_DW_4.ifc` (~418 MB) |
| orbiter | private | `Orbiter_v1.1_Gear_7.5.step` (~10 MB, long geometry) |
| blsn | private | `BLSN_007.stp` (~282 MB) |
| hospital | private | `Autodesk_Hospital_Metric_Architectural_Central.ifc` (~555 MB) |

Private shards need `TEST_MODELS_PRIVATE_TOKEN` (forks skip them). Visual-diff is **public coverage only** — rendering private models would publish them onto `visual-diff-assets`.

`build`, `perf-three-*`, `rc-regression`, `auto-publish` stay on the 150 GB SKU.

See `regression/shards/README.md`.

## Jobs

- `regression-pack` — tarball for perf jobs (parallel with shards, both `needs: build`)
- `regression-shard <id>` — one digest batch
- `run-ifc-regression` — aggregator (keeps that check name)
